### PR TITLE
linux-pam: 1.6.1 -> 1.7.1

### DIFF
--- a/pkgs/by-name/kb/kbd/package.nix
+++ b/pkgs/by-name/kb/kbd/package.nix
@@ -15,6 +15,7 @@
   xz,
   zstd,
   gitUpdater,
+  withVlock ? true,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,16 +31,19 @@ stdenv.mkDerivation rec {
   # reduces closure size for most use cases.
   outputs = [
     "out"
-    "vlock"
     "dev"
     "scripts"
     "man"
+  ]
+  ++ lib.optionals withVlock [
+    "vlock"
   ];
 
   configureFlags = [
     "--enable-optional-progs"
     "--enable-libkeymap"
     "--disable-nls"
+    (lib.enableFeature withVlock "vlock")
   ]
   ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
@@ -89,9 +93,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     check
-    pam
     bash
-  ];
+  ]
+  ++ lib.optionals withVlock [ pam ];
+
   NIX_LDFLAGS = lib.optional stdenv.hostPlatform.isStatic "-laudit";
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -13,6 +13,12 @@
   meson,
   pkg-config,
   systemdLibs,
+  docbook5,
+  libxslt,
+  libxml2,
+  w3m-batch,
+  findXMLCatalogs,
+  docbook_xsl_ns,
   nix-update-script,
 }:
 
@@ -35,8 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
-    # "doc"
-    # "man"
+    "doc"
+    "man"
     # "modules"
   ];
 
@@ -47,6 +53,13 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     gettext
+
+    libxslt
+    libxml2
+    w3m-batch
+    findXMLCatalogs
+    docbook_xsl_ns
+    docbook5
   ];
 
   buildInputs = [
@@ -60,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  mesonAutoFeatures = "auto";
   mesonFlags = [
     (lib.mesonEnable "logind" stdenv.buildPlatform.isLinux)
     (lib.mesonEnable "audit" stdenv.buildPlatform.isLinux)
@@ -71,7 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "econf" false)
     (lib.mesonEnable "selinux" false)
     (lib.mesonEnable "nis" false)
-    (lib.mesonEnable "docs" false)
     (lib.mesonBool "xtests" false)
     (lib.mesonBool "examples" false)
   ];

--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -2,98 +2,100 @@
   lib,
   stdenv,
   buildPackages,
-  fetchurl,
-  fetchpatch,
+  fetchFromGitHub,
   flex,
   db4,
   gettext,
+  ninja,
   audit,
   libxcrypt,
   nixosTests,
-  autoreconfHook269,
-  pkg-config-unwrapped,
+  meson,
+  pkg-config,
+  systemdLibs,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "linux-pam";
-  version = "1.6.1";
+  version = "1.7.1";
 
