### PR TITLE
gnss-sdr: 0.0.19.1 -> 0.0.20; add osmosdr support

### DIFF
--- a/pkgs/by-name/gn/gnss-sdr/fix_libcpu_features_install_path.patch
+++ b/pkgs/by-name/gn/gnss-sdr/fix_libcpu_features_install_path.patch
@@ -1,6 +1,8 @@
---- i/CMakeLists.txt
-+++ w/CMakeLists.txt
-@@ -1233,7 +1233,7 @@ if(NOT VOLKGNSSSDR_FOUND)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 839744f3a..3639bc1c4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1314,7 +1314,7 @@ if(NOT VOLKGNSSSDR_FOUND)
              BINARY_DIR ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/build
              CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
                  -DCMAKE_BUILD_TYPE=$<$<CONFIG:None>:None>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:NoOptWithASM>$<$<CONFIG:Coverage>:Coverage>$<$<CONFIG:O2WithASM>:O2WithASM>$<$<CONFIG:O3WithASM>:O3WithASM>$<$<CONFIG:ASAN>:ASAN>
@@ -9,7 +11,16 @@
              DOWNLOAD_COMMAND ""
              UPDATE_COMMAND ""
              PATCH_COMMAND ""
-@@ -1274,7 +1274,7 @@ if(NOT VOLKGNSSSDR_FOUND)
+@@ -1324,7 +1324,7 @@ if(NOT VOLKGNSSSDR_FOUND)
+     else()
+         if(SUPPORTED_CPU_FEATURES_ARCH)
+             set(VOLK_GNSSSDR_BUILD_BYPRODUCTS
+-                ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_FIND_LIBRARY_PREFIXES}volk_gnsssdr${CMAKE_STATIC_LIBRARY_SUFFIX}
++                ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/lib/${CMAKE_FIND_LIBRARY_PREFIXES}volk_gnsssdr${CMAKE_STATIC_LIBRARY_SUFFIX}
+                 ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/bin/volk_gnsssdr_profile
+             )
+             if(ENABLE_CPUFEATURES)
+@@ -1355,7 +1355,7 @@ if(NOT VOLKGNSSSDR_FOUND)
                      )
                      set(VOLK_GNSSSDR_BUILD_BYPRODUCTS
                          ${VOLK_GNSSSDR_BUILD_BYPRODUCTS}
@@ -18,7 +29,7 @@
                      )
                  endif()
              endif()
-@@ -1287,7 +1287,7 @@ if(NOT VOLKGNSSSDR_FOUND)
+@@ -1368,7 +1368,7 @@ if(NOT VOLKGNSSSDR_FOUND)
                  BINARY_DIR ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/build
                  CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
                      -DCMAKE_BUILD_TYPE=$<$<CONFIG:None>:None>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:NoOptWithASM>$<$<CONFIG:Coverage>:Coverage>$<$<CONFIG:O2WithASM>:O2WithASM>$<$<CONFIG:O3WithASM>:O3WithASM>$<$<CONFIG:ASAN>:ASAN>
@@ -27,7 +38,7 @@
                  DOWNLOAD_COMMAND ""
                  UPDATE_COMMAND ""
                  PATCH_COMMAND ""
-@@ -1306,7 +1306,7 @@ if(NOT VOLKGNSSSDR_FOUND)
+@@ -1387,12 +1387,12 @@ if(NOT VOLKGNSSSDR_FOUND)
                  BINARY_DIR ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/build
                  CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
                      -DCMAKE_BUILD_TYPE=$<$<CONFIG:None>:None>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:NoOptWithASM>$<$<CONFIG:Coverage>:Coverage>$<$<CONFIG:O2WithASM>:O2WithASM>$<$<CONFIG:O3WithASM>:O3WithASM>$<$<CONFIG:ASAN>:ASAN>
@@ -36,7 +47,31 @@
                  DOWNLOAD_COMMAND ""
                  UPDATE_COMMAND ""
                  PATCH_COMMAND ""
