### PR TITLE
nixos/bcachefs: include poly1305 and chacha20 kernel modules for kernel < 6.15

### DIFF
--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -179,13 +179,18 @@ in
 
       (lib.mkIf ((config.boot.initrd.supportedFilesystems.bcachefs or false) || (bootFs != { })) {
         inherit assertions;
-        # chacha20 and poly1305 are required only for decryption attempts
-        boot.initrd.availableKernelModules = [
-          "bcachefs"
-          "sha256"
-          "chacha20"
-          "poly1305"
-        ];
+        boot.initrd.availableKernelModules =
+          [
+            "bcachefs"
+            "sha256"
+          ]
+          ++ lib.optionals (config.boot.kernelPackages.kernel.kernelOlder "6.15") [
+            # chacha20 and poly1305 are required only for decryption attempts
+            # kernel 6.15 uses kernel api libraries for poly1305/chacha20: 4bf4b5046de0ef7f9dc50f3a9ef8a6dcda178a6d
+            # kernel 6.16 removes poly1305: ceef731b0e22df80a13d67773ae9afd55a971f9e
+            "poly1305"
+            "chacha20"
+          ];
         boot.initrd.systemd.extraBin = {
           # do we need this? boot/systemd.nix:566 & boot/systemd/initrd.nix:357
           "bcachefs" = "${pkgs.bcachefs-tools}/bin/bcachefs";


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/415981

kernel 6.16-rc1 removed the poly1305 algorithm in ceef731b0e22df80a13d67773ae9afd55a971f9e which broke building on NixOS
```
linux> root module: poly1305
linux> modprobe: FATAL: Module poly1305 not found in directory /nix/store/gbz2rhk04adcvhwpz678vb09j0jm10z6-linux-6.16-rc2-modules/lib/modules/6.16.0-rc2
```

```
commit ceef731b0e22df80a13d67773ae9afd55a971f9e
Author: Herbert Xu <herbert@gondor.apana.org.au>
Date:   Mon Apr 28 12:56:25 2025 +0800

    crypto: poly1305 - Remove algorithm
    
    As there are no in-kernel users of the Crypto API poly1305 left,
    remove it.
    
    Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
```

bcachefs switched to the kernel libraries for poly1305 and chacha20 in 6.15 in 4bf4b5046de0ef7f9dc50f3a9ef8a6dcda178a6d

```
commit 4bf4b5046de0ef7f9dc50f3a9ef8a6dcda178a6d
Author: Eric Biggers <ebiggers@google.com>
Date:   Tue Apr 1 21:33:33 2025 -0700

    bcachefs: use library APIs for ChaCha20 and Poly1305
    
    Just use the ChaCha20 and Poly1305 libraries instead of the clunky
    crypto API.  This is much simpler.  It is also slightly faster, since
    the libraries provide more direct access to the same
    architecture-optimized ChaCha20 and Poly1305 code.
    
    I've tested that existing encrypted bcachefs filesystems can be continue
    to be accessed with this patch applied.
    
    Reviewed-by: Ard Biesheuvel <ardb@kernel.org>
    Signed-off-by: Eric Biggers <ebiggers@google.com>
    Signed-off-by: Kent Overstreet <kent.overstreet@linux.dev>
```

Tested by installing encrypted bcachefs root, patching nixpkgs on 6.15.3, downgrading to 6.12, and upgrading to 6.16-rc2 on x86_64-linux

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
