### PR TITLE
vscode-json-languageserver: migrate from nodePackages

### DIFF
--- a/pkgs/by-name/vs/vscode-json-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-json-languageserver/package.nix
@@ -30,6 +30,10 @@ buildNpmPackage (finalAttrs: {
 
   dontNpmBuild = true;
 
+  postInstall = ''
+    ln -s $out/bin/vscode-json-languageserver $out/bin/vscode-json-language-server
+  '';
+
   meta = {
     description = "JSON language server";
     homepage = "https://github.com/microsoft/vscode/tree/${finalAttrs.src.tag}/extensions/json-language-features/server";

--- a/pkgs/by-name/vs/vscode-json-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-json-languageserver/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  typescript,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "vscode-json-languageserver";
+  version = "1.3.4";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vscode";
+    tag = "1.101.2";
+    hash = "sha256-wdI6VlJ4WoSNnwgkb6dkVYcq/P/yzflv5mE9PuYBVx4=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/extensions/json-language-features/server";
+
+  npmDepsHash = "sha256-akQukdYTe6um4xo+7T3wHxx+WrXfKYl5a1qwmqX72HQ=";
+
+  nativeBuildInputs = [ typescript ];
+
+  buildPhase = ''
+    runHook preBuild
+    tsc -p .
+    runHook postBuild
+  '';
+
+  dontNpmBuild = true;
+
+  meta = {
+    description = "JSON language server";
+    homepage = "https://github.com/microsoft/vscode/tree/${finalAttrs.src.tag}/extensions/json-language-features/server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryota2357 ];
+    mainProgram = "vscode-json-languageserver";
+  };
+})

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -274,6 +274,7 @@ mapAliases {
   inherit (pkgs) vsc-leetcode-cli; # Added 2023-08-30
   vscode-css-languageserver-bin = throw "vscode-css-languageserver-bin has been removed since the upstream repository is archived; consider using vscode-langservers-extracted instead."; # added 2024-06-26
   vscode-html-languageserver-bin = throw "vscode-html-languageserver-bin has been removed since the upstream repository is archived; consider using vscode-langservers-extracted instead."; # added 2024-06-26
+  inherit (pkgs) vscode-json-languageserver; # added 2025-06-19
   vscode-json-languageserver-bin = throw "vscode-json-languageserver-bin has been removed since the upstream repository is archived; consider using vscode-langservers-extracted instead."; # added 2024-06-26
   vscode-langservers-extracted = pkgs.vscode-langservers-extracted; # Added 2023-05-27
   vue-language-server = self.vls; # added 2023-08-20

--- a/pkgs/development/node-packages/main-programs.nix
+++ b/pkgs/development/node-packages/main-programs.nix
@@ -40,5 +40,4 @@
   purs-tidy = "purs-tidy";
   purty = "purty";
   pscid = "pscid";
-  vscode-json-languageserver = "vscode-json-languageserver";
 }

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -154,7 +154,6 @@
 , "vega-cli"
 , "vega-lite"
 , "vercel"
-, "vscode-json-languageserver"
 , "wavedrom-cli"
 , "webpack"
 , "wring"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -63785,56 +63785,6 @@ in
     bypassCache = true;
     reconstructLock = true;
   };
-  vscode-json-languageserver = nodeEnv.buildNodePackage {
-    name = "vscode-json-languageserver";
-    packageName = "vscode-json-languageserver";
-    version = "1.3.4";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/vscode-json-languageserver/-/vscode-json-languageserver-1.3.4.tgz";
-      sha512 = "+ghebnslXk6fVDySBrT0BVqozLDdmKY/qxgkDD4JtOQcU2vXc3e7jh7YyMxvuvE93E9OLvBqUrvajttj8xf3BA==";
-    };
-    dependencies = [
-      sources."agent-base-4.3.0"
-      sources."debug-3.1.0"
-      sources."es6-promise-4.2.8"
-      sources."es6-promisify-5.0.0"
-      sources."http-proxy-agent-2.1.0"
-      sources."https-proxy-agent-2.2.4"
-      sources."jsonc-parser-3.3.1"
-      sources."ms-2.0.0"
-      sources."request-light-0.4.0"
-      (
-        sources."vscode-json-languageservice-4.2.1"
-        // {
-          dependencies = [
-            sources."vscode-nls-5.2.0"
-          ];
-        }
-      )
-      sources."vscode-jsonrpc-6.0.0"
-      sources."vscode-languageserver-7.0.0"
-      (
-        sources."vscode-languageserver-protocol-3.16.0"
-        // {
-          dependencies = [
-            sources."vscode-languageserver-types-3.16.0"
-          ];
-        }
-      )
-      sources."vscode-languageserver-textdocument-1.0.12"
-      sources."vscode-languageserver-types-3.17.5"
-      sources."vscode-nls-4.1.2"
-      sources."vscode-uri-3.1.0"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "JSON language server";
-      license = "MIT";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
   wavedrom-cli = nodeEnv.buildNodePackage {
     name = "wavedrom-cli";
     packageName = "wavedrom-cli";


### PR DESCRIPTION
Migrate vscode-json-languageserver from nodePackages to pkgs/by-name.

See #229475.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
