### PR TITLE
mozillavpn: 2.27.0 → 2.29.0

### DIFF
--- a/pkgs/by-name/mo/mozillavpn/package.nix
+++ b/pkgs/by-name/mo/mozillavpn/package.nix
@@ -4,7 +4,6 @@
   cargo,
   cmake,
   fetchFromGitHub,
-  fetchpatch,
   go,
   lib,
   libcap,
@@ -23,36 +22,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mozillavpn";
-  version = "2.27.0";
+  version = "2.29.0";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-TfiEc5Lptr0ntp4buEEWbQTvNkVjZbdMWDv8CEZa6IM=";
+    hash = "sha256-Oh3qV5/fQNLjv3qnhRrgRV0d+homlGmEpTSeou3lZfE=";
   };
-  patches = [
-    # Provide default args for LottieStatus::changed so moc can call it (#10420)
-    (fetchpatch {
-      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/commit/e5abe5714a5b506e398c088d21672f00d6f93240.patch";
-      hash = "sha256-DU5wQ1DDF8DbmMIlohoEIDJ7/9+9GVwrvsr51T9bGx8=";
-    })
-    # Remove Qt.labls.qmlmodels usage (#10422)
-    (fetchpatch {
-      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/commit/4497972b1bf7b7f215dc6c1227d76d6825f5b958.patch";
-      hash = "sha256-RPRdARM/jXSHmTGGjiOrfJ7KVejp3JmUfsN5pmKYPuY=";
-    })
-    # Qt compat: Make sure to include what we use
-    (fetchpatch {
-      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/commit/0909d43447a7ddbc6ec20d108637524552848bd6.patch";
-      hash = "sha256-Hpn69hQxa269XH+Ku/MYD2GwdFhfCX4yoVRCEDfIOKc=";
-    })
-    # Use QDesktopUnixServices after qt 6.9.0
-    (fetchpatch {
-      url = "https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10424/commits/81e66044388459ffe2b08804ab5a326586ac7113.patch";
-      hash = "sha256-+v3NoTAdkjKEyBPbbJZQ2d11hJMyE3E4B9uYUerVa7c=";
-    })
-  ];
+  patches = [ ];
 
   netfilter = buildGoModule {
     pname = "${finalAttrs.pname}-netfilter";
@@ -67,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src patches;
-    hash = "sha256-SGC+YT5ATV/ZaP/wrm3c31OQBw6Pk8ZSXjxEPFdP2f8=";
+    hash = "sha256-Flsa93Nko/sHr9z+YW7xDFMVLOzJE4oJFAl841gpPpw=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Upgrade the Mozilla VPN client from 2.27.0 to 2.29.0.

- https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.28.0
- https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.29.0
- https://github.com/mozilla-mobile/mozilla-vpn-client/compare/v2.27.0...v2.29.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
