### PR TITLE
otel-desktop-viewer: 0.1.4 -> 0.2.2

### DIFF
--- a/pkgs/by-name/ot/otel-desktop-viewer/package.nix
+++ b/pkgs/by-name/ot/otel-desktop-viewer/package.nix
@@ -2,49 +2,60 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  testers,
-  otel-desktop-viewer,
+  fetchpatch,
   stdenv,
-  apple-sdk_12,
+  apple-sdk,
+  versionCheckHook,
+  nix-update-script,
+  ...
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "otel-desktop-viewer";
-  version = "0.1.4";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "CtrlSpice";
     repo = "otel-desktop-viewer";
-    rev = "v${version}";
-    hash = "sha256-kMgcco4X7X9WoCCH8iZz5qGr/1dWPSeQOpruTSUnonI=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-qvMpebhbg/OnheZIZBoiitGYUUMdTghSwEapblE0DkA=";
   };
 
-  # https://github.com/CtrlSpice/otel-desktop-viewer/issues/139
-  patches = [ ./version-0.1.4.patch ];
-
-  subPackages = [ "..." ];
-
-  vendorHash = "sha256-pH16DCYeW8mdnkkRi0zqioovZu9slVc3gAdhMYu2y98=";
+  # NOTE: This project uses Go workspaces, but 'buildGoModule' does not support
+  # them at the time of writing; trying to build with 'env.GOWORK = "off"'
+  # fails with the following error message:
+  #
+  #     main module (github.com/CtrlSpice/otel-desktop-viewer) does not contain package github.com/CtrlSpice/otel-desktop-viewer/desktopexporter
+  #
+  # cf. https://github.com/NixOS/nixpkgs/issues/203039
+  proxyVendor = true;
+  vendorHash = "sha256-1TH9JQDnvhi+b3LDCAooMKgYhPudM7NCNCc+WXtcv/4=";
 
   ldflags = [
     "-s"
     "-w"
+    "-X main.version=${finalAttrs.version}"
   ];
 
-  buildInputs = lib.optional stdenv.hostPlatform.isDarwin apple-sdk_12;
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk ];
 
-  passthru.tests.version = testers.testVersion {
-    inherit version;
-    package = otel-desktop-viewer;
-    command = "otel-desktop-viewer --version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/CtrlSpice/otel-desktop-viewer/releases/tag/v${version}";
+    changelog = "https://github.com/CtrlSpice/otel-desktop-viewer/releases/tag/v${finalAttrs.version}";
     description = "Receive & visualize OpenTelemtry traces locally within one CLI tool";
     homepage = "https://github.com/CtrlSpice/otel-desktop-viewer";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ gaelreyrol ];
+    maintainers = with lib.maintainers; [
+      gaelreyrol
+      jkachmar
+      lf-
+    ];
     mainProgram = "otel-desktop-viewer";
   };
-}
+})


### PR DESCRIPTION
## description

just what it says on the tin: bumps `otel-desktop-viewer` from 0.1.4 to 0.2.2 & does a little housekeeping:
- updates the package to use `versionCheckHook`
  - also properly sets the version w/ `ldFlags` so the check should work now
- adds `nix-update-script` to (hopefully?) keep it up-to-date 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
