### PR TITLE
amd-debug-tools: init at 0.2.3 & pythonPackges.cysystemd: init at 2.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25218,6 +25218,13 @@
     github = "tiferrei";
     githubId = 8849915;
   };
+  tigergorilla2 = {
+    name = "TigerGorilla2";
+    email = "tigergorilla2@proton.me";
+    github = "TigerGorilla2";
+    githubId = 108592791;
+    keys = [ { fingerprint = "F296 E613 4408 A425 0DAF  0263 200D 7FB9 535B 5658"; } ];
+  };
   tilcreator = {
     name = "TilCreator";
     email = "contact.nixos@tc-j.de";

--- a/pkgs/by-name/am/amd-debug-tools/package.nix
+++ b/pkgs/by-name/am/amd-debug-tools/package.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  python3Packages,
+  fetchgit,
+  nix-update-script,
+
+  # nativeBuildInputs
+  wrapGAppsNoGuiHook,
+  gobject-introspection,
+
+  # runtimeDeps
+  acpica-tools,
+  ethtool,
+  fwupd,
+  libdisplay-info,
+  power-profiles-daemon,
+  util-linux,
+
+  # tests
+  runCommand,
+  amd-debug-tools,
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "amd-debug-tools";
+  version = "0.2.3";
+  pyproject = true;
+
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/superm1/${pname}.git";
+    tag = version;
+    hash = "sha256-yWDpVHruVNUWaCUXkeBkXOeSOiW3D9fiQZ8B3Pkug3I=";
+  };
+
+  # Upstream bug: quote reuse inside f-string (only available since python 3.12)
+  # TODO: https://github.com/superm1/amd-debug-tools/pull/6
+  disabled = python3Packages.pythonOlder "3.12";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "setuptools-git-versioning>=2.0,<3"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
+
+    substituteInPlace src/amd_debug/validator.py \
+      --replace-fail '/usr/bin/powerprofilesctl' 'powerprofilesctl}'
+  '';
+
+  makeWrapperArgs =
+    let
+      runtimeDeps = lib.makeBinPath [
+        acpica-tools
+        ethtool
+        fwupd
+        libdisplay-info
+        power-profiles-daemon
+        # TODO: How to handle a program that re-execs itself with 'sudo'
+        # sudo
+        util-linux
+      ];
+    in
+    [
+      "--prefix"
+      "PATH"
+      ":"
+      "${runtimeDeps}"
+    ];
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    cysystemd
+    jinja2
+    matplotlib
+    packaging
+    pandas
+    pygobject3
+    pyudev
+    seaborn
+    tabulate
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsNoGuiHook
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    fwupd
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # These make calls to runtime dependencies which are not available in the test environement
+    "src/test_bios.py"
+    "src/test_pstate.py"
+    "src/test_s2idle.py"
+    "src/test_sleep_report.py"
+    "src/test_kernel.py"
+    "src/test_validator.py"
+  ];
+
+  disabledTests = [
+    # Upstream bug that results in an exception if /sys/firmware/acpi/tables/FACP does not exit
+    # TODO: https://github.com/superm1/amd-debug-tools/pull/7
+    "check_fadt_file_not_found"
+  ];
+
+  passthru.tests = {
+    amd-bios-version = runCommand "${pname}-test" { } ''
+      # '|| true' to catch an upstream bug that lets successful runs exit with status code 1
+      # https://github.com/superm1/amd-debug-tools/issues/4
+      ${amd-debug-tools}/bin/amd-bios version > $out || true
+      [ "$(cat $out)" = "${version}" ]
+    '';
+
+    amd-pstate-version = runCommand "${pname}-test" { } ''
+      # '|| true' to catch an upstream bug that lets successful runs exit with status code 1
+      # https://github.com/superm1/amd-debug-tools/issues/4
+      ${amd-debug-tools}/bin/amd-pstate version > $out || true
+      [ "$(cat $out)" = "${version}" ]
+    '';
+
+    amd-s2idle-version = runCommand "${pname}-test" { } ''
+      # '|| true' to catch an upstream bug that lets successful runs exit with status code 1
+      # https://github.com/superm1/amd-debug-tools/issues/4
+      ${amd-debug-tools}/bin/amd-s2idle version > $out || true
+      [ "$(cat $out)" = "${version}" ]
+    '';
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Helpful tools for debugging AMD Zen systems";
+    homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/superm1/amd-debug-tools.git/about";
+    changelog = "https://git.kernel.org/pub/scm/linux/kernel/git/superm1/amd-debug-tools.git/tag/?h=${version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.tigergorilla2 ];
+  };
+}

--- a/pkgs/development/python-modules/cysystemd/default.nix
+++ b/pkgs/development/python-modules/cysystemd/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  nix-update-script,
+
+  setuptools,
+  cython,
+  systemdLibs,
+}:
+
+buildPythonPackage rec {
+  pname = "cysystemd";
+  version = "2.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mosquito";
+    repo = "cysystemd";
+    tag = version;
+    hash = "sha256-K2SlTRPuFRvKUlWovWrS1BrbSBUF5FOI3aNC0FiCNfI=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  buildInputs = [
+    systemdLibs
+  ];
+
+  dependencies = [
+    cython
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "cysystemd"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Systemd wrapper using Cython";
+    homepage = "https://github.com/mosquito/cysystemd";
+    changelog = "https://github.com/mosquito/cysystemd/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.tigergorilla2 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3168,6 +3168,8 @@ self: super: with self; {
 
   cysignals = callPackage ../development/python-modules/cysignals { };
 
+  cysystemd = callPackage ../development/python-modules/cysystemd { };
+
   cython = callPackage ../development/python-modules/cython { };
 
   cython-test-exception-raiser =


### PR DESCRIPTION
[**amd-debug-tools**](https://git.kernel.org/pub/scm/linux/kernel/git/superm1/amd-debug-tools.git/about) help debug amd-pstate & s2idle on *AMD Zen* systems. These used to just be standalone python scripts (`amd_s2dile.py`, `amd_pstate.py`, and `amd_bios.py`), but got refactored into a python-module with the binaries (`amd-s2idle`, `amd-pstate`, and `amd-bios`) in it's [0.2.0](https://github.com/superm1/amd-debug-tools/releases/tag/0.2.0) release.

Note when testing the binaries that they currently exit with status 1 on success and 0 on some types of failure. ~~I haven't yet made an upstream bug report.~~) https://github.com/superm1/amd-debug-tools/pull/5

This also adds [**cysystemd**](https://github.com/mosquito/cysystemd), a python wrapper for systemd using Cython, as it is a dependency for **amd-debug-tools**. I can split it into a separate PR if that's preferred.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
