### PR TITLE
python3Packages.fastf1: init at 3.6.0

### DIFF
--- a/pkgs/development/python-modules/fastf1/default.nix
+++ b/pkgs/development/python-modules/fastf1/default.nix
@@ -1,0 +1,111 @@
+{
+  # lib & utils
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+
+  # build
+  hatchling,
+  hatch-vcs,
+
+  # deps
+  cryptography,
+  matplotlib,
+  numpy,
+  pandas,
+  platformdirs,
+  pydantic,
+  pyjwt,
+  python-dateutil,
+  rapidfuzz,
+  requests,
+  requests-cache,
+  scipy,
+  signalrcore,
+  timple,
+  websockets,
+
+  # test deps
+  requests-mock,
+}:
+
+buildPythonPackage rec {
+  pname = "fastf1";
+  version = "3.8.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "theOehrly";
+    repo = "Fast-F1";
+    tag = "v${version}";
+    hash = "sha256-PdkSeRQATXHr1DVu3JzUkquyi4g0uMABxm/1cEfBsC4=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    cryptography
+    matplotlib
+    numpy
+    pandas
+    platformdirs
+    pydantic
+    pyjwt
+    python-dateutil
+    rapidfuzz
+    requests
+    requests-cache
+    scipy
+    signalrcore
+    timple
+    websockets
+  ];
+  pythonRelaxDeps = [ "websockets" ];
+
+  postPatch = ''
+    # xdoctest's tests call the F1 API
+    # pytest-mpl's tests render images differently in the nix sandbox than in the test reference
+    substituteInPlace pytest.ini \
+      --replace-fail "addopts =" "" \
+      --replace-fail "  --doctest-glob=\"*.rst\"" "" \
+      --replace-fail "  --xdoctest" "" \
+      --replace-fail "  --mpl-baseline-path=fastf1/tests/mpl-baseline" "" \
+      --replace-fail "  --mpl-results-path=mpl-results" "" \
+      --replace-fail "  --mpl" ""
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  disabledTestPaths = [
+    # nix sandbox renders images differently than the test reference
+    "fastf1/tests/test_example_plots.py"
+
+    # requires network access
+    "fastf1/tests/test_api.py"
+    "fastf1/tests/test_core.py"
+    "fastf1/tests/test_events.py"
+    "fastf1/tests/test_input_data_handling.py"
+    "fastf1/tests/test_plotting.py"
+    "fastf1/tests/test_livetiming.py"
+    "fastf1/tests/test_mvapi.py"
+    "fastf1/tests/test_laps.py"
+    "fastf1/tests/test_telemetry.py"
+  ];
+
+  pythonImportsCheck = [ "fastf1" ];
+
+  meta = {
+    changelog = "https://github.com/theOehrly/Fast-F1/releases/tag/${src.tag}";
+    description = "Python package for accessing and analyzing Formula 1 results, schedules, timing data and telemetry";
+    homepage = "https://github.com/theOehrly/Fast-F1";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vaisriv ];
+  };
+}

--- a/pkgs/development/python-modules/signalrcore/default.nix
+++ b/pkgs/development/python-modules/signalrcore/default.nix
@@ -1,0 +1,72 @@
+{
+  # lib & utils
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+
+  # build
+  setuptools,
+
+  # deps
+  msgpack,
+
+  # test deps
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "signalrcore";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mandrewcito";
+    repo = "signalrcore";
+    tag = version;
+    hash = "sha256-BLbD6IYo4YN1bvB33MIfHUVPEIm1DND5oh/k07e4odI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ msgpack ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests
+  ];
+
+  disabledTests = [
+    # requires network access
+    "test_check_azure_url"
+    "test_send"
+    "test_build"
+    "test_skip_negotiation"
+    "test_unsubscribe"
+    "test_enable_trace"
+    "test_enable_trace_messagepack"
+  ];
+
+  disabledTestPaths = [
+    # requires network access
+    "test/integration/builder/certificates_test.py"
+    "test/integration/connection_state_test.py"
+    "test/integration/open_close_test.py"
+    "test/integration/reconnection/*"
+    "test/integration/send/*"
+    "test/integration/streamming/*"
+    "test/integration/trace_test.py"
+    "test/integration/transport_test.py"
+  ];
+
+  pythonImportsCheck = [ "signalrcore" ];
+
+  meta = {
+    mainProgram = "signalrcore";
+    description = "Complete Python client for ASP.NET Core SignalR — supporting all transports, encodings, authentication, and reconnection strategies";
+    homepage = "https://mandrewcito.github.io/signalrcore";
+    changelog = "https://github.com/mandrewcito/signalrcore/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vaisriv ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5397,6 +5397,8 @@ self: super: with self; {
 
   fastexcel = callPackage ../development/python-modules/fastexcel { };
 
+  fastf1 = callPackage ../development/python-modules/fastf1 { };
+
   fastgit = callPackage ../development/python-modules/fastgit { };
 
   fasthtml = callPackage ../development/python-modules/fasthtml { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17636,6 +17636,8 @@ self: super: with self; {
 
   sievelib = callPackage ../development/python-modules/sievelib { };
 
+  signalrcore = callPackage ../development/python-modules/signalrcore { };
+
   signalslot = callPackage ../development/python-modules/signalslot { };
 
   signedjson = callPackage ../development/python-modules/signedjson { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the Python library [FastF1](https://github.com/theOehrly/Fast-F1). From the library's [README](https://github.com/theOehrly/Fast-F1#): FastF1 is a python package for accessing and analyzing Formula 1 results, schedules, timing data and telemetry.

As well, set myself as the maintainer for FastF1.

Of note: FastF1 depends on `python3Packages.timple`, which I have packaged in PR #418308.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
