### PR TITLE
ccusage: init at 15.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7253,6 +7253,13 @@
     githubId = 103082;
     name = "Ed Brindley";
   };
+  eleloi = {
+    email = "eleloi@gmail.com";
+    github = "eleloi";
+    githubId = 14278421;
+    name = "Eloi Vallverdú";
+    keys = [ { fingerprint = "E585 7821 1BBA 9DA8 C1F3  4C46 BCB0 25FB 4B63 30F7"; } ];
+  };
   elesiuta = {
     email = "elesiuta@gmail.com";
     github = "elesiuta";

--- a/pkgs/by-name/cc/ccusage/package.nix
+++ b/pkgs/by-name/cc/ccusage/package.nix
@@ -1,0 +1,74 @@
+{ stdenv, lib, fetchFromGitHub, bun, makeWrapper, nix-update-script, }:
+
+let
+  version = "15.1.0";
+  src = fetchFromGitHub {
+    owner = "ryoppippi";
+    repo = "ccusage";
+    tag = "v${version}";
+    hash = "sha256-yscqhjjm5oVCJq6XzB1rr4C7Axctlmw4OonUCYSQ6f0=";
+  };
+  ccusage-deps = stdenv.mkDerivation (finalAttrs: {
+    inherit version src;
+    pname = "ccusage-deps";
+    nativeBuildInputs = [ bun ];
+    buildPhase = ''
+      runHook preBuild
+
+      bun install --no-save --ignore-scripts
+
+      runHook postBuild
+    '';
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r node_modules $out/
+
+      if [ -d docs ]; then
+        cp -r docs $out/
+      fi
+
+      runHook postInstall
+    '';
+    fixupPhase = ''
+      find $out -name "*.sh" -delete
+    '';
+    outputHash = "";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  });
+
+in stdenv.mkDerivation {
+  inherit version src;
+  pname = "ccusage";
+  nativeBuildInputs = [ bun makeWrapper ];
+  buildPhase = ''
+    runHook preBuild
+
+    ln -s ${ccusage-deps}/node_modules ./node_modules
+
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/ccusage
+    cp -r . $out/share/ccusage/
+
+    makeWrapper ${bun}/bin/bun $out/bin/ccusage \
+      --chdir "$out/share/ccusage" \
+      --add-flags "run ./src/index.ts"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "CLI tool for analyzing Claude Code usage from local JSONL files";
+    mainProgram = "ccusage";
+    homepage = "https://github.com/ryoppippi/ccusage";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eleloi ];
+  };
+}


### PR DESCRIPTION
This adds a new package for ccusage, a A CLI tool for analyzing Claude Code usage from local JSONL files. .

This is the soruce: `https://github.com/ryoppippi/ccusage`, i'm not the author, only have built the package.

## Things done

- Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix
manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] `sandbox = relaxed`
- [ ] `sandbox = true`
- [x] Tested, as applicable:
- [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside
[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [ ] or, for functions and "core" functionality, tests in
[lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
[pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [ ] made sure NixOS tests are
[linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the
relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review
rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review
usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or
backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and
[25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
- [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release
Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting
[24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and
[25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
- [ ] (Module updates) Added a release notes entry if the change is significant
- [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md),
[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md),
[maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing
documentation in corresponding paths.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
