### PR TITLE
jugglinglab: add jlab CLI tool, add flag to install example patterns

### DIFF
--- a/pkgs/by-name/ju/jugglinglab/cli.patch
+++ b/pkgs/by-name/ju/jugglinglab/cli.patch
@@ -1,0 +1,40 @@
+diff --git a/src/main/java/jugglinglab/JugglingLab.java b/src/main/java/jugglinglab/JugglingLab.java
+index 1f292b9..c8fe2cb 100644
+--- a/src/main/java/jugglinglab/JugglingLab.java
++++ b/src/main/java/jugglinglab/JugglingLab.java
+@@ -59,11 +59,10 @@ public class JugglingLab {
+         isWindows = osname.startsWith("windows");
+         isLinux = osname.startsWith("linux");
+ 
+-        // Decide on a base directory for file operations. First look for
+-        // working directory set by an enclosing script, which indicates Juggling
+-        // Lab is running from the command line.
+         String working_dir = System.getenv("JL_WORKING_DIR");
+-        isCLI = (working_dir != null);
++        // nixpkgs-specific env-var to simplify the distinction between CLI mode and normal mode
++        String isCLIStr = System.getenv("JL_IS_CLI");
++        isCLI = isCLIStr != null && isCLIStr.equals("1");
+ 
+         if (working_dir == null) {
+             // If not found, then see if there is a base directory set in the
+@@ -107,14 +106,12 @@ public class JugglingLab {
+         // want no command line arguments to run the full application, so that
+         // it launches when the user double-clicks on the jar.
+ 
+-        boolean run_application = true;
+-        String firstarg = null;
+-
+-        if (args.length > 0) {
+-            jlargs = new ArrayList<String>(Arrays.asList(args));
+-            firstarg = jlargs.remove(0).toLowerCase();
+-            run_application = firstarg.equals("start");
+-        }
++        jlargs = new ArrayList<String>(Arrays.asList(args));
++        // We don't use the upstream wrapper script in nixpkgs, which automatically
++        // adds "help" as the first argument when running as a CLI tool
++        if (jlargs.isEmpty()) jlargs.add(isCLI ? "help" : "start");
++        String firstarg = jlargs.remove(0).toLowerCase();
++        boolean run_application = firstarg.equals("start");
+ 
+         if (run_application) {
+             SwingUtilities.invokeLater(new Runnable() {

--- a/pkgs/by-name/ju/jugglinglab/package.nix
+++ b/pkgs/by-name/ju/jugglinglab/package.nix
@@ -32,6 +32,10 @@ maven.buildMavenPackage rec {
   patches = [
     # make sure mvnHash doesn't change when maven is updated
     ./fix-default-maven-plugin-versions.patch
+
+    # add some nixpkgs specific logic, so that we don't have to use upstream's
+    # wrapper scripts for launching the application in different modes
+    ./cli.patch
   ];
 
   mvnHash = "sha256-1Uzo9nRw+YR/sd7CC9MTPe/lttkRX6BtmcsHaagP1Do=";
@@ -63,6 +67,9 @@ maven.buildMavenPackage rec {
         "''${gappsWrapperArgs[@]}" \
         --add-flags "-Xss2048k -Djava.library.path=$out/lib/ortools-lib" \
         --add-flags "-jar $out/share/jugglinglab/JugglingLab.jar"
+
+    makeWrapper $out/bin/jugglinglab $out/bin/jlab \
+        --set-default JL_IS_CLI 1
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Add Command line tools & Juggling Lab pattern files.

But pattern files are not include by default, you have to set the options  :
`#install Juggling Lab pattern files`
`withPatterns ? false,`

If you want, you can also set the directory path :
`# string to define the path of the working directory`
`workingDir ? "",`
`# set the workingDir to the partterns dir of the package`
` workingDirPatterns ? false,`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [»] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.
