### PR TITLE
thunderbird-esr: bring back patches dropped by accident

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -44,10 +44,19 @@ let
         url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
         inherit sha512;
       };
-      extraPatches = [
-        # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.
-        ./no-buildconfig.patch
-      ];
+      extraPatches =
+        [
+          # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.
+          ./no-buildconfig.patch
+        ]
+        ++ lib.optionals (lib.versionOlder version "139") [
+          # clang-19 fixes for char_traits build issue
+          # https://github.com/rnpgp/rnp/pull/2242/commits/e0790a2c4ff8e09d52522785cec1c9db23d304ac
+          # https://github.com/rnpgp/sexpp/pull/54/commits/46744a14ffc235330bb99cebfaf294829c31bba4
+          # Remove when upstream bumps bundled rnp version: https://bugzilla.mozilla.org/show_bug.cgi?id=1893950
+          ./0001-Removed-lookup-against-basic_string-uint8_t.patch
+          ./0001-Implemented-char_traits-for-SEXP-octet_t.patch
+        ];
 
       extraPassthru = {
         icu73 = icu73';


### PR DESCRIPTION
In 9892cb76416 (PR #418362) I forgot that this patch list is shared.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Builds+tests are N/A: checked to evaluate to the .drv before PR #418362
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
