### PR TITLE
nixos/sillytavern: add it

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -98,6 +98,8 @@
 
 - [fw-fanctrl](https://github.com/TamtamHero/fw-fanctrl), a simple systemd service to better control Framework Laptop's fan(s). Available as [hardware.fw-fanctrl](#opt-hardware.fw-fanctrl.enable).
 
+- [SillyTavern](https://sillytavern.app/), LLM Frontend for Power Users. Available as [services.sillytavern](#opt-services.sillytavern.enable).
+
 - [mautrix-discord](https://github.com/mautrix/discord), a Matrix-Discord puppeting/relay bridge. Available as [services.mautrix-discord](#opt-services.mautrix-discord.enable).
 
 - [Timekpr-nExT](https://mjasnik.gitlab.io/timekpr-next/), a time managing application that helps optimizing time spent at computer for your subordinates, children or even for yourself. Available as [](#opt-services.timekpr.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1688,6 +1688,7 @@
   ./services/web-apps/sftpgo.nix
   ./services/web-apps/sharkey.nix
   ./services/web-apps/shiori.nix
+  ./services/web-apps/sillytavern.nix
   ./services/web-apps/silverbullet.nix
   ./services/web-apps/simplesamlphp.nix
   ./services/web-apps/slskd.nix

--- a/nixos/modules/services/web-apps/sillytavern.nix
+++ b/nixos/modules/services/web-apps/sillytavern.nix
@@ -1,0 +1,170 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.sillytavern;
+  defaultUser = "sillytavern";
+  defaultGroup = "sillytavern";
+in
+{
+  meta.maintainers = [
+    lib.maintainers.wrvsrx
+    lib.maintainers.A1ca7raz
+  ];
+
+  options = {
+    services.sillytavern = {
+      enable = lib.mkEnableOption "sillytavern";
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = defaultUser;
+        description = ''
+          User account under which the web-application run.
+        '';
+      };
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = defaultGroup;
+        description = ''
+          Group account under which the web-application run.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "sillytavern" { };
+
+      configFile = lib.mkOption {
+        type = lib.types.path;
+        default = "${pkgs.sillytavern}/lib/node_modules/sillytavern/config.yaml";
+        defaultText = lib.literalExpression "\${pkgs.sillytavern}/lib/node_modules/sillytavern/config.yaml";
+        description = ''
+          Path to the SillyTavern configuration file.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.nullOr lib.types.port;
+        default = null;
+        example = 8045;
+        description = ''
+          Port on which SillyTavern will listen.
+        '';
+      };
+
+      listenAddressIPv4 = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "127.0.0.1";
+        description = ''
+          Specific IPv4 address to listen to.
+        '';
+      };
+
+      listenAddressIPv6 = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "::1";
+        description = ''
+          Specific IPv6 address to listen to.
+        '';
+      };
+
+      listen = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        example = true;
+        description = ''
+          Whether to listen on all network interfaces.
+        '';
+      };
+
+      whitelist = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        example = true;
+        description = ''
+          Enables whitelist mode.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.sillytavern = {
+      description = "Silly Tavern";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      # required by sillytavern's extension manager
+      path = [ pkgs.git ];
+      environment.XDG_DATA_HOME = "%S";
+      serviceConfig = {
+        Type = "simple";
+        ExecStart =
+          let
+            f = x: name: lib.optional (x != null) "--${name}=${builtins.toString x}";
+          in
+          lib.concatStringsSep " " (
+            [
+              "${lib.getExe pkgs.sillytavern}"
+            ]
+            ++ f cfg.port "port"
+            ++ f cfg.listen "listen"
+            ++ f cfg.listenAddressIPv4 "listenAddressIPv4"
+            ++ f cfg.listenAddressIPv6 "listenAddressIPv6"
+            ++ f cfg.whitelist "whitelist"
+          );
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "always";
+        StateDirectory = "SillyTavern";
+        BindPaths = [
+          "%S/SillyTavern/extensions:${pkgs.sillytavern}/lib/node_modules/sillytavern/public/scripts/extensions/third-party"
+        ];
+
+        # Security hardening
+        CapabilityBoundingSet = [ "" ];
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+      };
+    };
+
+    users.users.${cfg.user} = lib.mkIf (cfg.user == defaultUser) {
+      description = "sillytavern service user";
+      isSystemUser = true;
+      inherit (cfg) group;
+    };
+
+    users.groups.${cfg.group} = lib.mkIf (cfg.group == defaultGroup) { };
+
+    systemd.tmpfiles.settings.sillytavern = {
+      "/var/lib/SillyTavern/data".d = {
+        mode = "0700";
+        inherit (cfg) user group;
+      };
+      "/var/lib/SillyTavern/extensions".d = {
+        mode = "0700";
+        inherit (cfg) user group;
+      };
+      "/var/lib/SillyTavern/config.yaml"."L+" = {
+        mode = "0600";
+        argument = cfg.configFile;
+        inherit (cfg) user group;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add sillytavern module. This PR should be merged after https://github.com/NixOS/nixpkgs/pull/432510.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
