### PR TITLE
gitignore: add .cursor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ update-git-commits.txt
 
 # Usually used for manual backports
 .worktree/
+
+# Cursor IDE
+.cursor/


### PR DESCRIPTION
I have specific cursor rules for nixpkgs, there is no way to place them anywhere else.
Ignore until we decide to support them