### PR TITLE
rimsort: init at 1.0.30

### DIFF
--- a/pkgs/by-name/ri/rimsort/package.nix
+++ b/pkgs/by-name/ri/rimsort/package.nix
@@ -1,0 +1,182 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+  fetchzip,
+  makeBinaryWrapper,
+
+  makeDesktopItem,
+  replaceVars,
+
+  todds,
+
+  steam,
+}:
+let
+  pname = "rimsort";
+  version = "1.0.30";
+
+  src = fetchFromGitHub {
+    owner = "RimSort";
+    repo = "RimSort";
+    rev = "v${version}";
+    hash = "sha256-f1wYoBC0EbkvYNJHkVuoMukJZMY7eNjCIzJra7/hpLs=";
+    fetchSubmodules = true;
+  };
+  steamworksSrc = fetchzip {
+    url = "https://web.archive.org/web/20250527013243/https://partner.steamgames.com/downloads/steamworks_sdk_162.zip"; # Steam sometimes requires auth to download.
+    hash = "sha256-yDA92nGj3AKTNI4vnoLaa+7mDqupQv0E4YKRRUWqyZw=";
+  };
+
+  steamfiles = python3Packages.buildPythonPackage {
+    pname = "steamfiles";
+    inherit version;
+    format = "setuptools";
+
+    src = "${src}/submodules/steamfiles";
+    dependencies = with python3Packages; [
+      protobuf
+      protobuf3-to-dict
+    ];
+  };
+
+  steam-run =
+    (steam.override {
+      privateTmp = false;
+    }).run;
+in
+
+stdenv.mkDerivation {
+  inherit pname;
+  inherit version;
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    cp -r ${src} source
+    chmod -R 755 source
+    cp ${steamworksSrc}/redistributable_bin/linux64/libsteam_api.so source/
+
+    runHook postUnpack
+  '';
+
+  sourceRoot = "source";
+
+  patches = [
+    (replaceVars ./todds-path.patch { inherit todds; })
+    (replaceVars ./steam-run.patch { inherit steam-run; })
+  ];
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  buildInputs =
+    [
+      todds
+      steamfiles
+    ]
+    ++ builtins.attrValues {
+      inherit (python3Packages)
+        beautifulsoup4
+        certifi
+        chardet
+        imageio
+        loguru
+        lxml
+        msgspec
+        natsort
+        networkx
+        packaging
+        platformdirs
+        psutil
+        pygit2
+        pygithub
+        pyperclip
+        pyside6
+        requests
+        sqlalchemy
+        steam
+        toposort
+        watchdog
+        xmltodict
+        steamworkspy
+        ;
+    };
+
+  dontBuild = true;
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-qt
+    pytest-xvfb
+  ];
+
+  doCheck = true;
+
+  preCheck = ''
+    export QT_DEBUG_PLUGINS=1
+    export QT_QPA_PLATFORM=offscreen
+    export HOME=$(mktemp -d) # Some tests require a writable directory
+  '';
+
+  disabledTestPaths = [
+    # requires network
+    "tests/models/metadata/test_metadata_factory.py"
+  ];
+
+  pytestFlags = [ "--doctest-modules" ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "RimSort";
+      desktopName = "RimSort";
+      exec = "rimsort";
+      icon = "io.github.rimsort.rimsort";
+      comment = "RimWorld Mod Manager";
+      categories = [ "Game" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/rimsort
+    cp -r ./* $out/lib/rimsort/
+
+    mkdir -p $out/bin
+
+    makeBinaryWrapper \
+      ${python3Packages.python.interpreter} \
+      $out/bin/rimsort \
+      --add-flags "-m app" \
+      --chdir $out/lib/rimsort \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --set RIMSORT_DISABLE_UPDATER 1
+
+    install -D ./themes/default-icons/AppIcon_a.png $out/share/icons/hicolor/512x512/apps/io.github.rimsort.rimsort
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Open source mod manager for the video game RimWorld";
+    homepage = "https://github.com/RimSort/RimSort";
+    license = with lib.licenses; [
+      gpl3Only
+      # For libsteam_api.so
+      (
+        unfreeRedistributable
+        // {
+          url = "https://partner.steamgames.com/documentation/sdk_access_agreement";
+        }
+      )
+    ];
+    maintainers = with lib.maintainers; [ weirdrock ];
+    mainProgram = "rimsort";
+    # steamworksSrc is x86_64-linux only
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/ri/rimsort/steam-run.patch
+++ b/pkgs/by-name/ri/rimsort/steam-run.patch
@@ -1,0 +1,26 @@
+diff --git a/app/utils/generic.py b/app/utils/generic.py
+--- a/app/utils/generic.py
++++ b/app/utils/generic.py
+@@ -255,7 +255,7 @@
+                 popen_args.extend(args)
+                 p = subprocess.Popen(popen_args)
+             else:
+-                popen_args = [executable_path]
++                popen_args = ["@steam-run@/bin/steam-run", executable_path]
+                 popen_args.extend(args)
+ 
+                 if sys.platform == "win32":
+diff --git a/app/utils/steam/steamcmd/wrapper.py b/app/utils/steam/steamcmd/wrapper.py
+--- a/app/utils/steam/steamcmd/wrapper.py
++++ b/app/utils/steam/steamcmd/wrapper.py
+@@ -316,8 +316,8 @@
+                 script_output.write("\n".join(script))
+             runner.message(f"Compiled & using script: {script_path}")
+             runner.execute(
+-                self.steamcmd,
+-                [f'+runscript "{script_path}"'],
++                "@steam-run@/bin/steam-run",
++                [self.steamcmd,  f'+runscript "{script_path}"'],
+                 len(publishedfileids),
+             )
+         else:

--- a/pkgs/by-name/ri/rimsort/todds-path.patch
+++ b/pkgs/by-name/ri/rimsort/todds-path.patch
@@ -1,0 +1,17 @@
+diff --git a/app/utils/todds/wrapper.py b/app/utils/todds/wrapper.py
+index a239fe0..3375b70 100644
+--- a/app/utils/todds/wrapper.py
++++ b/app/utils/todds/wrapper.py
+@@ -66,11 +66,7 @@ class ToddsInterface:
+         :param todds_arguments: list of todds args to be passed to the todds executable
+         """
+ 
+-        if self.system == "Windows":
+-            todds_executable = "todds.exe"
+-        else:
+-            todds_executable = "todds"
+-        todds_exe_path = str(AppInfo().application_folder / "todds" / todds_executable)
++        todds_exe_path = "@todds@/bin/todds"
+         logger.info("Checking for todds...")
+         if os.path.exists(todds_exe_path):
+             logger.debug(f"Found todds executable at: {todds_exe_path}")

--- a/pkgs/development/python-modules/gevent-eventemitter/default.nix
+++ b/pkgs/development/python-modules/gevent-eventemitter/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  gevent,
+
+  pytestCheckHook,
+
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "gevent-eventemitter";
+  version = "2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rossengeorgiev";
+    repo = "gevent-eventemitter";
+    tag = "v${version}";
+    hash = "sha256-aW4OsQi3N5yAMdbTd8rxbb2qYMfFJBR4WQFIXvxpiMw=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    gevent
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "EventEmitter using gevent";
+    homepage = "https://github.com/rossengeorgiev/gevent-eventemitter";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ weirdrock ];
+  };
+}

--- a/pkgs/development/python-modules/steam/default.nix
+++ b/pkgs/development/python-modules/steam/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  six,
+  pycryptodomex,
+  requests,
+  urllib3,
+  vdf,
+  gevent,
+  protobuf,
+  gevent-eventemitter,
+  cachetools,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "steam";
+  version = "1.4.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ValvePython";
+    repo = "steam";
+    rev = "v${version}";
+    hash = "sha256-OY04GsX3KMPvpsQl8sUurzFyJu+JKpES8B0iD6Z5uyw=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    six
+    pycryptodomex
+    requests
+    urllib3
+    vdf
+    gevent
+    protobuf
+    gevent-eventemitter
+    cachetools
+  ];
+
+  meta = {
+    description = "Python package for interacting with Steam";
+    homepage = "https://github.com/ValvePython/steam";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ weirdrock ];
+  };
+}

--- a/pkgs/development/python-modules/steamworkspy/default.nix
+++ b/pkgs/development/python-modules/steamworkspy/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  fetchzip,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+}:
+let
+  rev = "26780de81b8c14d48fe8d757c642086f2af2a66b";
+
+  src = fetchFromGitHub {
+    owner = "philippj";
+    repo = "SteamworksPy";
+    inherit rev;
+    hash = "sha256-nSGkEP6tny/Kv2+YjldFCYrLe1jnKOTa+w1/KCpSLsU=";
+
+  };
+  steamworksSrc = fetchzip {
+    url = "https://web.archive.org/web/20250527013243/https://partner.steamgames.com/downloads/steamworks_sdk_162.zip";
+    hash = "sha256-yDA92nGj3AKTNI4vnoLaa+7mDqupQv0E4YKRRUWqyZw=";
+  };
+
+  library = stdenv.mkDerivation {
+    pname = "steamworkspy-c";
+    version = rev;
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      cp -r ${src} source
+      chmod -R 755 source
+      cp -r ${steamworksSrc}/public/steam source/library/sdk/
+      cp ${steamworksSrc}/redistributable_bin/linux64/libsteam_api.so source/library/
+
+      runHook postUnpack
+    '';
+
+    sourceRoot = "source/library";
+
+    installPhase = ''
+      mkdir -p $out
+      cp SteamworksPy.so $out/
+    '';
+  };
+in
+
+buildPythonPackage {
+  pname = "steamworkspy";
+  version = rev;
+  pyproject = true;
+
+  inherit src;
+
+  build-system = [ setuptools ];
+
+  postInstall = ''
+    cp ${library}/SteamworksPy.so $out/lib
+  '';
+
+  meta = {
+    description = "Python API system for Valve's Steamworks";
+    homepage = "https://github.com/philippj/SteamworksPy";
+    license = with lib.licenses; [
+      mit
+      # For steamworks headers and libsteamapi.so
+      (
+        unfreeRedistributable
+        // {
+          url = "https://partner.steamgames.com/documentation/sdk_access_agreement";
+        }
+      )
+    ];
+    # steamworksSrc is x86_64-linux only
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ weirdrock ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17182,6 +17182,8 @@ self: super: with self; {
 
   stdlibs = callPackage ../development/python-modules/stdlibs { };
 
+  steam = callPackage ../development/python-modules/steam { };
+
   steamodd = callPackage ../development/python-modules/steamodd { };
 
   steamship = callPackage ../development/python-modules/steamship { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5737,6 +5737,8 @@ self: super: with self; {
 
   gevent = callPackage ../development/python-modules/gevent { };
 
+  gevent-eventemitter = callPackage ../development/python-modules/gevent-eventemitter { };
+
   gevent-socketio = callPackage ../development/python-modules/gevent-socketio { };
 
   gevent-websocket = callPackage ../development/python-modules/gevent-websocket { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17188,6 +17188,8 @@ self: super: with self; {
 
   steamship = callPackage ../development/python-modules/steamship { };
 
+  steamworkspy = callPackage ../development/python-modules/steamworkspy { };
+
   stem = callPackage ../development/python-modules/stem { };
 
   stemming = callPackage ../development/python-modules/stemming { };


### PR DESCRIPTION
Requires #413001 
Closes #304832 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
