### PR TITLE
nixos/autossh: overhaul module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -51,6 +51,9 @@
 - The AutoSSH module has been updated and requires configuration changes:
   - `services.autossh.sessions` now uses named attributes instead of a list, removing the need for sessions to have a `name`.
     - `services.autossh.sessions = [ { name = "some-name"; user = "some-user"; } ];` would be `services.autossh.sessions.some-name = { user = "some-user"; };`.
+  - `extraArguments` has been removed in favor of `sshArgs` and `destination`.
+    - `sshArgs` is a list of flags for the underlying SSH command (i.e. `[ "-N" "-D4343" ]`)
+    - `destination` is the user and host to connect to (i.e. `"bill@socks.example.net"`)
 
 - The `yeahwm` package and `services.xserver.windowManager.yeahwm` module were removed due to the package being broken and unmaintained upstream.
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -48,6 +48,10 @@
 
 - The Pocket ID module ([`services.pocket-id`][#opt-services.pocket-id.enable]) and package (`pocket-id`) has been updated to 1.0.0. Some environment variables have been changed or removed, see the [migration guide](https://pocket-id.org/docs/setup/migrate-to-v1/).
 
+- The AutoSSH module has been updated and requires configuration changes:
+  - `services.autossh.sessions` now uses named attributes instead of a list, removing the need for sessions to have a `name`.
+    - `services.autossh.sessions = [ { name = "some-name"; user = "some-user"; } ];` would be `services.autossh.sessions.some-name = { user = "some-user"; };`.
+
 - The `yeahwm` package and `services.xserver.windowManager.yeahwm` module were removed due to the package being broken and unmaintained upstream.
 
 - The `services.siproxd` module has been removed as `siproxd` is unmaintained and broken with libosip 5.x.

--- a/nixos/modules/services/networking/autossh.nix
+++ b/nixos/modules/services/networking/autossh.nix
@@ -110,8 +110,5 @@ in
           };
         })
       ) cfg.sessions;
-
-    environment.systemPackages = [ pkgs.autossh ];
-
   };
 }

--- a/nixos/modules/services/networking/autossh.nix
+++ b/nixos/modules/services/networking/autossh.nix
@@ -28,13 +28,17 @@ in
                 description = "Name of the user the AutoSSH session should run as";
               };
               monitoringPort = lib.mkOption {
-                type = lib.types.int;
+                type = lib.types.oneOf [
+                  lib.types.int
+                  lib.types.str
+                ];
                 default = 0;
                 example = 20000;
                 description = ''
-                  Port to be used by AutoSSH for peer monitoring. Note, that
-                  AutoSSH also uses mport+1. Value of 0 disables the keep-alive
-                  style monitoring
+                  Port to be used by AutoSSH for peer monitoring. Can be an integer,
+                  in which case AutoSSH also uses mport+1. If it is a string, should
+                  be in the format of port:port to use both instead of mport+1.
+                  A value of 0 disables the keep-alive style monitoring.
                 '';
               };
               sshArgs = lib.mkOption {

--- a/nixos/modules/services/networking/autossh.nix
+++ b/nixos/modules/services/networking/autossh.nix
@@ -95,18 +95,23 @@ in
           after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
 
-          # To be able to start the service with no network connection
-          environment.AUTOSSH_GATETIME = "0";
+          environment = {
+            # To be able to start the service with no network connection
+            AUTOSSH_GATETIME = "0";
 
-          # How often AutoSSH checks the network, in seconds
-          environment.AUTOSSH_POLL = "30";
+            # How often AutoSSH checks the network, in seconds
+            AUTOSSH_POLL = "30";
+
+            # We use the variable instead of the flag to allow `ssh -M` "master mode" to be used
+            AUTOSSH_PORT = toString value.monitoringPort;
+          };
 
           serviceConfig = {
             User = "${value.user}";
             # AutoSSH may exit with 0 code if the SSH session was
             # gracefully terminated by either local or remote side.
             Restart = "on-success";
-            ExecStart = "${pkgs.autossh}/bin/autossh -M ${toString value.monitoringPort} ${lib.strings.concatStringsSep " " value.sshArgs} ${value.destination}";
+            ExecStart = "${pkgs.autossh}/bin/autossh ${lib.strings.concatStringsSep " " value.sshArgs} ${value.destination}";
           };
         })
       ) cfg.sessions;

