### PR TITLE
python3Packages.python-keycloak: 7.0.2 -> 7.1.1

### DIFF
--- a/pkgs/development/python-modules/python-keycloak/default.nix
+++ b/pkgs/development/python-modules/python-keycloak/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-keycloak";
-  version = "7.0.2";
+  version = "7.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "marcospereirampj";
     repo = "python-keycloak";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3JHmVfGd5X5aEZt8O7Aj/UfYpLtDsI6MPwWxLo7SGBs=";
+    hash = "sha256-3BrXSktN0OYQJRRZ234z06pGHicJOIBUzSdMd6y95L4=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/python-keycloak/default.nix
+++ b/pkgs/development/python-modules/python-keycloak/default.nix
@@ -11,7 +11,7 @@
   requests-toolbelt,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-keycloak";
   version = "7.0.2";
   pyproject = true;
@@ -19,14 +19,14 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "marcospereirampj";
     repo = "python-keycloak";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-3JHmVfGd5X5aEZt8O7Aj/UfYpLtDsI6MPwWxLo7SGBs=";
   };
 
   postPatch = ''
     # Upstream doesn't set version
     substituteInPlace pyproject.toml \
-      --replace-fail 'version = "0.0.0"' 'version = "${version}"'
+      --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
   '';
 
   build-system = [ poetry-core ];
@@ -48,8 +48,8 @@ buildPythonPackage rec {
   meta = {
     description = "Provides access to the Keycloak API";
     homepage = "https://github.com/marcospereirampj/python-keycloak";
-    changelog = "https://github.com/marcospereirampj/python-keycloak/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/marcospereirampj/python-keycloak/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/python-keycloak/default.nix
+++ b/pkgs/development/python-modules/python-keycloak/default.nix
@@ -9,6 +9,9 @@
   poetry-core,
   requests,
   requests-toolbelt,
+  freezegun,
+  pytest-asyncio,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -40,8 +43,26 @@ buildPythonPackage (finalAttrs: {
     requests-toolbelt
   ];
 
-  # Test fixtures require a running keycloak instance
-  doCheck = false;
+  nativeCheckInputs = [
+    freezegun
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  # conftest.py requires these variables to be set,
+  # even if the respective tests are disabled
+  preCheck = ''
+    export KEYCLOAK_{HOST,PORT,ADMIN{,_PASSWORD}}=
+  '';
+
+  disabledTestPaths = [
+    # these tests require a running keycloak instance
+    "tests/test_keycloak_openid.py"
+    "tests/test_keycloak_admin.py"
+    "tests/test_keycloak_uma.py"
+    # requires docker
+    "tests/test_pkce_flow.py"
+  ];
 
   pythonImportsCheck = [ "keycloak" ];
 


### PR DESCRIPTION
https://github.com/marcospereirampj/python-keycloak/compare/refs/tags/v7.0.2...refs/tags/v7.1.1
https://github.com/marcospereirampj/python-keycloak/blob/refs/tags/v7.1.1/CHANGELOG.md

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 418687`
Commit: `8f59f8d0985f531520cbdd8ddd124bb8eed4594f`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 11 packages built:</summary>
  <ul>
    <li>python313Packages.python-keycloak</li>
    <li>python313Packages.python-keycloak.dist</li>
    <li>python313Packages.swh-auth</li>
    <li>python313Packages.swh-auth.dist</li>
    <li>python313Packages.swh-scanner</li>
    <li>python313Packages.swh-scanner.dist</li>
    <li>python313Packages.swh-web-client</li>
    <li>python313Packages.swh-web-client.dist</li>
    <li>python314Packages.python-keycloak</li>
    <li>python314Packages.python-keycloak.dist</li>
    <li>swh</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc