### PR TITLE
openlist: init at 4.0.1

### DIFF
--- a/pkgs/by-name/op/openlist/frontend.nix
+++ b/pkgs/by-name/op/openlist/frontend.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchzip,
+
+  nodejs,
+  pnpm_10,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "openlist-frontend";
+  version = "4.0.0-rc.4";
+
+  src = fetchFromGitHub {
+    owner = "OpenListTeam";
+    repo = "OpenList-Frontend";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZAEaGFOWzL3apV6KXokLV8GGhmp9C38npUhBngdPbq0=";
+  };
+
+  i18n = fetchzip {
+    url = "https://github.com/OpenListTeam/OpenList-Frontend/releases/download/v${finalAttrs.version}/i18n.tar.gz";
+    hash = "sha256-AzH1rZFqEH8sovZZfJykvsEmCedEZWigQFHWHl6/PiE=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_10.configHook
+  ];
+
+  pnpmDeps = pnpm_10.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-4NKzy4q6DjWgTL63WBEeDxjAsrgcM5vfHqtmZpS5dug=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp -r ${finalAttrs.i18n}/* src/lang/
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+    echo -n "v${finalAttrs.version}" > $out/VERSION
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Frontend of OpenList";
+    homepage = "https://github.com/OpenListTeam/OpenList-Frontend";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+  };
+})

--- a/pkgs/by-name/op/openlist/frontend.nix
+++ b/pkgs/by-name/op/openlist/frontend.nix
@@ -10,18 +10,18 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "openlist-frontend";
-  version = "4.0.0-rc.4";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "OpenListTeam";
     repo = "OpenList-Frontend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZAEaGFOWzL3apV6KXokLV8GGhmp9C38npUhBngdPbq0=";
+    hash = "sha256-WflnK/DXg2kmTcOD97jiZP8kb/cEdW7SrVnNQLrWKjA=";
   };
 
   i18n = fetchzip {
     url = "https://github.com/OpenListTeam/OpenList-Frontend/releases/download/v${finalAttrs.version}/i18n.tar.gz";
-    hash = "sha256-AzH1rZFqEH8sovZZfJykvsEmCedEZWigQFHWHl6/PiE=";
+    hash = "sha256-zms4x4C1CW39o/8uVm5gbasKCJQx6Oh3h66BHF1vnWY=";
     stripRoot = false;
   };
 
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-4NKzy4q6DjWgTL63WBEeDxjAsrgcM5vfHqtmZpS5dug=";
+    hash = "sha256-PTZ+Vhg3hNnORnulkzuVg6TF/jY0PvUWYja9z7S4GdM=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/op/openlist/package.nix
+++ b/pkgs/by-name/op/openlist/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "openlist";
-  version = "4.0.0";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "OpenListTeam";
     repo = "OpenList";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ir1yOVbf4qP0YUkE0yxOEp92PPMRyHw0VrIH5DQAvZQ=";
+    hash = "sha256-PqCGA2DAfZvDqdnQzqlmz2vlybYokJe+Ybzp5BcJDGU=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;

--- a/pkgs/by-name/op/openlist/package.nix
+++ b/pkgs/by-name/op/openlist/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  callPackage,
+  buildPackages,
+  installShellFiles,
+  versionCheckHook,
+  fuse,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "openlist";
+  version = "4.0.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenListTeam";
+    repo = "OpenList";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ir1yOVbf4qP0YUkE0yxOEp92PPMRyHw0VrIH5DQAvZQ=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      # '0000-00-00T00:00:00Z'
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  frontend = callPackage ./frontend.nix { };
+
+  proxyVendor = true;
+  vendorHash = "sha256-e1glgNp5aYl1cEuLdMMLa8sE9lSuiLVdPCX9pek5grE=";
+
+  buildInputs = [ fuse ];
+
+  tags = [ "jsoniter" ];
+
+  ldflags = [
+    "-s"
+    "-X \"github.com/OpenListTeam/OpenList/internal/conf.GitAuthor=The OpenList Projects Contributors <noreply@openlist.team>\""
+    "-X github.com/OpenListTeam/OpenList/internal/conf.Version=${finalAttrs.version}"
+    "-X github.com/OpenListTeam/OpenList/internal/conf.WebVersion=${finalAttrs.frontend.version}"
+  ];
+
+  preConfigure = ''
+    rm -rf public/dist
+    cp -r ${finalAttrs.frontend} public/dist
+  '';
+
+  preBuild = ''
+    ldflags+=" -X \"github.com/OpenListTeam/OpenList/internal/conf.BuiltAt=$(<SOURCE_DATE_EPOCH)\""
+    ldflags+=" -X github.com/OpenListTeam/OpenList/internal/conf.GitCommit=$(<COMMIT)"
+  '';
+
+  checkFlags =
+    let
+      # Skip tests that require network access
+      skippedTests = [
+        "TestHTTPAll"
+        "TestWebsocketAll"
+        "TestWebsocketCaller"
+        "TestDownloadOrder"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      installShellCompletion --cmd OpenList \
+        --bash <(${emulator} $out/bin/OpenList completion bash) \
+        --fish <(${emulator} $out/bin/OpenList completion fish) \
+        --zsh <(${emulator} $out/bin/OpenList completion zsh)
+
+      mkdir $out/share/powershell/ -p
+      ${emulator} $out/bin/OpenList completion powershell > $out/share/powershell/OpenList.Completion.ps1
+    ''
+  );
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/OpenList";
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = lib.getExe (callPackage ./update.nix { });
+
+  meta = {
+    description = "AList Fork to Anti Trust Crisis";
+    homepage = "https://github.com/OpenListTeam/OpenList";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "OpenList";
+  };
+})

--- a/pkgs/by-name/op/openlist/update.nix
+++ b/pkgs/by-name/op/openlist/update.nix
@@ -1,0 +1,47 @@
+{
+  writeShellApplication,
+  nix,
+  nix-update,
+  curl,
+  common-updater-scripts,
+  jq,
+}:
+
+writeShellApplication {
+  name = "update-openlist";
+  runtimeInputs = [
+    curl
+    jq
+    nix
+    common-updater-scripts
+    nix-update
+  ];
+
+  text = ''
+    # get old info
+    oldVersion=$(nix-instantiate --eval --strict -A "openlist.version" | jq -e -r)
+
+    get_latest_release() {
+        local repo=$1
+        curl --fail ''${GITHUB_TOKEN:+ -H "Authorization: bearer $GITHUB_TOKEN"} \
+             -s "https://api.github.com/repos/OpenListTeam/$repo/releases/latest" | jq -r ".tag_name"
+    }
+
+    version=$(get_latest_release "OpenList")
+    version="''${version#v}"
+    frontendVersion=$(get_latest_release "OpenList-Frontend")
+    frontendVersion="''${frontendVersion#v}"
+
+    if [[ "$oldVersion" == "$version" ]]; then
+        echo "Already up to date!"
+        exit 0
+    fi
+
+    nix-update openlist.frontend --version="$frontendVersion"
+    update-source-version openlist.frontend "$frontendVersion" \
+      --source-key=i18n --ignore-same-version \
+      --file=pkgs/by-name/op/openlist/frontend.nix
+
+    nix-update openlist --version="$version"
+  '';
+}


### PR DESCRIPTION
https://github.com/OpenListTeam/OpenList/releases/tag/v4.0.1

~~Waiting for https://github.com/OpenListTeam/OpenList-Frontend/pull/34~~ (Done)

The second commit was generated by updateScript. You can try running `nix-shell maintainers/scripts/update.nix --argstr package openlist` to test it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
