### PR TITLE
nexus: 3.70.1-02 -> 3.81.1-01, adopt

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -80,6 +80,8 @@
 
 - The `services.siproxd` module has been removed as `siproxd` is unmaintained and broken with libosip 5.x.
 
+- `nexus` deprecated the use of OrientDB and H2 v1.x. Manual steps to upgrade to nexus > 3.71.0 are required to migrate to the supported H2 v2.x database.
+
 - `netbox-manage` script created by the `netbox` module no longer uses `sudo -u netbox` internally. It can be run as root and will change it's user to `netbox` using `runuser`
 
 - `services.dwm-status.extraConfig` was replaced by [RFC0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-compliant [](#opt-services.dwm-status.settings), which is used to generate the config file. `services.dwm-status.order` is now moved to [](#opt-services.dwm-status.settings.order), as it's a part of the config file.

--- a/pkgs/by-name/ne/nexus3/nexus-bin.patch
+++ b/pkgs/by-name/ne/nexus3/nexus-bin.patch
@@ -1,0 +1,27 @@
+diff --git a/bin/nexus b/bin/nexus
+index 1a128c50a366..e0d9c7678f08
+--- a/bin/nexus
++++ b/bin/nexus
+@@ -11,8 +11,12 @@
+ ### END INIT INFO
+ 
+ original_dir=`pwd`
++scriptname=$0
+ 
+-actualfile=$(realpath "$0")
++if [ -z "$ALTERNATIVE_NAME" ]; then
++  scriptname=`dirname $0`"/"$ALTERNATIVE_NAME
++fi
++actualfile=$(realpath "$scriptname")
+ progname=`basename "$actualfile"`
+ linkdir=`dirname "$actualfile"`
+ HOME="$linkdir"
+@@ -217,7 +221,7 @@ case "$1" in
+     cd "$original_dir" || exit 1
+   ;;
+   *)
+-    echo "Usage: $0 {start|stop|run|run-redirect|status|restart|force-reload}"
++    echo "Usage: $scriptname {start|stop|run|run-redirect|status|restart|force-reload}"
+     exit 1
+   ;;
+ esac

--- a/pkgs/by-name/ne/nexus3/nexus-vm-opts.patch
+++ b/pkgs/by-name/ne/nexus3/nexus-vm-opts.patch
@@ -1,0 +1,14 @@
+diff --git a/bin/nexus b/bin/nexus
+index 5bd5c88a8fec..bd8080821b5d
+--- a/bin/nexus
++++ b/bin/nexus
+@@ -139,7 +139,8 @@ read_vmoptions() {
+
+ cd "$HOME" || exit 1
+ vmoptions_val=""
+-read_vmoptions "nexus.vmoptions"
++VM_OPTS=${VM_OPTS_FILE:-"$linkdir/$ALTERNATIVE_NAME.vmoptions"}
++read_vmoptions "$VM_OPTS"
+ INSTALL4J_ADD_VM_PARAMS="$INSTALL4J_ADD_VM_PARAMS $vmoptions_val"
+
+ # deduce the chosen data directory and prepare log and tmp directories  

--- a/pkgs/by-name/ne/nexus3/package.nix
+++ b/pkgs/by-name/ne/nexus3/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  jre_headless,
+  gawk,
+  nixosTests,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nexus";
+  version = "3.81.1-01";
+
+  src = fetchurl {
+    url = "https://download.sonatype.com/nexus/3/nexus-${version}-linux-x86_64.tar.gz";
+    hash = "sha256-3CiG/X8WyCx/HkrbUossOnTw6k56eP4ElBq1btxzOjg=";
+  };
+
+  preferLocalBuild = true;
+
+  sourceRoot = "${pname}-${version}";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  patches = [
+    ./nexus-bin.patch
+    ./nexus-vm-opts.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace bin/nexus.vmoptions \
+      --replace-fail ../sonatype-work /var/lib/sonatype-work \
+      --replace-fail =. =$out
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -rfv * $out
+    # Remove bundled runtime
+    rm -fvr $out/jdk/
+    rm -fv $out/bin/nexus.bat
+
+    wrapProgram $out/bin/nexus \
+      --set-default APP_JAVA_HOME ${jre_headless} \
+      --set ALTERNATIVE_NAME "nexus" \
+      --prefix PATH "${lib.makeBinPath [ gawk ]}"
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    inherit (nixosTests) nexus;
+  };
+
+  meta = {
+    description = "Repository manager for binary software components";
+    homepage = "https://www.sonatype.com/products/sonatype-nexus-oss";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.epl10;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      transcaffeine
+    ];
+  };
+}


### PR DESCRIPTION
Release notes: https://github.com/sonatype/nexus-public/releases/tag/release-3.81.1-01

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
- [ ] https://help.sonatype.com/en/upgrading-to-nexus-repository-3-71-0-and-beyond.html
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
