### PR TITLE
workflows/eval: don't fail without artifact from target branch

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -29,6 +29,8 @@ jobs:
       matrix:
         system: ${{ fromJSON(inputs.systems) }}
     name: ${{ matrix.system }}
+    outputs:
+      targetRunId: ${{ steps.targetRunId.outputs.targetRunId }}
     steps:
       - name: Enable swap
         run: |
@@ -88,8 +90,6 @@ jobs:
               throw new Error(`Could not find a push.yml workflow run for ${targetSha}.`)
             }
 
-            core.setOutput('targetRunId', run_id)
-
             // Waiting 120 * 5 sec = 10 min. max.
             // Eval takes max 5-6 minutes, normally.
             for (let i = 0; i < 120; i++) {
@@ -98,10 +98,15 @@ jobs:
                 run_id,
                 name: `merged-${system}`
               })
-              if (result.data.total_count > 0) return
+              if (result.data.total_count > 0) {
+                core.setOutput('targetRunId', run_id)
+                return
+              }
               await new Promise(resolve => setTimeout(resolve, 5000))
             }
-            throw new Error(`No merged-${system} artifact found.`)
+            // No artifact found at this stage. This usually means that Eval failed on the target branch.
+            // This should only happen when Eval is broken on the target branch and this PR fixes it.
+            // Continue without targetRunId to skip the remaining steps, but pass the job.
 
       - uses: actions/download-artifact@v4
         if: steps.targetRunId.outputs.targetRunId
@@ -133,7 +138,7 @@ jobs:
   compare:
     runs-on: ubuntu-24.04-arm
     needs: [eval]
-    if: inputs.targetSha
+    if: needs.eval.outputs.targetRunId
     permissions:
       statuses: write
     steps:


### PR DESCRIPTION
This can only happen if the target branch's eval run failed and we're trying to fix it. In this case, Eval should not fail, even though it might not be able to do a comparison and add the correct rebuild labels. But if we failed here, we wouldn't be able to merge the fix once we have required status checks.

This happened to @philiptaron in #418419.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
