### PR TITLE
python3Packages.plotly: 6.1.0 -> 6.1.2, unbreak on darwin

### DIFF
--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -103,11 +103,28 @@ buildPythonPackage rec {
     "test_acceptance_named"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    # requires local networking
-    "plotly/tests/test_io/test_renderers.py"
     # fails to launch kaleido subprocess
-    "plotly/tests/test_optional/test_kaleido"
+    "tests/test_optional/test_kaleido"
+    # numpy2 related error, RecursionError
+    # See: https://github.com/plotly/plotly.py/issues/4852
+    "tests/test_plotly_utils/validators/test_angle_validator.py"
+    "tests/test_plotly_utils/validators/test_any_validator.py"
+    "tests/test_plotly_utils/validators/test_color_validator.py"
+    "tests/test_plotly_utils/validators/test_colorlist_validator.py"
+    "tests/test_plotly_utils/validators/test_colorscale_validator.py"
+    "tests/test_plotly_utils/validators/test_dataarray_validator.py"
+    "tests/test_plotly_utils/validators/test_enumerated_validator.py"
+    "tests/test_plotly_utils/validators/test_fig_deepcopy.py"
+    "tests/test_plotly_utils/validators/test_flaglist_validator.py"
+    "tests/test_plotly_utils/validators/test_infoarray_validator.py"
+    "tests/test_plotly_utils/validators/test_integer_validator.py"
+    "tests/test_plotly_utils/validators/test_number_validator.py"
+    "tests/test_plotly_utils/validators/test_pandas_series_input.py"
+    "tests/test_plotly_utils/validators/test_string_validator.py"
+    "tests/test_plotly_utils/validators/test_xarray_input.py"
   ];
 
   pythonImportsCheck = [ "plotly" ];

--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -38,14 +38,14 @@
 
 buildPythonPackage rec {
   pname = "plotly";
-  version = "6.1.0";
+  version = "6.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "plotly";
     repo = "plotly.py";
     tag = "v${version}";
-    hash = "sha256-B5wjZTnL/T+zRbPd3tVSekDbYnKBvIdIpXhc3sUvT3E=";
+    hash = "sha256-+vIq//pDLaaTmRGW+oytho3TfMmLCtuIoHeFenLVcek=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Plotly has been failing on darwin since the bump to 6.1.0.

If I should rebase this branch onto staging, please let me know. I'm also happy to split the version update into a separate PR if that helps get this one merged sooner.

Hydra: https://hydra.nixos.org/job/nixpkgs/trunk/python313Packages.plotly.aarch64-darwin

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
