### PR TITLE
ghidra: make build helpers able to use `finalAttrs` and actually use them

### DIFF
--- a/pkgs/tools/security/ghidra/build-extension.nix
+++ b/pkgs/tools/security/ghidra/build-extension.nix
@@ -21,16 +21,17 @@ let
       platforms = oldMeta.platforms or ghidra.meta.platforms;
     };
 
-  buildGhidraExtension =
-    {
-      pname,
-      nativeBuildInputs ? [ ],
-      meta ? { },
-      ...
-    }@args:
-    stdenv.mkDerivation (
-      args
-      // {
+  buildGhidraExtension = lib.extendMkDerivation {
+    constructDrv = stdenv.mkDerivation;
+    extendDrvArgs =
+      finalAttrs:
+      {
+        pname,
+        nativeBuildInputs ? [ ],
+        meta ? { },
+        ...
+      }@args:
+      {
         nativeBuildInputs = nativeBuildInputs ++ [
           unzip
           jdk
@@ -67,18 +68,19 @@ let
           '';
 
         meta = metaCommon meta;
-      }
-    );
+      };
+  };
 
-  buildGhidraScripts =
-    {
-      pname,
-      meta ? { },
-      ...
-    }@args:
-    stdenv.mkDerivation (
-      args
-      // {
+  buildGhidraScripts = lib.extendMkDerivation {
+    constructDrv = stdenv.mkDerivation;
+    extendDrvArgs =
+      finalAttrs:
+      {
+        pname,
+        meta ? { },
+        ...
+      }@args:
+      {
         installPhase = ''
           runHook preInstall
 
@@ -100,8 +102,8 @@ let
         '';
 
         meta = metaCommon meta;
-      }
-    );
+      };
+  };
 in
 {
   inherit buildGhidraExtension buildGhidraScripts;

--- a/pkgs/tools/security/ghidra/extensions/findcrypt/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/findcrypt/default.nix
@@ -3,26 +3,23 @@
   fetchFromGitHub,
   buildGhidraExtension,
 }:
-let
-  version = "3.0.6";
-in
-buildGhidraExtension {
+buildGhidraExtension (finalAttrs: {
   pname = "findcrypt";
-  inherit version;
+  version = "3.0.6";
 
   src = fetchFromGitHub {
     owner = "antoniovazquezblanco";
     repo = "GhidraFindcrypt";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-VWi1MP72Vl4XCrbTvRA6qYPk2QyvRyVb9N8QQ/Zml0A=";
   };
 
   meta = {
     description = "Ghidra analysis plugin to locate cryptographic constants";
     homepage = "https://github.com/antoniovazquezblanco/GhidraFindcrypt";
-    downloadPage = "https://github.com/antoniovazquezblanco/GhidraFindcrypt/releases/tag/v${version}";
-    changelog = "https://github.com/antoniovazquezblanco/GhidraFindcrypt/releases/tag/v${version}";
+    downloadPage = "https://github.com/antoniovazquezblanco/GhidraFindcrypt/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/antoniovazquezblanco/GhidraFindcrypt/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.BonusPlay ];
   };
-}
+})

--- a/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/default.nix
@@ -4,40 +4,36 @@
   gradle,
   fetchFromGitHub,
 }:
-let
+ghidra.buildGhidraExtension (finalAttrs: {
+  pname = "ghidra-delinker-extension";
   version = "0.5.1";
-  self = ghidra.buildGhidraExtension {
-    pname = "ghidra-delinker-extension";
-    inherit version;
 
-    src = fetchFromGitHub {
-      owner = "boricj";
-      repo = "ghidra-delinker-extension";
-      rev = "v${version}";
-      hash = "sha256-h6F50Z7S6tPOl9mIhChLKoFxHuAkq/n36ysUEFwWGxI=";
-    };
-
-    postPatch = ''
-      substituteInPlace build.gradle \
-        --replace-fail '"''${getGitHash()}"' '"v${version}"'
-    '';
-
-    gradleBuildTask = "buildExtension";
-
-    __darwinAllowLocalNetworking = true;
-
-    mitmCache = gradle.fetchDeps {
-      pkg = self;
-      data = ./deps.json;
-    };
-
-    meta = {
-      description = "Ghidra extension for delinking executables back to object files";
-      homepage = "https://github.com/boricj/ghidra-delinker-extension";
-      license = lib.licenses.asl20;
-      maintainers = [ lib.maintainers.jchw ];
-      platforms = lib.platforms.unix;
-    };
+  src = fetchFromGitHub {
+    owner = "boricj";
+    repo = "ghidra-delinker-extension";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-h6F50Z7S6tPOl9mIhChLKoFxHuAkq/n36ysUEFwWGxI=";
   };
-in
-self
+
+  postPatch = ''
+    substituteInPlace build.gradle \
+      --replace-fail '"''${getGitHash()}"' '"v${finalAttrs.version}"'
+  '';
+
+  gradleBuildTask = "buildExtension";
+
+  __darwinAllowLocalNetworking = true;
+
+  mitmCache = gradle.fetchDeps {
+    pkg = finalAttrs.finalPackage;
+    data = ./deps.json;
+  };
+
+  meta = {
+    description = "Ghidra extension for delinking executables back to object files";
+    homepage = "https://github.com/boricj/ghidra-delinker-extension";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jchw ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/tools/security/ghidra/extensions/ghidra-golanganalyzerextension/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-golanganalyzerextension/default.nix
@@ -3,22 +3,22 @@
   fetchFromGitHub,
   buildGhidraExtension,
 }:
-buildGhidraExtension rec {
+buildGhidraExtension (finalAttrs: {
   pname = "Ghidra-GolangAnalyzerExtension";
   version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "mooncat-greenpy";
     repo = "Ghidra_GolangAnalyzerExtension";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-uxozIJ+BLcP1vBnLOCZD9ueY10hd37fON/Miii3zabo=";
   };
 
   meta = {
     description = "Facilitates the analysis of Golang binaries using Ghidra";
     homepage = "https://github.com/mooncat-greenpy/Ghidra_GolangAnalyzerExtension";
-    downloadPage = "https://github.com/mooncat-greenpy/Ghidra_GolangAnalyzerExtension/releases/tag/${version}";
+    downloadPage = "https://github.com/mooncat-greenpy/Ghidra_GolangAnalyzerExtension/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ivyfanchiang ];
   };
-}
+})

--- a/pkgs/tools/security/ghidra/extensions/kaiju/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/kaiju/default.nix
@@ -24,14 +24,14 @@ let
     }
   );
 
-  self = buildGhidraExtension rec {
+  self = buildGhidraExtension (finalAttrs: {
     pname = "kaiju";
     version = "250610";
 
     src = fetchFromGitHub {
       owner = "CERTCC";
       repo = "kaiju";
-      rev = version;
+      rev = finalAttrs.version;
       hash = "sha256-qqUnWakQDOBw3sI/6iWD9140iRAsM5PUEQJSV/3/8FQ=";
     };
 
@@ -58,7 +58,7 @@ let
     meta = {
       description = "A Java implementation of some features of the CERT Pharos Binary Analysis Framework for Ghidra";
       homepage = "https://github.com/CERTCC/kaiju";
-      downloadPage = "https://github.com/CERTCC/kaiju/releases/tag/${version}";
+      downloadPage = "https://github.com/CERTCC/kaiju/releases/tag/${finalAttrs.version}";
       license = lib.licenses.bsd3;
       maintainers = [ lib.maintainers.ivyfanchiang ];
       platforms = [
@@ -68,6 +68,6 @@ let
         "aarch64-darwin"
       ];
     };
-  };
+  });
 in
 self

--- a/pkgs/tools/security/ghidra/extensions/lightkeeper/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/lightkeeper/default.nix
@@ -3,14 +3,14 @@
   fetchFromGitHub,
   buildGhidraExtension,
 }:
-buildGhidraExtension rec {
+buildGhidraExtension (finalAttrs: {
   pname = "lightkeeper";
   version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "WorksButNotTested";
     repo = "lightkeeper";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-aGMWg6VQleKH/txlxpSw19QOotWZSqeW5Ve2SpWGhgA=";
   };
   preConfigure = ''
@@ -21,4 +21,4 @@ buildGhidraExtension rec {
     homepage = "https://github.com/WorksButNotTested/lightkeeper";
     license = lib.licenses.asl20;
   };
-}
+})

--- a/pkgs/tools/security/ghidra/extensions/wasm/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/wasm/default.nix
@@ -5,17 +5,14 @@
   ghidra,
   ant,
 }:
-let
-  version = "2.3.1";
-in
-buildGhidraExtension {
+buildGhidraExtension (finalAttrs: {
   pname = "wasm";
-  inherit version;
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "nneonneo";
     repo = "ghidra-wasm-plugin";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-aoSMNzv+TgydiXM4CbvAyu/YsxmdZPvpkZkYEE3C+V4=";
   };
 
@@ -35,9 +32,9 @@ buildGhidraExtension {
   meta = {
     description = "Ghidra Wasm plugin with disassembly and decompilation support";
     homepage = "https://github.com/nneonneo/ghidra-wasm-plugin";
-    downloadPage = "https://github.com/nneonneo/ghidra-wasm-plugin/releases/tag/v${version}";
-    changelog = "https://github.com/nneonneo/ghidra-wasm-plugin/releases/tag/v${version}";
+    downloadPage = "https://github.com/nneonneo/ghidra-wasm-plugin/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/nneonneo/ghidra-wasm-plugin/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.BonusPlay ];
   };
-}
+})


### PR DESCRIPTION
Ghidra components that were using `buildGhidraExtension` or `buildGhidraScripts` previously weren't able to use `finalAttrs`, which led to interesting `let` or `rec` constructs. This reworks the frame of the custom builders to extend the derivation itself instead, allowing us to use `finalAttrs` as we already do with other packages and builders.

`nixpkgs-review` does not seem to detect any changes, so I assume that means the packages pre- and post-change remain equivalent?

This PR conflicts with #415414 in spirit (as in, I would really like to use `finalAttrs` there as well), so I'll keep an eye out to see which PR gets merged first and then adapt the other one accordingly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
