### PR TITLE
gradle: fix usage of update-deps script without bwrap

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/update-deps.nix
+++ b/pkgs/development/tools/build-managers/gradle/update-deps.nix
@@ -129,8 +129,8 @@ lib.makeOverridable (
       export MITM_CACHE_CERT_DIR="$PWD"
       export MITM_CACHE_CA="$MITM_CACHE_CERT_DIR/ca.cer"
       popd >/dev/null
-      useBwrap="''${USE_BWRAP:-${toString useBwrap}}"
-      if [ -n "$useBwrap" ]; then
+      useBwrap="''${USE_BWRAP:-${if useBwrap then "1" else "0"}}"
+      if [[ "$useBwrap" -ne 0 ]]; then
         # bwrap isn't necessary, it's only used to prevent messy build scripts from touching ~
         bwrap \
           --unshare-all --share-net --clearenv --chdir / --setenv HOME /homeless-shelter \


### PR DESCRIPTION
The gradle build hook exposes an update-deps script that can, supposedly, run without bwrap if the USE_BWRAP environment is set to 0.

Unfortunately the test on the variable was checking if it had an non-empty value (using -n), but just above the variable is given a default value in cases when it is empty. This meant the variable could never be empty and therefore bwrap is always used (assuming the Nix parameter useBwrap is true).

By changing the test into an inequality check against zero, we can disable bwrap by setting `USE_BWRAP=0`. Any other value will leave bwrap enabled.

Unfortunately the lack of boolean values in bash make it non-obvious what the best representation and test for this should be. We could also check for equality against 1 for example, or some more complicated test that handles the string "false" as well. Using 0 as the false value seems common place enough in scripts though.

The conversion of `useBwrap` to a string needs to be adjusted, as `builtins.toString` actually returns an empty string for a false value.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
