### PR TITLE
Revert "treewide: passthru outputBin as `bin`"

### DIFF
--- a/pkgs/by-name/ap/aprutil/package.nix
+++ b/pkgs/by-name/ap/aprutil/package.nix
@@ -22,12 +22,12 @@ assert sslSupport -> openssl != null;
 assert bdbSupport -> db != null;
 assert ldapSupport -> openldap != null;
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "apr-util";
   version = "1.6.3";
 
   src = fetchurl {
-    url = "mirror://apache/apr/apr-util-${finalAttrs.version}.tar.bz2";
+    url = "mirror://apache/apr/${pname}-${version}.tar.bz2";
     sha256 = "sha256-pBB243EHRjJsOUUEKZStmk/KwM4Cd92P6gdv7DyXcrU=";
   };
 
@@ -44,7 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   nativeBuildInputs = [
     makeWrapper
@@ -122,4 +121,4 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = platforms.unix;
     license = licenses.asl20;
   };
-})
+}

--- a/pkgs/by-name/ca/cairo/package.nix
+++ b/pkgs/by-name/ca/cairo/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation (
       "devdoc"
     ];
     outputBin = "dev"; # very small
-    passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
     separateDebugInfo = true;
 
     nativeBuildInputs = [

--- a/pkgs/by-name/db/dbus-glib/package.nix
+++ b/pkgs/by-name/db/dbus-glib/package.nix
@@ -11,12 +11,12 @@
   glib,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "dbus-glib";
   version = "0.114";
 
   src = fetchurl {
-    url = "${finalAttrs.meta.homepage}/releases/dbus-glib/dbus-glib-${finalAttrs.version}.tar.gz";
+    url = "${meta.homepage}/releases/dbus-glib/dbus-glib-${version}.tar.gz";
     sha256 = "sha256-wJxcCFsqDjkbjufXg6HWP+RE6WcXzBgU1htej8KCenw=";
   };
 
@@ -26,7 +26,6 @@ stdenv.mkDerivation (finalAttrs: {
     "devdoc"
   ];
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   nativeBuildInputs = [
     pkg-config
@@ -65,4 +64,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     platforms = lib.platforms.unix;
   };
-})
+}

--- a/pkgs/by-name/ex/expat/package.nix
+++ b/pkgs/by-name/ex/expat/package.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ]; # TODO: fix referrers
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/gs/gspell/package.nix
+++ b/pkgs/by-name/gs/gspell/package.nix
@@ -17,7 +17,7 @@
   gnome,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "gspell";
   version = "1.14.0";
 
@@ -28,10 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gspell/${lib.versions.majorMinor finalAttrs.version}/gspell-${finalAttrs.version}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "ZOodjp7cHCW0WpIOgNr2dVnRhm/81/hDL+z+ptD+iJc=";
   };
 
@@ -62,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = "gspell";
+      packageName = pname;
       versionPolicy = "none";
     };
   };
@@ -75,4 +74,4 @@ stdenv.mkDerivation (finalAttrs: {
     teams = [ teams.gnome ];
     platforms = platforms.unix;
   };
-})
+}

--- a/pkgs/by-name/gt/gtk-layer-shell/package.nix
+++ b/pkgs/by-name/gt/gtk-layer-shell/package.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation (finalAttrs: {
     "devdoc"
   ];
   outputBin = "devdoc"; # for demo
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   src = fetchFromGitHub {
     owner = "wmww";

--- a/pkgs/by-name/gt/gtk4-layer-shell/package.nix
+++ b/pkgs/by-name/gt/gtk4-layer-shell/package.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
     "devdoc"
   ];
   outputBin = "devdoc";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   src = fetchFromGitHub {
     owner = "wmww";

--- a/pkgs/by-name/li/libadwaita/package.nix
+++ b/pkgs/by-name/li/libadwaita/package.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
     "devdoc"
   ];
   outputBin = "devdoc"; # demo app
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";

--- a/pkgs/by-name/li/libassuan/package.nix
+++ b/pkgs/by-name/li/libassuan/package.nix
@@ -9,12 +9,12 @@
   gitUpdater,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "libassuan";
   version = "3.0.2";
 
   src = fetchurl {
-    url = "mirror://gnupg/libassuan/libassuan-${finalAttrs.version}.tar.bz2";
+    url = "mirror://gnupg/libassuan/libassuan-${version}.tar.bz2";
     hash = "sha256-0pMc2tJm5jNRD5lw4aLzRgVeNRuxn5t4kSR1uAdMNvY=";
   };
 
@@ -24,7 +24,6 @@ stdenv.mkDerivation (finalAttrs: {
     "info"
   ];
   outputBin = "dev"; # libassuan-config
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   buildInputs = [
@@ -60,9 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
       provided.
     '';
     homepage = "https://gnupg.org/software/libassuan/";
-    changelog = "https://dev.gnupg.org/source/libassuan/browse/master/NEWS;libassuan-${finalAttrs.version}";
+    changelog = "https://dev.gnupg.org/source/libassuan/browse/master/NEWS;libassuan-${version}";
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
     maintainers = [ ];
   };
-})
+}