--- a/nixos/modules/services/networking/autossh.nix
+++ b/nixos/modules/services/networking/autossh.nix
@@ -88,9 +88,6 @@ in
         acc
         // {
           "autossh-${s.name}" =
-            let
-              mport = if s ? monitoringPort then s.monitoringPort else 0;
-            in
             {
               description = "AutoSSH session (" + s.name + ")";
 
@@ -108,7 +105,7 @@ in
                 # AutoSSH may exit with 0 code if the SSH session was
                 # gracefully terminated by either local or remote side.
                 Restart = "on-success";
-                ExecStart = "${pkgs.autossh}/bin/autossh -M ${toString mport} ${s.extraArguments}";
+                ExecStart = "${pkgs.autossh}/bin/autossh -M ${toString s.monitoringPort} ${s.extraArguments}";
               };
             };
         }

--- a/nixos/modules/services/networking/autossh.nix
+++ b/nixos/modules/services/networking/autossh.nix
@@ -37,15 +37,21 @@ in
                   style monitoring
                 '';
               };
-              extraArguments = lib.mkOption {
-                type = lib.types.separatedString " ";
-                example = "-N -D4343 bill@socks.example.net";
+              sshArgs = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                example = [
+                  "-N"
+                  "-D4343"
+                ];
                 description = ''
-                  Arguments to be passed to AutoSSH and retransmitted to SSH
-                  process. Some meaningful options include -N (don't run remote
-                  command), -D (open SOCKS proxy on local port), -R (forward
-                  remote port), -L (forward local port), -v (Enable debug). Check
-                  ssh manual for the complete list.
+                  Arguments to be passed to the SSH session, see `man ssh` for possible options.
+                '';
+              };
+              destination = lib.mkOption {
+                type = lib.types.str;
+                example = "bill@socks.example.net";
+                description = ''
+                  The user and host you want AutoSSH to connect to.
                 '';
               };
             };
@@ -62,7 +68,11 @@ in
           socks-peer = {
             user = "bill";
             monitoringPort = 20000;
-            extraArguments = "-N -D4343 billremote@socks.host.net";
+            sshArgs = [
+              "-N"
+              "-D4343"
+            ];
+            destination = "bill@socks.example.net";
           };
         };
 
@@ -96,7 +106,7 @@ in
             # AutoSSH may exit with 0 code if the SSH session was
             # gracefully terminated by either local or remote side.
             Restart = "on-success";
-            ExecStart = "${pkgs.autossh}/bin/autossh -M ${toString value.monitoringPort} ${value.extraArguments}";
+            ExecStart = "${pkgs.autossh}/bin/autossh -M ${toString value.monitoringPort} ${lib.strings.concatStringsSep " " value.sshArgs} ${value.destination}";
           };
         })
       ) cfg.sessions;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The current module is awkward, with one load-bearing string handling the (often lengthy) list of arguments as well as the destination. It also uses a list of sessions with a `name` property, when it would be more clear to assign them by name as attributes.

This is a sizeable breaking change, but I believe it is worth it to improve the module's clarity. However, I'm not really sure how to provide a useful error message, since the type signature of `services.autossh.sessions` is changing rather than being removed.

**Old config:**
```nix
services.autossh.sessions = [ {
  extraArguments = "-N -D4343 billremote@socks.host.net";
  monitoringPort = 20000;
  name = "socks-peer";
  user = "bill";
} ];
```

**New config:**
```nix
services.autossh.sessions.socks-peer = {
  destination = "billremote@socks.host.net";
  sshArgs = [ "-N" "-D4343" ];
  monitoringPort = 20000;
  user = "bill";
};
```

While I was at it, I also went and made various other small improvements. See the commits list for details.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
