### PR TITLE
nixos/postfix-tlspol: fix postfix group membership

### DIFF
--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -10,6 +10,7 @@ let
     hasPrefix
     mkEnableOption
     mkIf
+    mkMerge
     mkOption
     mkPackageOption
     types
@@ -121,100 +122,111 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    environment.etc."postfix-tlspol/config.yaml".source =
-      format.generate "postfix-tlspol.yaml" cfg.settings;
-
-    environment.systemPackages = [ cfg.package ];
-
-    # https://github.com/Zuplu/postfix-tlspol#postfix-configuration
-    services.postfix.config = mkIf (config.services.postfix.enable && cfg.configurePostfix) {
-      smtp_dns_support_level = "dnssec";
-      smtp_tls_security_level = "dane";
-      smtp_tls_policy_maps =
-        let
-          address =
-            if (hasPrefix "unix:" cfg.settings.server.address) then
-              cfg.settings.server.address
-            else
-              "inet:${cfg.settings.server.address}";
-        in
-        [ "socketmap:${address}:QUERYwithTLSRPT" ];
-    };
-
-    systemd.services.postfix-tlspol = {
-      after = [
-        "nss-lookup.target"
-        "network-online.target"
-      ];
-      wants = [
-        "nss-lookup.target"
-        "network-online.target"
-      ];
-      wantedBy = [ "multi-user.target" ];
-
-      description = "Postfix DANE/MTA-STS TLS policy socketmap service";
-      documentation = [ "https://github.com/Zuplu/postfix-tlspol" ];
-
-      # https://github.com/Zuplu/postfix-tlspol/blob/main/init/postfix-tlspol.service
-      serviceConfig = {
-        ExecStart = toString [
-          (lib.getExe cfg.package)
-          "-config"
-          "/etc/postfix-tlspol/config.yaml"
-        ];
-        ExecReload = "${lib.getExe' pkgs.util-linux "kill"} -HUP $MAINPID";
-        Restart = "always";
-        RestartSec = 5;
-
-        DynamicUser = true;
-
-        CacheDirectory = "postfix-tlspol";
-        CapabilityBoundingSet = [ "" ];
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        PrivateTmp = true;
-        PrivateUsers = true;
-        ProcSubset = "pid";
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectProc = "invisible";
-        ProtectSystem = "strict";
-        ReadOnlyPaths = [ "/etc/postfix-tlspol/config.yaml" ];
-        RemoveIPC = true;
-        RestrictAddressFamilies =
-          [
-            "AF_INET"
-            "AF_INET6"
-          ]
-          ++ lib.optionals (lib.hasPrefix "unix:" cfg.settings.server.address) [
-            "AF_UNIX"
-          ];
-        RestrictNamespace = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "@system-service"
-          "~@privileged @resources"
-        ];
-        SystemCallErrorNumber = "EPERM";
-        SecureBits = [
-          "noroot"
-          "noroot-locked"
-        ];
-        RuntimeDirectory = "postfix-tlspol";
-        RuntimeDirectoryMode = "1750";
-        WorkingDirectory = "/var/cache/postfix-tlspol";
-        UMask = "0117";
+  config = mkMerge [
+    (mkIf (cfg.enable && config.services.postfix.enable && cfg.configurePostfix) {
+      # https://github.com/Zuplu/postfix-tlspol#postfix-configuration
+      services.postfix.config = {
+        smtp_dns_support_level = "dnssec";
+        smtp_tls_security_level = "dane";
+        smtp_tls_policy_maps =
+          let
+            address =
+              if (hasPrefix "unix:" cfg.settings.server.address) then
+                cfg.settings.server.address
+              else
+                "inet:${cfg.settings.server.address}";
+          in
+          [ "socketmap:${address}:QUERYwithTLSRPT" ];
       };
-    };
-  };
+
+      systemd.services.postfix = {
+        wants = [ "postfix-tlspol.service" ];
+        after = [ "postfix-tlspol.service" ];
+      };
+
+      users.users.postfix.extraGroups = [ "postfix-tlspol" ];
+    })
+
+    (mkIf cfg.enable {
+      environment.etc."postfix-tlspol/config.yaml".source =
+        format.generate "postfix-tlspol.yaml" cfg.settings;
+
+      environment.systemPackages = [ cfg.package ];
+
+      systemd.services.postfix-tlspol = {
+        after = [
+          "nss-lookup.target"
+          "network-online.target"
+        ];
+        wants = [
+          "nss-lookup.target"
+          "network-online.target"
+        ];
+        wantedBy = [ "multi-user.target" ];
+
+        description = "Postfix DANE/MTA-STS TLS policy socketmap service";
+        documentation = [ "https://github.com/Zuplu/postfix-tlspol" ];
+
+        # https://github.com/Zuplu/postfix-tlspol/blob/main/init/postfix-tlspol.service
+        serviceConfig = {
+          ExecStart = toString [
+            (lib.getExe cfg.package)
+            "-config"
+            "/etc/postfix-tlspol/config.yaml"
+          ];
+          ExecReload = "${lib.getExe' pkgs.util-linux "kill"} -HUP $MAINPID";
+          Restart = "always";
+          RestartSec = 5;
+
+          DynamicUser = true;
+
+          CacheDirectory = "postfix-tlspol";
+          CapabilityBoundingSet = [ "" ];
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          PrivateUsers = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "strict";
+          ReadOnlyPaths = [ "/etc/postfix-tlspol/config.yaml" ];
+          RemoveIPC = true;
+          RestrictAddressFamilies =
+            [
+              "AF_INET"
+              "AF_INET6"
+            ]
+            ++ lib.optionals (lib.hasPrefix "unix:" cfg.settings.server.address) [
+              "AF_UNIX"
+            ];
+          RestrictNamespace = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged @resources"
+          ];
+          SystemCallErrorNumber = "EPERM";
+          SecureBits = [
+            "noroot"
+            "noroot-locked"
+          ];
+          RuntimeDirectory = "postfix-tlspol";
+          RuntimeDirectoryMode = "1750";
+          WorkingDirectory = "/var/cache/postfix-tlspol";
+          UMask = "0117";
+        };
+      };
+    })
+  ];
 }

--- a/nixos/tests/postfix-tlspol.nix
+++ b/nixos/tests/postfix-tlspol.nix
@@ -8,6 +8,7 @@
   meta.maintainers = with lib.maintainers; [ hexa ];
 
   nodes.machine = {
+    services.postfix.enable = true;
     services.postfix-tlspol.enable = true;
   };
 
@@ -17,6 +18,7 @@
     import json
 
     machine.wait_for_unit("postfix-tlspol.service")
+    machine.succeed("systemctl show -P SupplementaryGroups postfix.service | grep postfix-tlspol")
 
     with subtest("Interact with the service"):
       machine.succeed("postfix-tlspol -purge")


### PR DESCRIPTION
Fixes the group membership for postfix.service in the postfix-tlspol
group.

Makes the postfix.service start up after postfix-tlspol.service, because
it depends on it for the TLS policy lookups.

https://github.com/NixOS/nixpkgs/pull/415482#issuecomment-2993033504

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