--- a/pkgs/by-name/li/libdazzle/package.nix
+++ b/pkgs/by-name/li/libdazzle/package.nix
@@ -19,7 +19,7 @@
   gnome,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "libdazzle";
   version = "3.44.0";
 
@@ -29,10 +29,9 @@ stdenv.mkDerivation (finalAttrs: {
     "devdoc"
   ];
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libdazzle/${lib.versions.majorMinor finalAttrs.version}/libdazzle-${finalAttrs.version}.tar.xz";
+    url = "mirror://gnome/sources/libdazzle/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "PNPkXrbiaAywXVLh6A3Y+dWdR2UhLw4o945sF4PRjq4=";
   };
 
@@ -76,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = "libdazzle";
+      packageName = pname;
     };
   };
 
@@ -95,4 +94,4 @@ stdenv.mkDerivation (finalAttrs: {
     teams = [ teams.gnome ];
     platforms = platforms.unix;
   };
-})
+}

--- a/pkgs/by-name/li/libevent/package.nix
+++ b/pkgs/by-name/li/libevent/package.nix
@@ -12,12 +12,12 @@
   static ? stdenv.hostPlatform.isStatic,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "libevent";
   version = "2.1.12";
 
   src = fetchurl {
-    url = "https://github.com/libevent/libevent/releases/download/release-${finalAttrs.version}-stable/libevent-${finalAttrs.version}-stable.tar.gz";
+    url = "https://github.com/libevent/libevent/releases/download/release-${version}-stable/libevent-${version}-stable.tar.gz";
     sha256 = "1fq30imk8zd26x8066di3kpc5zyfc5z6frr3zll685zcx4dxxrlj";
   };
 
@@ -48,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ] ++ lib.optional sslSupport "openssl";
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
   propagatedBuildOutputs = [ "out" ] ++ lib.optional sslSupport "openssl";
 
   nativeBuildInputs = [
@@ -88,4 +87,4 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.bsd3;
     platforms = platforms.all;
   };
-})
+}

--- a/pkgs/by-name/li/libgpg-error/package.nix
+++ b/pkgs/by-name/li/libgpg-error/package.nix
@@ -23,13 +23,12 @@ let
   };
 in
 stdenv.mkDerivation (
-  finalAttrs:
-  {
+  rec {
     pname = "libgpg-error";
     version = "1.51";
 
     src = fetchurl {
-      url = "mirror://gnupg/libgpg-error/libgpg-error-${finalAttrs.version}.tar.bz2";
+      url = "mirror://gnupg/${pname}/${pname}-${version}.tar.bz2";
       hash = "sha256-vg8bLba5Pu1VNpzfefGfcnUMjHw5/CC1d+ckVFQn5rI=";
     };
 
@@ -50,7 +49,6 @@ stdenv.mkDerivation (
       "info"
     ];
     outputBin = "dev"; # deps want just the lib, most likely
-    passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
     # If architecture-dependent MO files aren't available, they're generated
     # during build, so we need gettext for cross-builds.
@@ -80,7 +78,7 @@ stdenv.mkDerivation (
       homepage = "https://www.gnupg.org/software/libgpg-error/index.html";
       changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=NEWS;hb=refs/tags/libgpg-error-${version}";
       description = "Small library that defines common error values for all GnuPG components";
-      mainProgram = if genPosixLockObjOnly then "gen-posix-lock-obj" else "gpg-error";
+      mainProgram = "gen-posix-lock-obj";
 
       longDescription = ''
         Libgpg-error is a small library that defines common error values

--- a/pkgs/by-name/li/liboil/package.nix
+++ b/pkgs/by-name/li/liboil/package.nix
@@ -5,12 +5,12 @@
   pkg-config,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "liboil";
   version = "0.3.17";
 
   src = fetchurl {
-    url = "${finalAttrs.meta.homepage}/download/liboil-${finalAttrs.version}.tar.gz";
+    url = "${meta.homepage}/download/liboil-${version}.tar.gz";
     sha256 = "0sgwic99hxlb1av8cm0albzh8myb7r3lpcwxfm606l0bkc3h4pqh";
   };
 
@@ -22,7 +22,6 @@ stdenv.mkDerivation (finalAttrs: {
     "devdoc"
   ];
   outputBin = "dev"; # oil-bugreport
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -43,4 +42,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ lovek323 ];
     platforms = platforms.all;
   };
-})
+}

