### PR TITLE
nixos-rebuild-ng: skip broken test for Nix < 2.18

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -18,6 +18,7 @@
   # passthru.tests
   nixosTests,
   nixVersions,
+  lixPackageSets,
   nixos-rebuild-ng,
 }:
 let
@@ -26,6 +27,8 @@ let
   # implemented in newer versions of Nix, but not necessary 2.18.
   # However, Lix is a fork of Nix 2.18, so this looks like a good version
   # to cut specific functionality.
+  # ATTN: This currently doesn't disambiguate between Nix and Lix, so using this
+  # in a conditional needs careful checking against both Nix implementations.
   withNix218 = lib.versionAtLeast nix.version "2.18";
 in
 python3Packages.buildPythonApplication rec {
@@ -117,6 +120,14 @@ python3Packages.buildPythonApplication rec {
         with_nix_2_3 = nixos-rebuild-ng.override {
           # oldest / minimum supported version in nixpkgs
           nix = nixVersions.nix_2_3;
+        };
+        with_lix_latest = nixos-rebuild-ng.override {
+          # oldest / minimum supported version in nixpkgs
+          nix = lixPackageSets.latest.lix;
+        };
+        with_lix_stable = nixos-rebuild-ng.override {
+          # oldest / minimum supported version in nixpkgs
+          nix = lixPackageSets.stable.lix;
         };
 
         inherit (nixosTests)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -5,7 +5,6 @@
   installShellFiles,
   mkShell,
   nix,
-  nixosTests,
   python3,
   python3Packages,
   runCommand,
@@ -16,6 +15,10 @@
   # Very long tmp dirs lead to "too long for Unix domain socket"
   # SSH ControlPath errors. Especially macOS sets long TMPDIR paths.
   withTmpdir ? if stdenv.hostPlatform.isDarwin then "/tmp" else null,
+  # passthru.tests
+  nixosTests,
+  nixVersions,
+  nixos-rebuild-ng,
 }:
 let
   executable = if withNgSuffix then "nixos-rebuild-ng" else "nixos-rebuild";
@@ -105,6 +108,17 @@ python3Packages.buildPythonApplication rec {
       };
 
       tests = {
+        with_nix_latest = nixos-rebuild-ng.override {
+          nix = nixVersions.latest;
+        };
+        with_nix_stable = nixos-rebuild-ng.override {
+          nix = nixVersions.stable;
+        };
+        with_nix_2_3 = nixos-rebuild-ng.override {
+          # oldest / minimum supported version in nixpkgs
+          nix = nixVersions.nix_2_3;
+        };
+
         inherit (nixosTests)
           nixos-rebuild-install-bootloader-ng
           nixos-rebuild-specialisations-ng

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -11,6 +11,7 @@ import pytest
 from pytest import MonkeyPatch
 
 import nixos_rebuild as nr
+from nixos_rebuild.constants import WITH_NIX_2_18
 
 from .helpers import get_qualified_name
 
@@ -514,6 +515,10 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
 @patch("subprocess.run", autospec=True)
 @patch("uuid.uuid4", autospec=True)
 @patch(get_qualified_name(nr.cleanup_ssh), autospec=True)
+@pytest.mark.skipif(
+    not WITH_NIX_2_18,
+    reason="Tests internal logic based on the assumption that Nix >= 2.18",
+)
 def test_execute_nix_switch_build_target_host(
     mock_cleanup_ssh: Mock,
     mock_uuid4: Mock,


### PR DESCRIPTION
The mock test for building with remote, but distinct target and build host checks a bunch of internals (how many shell commands are executed, which ones exactly) that are special cased on WITH_NIX_2_18, so the test breaks when that is false. I've opted to simply skip the test for now since the expected call list is very annoying to keep maintained and updated for multiple versions.

This should fix NixOS configurations with config nix.package.version < 2.18. To keep it that way, I've added nixos-rebuild-ng with some nixVersions to passthru.tests that aren't likely to be removed in the short term.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
