### PR TITLE
nixos/{libeufin,roundcube,immich}: fix postgresql.package regression

### DIFF
--- a/nixos/modules/services/finance/libeufin/common.nix
+++ b/nixos/modules/services/finance/libeufin/common.nix
@@ -96,7 +96,9 @@ libeufinComponent:
             };
           in
           {
-            path = [ config.services.postgresql.package ];
+            path = [
+              (if cfg.createLocalDatabase then config.services.postgresql.package else pkgs.postgresql)
+            ];
             serviceConfig = {
               Type = "oneshot";
               DynamicUser = true;

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -272,7 +272,7 @@ in
     ];
 
     systemd.services.roundcube-setup = lib.mkMerge [
-      (lib.mkIf (cfg.database.host == "localhost") {
+      (lib.mkIf localDB {
         requires = [ "postgresql.service" ];
         after = [ "postgresql.service" ];
       })
@@ -281,7 +281,9 @@ in
         after = [ "network-online.target" ];
         wantedBy = [ "multi-user.target" ];
 
-        path = [ config.services.postgresql.package ];
+        path = [
+          (if localDB then config.services.postgresql.package else pkgs.postgresql)
+        ];
         script =
           let
             psql = "${lib.optionalString (!localDB) "PGPASSFILE=${cfg.database.passwordFile}"} psql ${

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -46,6 +46,9 @@ let
     mkOption
     mkEnableOption
     ;
+
+  postgresqlPackage =
+    if cfg.database.enable then config.services.postgresql.package else pkgs.postgresql;
 in
 {
   options.services.immich = {
@@ -265,7 +268,7 @@ in
       in
       [
         ''
-          ${lib.getExe' config.services.postgresql.package "psql"} -d "${cfg.database.name}" -f "${sqlFile}"
+          ${lib.getExe' postgresqlPackage "psql"} -d "${cfg.database.name}" -f "${sqlFile}"
         ''
       ];
 
@@ -333,7 +336,7 @@ in
       path = [
         # gzip and pg_dumpall are used by the backup service
         pkgs.gzip
-        config.services.postgresql.package
+        postgresqlPackage
       ];
 
       serviceConfig = commonServiceConfig // {


### PR DESCRIPTION
Introduced in #416806. See #417821 for more details about the fix.

I grepped for `config.services.postgresql.package`. The following also enable the postgresql module itself, so should be OK without fix:
- taler
- odoo
- dependency-track
- froide-govplan
- keycloak

The following are already fixed:
- mastodon
- discourse (either fixed or was already correct from the start)

## Things done

- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