--- a/pkgs/by-name/li/libpanel/package.nix
+++ b/pkgs/by-name/li/libpanel/package.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   src = fetchurl {
     url = "mirror://gnome/sources/libpanel/${lib.versions.majorMinor finalAttrs.version}/libpanel-${finalAttrs.version}.tar.xz";

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
     "devdoc"
   ];
   outputBin = "devdoc"; # demo app
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   src = fetchurl {
     url = "mirror://gnome/sources/libshumate/${lib.versions.majorMinor finalAttrs.version}/libshumate-${finalAttrs.version}.tar.xz";

--- a/pkgs/by-name/on/oniguruma/package.nix
+++ b/pkgs/by-name/on/oniguruma/package.nix
@@ -5,13 +5,13 @@
   autoreconfHook,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "oniguruma";
   version = "6.9.10";
 
   # Note: do not use fetchpatch or fetchFromGitHub to keep this package available in __bootPackages
   src = fetchurl {
-    url = "https://github.com/kkos/oniguruma/releases/download/v${finalAttrs.version}/onig-${finalAttrs.version}.tar.gz";
+    url = "https://github.com/kkos/oniguruma/releases/download/v${version}/onig-${version}.tar.gz";
     sha256 = "sha256-Klz8WuJZ5Ol/hraN//wVLNr/6U4gYLdwy4JyONdp/AU=";
   };
 
@@ -21,7 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
   ];
   outputBin = "dev"; # onig-config
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   nativeBuildInputs = [ autoreconfHook ];
   configureFlags = [ "--enable-posix-api=yes" ];
@@ -34,4 +33,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [ artturin ];
     platforms = platforms.unix;
   };
-})
+}

--- a/pkgs/by-name/sd/sdl2-compat/package.nix
+++ b/pkgs/by-name/sd/sdl2-compat/package.nix
@@ -79,8 +79,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
-
     tests =
       {
         pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
@@ -113,7 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://libsdl.org";
     changelog = "https://github.com/libsdl-org/sdl2-compat/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.zlib;
-    mainProgram = "sdl2-config";
     maintainers = with lib.maintainers; [
       nadiaholmquist
     ];

--- a/pkgs/development/libraries/apr/default.nix
+++ b/pkgs/development/libraries/apr/default.nix
@@ -6,12 +6,12 @@
   autoreconfHook,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "apr";
   version = "1.7.6";
 
   src = fetchurl {
-    url = "mirror://apache/apr/apr-${finalAttrs.version}.tar.bz2";
+    url = "mirror://apache/apr/${pname}-${version}.tar.bz2";
     hash = "sha256-SQMNktJXXac1eRtJbcMi885c/5SUd5uozCjH9Gxd6zI=";
   };
 
@@ -29,7 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   preConfigure = ''
     configureFlagsArray+=("--with-installbuilddir=$dev/share/build")
@@ -83,4 +82,4 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.asl20;
     maintainers = [ ];
   };
-})
+}

--- a/pkgs/development/libraries/libhandy/0.x.nix
+++ b/pkgs/development/libraries/libhandy/0.x.nix
@@ -18,7 +18,7 @@
   hicolor-icon-theme,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "libhandy";
   version = "0.0.13";
 
@@ -28,13 +28,12 @@ stdenv.mkDerivation (finalAttrs: {
     "devdoc"
   ];
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
-    repo = "libhandy";
-    tag = "v${finalAttrs.version}";
+    repo = pname;
+    rev = "v${version}";
     sha256 = "1y23k623sjkldfrdiwfarpchg5mg58smcy1pkgnwfwca15wm1ra5";
   };
 
@@ -84,4 +83,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     platforms = platforms.unix;
   };
-})
+}

--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -25,7 +25,7 @@
   runCommand,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "libhandy";
   version = "1.8.3";
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputBin = "dev";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libhandy/${lib.versions.majorMinor finalAttrs.version}/libhandy-${finalAttrs.version}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     hash = "sha256-BbSXIpBz/1V/ELMm4HTFBm+HQ6MC1IIKuXvLXNLasIc=";
   };
 
@@ -122,9 +122,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru =
     {
-      bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
       updateScript = gnome.updateScript {
-        packageName = "libhandy";
+        packageName = pname;
         versionPolicy = "odd-unstable";
       };
     }
@@ -151,4 +150,4 @@ stdenv.mkDerivation (finalAttrs: {
     teams = [ teams.gnome ];
     platforms = platforms.unix;
   };
-})
+}

--- a/pkgs/development/libraries/libusb-compat/0.1.nix
+++ b/pkgs/development/libraries/libusb-compat/0.1.nix
@@ -7,7 +7,7 @@
   libusb1,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation rec {
   pname = "libusb-compat";
   version = "0.1.8";
 
@@ -16,12 +16,11 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ]; # get rid of propagating systemd closure
   outputBin = "dev";
-  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fixes lib.getExe
 
   src = fetchFromGitHub {
     owner = "libusb";
     repo = "libusb-compat-0.1";
-    tag = "v${finalAttrs.version}";
+    rev = "v${version}";
     sha256 = "sha256-pAPERYSxoc47gwpPUoMkrbK8TOXyx03939vlFN0hHRg=";
   };
 
@@ -37,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   # without this, libusb-compat is unable to find libusb1
   postFixup = ''
     find $out/lib -name \*.so\* -type f -exec \
-      patchelf --set-rpath ${lib.makeLibraryPath finalAttrs.buildInputs} {} \;
+      patchelf --set-rpath ${lib.makeLibraryPath buildInputs} {} \;
   '';
 
   meta = with lib; {
@@ -51,4 +50,4 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;
   };
-})
+}


### PR DESCRIPTION
Reverts NixOS/nixpkgs#410952; eval failure. Will fix.