### PR TITLE
datadog-agent: 7.56.2 -> 7.70.2

### DIFF
--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -18,17 +18,17 @@
 
 let
   # keep this in sync with github.com/DataDog/agent-payload dependency
-  payloadVersion = "5.0.124";
+  payloadVersion = "5.0.164";
   python = pythonPackages.python;
   owner = "DataDog";
   repo = "datadog-agent";
   goPackagePath = "github.com/${owner}/${repo}";
-  version = "7.56.2";
+  version = "7.70.2";
 
   src = fetchFromGitHub {
     inherit owner repo;
-    rev = version;
-    hash = "sha256-rU3eg92MuGs/6r7oJho2roeUCZoyfqYt1xOERoRPqmQ=";
+    tag = version;
+    hash = "sha256-yXtybHWrm+6kWW396FLlRZI0YVuThGuLfSYzoNXAEBU=";
   };
   rtloader = stdenv.mkDerivation {
     pname = "datadog-agent-rtloader";
@@ -49,11 +49,7 @@ buildGoModule rec {
 
   doCheck = false;
 
-  vendorHash =
-    if stdenv.hostPlatform.isDarwin then
-      "sha256-3Piq5DPMTZUEjqNkw5HZY25An2kATX6Jac9unQfZnZc="
-    else
-      "sha256-FR0Et3DvjJhbYUPy9mpN0QCJ7QDU4VRZFUTL0J1FSXw=";
+  vendorHash = "sha256-iWOwhfSI7mLmDy6yewV0h9Y4pjYAV6Tz6TxsINOxYMg=";
 
   subPackages = [
     "cmd/agent"
@@ -67,10 +63,14 @@ buildGoModule rec {
     makeWrapper
   ];
   buildInputs = [ rtloader ] ++ lib.optionals withSystemd [ systemd ];
-  PKG_CONFIG_PATH = "${python}/lib/pkgconfig";
+
+  proxyVendor = true;
+
+  env.PKG_CONFIG_PATH = "${python}/lib/pkgconfig";
 
   tags = [
     "ec2"
+    "kubelet"
     "python"
     "process"
     "log"
@@ -97,7 +97,7 @@ buildGoModule rec {
   postPatch = ''
     sed -e "s|PyChecksPath =.*|PyChecksPath = filepath.Join(_here, \"..\", \"${python.sitePackages}\")|" \
         -e "s|distPath =.*|distPath = filepath.Join(_here, \"..\", \"share\", \"datadog-agent\")|" \
-        -i cmd/agent/common/path/path_nix.go
+        -i pkg/util/defaultpaths/path_nix.go
     sed -e "s|/bin/hostname|${lib.getBin hostname}/bin/hostname|" \
         -i pkg/util/hostname/fqdn_nix.go
   '';

--- a/pkgs/tools/networking/dd-agent/integrations-core.nix
+++ b/pkgs/tools/networking/dd-agent/integrations-core.nix
@@ -42,14 +42,14 @@
 
 let
   inherit (lib) attrValues mapAttrs;
+  version = "7.70.2";
 
   src = fetchFromGitHub {
     owner = "DataDog";
     repo = "integrations-core";
-    rev = version;
-    sha256 = "sha256-p5eoNNHQQl314mfUk2t3qQaerPu02GKA+tKkAY7bojk=";
+    tag = version;
+    hash = "sha256-3H8nQpy/m53ZjtDfe6s89yowBXnPt+1ARfWxcx+JwQM=";
   };
-  version = "7.56.2";
 
   # Build helper to build a single datadog integration package.
   buildIntegration =
@@ -75,19 +75,13 @@ let
     pname = "checks-base";
     sourceRoot = "datadog_checks_base";
 
-    # Make setuptools build the 'base' and 'checks' modules.
-    postPatch = ''
-      substituteInPlace setup.py \
-        --replace "from setuptools import setup" "from setuptools import find_packages, setup" \
-        --replace "packages=['datadog_checks']" "packages=find_packages()"
-    '';
-
-    propagatedBuildInputs = with python3Packages; [
+    dependencies = with python3Packages; [
       binary
       cachetools
       cryptography
       immutables
       jellyfish
+      lazy-loader
       prometheus-client
       protobuf
       pydantic


### PR DESCRIPTION
Closes #418555

https://github.com/DataDog/datadog-agent/releases/tag/7.70.2
Diff: https://github.com/DataDog/datadog-agent/compare/7.56.2...7.70.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
