### PR TITLE
decklink: fix build for kernel 6.15

### DIFF
--- a/pkgs/os-specific/linux/decklink/02-rename-timer-delete.patch
+++ b/pkgs/os-specific/linux/decklink/02-rename-timer-delete.patch
@@ -1,0 +1,26 @@
+diff --git a/blackmagic-io-14.4.1a4/bm_util.c b/blackmagic-io-14.4.1a4/bm_util.c
+index 66751cb..bf9723c 100644
+--- a/blackmagic-io-14.4.1a4/bm_util.c
++++ b/blackmagic-io-14.4.1a4/bm_util.c
+@@ -471,10 +471,10 @@ void bm_timer_free(bm_timer_t* timer)
+ {
+ #if KERNEL_VERSION_OR_LATER(4, 15, 0)
+ 	struct bm_timer_wrapper* timer_wrapper = container_of(timer, struct bm_timer_wrapper, timer);
+-	del_timer(timer);
++	timer_delete(timer);
+ 	bm_kfree(timer_wrapper);
+ #else
+-	del_timer(timer);
++	timer_delete(timer);
+ 	bm_kfree(timer);
+ #endif
+ }
+@@ -491,7 +491,7 @@ void bm_timer_expire_at(bm_timer_t* timer, uint64_t ns)
+ 
+ void bm_timer_cancel(bm_timer_t* timer)
+ {
+-	del_timer_sync(timer);
++	timer_delete_sync(timer);
+ }
+ 
+ // Event waiting

--- a/pkgs/os-specific/linux/decklink/default.nix
+++ b/pkgs/os-specific/linux/decklink/default.nix
@@ -13,14 +13,19 @@ stdenv.mkDerivation (finalAttrs: {
   # See pkgs/by-name/bl/blackmagic-desktop-video/package.nix for more.
   inherit (blackmagic-desktop-video) src version;
 
-  patches = lib.optionals (lib.versionAtLeast kernel.modDirVersion "6.13") [
-    # needed for version 14.4.x to build for kernel 6.13
-    (fetchpatch {
-      name = "01-update-makefiles";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/01-update-makefiles.patch?h=decklink";
-      hash = "sha256-l3iu0fG/QJMdGI/WSlNn+qjF4nK25JxoiwhPrMGTqE4=";
-    })
-  ];
+  patches =
+    (lib.optionals (lib.versionAtLeast kernel.modDirVersion "6.13") [
+      # needed for version 14.4.x to build for kernel 6.13
+      (fetchpatch {
+        name = "01-update-makefiles";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/01-update-makefiles.patch?h=decklink";
+        hash = "sha256-l3iu0fG/QJMdGI/WSlNn+qjF4nK25JxoiwhPrMGTqE4=";
+      })
+    ])
+    ++ (lib.optionals (lib.versionAtLeast kernel.modDirVersion "6.15") [
+      # needed for version 14.4.x to build for kernel 6.15
+      ./02-rename-timer-delete.patch
+    ]);
 
   KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
   INSTALL_MOD_PATH = placeholder "out";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Build tested via:

```
NIXPKGS_ALLOW_UNFREE=1 nix build .#linuxKernel.packages.linux_6_15.decklink --print-build-logs --impure --keep-failed
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
