### PR TITLE
[24.11] rubyPackages.rack: 3.0.10 -> 3.0.18

### DIFF
--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -3216,10 +3216,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0x3mijjklsrlzfmwqp7x58fla7sk8pfwijhk988nmba787r8rf9g";
+      sha256 = "sha256-jvf8FQWxB3oUmjkGK8oDRvPDTmy9/oLVF3M/nZxAyHc=";
       type = "gem";
     };
-    version = "3.0.10";
+    version = "3.0.18";
   };
   rack-protection = {
     dependencies = [


### PR DESCRIPTION
Fixes CVE-2025-46727, CVE-2025-27610, CVE-2025-27111 and CVE-2025-25184.

Changes:
https://github.com/rack/rack/blob/v3.0.18/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 418771`
Commit: `fb8569cee38ac179a248a1ff4510aff65cc0e5f8`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 64 packages built:</summary>
  <ul>
    <li>rubyPackages.actioncable (rubyPackages_3_3.actioncable)</li>
    <li>rubyPackages.actionmailbox (rubyPackages_3_3.actionmailbox)</li>
    <li>rubyPackages.actionmailer (rubyPackages_3_3.actionmailer)</li>
    <li>rubyPackages.actionpack (rubyPackages_3_3.actionpack)</li>
    <li>rubyPackages.actiontext (rubyPackages_3_3.actiontext)</li>
    <li>rubyPackages.activestorage (rubyPackages_3_3.activestorage)</li>
    <li>rubyPackages.camping (rubyPackages_3_3.camping)</li>
    <li>rubyPackages.rack (rubyPackages_3_3.rack)</li>
    <li>rubyPackages.rack-protection (rubyPackages_3_3.rack-protection)</li>
    <li>rubyPackages.rack-session (rubyPackages_3_3.rack-session)</li>
    <li>rubyPackages.rack-test (rubyPackages_3_3.rack-test)</li>
    <li>rubyPackages.rackup (rubyPackages_3_3.rackup)</li>
    <li>rubyPackages.rails (rubyPackages_3_3.rails)</li>
    <li>rubyPackages.railties (rubyPackages_3_3.railties)</li>
    <li>rubyPackages.redis-rack (rubyPackages_3_3.redis-rack)</li>
    <li>rubyPackages.sinatra (rubyPackages_3_3.sinatra)</li>
    <li>rubyPackages_3_1.actioncable</li>
    <li>rubyPackages_3_1.actionmailbox</li>
    <li>rubyPackages_3_1.actionmailer</li>
    <li>rubyPackages_3_1.actionpack</li>
    <li>rubyPackages_3_1.actiontext</li>
    <li>rubyPackages_3_1.activestorage</li>
    <li>rubyPackages_3_1.camping</li>
    <li>rubyPackages_3_1.rack</li>
    <li>rubyPackages_3_1.rack-protection</li>
    <li>rubyPackages_3_1.rack-session</li>
    <li>rubyPackages_3_1.rack-test</li>
    <li>rubyPackages_3_1.rackup</li>
    <li>rubyPackages_3_1.rails</li>
    <li>rubyPackages_3_1.railties</li>
    <li>rubyPackages_3_1.redis-rack</li>
    <li>rubyPackages_3_1.sinatra</li>
    <li>rubyPackages_3_2.actioncable</li>
    <li>rubyPackages_3_2.actionmailbox</li>
    <li>rubyPackages_3_2.actionmailer</li>
    <li>rubyPackages_3_2.actionpack</li>
    <li>rubyPackages_3_2.actiontext</li>
    <li>rubyPackages_3_2.activestorage</li>
    <li>rubyPackages_3_2.camping</li>
    <li>rubyPackages_3_2.rack</li>
    <li>rubyPackages_3_2.rack-protection</li>
    <li>rubyPackages_3_2.rack-session</li>
    <li>rubyPackages_3_2.rack-test</li>
    <li>rubyPackages_3_2.rackup</li>
    <li>rubyPackages_3_2.rails</li>
    <li>rubyPackages_3_2.railties</li>
    <li>rubyPackages_3_2.redis-rack</li>
    <li>rubyPackages_3_2.sinatra</li>
    <li>rubyPackages_3_4.actioncable</li>
    <li>rubyPackages_3_4.actionmailbox</li>
    <li>rubyPackages_3_4.actionmailer</li>
    <li>rubyPackages_3_4.actionpack</li>
    <li>rubyPackages_3_4.actiontext</li>
    <li>rubyPackages_3_4.activestorage</li>
    <li>rubyPackages_3_4.camping</li>
    <li>rubyPackages_3_4.rack</li>
    <li>rubyPackages_3_4.rack-protection</li>
    <li>rubyPackages_3_4.rack-session</li>
    <li>rubyPackages_3_4.rack-test</li>
    <li>rubyPackages_3_4.rackup</li>
    <li>rubyPackages_3_4.rails</li>
    <li>rubyPackages_3_4.railties</li>
    <li>rubyPackages_3_4.redis-rack</li>
    <li>rubyPackages_3_4.sinatra</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
