### PR TITLE
verso: init at 0-unstable-2025-06-15

### DIFF
--- a/pkgs/by-name/ve/verso/package.nix
+++ b/pkgs/by-name/ve/verso/package.nix
@@ -1,0 +1,152 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitLab,
+  unstableGitUpdater,
+
+  llvmPackages_14,
+  m4,
+  pkg-config,
+  python3,
+  wrapGAppsHook3,
+  writableTmpDirAsHomeHook,
+
+  apple-sdk_14,
+  fontconfig,
+  gst_all_1,
+  libGL,
+  libunwind,
+  libxkbcommon,
+  openssl,
+  wayland,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "verso";
+  version = "0-unstable-2025-06-15";
+
+  src = fetchFromGitLab {
+    owner = "verso-browser";
+    repo = "verso";
+    rev = "ace264e0e73da37bfb14818d92f0e54946ce9871";
+    hash = "sha256-gjg7qs2ik1cJcE6OTGN4KdljqJDGokCo4JdR+KopMJw=";
+  };
+
+  depsExtraArgs = {
+    # The vendoring process copies subdirectories, but there are some files that
+    # try to read files from their parent directories during build time
+    # We avoid this issue by placing the used file into the subdirectory
+    postBuild = ''
+      pushd $out/git/*/components/net
+      cp ../../resources/rippy.png ./rippy.png
+      substituteInPlace image_cache.rs \
+        --replace-fail '../../resources/rippy.png' './rippy.png'
+      popd
+    '';
+  };
+
+  cargoHash = "sha256-dYsqr9c5n2lDt1K9EpAzkJXwmr2eJ+ExT53dlTEYraY=";
+
+  postPatch = ''
+    # The original script assumes things about the directory layout of the build
+    substituteInPlace "$cargoDepsCopy"/script_bindings-*/codegen/run.py --replace-fail \
+      "SERVO_ROOT =" \
+      "SERVO_ROOT = '$(pwd)' #"
+
+    # Set a better default resource directory search path
+    substituteInPlace src/config.rs --replace-fail \
+      "let root_dir = std::env::current_dir()" \
+      "let root_dir = { use std::str::FromStr; std::path::PathBuf::from_str(\"$out/share/verso\") }"
+
+    # This is not actually needed since we have the "versoview" binary placed
+    # right next to verso, but it's better to be safe
+    substituteInPlace verso/src/main.rs --replace-fail \
+      "let versoview_path = current_exe().unwrap().parent().unwrap().join(\"versoview\");" \
+      "let versoview_path = std::path::Path::new(\"$out/bin/versoview\");"
+  '';
+
+  # Fix invalid option errors during linking
+  # https://github.com/mozilla/nixpkgs-mozilla/commit/c72ff151a3e25f14182569679ed4cd22ef352328
+  preConfigure = ''
+    unset AS
+  '';
+
+  env.RUSTC_BOOTSTRAP = 1;
+
+  cargoBuildFlags = [
+    "-p=versoview"
+    "-p=verso"
+  ];
+
+  nativeBuildInputs = [
+    llvmPackages_14.llvm
+    m4
+    python3
+    rustPlatform.bindgenHook
+    writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      fontconfig
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gst-plugins-bad
+      gst_all_1.gst-plugins-ugly
+      libunwind
+      openssl
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      apple-sdk_14
+    ];
+
+  # Note: it might be better to disable automatic wrapping and only wrap versoview
+  # Note: using patchelf --add-rpath in postFixup could be better than setting LD_LIBRARY_PATH
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          libGL
+          libxkbcommon
+          wayland
+        ]
+      }
+    )
+  '';
+
+  postInstall = ''
+    install -Dm644 org.versotile.verso.desktop $out/share/applications/org.versotile.verso.desktop
+    install -Dm644 icons/icon256x256.png $out/share/icons/hicolor/256x256/apps/org.versotile.verso.png
+
+    # Install the resource directory into our patched default location
+    mkdir -p "$out/share/verso"
+    cp -r ./resources "$out/share/verso/resources"
+  '';
+
+  # checks fail to compile due to vendoring issues
+  doCheck = false;
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Web browser built on top of the Servo web engine";
+    homepage = "https://gitlab.com/verso-browser/verso";
+    downloadPage = "https://gitlab.com/verso-browser/verso";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      ethancedwards8
+      tomasajt
+    ];
+    teams = [ lib.teams.ngi ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Related: https://github.com/ngi-nix/projects/issues/71
Closes: https://github.com/ngi-nix/projects/issues/1826

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
