### PR TITLE
leanblueprint 0.0.10 -> 0.0.18 and tests

### DIFF
--- a/pkgs/development/python-modules/leanblueprint/default.nix
+++ b/pkgs/development/python-modules/leanblueprint/default.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  pkgs,
   buildPythonPackage,
   fetchFromGitHub,
+  callPackage,
 
   # build-system
   setuptools,
@@ -45,8 +47,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "leanblueprint" ];
 
+  passthru.tests.simple-blueprint = callPackage ./tests/simple-blueprint.nix { };
+
   meta = {
-    description = "This plasTeX plugin allowing to write blueprints for Lean 4 projects";
+    description = "A plasTeX plugin allowing to write blueprints for Lean 4 projects";
     homepage = "https://github.com/PatrickMassot/leanblueprint";
     maintainers = with lib.maintainers; [ niklashh ];
     license = lib.licenses.asl20;

--- a/pkgs/development/python-modules/leanblueprint/default.nix
+++ b/pkgs/development/python-modules/leanblueprint/default.nix
@@ -17,16 +17,16 @@
   jinja2,
   gitpython,
 }:
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "leanblueprint";
-  version = "0.0.10";
+  version = "0.0.18";
   pyproject = true;
 
   src = fetchFromGitHub {
     repo = "leanblueprint";
     owner = "PatrickMassot";
-    rev = "v0.0.10";
-    hash = "sha256-CUYdxEXgTf2vKDiOoeW4RV6tQ6prFhA4qMc0olZtZBM=";
+    tag = "v${version}";
+    hash = "sha256-kikeLc0huJHe4Fq207U8sdRrH26bzpo+IVKjsLnrWgY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/content/test.tex
+++ b/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/content/test.tex
@@ -1,0 +1,5 @@
+\chapter{Test Chapter}
+
+\begin{theorem}\label{def:one_add_one_eq_two}\lean{one_add_one_eq_two}\leanok
+  $1 + 1 = 2$
+\end{theorem}

--- a/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/latexmkrc
+++ b/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/latexmkrc
@@ -1,0 +1,3 @@
+$pdf_mode = 1;
+$pdflatex = 'pdflatex';
+@default_files = ('print.tex');

--- a/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/plastex.cfg
+++ b/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/plastex.cfg
@@ -1,0 +1,5 @@
+[general]
+plugins=plastexdepgraph  plastexshowmore  leanblueprint
+
+[files]
+directory=../web/

--- a/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/print.tex
+++ b/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/print.tex
@@ -1,0 +1,11 @@
+\documentclass[a4paper]{report}
+\newtheorem{theorem}{Theorem}[chapter]
+\newcommand{\lean}[1]{}
+\newcommand{\leanok}{}
+
+\title{Leanblueprint Test}
+
+\begin{document}
+\maketitle
+\input{content/test.tex}
+\end{document}

--- a/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/web.tex
+++ b/pkgs/development/python-modules/leanblueprint/tests/blueprint/src/web.tex
@@ -1,0 +1,10 @@
+\documentclass[a4paper]{report}
+\usepackage[showmore, dep_graph]{blueprint}
+\newtheorem{theorem}{Theorem}[chapter]
+
+\title{Leanblueprint Test}
+
+\begin{document}
+\maketitle
+\input{content/test.tex}
+\end{document}

--- a/pkgs/development/python-modules/leanblueprint/tests/simple-blueprint.nix
+++ b/pkgs/development/python-modules/leanblueprint/tests/simple-blueprint.nix
@@ -1,0 +1,62 @@
+{
+  stdenv,
+
+  # dependencies
+  git,
+  texlive,
+  texlivePackages,
+
+  leanblueprint,
+}:
+stdenv.mkDerivation {
+  name = "leanblueprint-test";
+  src = ./blueprint/src;
+
+  nativeBuildInputs = [
+    leanblueprint
+    git
+    texlive.combined.scheme-small
+    texlivePackages.latexmk
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # A git repository is required by leanblueprint
+    git init
+
+    # A lakefile is required by leanblueprint
+    echo > lakefile.lean
+
+    # Copy minimal blueprint
+    mkdir -p blueprint/src
+    cp -r $src/. blueprint/src
+
+    leanblueprint web
+    leanblueprint pdf
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r blueprint/web $out
+    cp -r blueprint/print $out
+    runHook postInstall
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    grep -q "Leanblueprint Test" $out/web/index.html
+    grep -q "Test Chapter" $out/web/index.html
+    grep -q "Test Chapter" $out/web/sect0001.html
+    grep -q "def:one_add_one_eq_two" $out/web/sect0001.html
+    grep -q "sect0001.html#def:one_add_one_eq_two" $out/web/dep_graph_document.html
+    test -d $out/web/js
+    test -d $out/web/styles
+
+    test -f $out/print/print.pdf
+    runHook postCheck
+  '';
+}

--- a/pkgs/development/python-modules/plasTeX/default.nix
+++ b/pkgs/development/python-modules/plasTeX/default.nix
@@ -12,7 +12,7 @@
   jinja2,
   unidecode,
 }:
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "plasTeX";
   version = "3.1";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage {
   src = fetchFromGitHub {
     repo = "plastex";
     owner = "plastex";
-    rev = "193747318f7ebadd19eaaa1e9996da42a31a2697"; # The same as what is published on PyPi for version 3.1. See <https://github.com/plastex/plastex/issues/386>
+    tag = version;
     hash = "sha256-Muuin7n0aPOZwlUaB32pONy5eyIjtPNb4On5gC9wOcQ=";
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumped leanblueprint from `0.0.10` to `0.0.18`, and added a test derivation (in `passthru.tests`, correct me if there is a better place) for building a sample blueprint static web page and PDF file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
