### PR TITLE
python313Packages.flask-security: fix python 3.13 compat

### DIFF
--- a/pkgs/development/python-modules/flask-security/default.nix
+++ b/pkgs/development/python-modules/flask-security/default.nix
@@ -45,7 +45,6 @@
   mongoengine,
   mongomock,
   peewee,
-  pony,
   pytestCheckHook,
   requests,
   zxcvbn,
@@ -111,7 +110,6 @@ buildPythonPackage rec {
       mongoengine
       mongomock
       peewee
-      pony
       pytestCheckHook
       requests
       zxcvbn
@@ -132,11 +130,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "flask_security" ];
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/pallets-eco/flask-security/blob/${src.tag}/CHANGES.rst";
     homepage = "https://github.com/pallets-eco/flask-security";
     description = "Quickly add security features to your Flask application";
-    license = licenses.mit;
-    maintainers = with maintainers; [ gador ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gador ];
   };
 }

--- a/pkgs/development/python-modules/flask-sqlalchemy-lite/default.nix
+++ b/pkgs/development/python-modules/flask-sqlalchemy-lite/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     # fix python3.13 compat
     (fetchpatch2 {
       url = "https://github.com/pallets-eco/flask-sqlalchemy-lite/commit/b4117beaa6caa0a5945d6e3451db8b80dc4cc8cf.patch?full_index=1";
-      hash = "sha256-S0LGRJCoo0rHNk8K/XPcYl0C0QTruZhN02lC2KlKG+I=";
+      hash = "sha256-zCeUWB3iuKqco030pULaRpRsIOpSRz9+VYxI/RQhIyw=";
     })
   ];
 

--- a/pkgs/development/python-modules/flask-sqlalchemy-lite/default.nix
+++ b/pkgs/development/python-modules/flask-sqlalchemy-lite/default.nix
@@ -2,6 +2,7 @@
   aiosqlite,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   flask,
   flit-core,
   lib,
@@ -20,6 +21,14 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-LpdPp5Gp74DSJqD1DJqwNeaMKdN5pEAUkxnKGYZcVis=";
   };
+
+  patches = [
+    # fix python3.13 compat
+    (fetchpatch2 {
+      url = "https://github.com/pallets-eco/flask-sqlalchemy-lite/commit/b4117beaa6caa0a5945d6e3451db8b80dc4cc8cf.patch?full_index=1";
+      hash = "sha256-S0LGRJCoo0rHNk8K/XPcYl0C0QTruZhN02lC2KlKG+I=";
+    })
+  ];
 
   build-system = [ flit-core ];
 


### PR DESCRIPTION
`flask-security` only needs `pony`for python versions older than 3.11: https://github.com/pallets-eco/flask-security/blob/e386da617ffff93af5b3f41480d4a896468cf3e5/pyproject.toml#L78

Also fetches a newer commit for `flask-sqlalchemy-lite` to work with python 3.13

fixes https://github.com/NixOS/nixpkgs/pull/414137#issuecomment-2990693247

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
