### PR TITLE
python3Packages.root: add Python package for root

### DIFF
--- a/pkgs/development/python-modules/root/default.nix
+++ b/pkgs/development/python-modules/root/default.nix
@@ -1,0 +1,42 @@
+{
+  buildPythonPackage,
+  python,
+  root,
+}:
+
+let
+  unwrapped = root.override { python3 = python; };
+in
+buildPythonPackage rec {
+  # ROOT builds the C++ libraries and CPython extensions in one package and
+  # python versions must never be mixed
+  passthru = {
+    inherit unwrapped;
+  };
+
+  inherit (unwrapped) pname version meta;
+
+  src = null;
+
+  format = "other"; # disables setuptools/pyproject logic
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/${python.sitePackages}
+    rmdir $out/${python.sitePackages}
+    ln -s ${unwrapped}/lib $out/${python.sitePackages}
+  '';
+
+  # Those namespaces are looked up dynamically via ROOTs CPython extension, so
+  # these checks cover the most fragile parts of the package
+  pythonImportsCheck = [
+    "ROOT"
+    "ROOT.Experimental"
+    "ROOT.Math"
+    "ROOT.RooFit"
+    "ROOT.std"
+  ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15571,6 +15571,10 @@ self: super: with self; {
 
   roonapi = callPackage ../development/python-modules/roonapi { };
 
+  root = callPackage ../development/python-modules/root {
+    inherit (pkgs) root;
+  };
+
   rope = callPackage ../development/python-modules/rope { };
 
   ropgadget = callPackage ../development/python-modules/ropgadget { };


### PR DESCRIPTION
Closes #241454.

I checked that this works with different Python versions, from Python 3.10 to Python 3.13.

@ShamrockLee, @veprbl 