### PR TITLE
rotonda: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/by-name/ro/rotonda/package.nix
+++ b/pkgs/by-name/ro/rotonda/package.nix
@@ -2,31 +2,54 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  stdenv,
   nix-update-script,
+  testers,
+  rotonda,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rotonda";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "NLnetLabs";
     repo = "rotonda";
-    tag = "v${version}";
-    hash = "sha256-DpFrJH37ysNc3hv7UrDktqRWrucAX6ZlpwUAT0PDm5k=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-B2sdQr9PctWZBpDuatJkUApW5T98BQa4HiqL8+HHevY=";
   };
 
-  passthru.updateScript = nix-update-script { };
-
   useFetchCargoVendor = true;
-  cargoHash = "sha256-cWPsFUa31hcNzqSSBbnhWccJqYGQbpbZNcVr0G14cqE=";
+  cargoHash = "sha256-XbBlA7QYUtD4uBz4t5ZR70o9bMgVLeSzq6Lexe0jzME=";
+
+  checkFlags =
+    lib.optionals
+      (stdenv.hostPlatform.system == "aarch64-darwin" || stdenv.hostPlatform.system == "x86_64-darwin")
+      [
+        # Attempted to create a NULL object.
+        "--skip=manager::tests::added_target_should_be_spawned"
+        # Lazy instance has previously been poisoned
+        "--skip=manager::tests::modified_settings_are_correctly_announced"
+        "--skip=manager::tests::removed_target_should_be_terminated"
+        "--skip=manager::tests::unused_unit_should_not_be_spawned"
+      ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = rotonda;
+      command = "rotonda --version";
+      # tag/release with this version string, please revert to `inherit (finalAttrs) version;` on next release
+      version = "0.4.3-dev";
+    };
+  };
 
   meta = {
     description = "Rotonda - composable, programmable BGP Engine";
     homepage = "https://github.com/NLnetLabs/rotonda";
-    changelog = "https://github.com/NLnetLabs/rotonda/blob/refs/tags/${src.tag}/Changelog.md";
+    changelog = "https://github.com/NLnetLabs/rotonda/blob/refs/tags/${finalAttrs.src.tag}/Changelog.md";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ _0x4A6F ];
     mainProgram = "rotonda";
   };
-}
+})


### PR DESCRIPTION
Upgrade to [0.4.2](https://github.com/NLnetLabs/rotonda/releases/tag/v0.4.2) including these [changes](https://github.com/NLnetLabs/rotonda/compare/v0.4.1...v0.4.2).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
