### PR TITLE
ld-audit-search-mod: init at 0-unstable-2025-06-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5944,6 +5944,12 @@
     githubId = 58050402;
     name = "Jost Alemann";
   };
+  DDoSolitary = {
+    email = "DDoSolitary@gmail.com";
+    github = "DDoSolitary";
+    githubId = 25856103;
+    name = "DDoSolitary";
+  };
   dduan = {
     email = "daniel@duan.ca";
     github = "dduan";

--- a/pkgs/by-name/ld/ld-audit-search-mod/package.nix
+++ b/pkgs/by-name/ld/ld-audit-search-mod/package.nix
@@ -1,0 +1,40 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  storeDir ? builtins.storeDir,
+  spdlog,
+  yaml-cpp,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ld-audit-search-mod";
+  version = "0-unstable-2025-06-19";
+
+  src = fetchFromGitHub {
+    repo = finalAttrs.pname;
+    owner = "DDoSolitary";
+    rev = "261f475f154d0f1f0766d6756af9c714eeeb14ea";
+    hash = "sha256-c6ub+m4ihIE3gh6yHtLfJIVqm12C46wThrBCqp8SOLE=";
+    sparseCheckout = [ "src" ];
+  };
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  buildInputs = [
+    spdlog
+    yaml-cpp
+  ];
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "NIX_RTLD_NAME" (builtins.baseNameOf stdenv.cc.bintools.dynamicLinker))
+    (lib.cmakeFeature "NIX_STORE_DIR" storeDir)
+  ];
+
+  meta = {
+    inherit (finalAttrs.src.meta) homepage;
+    description = "Audit module that modifies ld.so library search behavior";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ld/ld-audit-search-mod/package.nix
+++ b/pkgs/by-name/ld/ld-audit-search-mod/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0-unstable-2025-06-19";
 
   src = fetchFromGitHub {
-    repo = finalAttrs.pname;
+    repo = "ld-audit-search-mod";
     owner = "DDoSolitary";
     rev = "261f475f154d0f1f0766d6756af9c714eeeb14ea";
     hash = "sha256-c6ub+m4ihIE3gh6yHtLfJIVqm12C46wThrBCqp8SOLE=";
@@ -35,6 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs.src.meta) homepage;
     description = "Audit module that modifies ld.so library search behavior";
     license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.atry
+      lib.maintainers.DDoSolitary
+    ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
## Things done

This PR adds [ld-audit-search-mod](https://github.com/DDoSolitary/ld-audit-search-mod), a potential solution for https://github.com/NixOS/nixpkgs/issues/327854

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.


I manually tested it. It works fine as documented in the upstream README.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
