### PR TITLE
libajantv2: 17.1.3 -> 17.5.0

### DIFF
--- a/pkgs/by-name/li/libajantv2/package.nix
+++ b/pkgs/by-name/li/libajantv2/package.nix
@@ -8,17 +8,18 @@
   mbedtls,
   udev,
   linuxPackages,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
   pname = "libajantv2";
-  version = "17.1.3";
+  version = "17.5.0";
 
   src = fetchFromGitHub {
     owner = "aja-video";
     repo = "libajantv2";
     rev = "ntv2_${builtins.replaceStrings [ "." ] [ "_" ] version}";
-    hash = "sha256-7APoPj2LnvdwfuVforoJz0YxKU1WmAgRqIfXao4IZmY=";
+    hash = "sha256-/BfFbBScS75TpUZEeYzAHd1PtnZgnCNfGtjwYPJJjkg=";
   };
   patches = [
     ./use-system-mbedtls.patch

--- a/pkgs/by-name/li/libajantv2/use-system-mbedtls.patch
+++ b/pkgs/by-name/li/libajantv2/use-system-mbedtls.patch
@@ -1,16 +1,9 @@
-Commit ID: 1aeee534119a22e717ce3d0e9f62c8791cd825b9
-Change ID: pzyrusopmyvtvnwnruvrltqtpqtzxrpo
-Author: Luke Granger-Brown <git@lukegb.com> (2024-12-20 18:03:16)
-Committer: Luke Granger-Brown <git@lukegb.com> (2024-12-20 18:03:25)
-
-    Use system mbedtls, rather than downloading from a random Git branch...
-
 diff --git a/ajantv2/CMakeLists.txt b/ajantv2/CMakeLists.txt
-index ffa572e9c8..74c23e8e4e 100644
+index 8037dd4b..aa6e6577 100644
 --- a/ajantv2/CMakeLists.txt
 +++ b/ajantv2/CMakeLists.txt
-@@ -52,49 +52,13 @@
- else()
+@@ -55,49 +55,13 @@ else()
+     endif()
      message(STATUS "NTV2 SDK will load signed 3rd-party plugins")
  
 -    set(MBEDTLS_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/mbedtls-install)
@@ -23,7 +16,6 @@ index ffa572e9c8..74c23e8e4e 100644
 -        set(MBEDCRYPTO_LIBRARY ${MBEDTLS_LIBRARY_DIR}/mbedcrypto.lib)
 -        set(MBEDTLS_EXTRA_CONFIG_FLAGS
 -                "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
--                "-DMSVC_STATIC_RUNTIME=ON"
 -                "-DCMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}")
 -    elseif (CMAKE_SYSTEM_NAME MATCHES "^(Linux|Darwin)$")
 -        set(MBEDTLS_LIBRARY ${MBEDTLS_LIBRARY_DIR}/libmbedtls.a)
@@ -35,7 +27,7 @@ index ffa572e9c8..74c23e8e4e 100644
 -    # BUILD_BYPRODUCTS informing CMake where the .a files are located is required to make Ninja build work
 -    ExternalProject_Add(
 -        mbedtls
--        GIT_REPOSITORY https://github.com/aja-video/mbedtls.git
+-        GIT_REPOSITORY ${AJANTV2_MBEDTLS_URL}
 -        GIT_TAG fix-win-dll-cmake
 -        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${MBEDTLS_INSTALL_DIR}
 -                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -46,6 +38,7 @@ index ffa572e9c8..74c23e8e4e 100644
 -                    -DUSE_STATIC_MBEDTLS_LIBRARY=ON
 -                    -DUSE_SHARED_MBEDTLS_LIBRARY=OFF
 -                    ${MBEDTLS_EXTRA_CONFIG_FLAGS}
+-		CMAKE_CACHE_ARGS "-DCMAKE_OSX_ARCHITECTURES:STRING=${CMAKE_OSX_ARCHITECTURES}"
 -        BUILD_ALWAYS TRUE
 -        BUILD_BYPRODUCTS ${MBEDTLS_LIBRARY} ${MBEDX509_LIBRARY} ${MBEDCRYPTO_LIBRARY}
 -    )
@@ -62,7 +55,7 @@ index ffa572e9c8..74c23e8e4e 100644
  endif()
  
  
-@@ -668,10 +632,6 @@
+@@ -671,10 +635,6 @@ if (NOT TARGET ${PROJECT_NAME})
          aja_ntv2_log_build_info()
  
          add_library(${PROJECT_NAME} SHARED ${TARGET_SOURCES})
@@ -73,7 +66,7 @@ index ffa572e9c8..74c23e8e4e 100644
  
          target_compile_definitions(${PROJECT_NAME} PUBLIC
              ${TARGET_COMPILE_DEFS_DYNAMIC}
-@@ -687,10 +647,6 @@
+@@ -690,10 +650,6 @@ if (NOT TARGET ${PROJECT_NAME})
  
          add_library(${PROJECT_NAME} STATIC ${TARGET_SOURCES})
  


### PR DESCRIPTION
WIP. Hopefully fixes hydra fail for `linuxPackages_5_10_hardened.ajantv2`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
