### PR TITLE
kaniko: 1.24.0 -> 1.25.0

### DIFF
--- a/pkgs/by-name/ka/kaniko/package.nix
+++ b/pkgs/by-name/ka/kaniko/package.nix
@@ -6,17 +6,18 @@
   installShellFiles,
   testers,
   kaniko,
+  versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "kaniko";
-  version = "1.24.0";
+  version = "1.25.0";
 
   src = fetchFromGitHub {
-    owner = "GoogleContainerTools";
+    owner = "chainguard-dev";
     repo = "kaniko";
-    rev = "v${version}";
-    hash = "sha256-Y/sdbLcmBxUBU9io1RV/CnbuBN4I334BWUDeBoHFRm8=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-6WOczDWIbxFH9OLMQ+KirUEwPeiq3vFm3MdQQk9D+po=";
   };
 
   vendorHash = null;
@@ -24,29 +25,34 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/GoogleContainerTools/kaniko/pkg/version.version=${version}"
+    "-X github.com/chainguard-dev/kaniko/pkg/version.version=${finalAttrs.version}"
   ];
+
+  excludedPackages = [ "hack/release_notes" ];
 
   nativeBuildInputs = [ installShellFiles ];
 
   doCheck = false; # requires docker, container-diff (unpackaged yet)
 
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    for shell in bash fish zsh; do
-      $out/bin/executor completion $shell > executor.$shell
-      installShellCompletion executor.$shell
-    done
-  '';
+  postInstall =
+    let
+      inherit (finalAttrs.meta) mainProgram;
+    in
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      for shell in bash fish zsh; do
+        $out/bin/${mainProgram} completion $shell > ${mainProgram}.$shell
+        installShellCompletion ${mainProgram}.$shell
+      done
+    '';
 
-  passthru.tests.version = testers.testVersion {
-    package = kaniko;
-    version = version;
-    command = "${kaniko}/bin/executor version";
-  };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "Tool to build container images from a Dockerfile, inside a container or Kubernetes cluster";
-    homepage = "https://github.com/GoogleContainerTools/kaniko";
+    homepage = "https://github.com/chainguard-dev/kaniko";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
@@ -55,4 +61,4 @@ buildGoModule rec {
     ];
     mainProgram = "executor";
   };
-}
+})


### PR DESCRIPTION


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Org has changed since the upstream was archived. Forking org has history with the project. CC: @qjoly

Diff: https://github.com/chainguard-dev/kaniko/compare/v1.24.0...v1.25.0

Moved to chainguard-dev fork after original GoogleContainerTools project was archived.
Use finalAttrs pattern instead of rec.
Replace passthru version test with versionCheckHook.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
