### PR TITLE
btcpayserver: 2.1.4 -> 2.1.5

### DIFF
--- a/pkgs/by-name/bt/btcpayserver/deps.json
+++ b/pkgs/by-name/bt/btcpayserver/deps.json
@@ -51,8 +51,8 @@
   },
   {
     "pname": "BTCPayServer.Lightning.All",
-    "version": "1.6.10",
-    "hash": "sha256-v2D43E9aEFKN/oMP4W98BST+WBMRDLDBD6AKJZey7PA="
+    "version": "1.6.11",
+    "hash": "sha256-HId8axtrx8i205y1uytHp/04/DyKsXzJwSEMzpr7Mzk="
   },
   {
     "pname": "BTCPayServer.Lightning.Charge",
@@ -96,8 +96,8 @@
   },
   {
     "pname": "BTCPayServer.Lightning.Phoenixd",
-    "version": "1.5.7",
-    "hash": "sha256-kDl8tDEzrwNwyFRp77NSFw0WkHwudeS5pefJNSvq/IM="
+    "version": "1.5.8",
+    "hash": "sha256-pISNuSZW/B0MZ5VkW8nHAENTOUoFI+YfvrubD/vh74w="
   },
   {
     "pname": "BTCPayServer.NETCore.Plugins",

--- a/pkgs/by-name/bt/btcpayserver/package.nix
+++ b/pkgs/by-name/bt/btcpayserver/package.nix
@@ -8,13 +8,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "2.1.4";
+  version = "2.1.5";
 
   src = fetchFromGitHub {
     owner = "btcpayserver";
     repo = "btcpayserver";
     tag = "v${version}";
-    hash = "sha256-GY6s/em5jlok1IFe474bD1L34Zlr6gYtG+Wn6eZxMIc=";
+    hash = "sha256-qm/MdgM5sPQu7fI1S8qf/dvkMZbmP4rLA1RdSQHSawE=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";


### PR DESCRIPTION
- [x] The [nix-bitcoin VM test](https://gist.github.com/erikarvstedt/ce81f700baa591c5d93138ca1870fc47) succeeds on `x86_64-linux`.

Notes for reviewers:
You can verify GPG signatures with `refetch=1 pkgs/by-name/bt/btcpayserver/update.sh`.

cc @prusnak