### PR TITLE
[Backport release-24.11] udisks2: Fix CVE-2025-6019

### DIFF
--- a/pkgs/by-name/li/libblockdev/package.nix
+++ b/pkgs/by-name/li/libblockdev/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   autoreconfHook,
   pkg-config,
   gtk-doc,
@@ -40,6 +41,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "${finalAttrs.version}-1";
     hash = "sha256-WCMedMkaMMhZbB3iJu3c+CTT3AvOjzOSYP45J+NQEDQ=";
   };
+
+  patches = [
+    # CVE-2025-6019: https://www.openwall.com/lists/oss-security/2025/06/17/5
+    (fetchpatch {
+      url = "https://github.com/storaged-project/libblockdev/commit/4e35eb93e4d2672686789b9705623cc4f9f85d02.patch";
+      hash = "sha256-3pQxvbFX6jmT5LCaePoVfvPTNPoTPPhT0GcLaGkVVso=";
+    })
+  ];
 
   outputs = [
     "out"

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   substituteAll,
   pkg-config,
   gnused,
@@ -82,6 +83,13 @@ stdenv.mkDerivation rec {
         parted
         util-linux
       ];
+    })
+
+    # CVE-2025-6019: https://www.openwall.com/lists/oss-security/2025/06/17/5
+    (fetchpatch {
+      name = "CVE-2025-6019-2.patch";
+      url = "https://www.openwall.com/lists/oss-security/2025/06/17/5/2";
+      hash = "sha256-pgTA6yxQ1o9OU3qBeV1lh2O6mBkaUcc9md4uwFwz+AM=";
     })
   ];
 


### PR DESCRIPTION
Backport of #417763 to `release-24.11`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
  
