### PR TITLE
[Backport release-25.05] shellhub-agent: 0.19.0 -> 0.19.1

### DIFF
--- a/pkgs/by-name/sh/shellhub-agent/package.nix
+++ b/pkgs/by-name/sh/shellhub-agent/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule rec {
   pname = "shellhub-agent";
-  version = "0.19.0";
+  version = "0.19.1";
 
   src = fetchFromGitHub {
     owner = "shellhub-io";
     repo = "shellhub";
     rev = "v${version}";
-    hash = "sha256-xoGOiaUIjlR2l+l+oM1s3J7YBW9af2dfd+hXwq8zZU8=";
+    hash = "sha256-xFCUq1x9C+W1xxo6UIpW7ej7ltquvEqNUUvvF86rA9o=";
   };
 
   modRoot = "./agent";


### PR DESCRIPTION
Backport of #417128 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
  