-@@ -1346,7 +1346,7 @@ if(NOT VOLKGNSSSDR_FOUND)
+                 BUILD_COMMAND ${VOLK_GNSSSDR_BUILD_COMMAND}
+-                BUILD_BYPRODUCTS ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_FIND_LIBRARY_PREFIXES}volk_gnsssdr${CMAKE_STATIC_LIBRARY_SUFFIX}
++                BUILD_BYPRODUCTS ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/lib/${CMAKE_FIND_LIBRARY_PREFIXES}volk_gnsssdr${CMAKE_STATIC_LIBRARY_SUFFIX}
+                     ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/bin/volk_gnsssdr_profile
+                     ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/bin/volk_gnsssdr-config-info
+                 INSTALL_DIR ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install
+@@ -1406,7 +1406,7 @@ if(NOT VOLKGNSSSDR_FOUND)
+     endif()
+ 
+     add_library(volk_gnsssdr UNKNOWN IMPORTED)
+-    set_property(TARGET volk_gnsssdr PROPERTY IMPORTED_LOCATION ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/${CMAKE_INSTALL_LIBDIR}/libvolk_gnsssdr${CMAKE_STATIC_LIBRARY_SUFFIX})
++    set_property(TARGET volk_gnsssdr PROPERTY IMPORTED_LOCATION ${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/lib/libvolk_gnsssdr${CMAKE_STATIC_LIBRARY_SUFFIX})
+     set(VOLK_GNSSSDR_INCLUDE_DIRS "${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/build/include/;${GNSSSDR_SOURCE_DIR}/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/include;${ORC_INCLUDE_DIRS}")
+     set(VOLK_GNSSSDR_LIBRARIES volk_gnsssdr ${ORC_LIBRARIES_STATIC})
+     if(CPUFEATURES_FOUND)
+@@ -1419,7 +1419,7 @@ if(NOT VOLKGNSSSDR_FOUND)
+         add_dependencies(Volkgnsssdr::volkgnsssdr volk_gnsssdr_module)
+         set_target_properties(Volkgnsssdr::volkgnsssdr PROPERTIES
+             IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+-            IMPORTED_LOCATION "${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/${CMAKE_INSTALL_LIBDIR}/libvolk_gnsssdr${CMAKE_STATIC_LIBRARY_SUFFIX}"
++            IMPORTED_LOCATION "${GNSSSDR_BINARY_DIR}/volk_gnsssdr_module/install/lib/libvolk_gnsssdr${CMAKE_STATIC_LIBRARY_SUFFIX}"
+             INCLUDE_DIRECTORIES "${VOLK_GNSSSDR_INCLUDE_DIRS}"
+             INTERFACE_INCLUDE_DIRECTORIES "${VOLK_GNSSSDR_INCLUDE_DIRS}"
+             INTERFACE_LINK_LIBRARIES "${VOLK_GNSSSDR_LIBRARIES}"
+@@ -1427,7 +1427,7 @@ if(NOT VOLKGNSSSDR_FOUND)
          if(CMAKE_VERSION VERSION_GREATER 3.0 AND SUPPORTED_CPU_FEATURES_ARCH)
              if(NOT CPUFEATURES_FOUND AND ENABLE_CPUFEATURES)
                  set_target_properties(Volkgnsssdr::volkgnsssdr PROPERTIES

--- a/pkgs/by-name/gn/gnss-sdr/package.nix
+++ b/pkgs/by-name/gn/gnss-sdr/package.nix
@@ -19,6 +19,7 @@
   matio,
   pugixml,
   protobuf,
+  enableOsmosdr ? true,
 }:
 
 gnuradio.pkgs.mkDerivation rec {
@@ -81,6 +82,9 @@ gnuradio.pkgs.mkDerivation rec {
     ]
     ++ lib.optionals (gnuradio.hasFeature "gr-pdu") [
       gnuradio.unwrapped.libad9361
+    ]
+    ++ lib.optionals (enableOsmosdr) [
+      gnuradio.pkgs.osmosdr
     ];
 
   cmakeFlags = [
@@ -98,6 +102,7 @@ gnuradio.pkgs.mkDerivation rec {
     (lib.cmakeBool "ENABLE_UHD" (gnuradio.hasFeature "gr-uhd"))
     (lib.cmakeBool "ENABLE_FMCOMMS2" (gnuradio.hasFeature "gr-iio" && gnuradio.hasFeature "gr-pdu"))
     (lib.cmakeBool "ENABLE_PLUTOSDR" (gnuradio.hasFeature "gr-iio"))
+    (lib.cmakeBool "ENABLE_OSMOSDR" enableOsmosdr)
     (lib.cmakeBool "ENABLE_UNIT_TESTING" false)
 
     # Requires unpackaged gnsstk

--- a/pkgs/by-name/gn/gnss-sdr/package.nix
+++ b/pkgs/by-name/gn/gnss-sdr/package.nix
@@ -23,13 +23,13 @@
 
 gnuradio.pkgs.mkDerivation rec {
   pname = "gnss-sdr";
-  version = "0.0.19.1";
+  version = "0.0.20";
 
   src = fetchFromGitHub {
     owner = "gnss-sdr";
     repo = "gnss-sdr";
     rev = "v${version}";
-    sha256 = "sha256-IbkYdw1pwI+FMnZMChsxMz241Kv4EzMcBb0mm6/jq1k=";
+    hash = "sha256-kQv8I4dcWeRuAfYtD5EAAMwvfnOTi+QWDogUZb4M/qQ=";
   };
 
   patches = [
@@ -98,8 +98,11 @@ gnuradio.pkgs.mkDerivation rec {
     (lib.cmakeBool "ENABLE_UHD" (gnuradio.hasFeature "gr-uhd"))
     (lib.cmakeBool "ENABLE_FMCOMMS2" (gnuradio.hasFeature "gr-iio" && gnuradio.hasFeature "gr-pdu"))
     (lib.cmakeBool "ENABLE_PLUTOSDR" (gnuradio.hasFeature "gr-iio"))
-    (lib.cmakeBool "ENABLE_AD9361" (gnuradio.hasFeature "gr-pdu"))
     (lib.cmakeBool "ENABLE_UNIT_TESTING" false)
+
+    # Requires unpackaged gnsstk
+    # Only relevant if you want to run gnss-sdr on FPGA SoCs like Zynq
+    # (lib.cmakeBool "ENABLE_AD9361" (gnuradio.hasFeature "gr-pdu"))
 
     # gnss-sdr doesn't truly depend on BLAS or LAPACK, as long as
     # armadillo is built using both, so skip checking for them.


### PR DESCRIPTION
* Updated to 0.0.20. Fixed the following build error:

```cxx
gnss-sdr> In file included from /build/source/src/algorithms/conditioner/adapters/array_signal_conditioner.cc:20:
gnss-sdr> /nix/store/k9g0rilb267qaqs6ysad430zinf95sfk-glog-0.7.1/include/glog/logging.h:60:4: error: #error <glog/logging.h> was not included correctly. See the documentation for how to consume the library.
gnss-sdr>    60 | #  error <glog/logging.h> was not included correctly. See the documentation for how to consume the library.
gnss-sdr>       |    ^~~~~
```

* Added osmosdr support. Tested with a HackRF One. Solves #159996

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
