### PR TITLE
chameleon-cli: init at 2.0.0-unstable-2025-08-04

### DIFF
--- a/pkgs/by-name/ch/chameleon-cli/package.nix
+++ b/pkgs/by-name/ch/chameleon-cli/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  makeWrapper,
+  xz,
+  python3,
+}:
+
+let
+  # https://github.com/RfidResearchGroup/ChameleonUltra/blob/main/software/script/requirements.txt
+  pythonPath =
+    with python3.pkgs;
+    makePythonPath [
+      colorama
+      prompt-toolkit
+      pyserial
+    ];
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chameleon-cli";
+  version = "2.0.0-unstable-2025-08-04";
+
+  src = fetchFromGitHub {
+    owner = "RfidResearchGroup";
+    repo = "ChameleonUltra";
+    rev = "098e0a914b206900f7ea7ae7265486c4349ab644";
+    sparseCheckout = [ "software" ];
+    hash = "sha256-WKxP4jLHkTqBO+nwxhr8DRb3TzDIMlwjA4v+6txQbDo=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/software";
+
+  patches = [
+    # Use execute_tool to simplify running hardnested tool,
+    # also fix when the dir conatains hardnested is read only
+    # https://github.com/RfidResearchGroup/ChameleonUltra/pull/266
+    (fetchpatch {
+      url = "https://github.com/RfidResearchGroup/ChameleonUltra/commit/39270fd09ee61ef0659bf3b79ffa4d2b27f3ba63.patch";
+      hash = "sha256-OlHQ2cL+NFdTsSPFI9geg3dabATRjyKxGp5gGG+eDl8=";
+      stripLen = 1;
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace src/CMakeLists.txt \
+      --replace-fail "liblzma" "lzma" \
+      --replace-fail "FetchContent_MakeAvailable(xz)" ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+
+  buildInputs = [
+    xz
+  ];
+
+  cmakeFlags = [
+    "-S"
+    "../src"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/libexec
+    cp -r ../script/* $out/libexec
+    rm -r $out/libexec/tests
+    rm $out/libexec/requirements.txt
+    makeWrapper ${lib.getExe python3} $out/bin/chameleon-cli \
+      --add-flags "$out/libexec/chameleon_cli_main.py" \
+      --prefix PYTHONPATH : ${pythonPath}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Command line interface for Chameleon Ultra";
+    homepage = "https://github.com/RfidResearchGroup/ChameleonUltra";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "chameleon-cli";
+    maintainers = with lib.maintainers; [ azuwis ];
+  };
+})

--- a/pkgs/by-name/ch/chameleon-cli/update.sh
+++ b/pkgs/by-name/ch/chameleon-cli/update.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils nix-update
+
+# This update script exists, because nix-update is unable to ignore `dev`
+# tags that exist on the upstream repo.
+#
+# Once https://github.com/Mic92/nix-update/issues/322 is resolved it can be
+# removed.
+
+set -exuo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+nix-update --version=branch chameleon-cli
+
+tag=$(git ls-remote --tags --refs --sort='-version:refname' https://github.com/RfidResearchGroup/ChameleonUltra.git 'v*' | head -n 1 | cut --delimiter=/ --field=3-)
+tag="${tag#v}"
+sed -i -e 's|version = "[^-]*-unstable-|version = "'"${tag}"'-unstable-|' pkgs/by-name/ch/chameleon-cli/package.nix


### PR DESCRIPTION
Homepage: https://github.com/RfidResearchGroup/ChameleonUltra
Description: Command line interface for Chameleon Ultra

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