-  src = fetchurl {
-    url = "https://github.com/linux-pam/linux-pam/releases/download/v${version}/Linux-PAM-${version}.tar.xz";
-    hash = "sha256-+JI8dAFZBS1xnb/CovgZQtaN00/K9hxwagLJuA/u744=";
+  src = fetchFromGitHub {
+    owner = "linux-pam";
+    repo = "linux-pam";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kANcwxifQz2tYPSrSBSFiYNTm51Gr10L/zroCqm8ZHQ=";
   };
 
-  patches = [
-    ./suid-wrapper-path.patch
-    # required for fixing CVE-2025-6020
-    (fetchpatch {
-      url = "https://github.com/linux-pam/linux-pam/commit/10b80543807e3fc5af5f8bcfd8bb6e219bb3cecc.patch";
-      hash = "sha256-VS3D3wUbDxDXRriIuEvvgeZixzDA58EfiLygfFeisGg=";
-    })
-    # Manually cherry-picked from 475bd60c552b98c7eddb3270b0b4196847c0072e
-    ./CVE-2025-6020.patch
-  ];
-
-  # Case-insensitivity workaround for https://github.com/linux-pam/linux-pam/issues/569
-  postPatch =
-    lib.optionalString (stdenv.buildPlatform.isDarwin && stdenv.buildPlatform != stdenv.hostPlatform)
-      ''
-        rm CHANGELOG
-        touch ChangeLog
-      '';
+  # patching unix_chkpwd is required as the nix store entry does not have the necessary bits
+  postPatch = ''
+    substituteInPlace modules/module-meson.build \
+      --replace-fail "sbindir / 'unix_chkpwd'" "'/run/wrappers/bin/unix_chkpwd'"
+  '';
 
   outputs = [
     "out"
-    "doc"
-    "man" # "modules"
+    # "doc"
+    # "man"
+    # "modules"
   ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  # autoreconfHook269 is needed for `suid-wrapper-path.patch` above.
-  # pkg-config-unwrapped is needed for `AC_CHECK_LIB` and `AC_SEARCH_LIBS`
   nativeBuildInputs = [
     flex
-    autoreconfHook269
-    pkg-config-unwrapped
-  ]
-  ++ lib.optional stdenv.buildPlatform.isDarwin gettext;
+    meson
+    ninja
+    pkg-config
+    gettext
+  ];
 
   buildInputs = [
     db4
     libxcrypt
   ]
-  ++ lib.optional stdenv.buildPlatform.isLinux audit;
+  ++ lib.optionals stdenv.buildPlatform.isLinux [
+    audit
+    systemdLibs
+  ];
 
   enableParallelBuilding = true;
 
-  configureFlags = [
-    "--includedir=${placeholder "out"}/include/security"
-    "--enable-sconfigdir=/etc/security"
-    # The module is deprecated. We re-enable it explicitly until NixOS
-    # module stops using it.
-    "--enable-lastlog"
-  ];
-
-  installFlags = [
-    "SCONFIGDIR=${placeholder "out"}/etc/security"
+  mesonFlags = [
+    (lib.mesonEnable "logind" stdenv.buildPlatform.isLinux)
+    (lib.mesonEnable "audit" stdenv.buildPlatform.isLinux)
+    (lib.mesonEnable "pam_lastlog" (!stdenv.hostPlatform.isMusl)) # TODO: switch to pam_lastlog2, pam_lastlog is deprecated and broken on musl
+    (lib.mesonEnable "pam_unix" true)
+    # (lib.mesonBool "pam-debug" true) # warning: slower execution due to debug makes VM tests fail!
+    (lib.mesonOption "sysconfdir" "etc") # relative to meson prefix, which is $out
+    (lib.mesonEnable "elogind" false)
+    (lib.mesonEnable "econf" false)
+    (lib.mesonEnable "selinux" false)
+    (lib.mesonEnable "nis" false)
+    (lib.mesonEnable "docs" false)
+    (lib.mesonBool "xtests" false)
+    (lib.mesonBool "examples" false)
   ];
 
   doCheck = false; # fails
 
-  passthru.tests = {
-    inherit (nixosTests)
-      pam-oath-login
-      pam-u2f
-      pam-lastlog
-      shadow
-      sssd-ldap
-      ;
+  passthru = {
+    tests = {
+      inherit (nixosTests)
+        pam-oath-login
+        pam-u2f
+        pam-lastlog
+        shadow
+        sssd-ldap
+        ;
+    };
+    updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/linux-pam/linux-pam/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/linux-pam/linux-pam";
     description = "Pluggable Authentication Modules, a flexible mechanism for authenticating user";
-    platforms = platforms.linux;
-    license = licenses.bsd3;
+    platforms = lib.platforms.linux;
+    license = lib.licenses.bsd3;
   };
-}
+})

--- a/pkgs/by-name/li/linux-pam/suid-wrapper-path.patch
+++ b/pkgs/by-name/li/linux-pam/suid-wrapper-path.patch
@@ -1,6 +1,0 @@
-It needs the SUID version during runtime, and that can't be in /nix/store/**
---- a/modules/pam_unix/Makefile.am
-+++ b/modules/pam_unix/Makefile.am
-@@ -21 +21 @@
--	-DCHKPWD_HELPER=\"$(sbindir)/unix_chkpwd\" \
-+	-DCHKPWD_HELPER=\"/run/wrappers/bin/unix_chkpwd\" \

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -203,6 +203,8 @@ let
   #  $ curl -s https://api.github.com/repos/systemd/systemd/releases/latest | \
   #     jq '.created_at|strptime("%Y-%m-%dT%H:%M:%SZ")|mktime'
   releaseTimestamp = "1734643670";
+
+  kbd' = if withPam then kbd else kbd.override { withVlock = false; };
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname version;
@@ -396,7 +398,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libxcrypt
-    libcap
+    (if withPam then libcap else libcap.override { usePam = false; })
     libuuid
     linuxHeaders
     bashInteractive # for patch shebangs
@@ -485,8 +487,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "pkgconfigdatadir" "${placeholder "dev"}/share/pkgconfig")
 
     # Keyboard
-    (lib.mesonOption "loadkeys-path" "${kbd}/bin/loadkeys")
-    (lib.mesonOption "setfont-path" "${kbd}/bin/setfont")
+    (lib.mesonOption "loadkeys-path" "${kbd'}/bin/loadkeys")
+    (lib.mesonOption "setfont-path" "${kbd'}/bin/setfont")
 
     # SBAT
     (lib.mesonOption "sbat-distro" "nixos")
@@ -923,8 +925,9 @@ stdenv.mkDerivation (finalAttrs: {
       withUtmp
       util-linux
       kmod
-      kbd
       ;
+
+    kbd = kbd';
 
     # Many TPM2-related units are only installed if this trio of features are
     # enabled. See https://github.com/systemd/systemd/blob/876ee10e0eb4bbb0920bdab7817a9f06cc34910f/units/meson.build#L521


### PR DESCRIPTION
PAM now uses meson to build, so the package needed to essentially be rewritten.
PAM also now uses logind for login limits. To not get infinite recursion, PAM was first stripped from `systemdMinimal`, then `systemdMinimal` was used as logind lib.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
