### PR TITLE
workflows/labels: various fixes

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -72,8 +72,8 @@ jobs:
               maxConcurrent: 1,
               // Hourly limit is at 5000, but other jobs need some, too!
               // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
-              reservoir: 1000,
-              reservoirRefreshAmount: 1000,
+              reservoir: 500,
+              reservoirRefreshAmount: 500,
               reservoirRefreshInterval: 60 * 60 * 1000
             })
             // Pause between mutative requests

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -152,7 +152,17 @@ jobs:
                     status: prEventCondition ? 'in_progress' : 'success',
                     exclude_pull_requests: true,
                     head_sha: pull_request.head.sha
-                  })).data.workflow_runs[0]?.id
+                  })).data.workflow_runs[0]?.id ??
+                    // TODO: Remove this after 2025-09-17, at which point all eval.yml artifacts will have expired.
+                    (await github.rest.actions.listWorkflowRuns({
+                      ...context.repo,
+                      // In older PRs, we need eval.yml instead of pr.yml.
+                      workflow_id: 'eval.yml',
+                      event: 'pull_request_target',
+                      status: 'success',
+                      exclude_pull_requests: true,
+                      head_sha: pull_request.head.sha
+                    })).data.workflow_runs[0]?.id
 
                   // Newer PRs might not have run Eval to completion, yet. We can skip them, because this
                   // job will be run as part of that Eval run anyway.

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -186,7 +186,11 @@ jobs:
 
                   // Get all currently set labels that we manage
                   const before =
-                    pull_request.labels.map(({ name }) => name)
+                    (await github.paginate(github.rest.issues.listLabelsOnIssue, {
+                      ...context.repo,
+                      issue_number: pull_request.number
+                    }))
+                    .map(({ name }) => name)
                     .filter(name =>
                       name.startsWith('10.rebuild') ||
                       name == '11.by: package-maintainer' ||

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/eval.yml
       - .github/workflows/lint.yml
       - .github/workflows/pr.yml
+      - .github/workflows/labels.yml
       - .github/workflows/reviewers.yml # needs eval results from the same event type
   pull_request_target:
 

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -100,7 +100,7 @@ let
           (getLabels rebuildCountByKernel)
           # Adds "10.rebuild-*-stdenv" label if the "stdenv" attribute was changed
           ++ lib.mapAttrsToList (kernel: _: "10.rebuild-${kernel}-stdenv") (
-            lib.filterAttrs (_: kernelRebuilds: kernelRebuilds ? "stdenv") rebuildsByKernel
+            lib.filterAttrs (_: lib.elem "stdenv") rebuildsByKernel
           )
           # Adds the "11.by: package-maintainer" label if all of the packages directly
           # changed are maintained by the PR's author. (https://github.com/NixOS/ofborg/blob/df400f44502d4a4a80fa283d33f2e55a4e43ee90/ofborg/src/tagger.rs#L83-L88)


### PR DESCRIPTION
A collection of fixes for the labels workflow. I took the first 3 commits out of #417916, because that PR is likely open for a bit longer with the bigger refactor and the change about first-time contributor labels.

- Fixed the `rebuild-xxx-stdenv` labels, which were not set since December, aka since the OfBorg migration.
- Fixed a theoretical race condition after we introduced the bottleneck throttling.
- Lowered the API call reservoir to 500. I did not go to 250 as mentioned in https://github.com/NixOS/nixpkgs/pull/417512#issuecomment-2981033239, because after looking at the data since yesterday, I think we peaked at around 200 API requests for labeling over an hour. Given that the job would become heavily throttled once it hits empties the tank, I'd rather have a bit more room. We can still test with confidence, because not every hour hits the total peak of 3.5k - some are only at 1.5k at the end. So we can estimate from the ~2nd to last Labels run how "busy" this run was, and then manually trigger a *big* run, which should hit the 500 to test. Without any risk to hit the 5k limit.

Two more commits on top:
- Run the full PR workflow in `pull_request` when labels.yml is changed as well. This was an oversight when we moved labels into the PR workflow. This will prevent basic syntax errors like we had one recently making it through to master.
- Fix labeling on older PRs, before the Eval->PR change. An example can be seen in #416459, where we had 4 approvals in a row... but the approvals label not being picked up until the force push 2 days later. The labels workflow needs to look for both `pr.yml` and `eval.yml`.

The last fix also means we'll need to run the labeling backwards for a few days - which would be a great test for the throttling. So once we merge that, I would try this carefully.

## Things done

- [x] Tested in my fork (except for the last commit, because I don't have old eval runs...)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
