### PR TITLE
treewide: passthru outputBin as `bin`

### DIFF
--- a/pkgs/by-name/ap/aprutil/package.nix
+++ b/pkgs/by-name/ap/aprutil/package.nix
@@ -22,12 +22,12 @@ assert sslSupport -> openssl != null;
 assert bdbSupport -> db != null;
 assert ldapSupport -> openldap != null;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "apr-util";
   version = "1.6.3";
 
   src = fetchurl {
-    url = "mirror://apache/apr/${pname}-${version}.tar.bz2";
+    url = "mirror://apache/apr/apr-util-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-pBB243EHRjJsOUUEKZStmk/KwM4Cd92P6gdv7DyXcrU=";
   };
 
@@ -111,6 +111,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit sslSupport bdbSupport ldapSupport;
+    bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
   };
 
   meta = with lib; {
@@ -121,4 +122,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.asl20;
   };
-}
+})

--- a/pkgs/by-name/ca/cairo/package.nix
+++ b/pkgs/by-name/ca/cairo/package.nix
@@ -132,6 +132,7 @@ stdenv.mkDerivation (
           -es'|^Cflags:\(.*\)$|Cflags: \1 -I${freetype.dev}/include/freetype2 -I${freetype.dev}/include|g'
     '';
 
+    passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
     passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
     meta = with lib; {

--- a/pkgs/by-name/db/dbus-glib/package.nix
+++ b/pkgs/by-name/db/dbus-glib/package.nix
@@ -11,12 +11,12 @@
   glib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dbus-glib";
   version = "0.114";
 
   src = fetchurl {
-    url = "${meta.homepage}/releases/dbus-glib/dbus-glib-${version}.tar.gz";
+    url = "${finalAttrs.meta.homepage}/releases/dbus-glib/dbus-glib-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-wJxcCFsqDjkbjufXg6HWP+RE6WcXzBgU1htej8KCenw=";
   };
 
@@ -51,7 +51,10 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  passthru = { inherit dbus glib; };
+  passthru = {
+    inherit dbus glib;
+    bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+  };
 
   meta = {
     homepage = "https://dbus.freedesktop.org";
@@ -64,4 +67,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ex/expat/package.nix
+++ b/pkgs/by-name/ex/expat/package.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "$"'{_IMPORT_PREFIX}' $out
   '';
 
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
   passthru.tests = {
     inherit python3;
     inherit (python3.pkgs) xmltodict;

--- a/pkgs/by-name/gs/gspell/package.nix
+++ b/pkgs/by-name/gs/gspell/package.nix
@@ -17,7 +17,7 @@
   gnome,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gspell";
   version = "1.14.0";
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   outputBin = "dev";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gspell/${lib.versions.majorMinor finalAttrs.version}/gspell-${finalAttrs.version}.tar.xz";
     sha256 = "ZOodjp7cHCW0WpIOgNr2dVnRhm/81/hDL+z+ptD+iJc=";
   };
 
@@ -60,8 +60,9 @@ stdenv.mkDerivation rec {
   ];
 
   passthru = {
+    bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "gspell";
       versionPolicy = "none";
     };
   };
@@ -74,4 +75,4 @@ stdenv.mkDerivation rec {
     teams = [ teams.gnome ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/gt/gtk-layer-shell/package.nix
+++ b/pkgs/by-name/gt/gtk-layer-shell/package.nix
@@ -62,6 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dexamples=true"
   ];
 
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+
   meta = with lib; {
     description = "Library to create panels and other desktop components for Wayland using the Layer Shell protocol";
     mainProgram = "gtk-layer-demo";

--- a/pkgs/by-name/gt/gtk4-layer-shell/package.nix
+++ b/pkgs/by-name/gt/gtk4-layer-shell/package.nix
@@ -64,6 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dexamples=true"
   ];
 
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+
   meta = with lib; {
     description = "Library to create panels and other desktop components for Wayland using the Layer Shell protocol and GTK4";
     mainProgram = "gtk4-layer-demo";

--- a/pkgs/by-name/li/libadwaita/package.nix
+++ b/pkgs/by-name/li/libadwaita/package.nix
@@ -121,6 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
     updateScript = gnome.updateScript {
       packageName = finalAttrs.pname;
     };

--- a/pkgs/by-name/li/libassuan/package.nix
+++ b/pkgs/by-name/li/libassuan/package.nix
@@ -9,12 +9,12 @@
   gitUpdater,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libassuan";
   version = "3.0.2";
 
   src = fetchurl {
-    url = "mirror://gnupg/libassuan/libassuan-${version}.tar.bz2";
+    url = "mirror://gnupg/libassuan/libassuan-${finalAttrs.version}.tar.bz2";
     hash = "sha256-0pMc2tJm5jNRD5lw4aLzRgVeNRuxn5t4kSR1uAdMNvY=";
   };
 
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     sed -i 's,#include <gpg-error.h>,#include "${libgpg-error.dev}/include/gpg-error.h",g' $dev/include/assuan.h
   '';
 
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
   passthru.updateScript = gitUpdater {
     url = "https://dev.gnupg.org/source/libassuan.git";
     rev-prefix = "libassuan-";
@@ -59,9 +60,9 @@ stdenv.mkDerivation rec {
       provided.
     '';
     homepage = "https://gnupg.org/software/libassuan/";
-    changelog = "https://dev.gnupg.org/source/libassuan/browse/master/NEWS;libassuan-${version}";
+    changelog = "https://dev.gnupg.org/source/libassuan/browse/master/NEWS;libassuan-${finalAttrs.version}";
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/li/libdazzle/package.nix
+++ b/pkgs/by-name/li/libdazzle/package.nix
@@ -19,7 +19,7 @@
   gnome,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libdazzle";
   version = "3.44.0";
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   outputBin = "dev";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libdazzle/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/libdazzle/${lib.versions.majorMinor finalAttrs.version}/libdazzle-${finalAttrs.version}.tar.xz";
     sha256 = "PNPkXrbiaAywXVLh6A3Y+dWdR2UhLw4o945sF4PRjq4=";
   };
 
@@ -74,8 +74,9 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
+    passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "libdazzle";
     };
   };
 
@@ -94,4 +95,4 @@ stdenv.mkDerivation rec {
     teams = [ teams.gnome ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/li/libevent/package.nix
+++ b/pkgs/by-name/li/libevent/package.nix
@@ -12,12 +12,12 @@
   static ? stdenv.hostPlatform.isStatic,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libevent";
   version = "2.1.12";
 
   src = fetchurl {
-    url = "https://github.com/libevent/libevent/releases/download/release-${version}-stable/libevent-${version}-stable.tar.gz";
+    url = "https://github.com/libevent/libevent/releases/download/release-${finalAttrs.version}-stable/libevent-${finalAttrs.version}-stable.tar.gz";
     sha256 = "1fq30imk8zd26x8066di3kpc5zyfc5z6frr3zll685zcx4dxxrlj";
   };
 
@@ -69,6 +69,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+
   meta = with lib; {
     description = "Event notification library";
     mainProgram = "event_rpcgen.py";
@@ -87,4 +89,4 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/by-name/li/libgpg-error/package.nix
+++ b/pkgs/by-name/li/libgpg-error/package.nix
@@ -23,12 +23,13 @@ let
   };
 in
 stdenv.mkDerivation (
-  rec {
+  finalAttrs:
+  {
     pname = "libgpg-error";
     version = "1.51";
 
     src = fetchurl {
-      url = "mirror://gnupg/${pname}/${pname}-${version}.tar.bz2";
+      url = "mirror://gnupg/libgpg-error/libgpg-error-${finalAttrs.version}.tar.bz2";
       hash = "sha256-vg8bLba5Pu1VNpzfefGfcnUMjHw5/CC1d+ckVFQn5rI=";
     };
 
@@ -74,11 +75,13 @@ stdenv.mkDerivation (
 
     doCheck = true; # not cross
 
+    passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+
     meta = {
       homepage = "https://www.gnupg.org/software/libgpg-error/index.html";
-      changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=NEWS;hb=refs/tags/libgpg-error-${version}";
+      changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=NEWS;hb=refs/tags/libgpg-error-${finalAttrs.version}";
       description = "Small library that defines common error values for all GnuPG components";
-      mainProgram = "gen-posix-lock-obj";
+      mainProgram = if genPosixLockObjOnly then "gen-posix-lock-obj" else "gpg-error";
 
       longDescription = ''
         Libgpg-error is a small library that defines common error values

--- a/pkgs/by-name/li/liboil/package.nix
+++ b/pkgs/by-name/li/liboil/package.nix
@@ -5,12 +5,12 @@
   pkg-config,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "liboil";
   version = "0.3.17";
 
   src = fetchurl {
-    url = "${meta.homepage}/download/liboil-${version}.tar.gz";
+    url = "${finalAttrs.meta.homepage}/download/liboil-${finalAttrs.version}.tar.gz";
     sha256 = "0sgwic99hxlb1av8cm0albzh8myb7r3lpcwxfm606l0bkc3h4pqh";
   };
 
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
   # fixes a cast in inline asm: easier than patching
   buildFlags = lib.optional stdenv.hostPlatform.isDarwin "CFLAGS=-fheinous-gnu-extensions";
 
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+
   meta = with lib; {
     description = "Library of simple functions that are optimized for various CPUs";
     mainProgram = "oil-bugreport";
@@ -42,4 +44,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ lovek323 ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/by-name/li/libpanel/package.nix
+++ b/pkgs/by-name/li/libpanel/package.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
     updateScript = gnome.updateScript {
       packageName = "libpanel";
       versionPolicy = "odd-unstable";

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -90,6 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
     updateScript = gnome.updateScript {
       packageName = "libshumate";
     };

--- a/pkgs/by-name/on/oniguruma/package.nix
+++ b/pkgs/by-name/on/oniguruma/package.nix
@@ -5,13 +5,13 @@
   autoreconfHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "oniguruma";
   version = "6.9.10";
 
   # Note: do not use fetchpatch or fetchFromGitHub to keep this package available in __bootPackages
   src = fetchurl {
-    url = "https://github.com/kkos/oniguruma/releases/download/v${version}/onig-${version}.tar.gz";
+    url = "https://github.com/kkos/oniguruma/releases/download/v${finalAttrs.version}/onig-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-Klz8WuJZ5Ol/hraN//wVLNr/6U4gYLdwy4JyONdp/AU=";
   };
 
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   configureFlags = [ "--enable-posix-api=yes" ];
 
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+
   meta = with lib; {
     homepage = "https://github.com/kkos/oniguruma";
     description = "Regular expressions library";
@@ -33,4 +35,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ artturin ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/sd/sdl2-compat/package.nix
+++ b/pkgs/by-name/sd/sdl2-compat/package.nix
@@ -79,6 +79,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+
     tests =
       {
         pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
@@ -111,6 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://libsdl.org";
     changelog = "https://github.com/libsdl-org/sdl2-compat/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.zlib;
+    mainProgram = "sdl2-config";
     maintainers = with lib.maintainers; [
       nadiaholmquist
     ];

--- a/pkgs/development/libraries/apr/default.nix
+++ b/pkgs/development/libraries/apr/default.nix
@@ -6,12 +6,12 @@
   autoreconfHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "apr";
   version = "1.7.6";
 
   src = fetchurl {
-    url = "mirror://apache/apr/${pname}-${version}.tar.bz2";
+    url = "mirror://apache/apr/apr-${finalAttrs.version}.tar.bz2";
     hash = "sha256-SQMNktJXXac1eRtJbcMi885c/5SUd5uozCjH9Gxd6zI=";
   };
 
@@ -74,6 +74,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+
   meta = with lib; {
     homepage = "https://apr.apache.org/";
     description = "Apache Portable Runtime library";
@@ -82,4 +84,4 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/libraries/libhandy/0.x.nix
+++ b/pkgs/development/libraries/libhandy/0.x.nix
@@ -18,7 +18,7 @@
   hicolor-icon-theme,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libhandy";
   version = "0.0.13";
 
@@ -32,8 +32,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     domain = "source.puri.sm";
     owner = "Librem5";
-    repo = pname;
-    rev = "v${version}";
+    repo = "libhandy";
+    tag = "v${finalAttrs.version}";
     sha256 = "1y23k623sjkldfrdiwfarpchg5mg58smcy1pkgnwfwca15wm1ra5";
   };
 
@@ -75,6 +75,8 @@ stdenv.mkDerivation rec {
       meson test --print-errorlogs
   '';
 
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
+
   meta = with lib; {
     description = "Library full of GTK widgets for mobile phones";
     mainProgram = "handy-0.0-demo";
@@ -83,4 +85,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/development/libraries/libhandy/default.nix
+++ b/pkgs/development/libraries/libhandy/default.nix
@@ -25,7 +25,7 @@
   runCommand,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libhandy";
   version = "1.8.3";
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   outputBin = "dev";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/libhandy/${lib.versions.majorMinor finalAttrs.version}/libhandy-${finalAttrs.version}.tar.xz";
     hash = "sha256-BbSXIpBz/1V/ELMm4HTFBm+HQ6MC1IIKuXvLXNLasIc=";
   };
 
@@ -122,8 +122,9 @@ stdenv.mkDerivation rec {
 
   passthru =
     {
+      bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
       updateScript = gnome.updateScript {
-        packageName = pname;
+        packageName = "libhandy";
         versionPolicy = "odd-unstable";
       };
     }
@@ -150,4 +151,4 @@ stdenv.mkDerivation rec {
     teams = [ teams.gnome ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/development/libraries/libusb-compat/0.1.nix
+++ b/pkgs/development/libraries/libusb-compat/0.1.nix
@@ -7,7 +7,7 @@
   libusb1,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libusb-compat";
   version = "0.1.8";
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "libusb";
     repo = "libusb-compat-0.1";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-pAPERYSxoc47gwpPUoMkrbK8TOXyx03939vlFN0hHRg=";
   };
 
@@ -36,8 +36,10 @@ stdenv.mkDerivation rec {
   # without this, libusb-compat is unable to find libusb1
   postFixup = ''
     find $out/lib -name \*.so\* -type f -exec \
-      patchelf --set-rpath ${lib.makeLibraryPath buildInputs} {} \;
+      patchelf --set-rpath ${lib.makeLibraryPath finalAttrs.buildInputs} {} \;
   '';
+
+  passthru.bin = finalAttrs.finalPackage.${finalAttrs.outputBin}; # fix lib.getExe
 
   meta = with lib; {
     homepage = "https://libusb.info/";
@@ -50,4 +52,4 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
redo of https://github.com/NixOS/nixpkgs/pull/410952, but modified to move all `passthru.bin` additions to where `passthru` usually is located: above `meta`. This makes the expression less brittle if e.g. passthru in the future has to be reworked to use `lib.optionalAttrs`.
Superseeds https://github.com/NixOS/nixpkgs/pull/418424

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
