### PR TITLE
Remove obsolete Python future dependency for duplicity

### DIFF
--- a/pkgs/by-name/du/duplicity/package.nix
+++ b/pkgs/by-name/du/duplicity/package.nix
@@ -92,7 +92,6 @@ let
         pycrypto
         # Currently marked as broken.
         # pydrive2
-        future
       ]
       ++ paramiko.optional-dependencies.invoke;
 


### PR DESCRIPTION
Currently, evaluating the duplicity derivation results in the following error:
```
       … while evaluating derivation 'duplicity-3.0.4.1'
         whose name attribute is located at /nix/store/wihx4rw5c0352k6rzzn6jk7p31csjjjw-source/pkgs/stdenv/generic/make-derivation.nix:468:13

       … while evaluating attribute 'buildInputs' of derivation 'duplicity-3.0.4.1'
         at /nix/store/wihx4rw5c0352k6rzzn6jk7p31csjjjw-source/pkgs/stdenv/generic/make-derivation.nix:523:13:
          522|             depsHostHost = elemAt (elemAt dependencies 1) 0;
          523|             buildInputs = elemAt (elemAt dependencies 1) 1;
             |             ^
          524|             depsTargetTarget = elemAt (elemAt dependencies 2) 0;

       … while evaluating the attribute 'out.outPath'
         at /nix/store/wihx4rw5c0352k6rzzn6jk7p31csjjjw-source/lib/customisation.nix:400:13:
          399|               drv.${outputName}.drvPath;
          400|             outPath =
             |             ^
          401|               assert condition;

       … in the condition of the assert statement
         at /nix/store/wihx4rw5c0352k6rzzn6jk7p31csjjjw-source/lib/customisation.nix:401:15:
          400|             outPath =
          401|               assert condition;
             |               ^
          402|               drv.${outputName}.outPath;

       … in the right operand of the IMPL (->) operator
         at /nix/store/wihx4rw5c0352k6rzzn6jk7p31csjjjw-source/pkgs/development/interpreters/python/mk-python-derivation.nix:462:11:
          461|           drv.disabled
          462|           -> throw "${removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
             |           ^
          463|         ) { } drv

       … while calling the 'throw' builtin
         at /nix/store/wihx4rw5c0352k6rzzn6jk7p31csjjjw-source/pkgs/development/interpreters/python/mk-python-derivation.nix:462:14:
          461|           drv.disabled
          462|           -> throw "${removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
             |              ^
          463|         ) { } drv

       error: future-1.0.0 not supported for interpreter python3.13
```

Since upstream removed their dependency on future a few years ago (see [this commit](https://gitlab.com/duplicity/duplicity/-/commit/5505fb51a489a8306901a14d93c7aaec5dec41b2) and [this commit](https://gitlab.com/duplicity/duplicity/-/commit/b5b0182d99d2036ffeaecd87c96a9920ad65b5d4)), the easiest solution here is to simply remove `future` from the `package.nix`, which is what this PR does.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
