### PR TITLE
sfwbar: 1.0_beta16 -> 1.0_beta16.1

### DIFF
--- a/pkgs/by-name/sf/sfwbar/package.nix
+++ b/pkgs/by-name/sf/sfwbar/package.nix
@@ -16,18 +16,16 @@
   docutils,
   wayland-scanner,
 }:
-let
-  version = "1.0_beta16";
-in
-stdenv.mkDerivation {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "sfwbar";
-  inherit version;
+  version = "1.0_beta16.1";
 
   src = fetchFromGitHub {
     owner = "LBCrion";
     repo = "sfwbar";
-    rev = "v${version}";
-    hash = "sha256-jMEbw3Xla2cod/oKFQ4bD3sTHi7DZ0deG0H0Yt0Y7ck=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WA9BXX+0VR8eSdHOYLs+DoazBqVwMllQSxkubq4SkWo=";
   };
 
   buildInputs = [
@@ -57,7 +55,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "https://github.com/LBCrion/sfwbar";
     description = "Flexible taskbar application for wayland compositors, designed with a stacking layout in mind";
-    changelog = "https://github.com/LBCrion/sfwbar/releases/tag/v${version}";
+    changelog = "https://github.com/LBCrion/sfwbar/releases/tag/v${finalAttrs.version}";
     mainProgram = "sfwbar";
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
@@ -66,4 +64,4 @@ stdenv.mkDerivation {
     ];
     license = lib.licenses.gpl3Only;
   };
-}
+})


### PR DESCRIPTION
This fixes the build after NixOS/nixpkgs#409607 broke it.

Diff: https://github.com/LBCrion/sfwbar/compare/refs/tags/v1.0_beta16...refs/tags/v1.0_beta16.1

Changelog: https://github.com/LBCrion/sfwbar/releases/tag/v1.0_beta16.1

Also, switch to finalAttrs style.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.
