### PR TITLE
spire: move to finalAttrs pattern and enable tests

### DIFF
--- a/pkgs/by-name/sp/spire/package.nix
+++ b/pkgs/by-name/sp/spire/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "spire";
   version = "1.12.3";
 
@@ -17,16 +17,49 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "spiffe";
     repo = "spire";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-ZtSJ5/Qg4r2dkFGM/WiDWwQc2OtkX45kGXTdXU35Cng=";
   };
 
   vendorHash = "sha256-1ngjcqGwUNMyR/wBCo0MYguD1gGH8rbI2j9BB+tGL9k=";
 
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/spiffe/spire/pkg/common/version.gittag=${finalAttrs.version}"
+  ];
+
   subPackages = [
     "cmd/spire-agent"
     "cmd/spire-server"
   ];
+
+  excludedPackages = [
+    # ensure these files aren't evaluated, see preCheck
+    "test/tmpsimulator"
+    "pkg/agent/plugin/nodeattestor/tpmdevid"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  checkFlags =
+    let
+      skippedTests = [
+        # wants to reach remote TUF mirror
+        "TestDockerConfig"
+        "TestPlugin"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  preCheck = ''
+    # remove test files which reference github.com/google/go-tpm-tools/simulator
+    # since it requires cgo and some missing header files
+    rm -rf test/tpmsimulator pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
+
+    # unset to run all tests
+    unset subPackages
+  '';
 
   # Usually either the agent or server is needed for a given use case, but not both
   postInstall = ''
@@ -38,11 +71,34 @@ buildGoModule rec {
     ln -vs $server/bin/spire-server $out/bin/spire-server
   '';
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/spire-agent -h
+    if [ "$($out/bin/spire-agent --version 2>&1)" != "${finalAttrs.version}" ]; then
+      echo "spire-agent version does not match"
+      exit 1
+    fi
+
+    $out/bin/spire-server -h
+    if [ "$($out/bin/spire-server --version 2>&1)" != "${finalAttrs.version}" ]; then
+      echo "spire-server version does not match"
+      exit 1
+    fi
+
+    runHook postInstallCheck
+  '';
+
   meta = {
     description = "SPIFFE Runtime Environment";
-    homepage = "https://github.com/spiffe/spire";
-    changelog = "https://github.com/spiffe/spire/releases/tag/v${version}";
+    homepage = "https://spiffe.io/";
+    downloadPage = "https://github.com/spiffe/spire";
+    changelog = "https://github.com/spiffe/spire/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ fkautz ];
+    maintainers = with lib.maintainers; [
+      fkautz
+      jk
+    ];
   };
-}
+})


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* Moved to finalAttrs pattern to eliminate use of rec
* Enable the majority of tests
* Added install check with version checks which run on compatible builders
* Updated homepage
  * Potential alternative: https://spiffe.io/docs/latest/spire-about/
* Added myself as a maintainer
* Added ldflags to reduce binary size and add version info

before:

```
❯ du -h $(readlink -f ./result/bin/spire-agent)
52M	/nix/store/ahvg69frq7y03awjyzaga96l3wfbpf25-spire-1.12.2-agent/bin/spire-agent
❯ du -h $(readlink -f ./result/bin/spire-server)
167M	/nix/store/g8hfzvyfac9ilxlj5n90sl32yx0db9hk-spire-1.12.2-server/bin/spire-server
```

after:

```
❯ du -h $(readlink -f ./result/bin/spire-agent)
45M	/nix/store/q7lyz967ywqfrqnpr0zx3abaq02rrazx-spire-1.12.3-agent/bin/spire-agent
❯ du -h $(readlink -f ./result/bin/spire-server)
144M	/nix/store/ja9qvv2vmdvvcmb8spfbrfcvwbwvzx3f-spire-1.12.3-server/bin/spire-server
```

7M & 23M savings respectively

cc: @fkautz

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
