### PR TITLE
k2pdfopt: fix build against mupdf >= 1.26.0

### DIFF
--- a/pkgs/by-name/k2/k2pdfopt/mupdf-k2pdfopt-fixup.patch
+++ b/pkgs/by-name/k2/k2pdfopt/mupdf-k2pdfopt-fixup.patch
@@ -1,0 +1,20 @@
+mupdf_patch: resolve merge conflicts
+
+mupdf_patch no longer applies cleanly against mupdf >= 1.25.0, due to merge conflicts in source/fitz/stext-device.c::fz_new_stext_device arising from the following commits
+* https://cgit.ghostscript.com/cgi-bin/cgit.cgi/mupdf.git/diff/source/fitz/stext-device.c?id=bd8d337939f36f55b96cb6984f5c7bbf2f488ce0#:~:text=14%20%40%40-,fz%5Fnew%5Fstext%5Fdevice%28
+* https://cgit.ghostscript.com/cgi-bin/cgit.cgi/mupdf.git/diff/source/fitz/stext-device.c?id=3c260284afce11bb50f32950a7c9f64e6af1af15#:~:text=11%20%40%40-,fz%5Fnew%5Fstext%5Fdevice%28
+This patch resolves these merge conflicts.
+---
++++
+@@ -15,7 +15,7 @@
+-@@ -971,6 +971,9 @@
+- 
+- 	if (opts)
+- 		dev->flags = opts->flags;
++@@ -2460,6 +2460,9 @@ fz_new_stext_device(fz_context *ctx, fz_stext_page *page, const fz_stext_options
++ 			dev->super.stroke_path = fz_stext_stroke_path;
++ 		}
++ 	}
+ +/* willus mod */
+ +else dev->flags=0;
+ +


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `465af216b0b75c7675dc8822a1f2e88d70ad705c`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>k2pdfopt</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc