### PR TITLE
[Backport release-24.11] tio: fix Bash completion

### DIFF
--- a/pkgs/by-name/ti/tio/package.nix
+++ b/pkgs/by-name/ti/tio/package.nix
@@ -29,13 +29,13 @@ stdenv.mkDerivation (finalAttrs: {
     inih
     lua
     glib
+    bash-completion
   ] ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ darwin.apple_sdk.frameworks.IOKit ];
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
-    bash-completion
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Backport of #418512 to `release-24.11`.

- [X] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
  