### PR TITLE
sanitiseHeaderPathsHook: init

### DIFF
--- a/pkgs/by-name/ed/edencommon/package.nix
+++ b/pkgs/by-name/ed/edencommon/package.nix
@@ -6,7 +6,7 @@
 
   cmake,
   ninja,
-  removeReferencesTo,
+  sanitiseHeaderPathsHook,
 
   glog,
   gflags,
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
-    removeReferencesTo
+    sanitiseHeaderPathsHook
   ];
 
   buildInputs = [
@@ -96,18 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail \
         'find_package(FBThrift CONFIG REQUIRED COMPONENTS cpp2 py)' \
         'find_package(FBThrift CONFIG REQUIRED COMPONENTS cpp2)'
-  '';
-
-  postFixup = ''
-    # Sanitize header paths to avoid runtime dependencies leaking in
-    # through `__FILE__`.
-    (
-      shopt -s globstar
-      for header in "$dev/include"/**/*.h; do
-        sed -i "1i#line 1 \"$header\"" "$header"
-        remove-references-to -t "$dev" "$header"
-      done
-    )
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/fb/fbthrift/package.nix
+++ b/pkgs/by-name/fb/fbthrift/package.nix
@@ -7,7 +7,7 @@
 
   cmake,
   ninja,
-  removeReferencesTo,
+  sanitiseHeaderPathsHook,
 
   openssl,
   gflags,
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
-    removeReferencesTo
+    sanitiseHeaderPathsHook
   ];
 
   buildInputs = [
@@ -103,18 +103,6 @@ stdenv.mkDerivation (finalAttrs: {
       # it. I don‘t know, either. It scares me.
       (lib.cmakeFeature "CMAKE_SHARED_LINKER_FLAGS" "-Wl,-undefined,dynamic_lookup")
     ];
-
-  postFixup = ''
-    # Sanitize header paths to avoid runtime dependencies leaking in
-    # through `__FILE__`.
-    (
-      shopt -s globstar
-      for header in "$out/include"/**/*.h; do
-        sed -i "1i#line 1 \"$header\"" "$header"
-        remove-references-to -t "$out" "$header"
-      done
-    )
-  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/fb/fbthrift/package.nix
+++ b/pkgs/by-name/fb/fbthrift/package.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # Homebrew sets this, and the shared library build fails without
-      # it. I don‘t know, either. It scares me.
+      # it. I don’t know, either. It scares me.
       (lib.cmakeFeature "CMAKE_SHARED_LINKER_FLAGS" "-Wl,-undefined,dynamic_lookup")
     ];
 

--- a/pkgs/by-name/fi/fizz/package.nix
+++ b/pkgs/by-name/fi/fizz/package.nix
@@ -6,7 +6,7 @@
 
   cmake,
   ninja,
-  removeReferencesTo,
+  sanitiseHeaderPathsHook,
 
   openssl,
   glog,
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
-    removeReferencesTo
+    sanitiseHeaderPathsHook
   ];
 
   buildInputs = [
@@ -100,18 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       export GTEST_FILTER="-${lib.concatStringsSep ":" disabledTests}"
     '';
-
-  postFixup = ''
-    # Sanitize header paths to avoid runtime dependencies leaking in
-    # through `__FILE__`.
-    (
-      shopt -s globstar
-      for header in "$dev/include"/**/*.h; do
-        sed -i "1i#line 1 \"$header\"" "$header"
-        remove-references-to -t "$dev" "$header"
-      done
-    )
-  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/fo/folly/package.nix
+++ b/pkgs/by-name/fo/folly/package.nix
@@ -8,7 +8,7 @@
   cmake,
   ninja,
   pkg-config,
-  removeReferencesTo,
+  sanitiseHeaderPathsHook,
 
   double-conversion,
   fast-float,
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     pkg-config
-    removeReferencesTo
+    sanitiseHeaderPathsHook
   ];
 
   # See CMake/folly-deps.cmake in the Folly source tree.
