### PR TITLE
tcld: 0.40.0 -> 0.41.0

### DIFF
--- a/pkgs/by-name/tc/tcld/package.nix
+++ b/pkgs/by-name/tc/tcld/package.nix
@@ -4,24 +4,45 @@
   lib,
   stdenvNoCC,
   installShellFiles,
+  versionCheckHook,
   nix-update-script,
   ...
 }:
 
 buildGoModule (finalAttrs: {
   pname = "tcld";
-  version = "0.40.0";
+  version = "0.41.0";
   src = fetchFromGitHub {
     owner = "temporalio";
     repo = "tcld";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-bIJSvop1T3yiLs/LTgFxIMmObfkVfvvnONyY4Bsjj8g=";
+    hash = "sha256-Jnm6l9Jj1mi9esDS6teKTEMhq7V1QD/dTl3qFhKsW4o=";
+    # Populate values from the git repository; by doing this in 'postFetch' we
+    # can delete '.git' afterwards and the 'src' should stay reproducible.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      # Replicate 'COMMIT' and 'DATE' variables from upstream's Makefile.
+      git rev-parse --short=12 HEAD > $out/COMMIT
+      git log -1 --format=%cd --date=iso-strict > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -exec rm -rf '{}' '+'
+    '';
   };
+
   vendorHash = "sha256-GOko8nboj7eN4W84dqP3yLD6jK7GA0bANV0Tj+1GpgY=";
-  ldFlags = [
+
+  subPackages = [ "cmd/tcld" ];
+  ldflags = [
     "-s"
     "-w"
+    "-X=github.com/temporalio/tcld/app.version=${finalAttrs.version}"
   ];
+
+  # ldflags based on metadata from git.
+  preBuild = ''
+    ldflags+=" -X=github.com/temporalio/tcld/app.date=$(cat SOURCE_DATE_EPOCH)"
+    ldflags+=" -X=github.com/temporalio/tcld/app.commit=$(cat COMMIT)"
+  '';
 
   # FIXME: Remove after https://github.com/temporalio/tcld/pull/447 lands.
   patches = [ ./compgen.patch ];
@@ -36,12 +57,19 @@ buildGoModule (finalAttrs: {
     installShellCompletion --cmd tcld --zsh ${./zsh_autocomplete}
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "version";
+
   passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Temporal cloud cli";
     homepage = "https://www.github.com/temporalio/tcld";
+    changelog = "https://github.com/temporalio/tcld/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     teams = [ lib.teams.mercury ];
+    mainProgram = "tcld";
   };
 })


### PR DESCRIPTION
## description

bump `tcld` 0.40.0 -> 0.41.0, also:
* parse commit & date info from git repo similar to how other Go packages do this
* set version, commit, and date in `ldflags`
* add version check hook

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
