### PR TITLE
lib.systems.examples: Split glibc powerpc64 back into 2 ABI options

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -21,9 +21,13 @@ rec {
     config = "powerpc64le-unknown-linux-musl";
   };
 
-  ppc64 = {
+  ppc64-elfv1 = {
+    config = "powerpc64-unknown-linux-gnuabielfv1";
+  };
+  ppc64-elfv2 = {
     config = "powerpc64-unknown-linux-gnuabielfv2";
   };
+  ppc64 = ppc64-elfv2;
   ppc64-musl = {
     config = "powerpc64-unknown-linux-musl";
     gcc = {


### PR DESCRIPTION
ELFv1 is the historically better supported one on glibc, ELFv2 seems to have some issues with our toolchain.

Restore the option to pick the ABI with `pkgsCross`.

---

The split ABI options were initially introduced in 72b3badb6197a042c52397fcea467f630628c75c, and removed again in 8ea1660b9e45f36d597af201b0f752478388ca66 due to lack of support for specifying these ABIs via the config string. We have since gone back to specifying the ABI in the config string, so there shouldn't be any issue with bringing this back either.

Bootstrapping Nixpkgs on powerpc64 got stuck due to `valgrind` really not being happy with ELFv2 (#295906), so I'd like to try using the tried-and-tested ABI for this platform instead (eventually… this doesn't have a *suuuuper* high priority for me rn). This is a first step towards that.

---

72b3badb6197a042c52397fcea467f630628c75c mentioned:

> Many other platforms are moving to ELFv2 too, such as FreeBSD (as of v13) and Gentoo (as of late 2020).

- I believe FreeBSD did end up switching to ELFv2
- Gentoo I think still defaults to ELFv1, with ELFv2 labeled as a not supported option
  https://wiki.gentoo.org/wiki/Project:PowerPC#Key_facts

And to give some more examples:
- Debian is on glibc ELFv1, and I doubt that'll be changed anytime soon.
- Adélie Linux is on musl, so they need to use ELFv2. They use various patches to fix ELF 1 vs 2 issues.
- Void Linux used to have a glibc ELFv2 fork, but it was first [scaled back](https://voidlinux-ppc.org/news/the-future-of-big-endian-in-void-ppc/) due to lack of resources, and then [ceased to be maintained altogether](https://voidlinux-ppc.org/news/project-status-update-for-2023/) in favour of the musl ELFv2 distro Chimera Linux.

---

`pkgsCross.ppc64-elfv1.hello` builds (and runs) fine on my end.

CC @r-burns, as the author of the aforementioned two commits. Don't know if you still have an interest in big-endian powerpc64 and this ABI stuff.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