@@ -190,18 +190,6 @@ stdenv.mkDerivation (finalAttrs: {
     }
 
     runHook postCheck
-  '';
-
-  postFixup = ''
-    # Sanitize header paths to avoid runtime dependencies leaking in
-    # through `__FILE__`.
-    (
-      shopt -s globstar
-      for header in "$dev/include"/**/*.h; do
-        sed -i "1i#line 1 \"$header\"" "$header"
-        remove-references-to -t "$dev" "$header"
-      done
-    )
   '';
 
   passthru = {

--- a/pkgs/by-name/gt/gtest/package.nix
+++ b/pkgs/by-name/gt/gtest/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   ninja,
+  sanitiseHeaderPathsHook,
   # Enable C++17 support
   #     https://github.com/google/googletest/issues/3081
   # Projects that require a higher standard can override this package.
@@ -47,6 +48,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     ninja
+    sanitiseHeaderPathsHook
   ];
 
   cmakeFlags =

--- a/pkgs/by-name/mv/mvfst/package.nix
+++ b/pkgs/by-name/mv/mvfst/package.nix
@@ -6,7 +6,7 @@
 
   cmake,
   ninja,
-  removeReferencesTo,
+  sanitiseHeaderPathsHook,
 
   folly,
   gflags,
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
-    removeReferencesTo
+    sanitiseHeaderPathsHook
   ];
 
   buildInputs = [
@@ -121,21 +121,6 @@ stdenv.mkDerivation (finalAttrs: {
     }
 
     runHook postCheck
-  '';
-
-  postFixup = ''
-    # Sanitize header paths to avoid runtime dependencies leaking in
-    # through `__FILE__`.
-    (
-      shopt -s globstar
-      for header in "$dev/include"/**/*.h; do
-        sed -i "1i#line 1 \"$header\"" "$header"
-        remove-references-to -t "$dev" "$header"
-      done
-    )
-
-    # TODO: Do this in `gtest` rather than downstream.
-    remove-references-to -t ${gtest.dev} $out/lib/*
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/sa/sanitiseHeaderPathsHook/package.nix
+++ b/pkgs/by-name/sa/sanitiseHeaderPathsHook/package.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  makeSetupHook,
+  removeReferencesTo,
+}:
+
+makeSetupHook {
+  name = "sanitise-header-paths-hook";
+
+  substitutions = {
+    removeReferencesTo = lib.getExe removeReferencesTo;
+  };
+
+  meta = {
+    description = "Setup hook to sanitise header file paths to avoid leaked references through `__FILE__`";
+    maintainers = [ lib.maintainers.emily ];
+  };
+} ./sanitise-header-paths-hook.bash

--- a/pkgs/by-name/sa/sanitiseHeaderPathsHook/sanitise-header-paths-hook.bash
+++ b/pkgs/by-name/sa/sanitiseHeaderPathsHook/sanitise-header-paths-hook.bash
@@ -1,0 +1,10 @@
+sanitiseHeaderPaths() {
+  local header
+  while IFS= read -r -d '' header; do
+    nixLog "sanitising header path in $header"
+    sed -i "1i#line 1 \"$header\"" "$header"
+    @removeReferencesTo@ -t "${!outputInclude}" "$header"
+  done < <(find "${!outputInclude}/include" -type f -print0)
+}
+
+preFixupHooks+=(sanitiseHeaderPaths)

--- a/pkgs/by-name/wa/wangle/package.nix
+++ b/pkgs/by-name/wa/wangle/package.nix
@@ -6,7 +6,7 @@
 
   cmake,
   ninja,
-  removeReferencesTo,
+  sanitiseHeaderPathsHook,
 
   folly,
   fizz,
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
-    removeReferencesTo
+    sanitiseHeaderPathsHook
   ];
 
   buildInputs = [
@@ -107,18 +107,6 @@ stdenv.mkDerivation (finalAttrs: {
     }
 
     runHook postCheck
-  '';
-
-  postFixup = ''
-    # Sanitize header paths to avoid runtime dependencies leaking in
-    # through `__FILE__`.
-    (
-      shopt -s globstar
-      for header in "$dev/include"/**/*.h; do
-        sed -i "1i#line 1 \"$header\"" "$header"
-        remove-references-to -t "$dev" "$header"
-      done
-    )
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -12,6 +12,7 @@
   gmp,
   mpfr,
   libmpc,
+  sanitiseHeaderPathsHook,
   libucontext ? null,
   libxcrypt ? null,
   isSnapshot ? false,
@@ -42,6 +43,10 @@ in
       texinfo
       which
       gettext
+
+      # Prevent GCC leaking into the runtime closure of C++ packages
+      # through headers using `__FILE__`.
+      sanitiseHeaderPathsHook
     ]
     ++ optionals (perl != null) [ perl ]
     ++ optionals (with stdenv.targetPlatform; isVc4 || isRedox || isSnapshot && flex != null) [ flex ]

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -49,6 +49,7 @@
     !enablePlugin
     || (stdenv.targetPlatform.isAvr && stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64),
   nukeReferences,
+  sanitiseHeaderPathsHook,
   callPackage,
   majorMinorVersion,
   apple-sdk,
@@ -179,6 +180,7 @@ let
       pkgsBuildTarget
       profiledCompiler
       reproducibleBuild
+      sanitiseHeaderPathsHook
       staticCompiler
       stdenv
       targetPackages


### PR DESCRIPTION
C++ headers often use `__FILE__` in error messages, causing the development outputs of libraries to leak into the runtime closure of packages using them. This hook abstracts away a pattern used in a few places throughout the tree to have headers identify themselves by a sanitized path that does not cause runtime dependencies.

This does unfortunately mean that compiler error messages will reference the sanitized path. The only alternatives I can imagine are to patch compilers to handle `__FILE__` specially, or to have libraries propagate a hook that removes references. The latter would potentially need to be propagated recursively due to `#include` semantics and would be less precise than this.

Adding the hook to GCC (for `libstdc++` headers) reduces the WebKitGTK runtime closure size from 1.45 GiB to 1.22 GiB on `aarch64-linux`, as measured by `nix-tree`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
