### PR TITLE
python3Packages.timple: init at 0.1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25865,6 +25865,12 @@
     githubId = 1525767;
     name = "Vaibhav Sagar";
   };
+  vaisriv = {
+    email = "vai.sriv@icloud.com";
+    github = "vaisriv";
+    githubId = 46390109;
+    name = "Vai";
+  };
   valebes = {
     email = "valebes@gmail.com";
     github = "valebes";

--- a/pkgs/development/python-modules/timple/default.nix
+++ b/pkgs/development/python-modules/timple/default.nix
@@ -1,0 +1,64 @@
+{
+  # lib & utils
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  nix-update-script,
+  setuptools,
+
+  # deps
+  matplotlib,
+  numpy,
+
+  # tests
+  pytestCheckHook,
+  pandas,
+}:
+
+buildPythonPackage rec {
+  pname = "timple";
+  version = "0.1.8";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "theOehrly";
+    repo = "timple";
+    tag = "v${version}";
+    hash = "sha256-tfw+m1ZrU5A9KbXmMS4c1AIP4f/9YT3/o7HRb/uxUSM";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    matplotlib
+    numpy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pandas
+  ];
+  pythonImportsCheck = [ "timple" ];
+
+  disabledTests = [
+    # wants write access to nix store
+    "test_mpl_default_functionality"
+  ];
+  disabledTestPaths = [
+    # gui plotting tests
+    "timple/tests/test_timple.py"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/theOehrly/timple/releases/tag/v${version}";
+    description = "Extended functionality for plotting timedelta-like values with Matplotlib";
+    homepage = "https://github.com/theOehrly/timple";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vaisriv ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17555,6 +17555,8 @@ self: super: with self; {
 
   timm = callPackage ../development/python-modules/timm { };
 
+  timple = callPackage ../development/python-modules/timple { };
+
   timy = callPackage ../development/python-modules/timy { };
 
   tiny-cuda-nn = toPythonModule (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the Python library [Timple](https://github.com/theOehrly/Timple). From the library's [README](https://github.com/theOehrly/Timple#timple): Timple offers extended functionality for plotting timedelta values with Matplotlib.

Timple is required for the [FastF1](https://github.com/theOehrly/Fast-F1) python library, which I have packaged in PR #418309.

As well, add myself to the Nixpkgs maintainers list, and set myself as the maintainer for Timple.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
