### PR TITLE
nixos/nextcloud: Allow disabling initial admin user creation on Nextcloud >= 32

### DIFF
--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -30,8 +30,8 @@ let
         }
       ];
 
-      adminuser = "root";
-      adminpass = "hunter2";
+      adminuser = pkgs.lib.mkDefault "root";
+      adminpass = pkgs.lib.mkDefault "hunter2";
 
       test-helpers.rclone = "${pkgs.writeShellScript "rclone" ''
         set -euo pipefail
@@ -129,13 +129,16 @@ let
           }
         );
     in
-    map callNextcloudTest [
-      ./basic.nix
-      ./with-declarative-redis-and-secrets.nix
-      ./with-mysql-and-memcached.nix
-      ./with-postgresql-and-redis.nix
-      ./with-objectstore.nix
-    ];
+    map callNextcloudTest (
+      [
+        ./basic.nix
+        ./with-declarative-redis-and-secrets.nix
+        ./with-mysql-and-memcached.nix
+        ./with-postgresql-and-redis.nix
+        ./with-objectstore.nix
+      ]
+      ++ (pkgs.lib.optional (version >= 32) ./without-admin-user.nix)
+    );
 in
 listToAttrs (
   concatMap genTests [

--- a/nixos/tests/nextcloud/without-admin-user.nix
+++ b/nixos/tests/nextcloud/without-admin-user.nix
@@ -1,0 +1,48 @@
+{
+  name,
+  pkgs,
+  testBase,
+  system,
+  ...
+}:
+
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+runTest (
+  {
+    config,
+    lib,
+    ...
+  }:
+  rec {
+    inherit name;
+
+    meta.maintainers = lib.teams.nextcloud.members;
+
+    imports = [ testBase ];
+
+    nodes = {
+      nextcloud =
+        { config, pkgs, ... }:
+        {
+          services.nextcloud = {
+            config = {
+              dbtype = "sqlite";
+              adminuser = null;
+              adminpassFile = lib.mkForce null;
+            };
+          };
+        };
+    };
+
+    adminuser = "root";
+    # This needs to be a "secure" password, since the password_policy app is enabled after installation and will forbid "simple" passwords.
+    adminpass = "+CVpTwaOEktxsFc6";
+
+    # Manually create the adminuser to make the default set of tests pass.
+    # If adminuser was already created during the installation this command would not succeed.
+    # This user name must always match the default value in services.nextcloud.config.adminuser!
+    test-helpers.init = ''
+      nextcloud.succeed("OC_PASS=${adminpass} nextcloud-occ user:add ${adminuser} --password-from-env")
+    '';
+  }
+)


### PR DESCRIPTION
With nextcloud/server#53212 it is not longer necessary to specify a username and password for an initial admin account during installation.

This needs a solution for https://github.com/NixOS/nixpkgs/issues/412675 in order to be able to create the adminuser through nextcloud-occ.

I will make it a draft for now due to the occ env var problem, but we can already merge it before Nextcloud 32 is released, as the logic checks for a compatible version.

The WIP commit is there to test the feature locally, because a daily build of the master branch has to be used for this unreleased feature.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
