### PR TITLE
pycapnp: update to Cython 3

### DIFF
--- a/pkgs/development/python-modules/pycapnp/default.nix
+++ b/pkgs/development/python-modules/pycapnp/default.nix
@@ -2,8 +2,9 @@
   lib,
   buildPythonPackage,
   capnproto,
-  cython_0,
+  cython,
   fetchFromGitHub,
+  fetchpatch2,
   isPy27,
   isPyPy,
   pkgconfig,
@@ -22,8 +23,16 @@ buildPythonPackage rec {
     sha256 = "sha256-SVeBRJMMR1Z8+S+QoiUKGRFGUPS/MlmWLi1qRcGcPoE=";
   };
 
+  patches = [
+    (fetchpatch2 {
+      name = "cython-3.patch";
+      url = "https://github.com/capnproto/pycapnp/pull/334.diff?full_index=1";
+      hash = "sha256-we7v4RaL7c1tePWl+oYfzMHAfnvnpdMkQgVu9YLwC6Y=";
+    })
+  ];
+
   nativeBuildInputs = [
-    cython_0
+    cython
     pkgconfig
   ];
 

--- a/pkgs/development/python-modules/pycapnp/default.nix
+++ b/pkgs/development/python-modules/pycapnp/default.nix
@@ -1,29 +1,41 @@
 {
   lib,
   buildPythonPackage,
-  capnproto,
-  cython,
+  replaceVars,
   fetchFromGitHub,
   fetchpatch2,
-  isPy27,
-  isPyPy,
+  setuptools,
+  wheel,
+  capnproto,
+  cython,
   pkgconfig,
+  pytest-asyncio,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pycapnp";
   version = "2.0.0";
-  format = "setuptools";
-  disabled = isPyPy || isPy27;
+  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "capnproto";
     repo = "pycapnp";
     tag = "v${version}";
-    sha256 = "sha256-SVeBRJMMR1Z8+S+QoiUKGRFGUPS/MlmWLi1qRcGcPoE=";
+    hash = "sha256-SVeBRJMMR1Z8+S+QoiUKGRFGUPS/MlmWLi1qRcGcPoE=";
   };
 
   patches = [
+    # pycapnp hardcodes /usr/include and /usr/local/include as the paths to search
+    # for capnproto's built-in schemas in; replace them with the path to our copy of
+    # capnproto.
+    #
+    # Theoretically, this mechanism could also be used to load capnproto schemas
+    # exposed by other packages (e.g. capnproto-java), which we could support using
+    # a setup hook; but in practice nobody seems to use this mechanism for anything
+    # other than the builtin schemas (based on quick GitHub code search), so I don't
+    # think it's worthwhile.
+    (replaceVars ./include-paths.patch { inherit capnproto; })
     (fetchpatch2 {
       name = "cython-3.patch";
       url = "https://github.com/capnproto/pycapnp/pull/334.diff?full_index=1";
@@ -31,21 +43,34 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [
+  build-system = [
+    setuptools
+    wheel
     cython
     pkgconfig
   ];
 
   buildInputs = [ capnproto ];
 
-  # Tests depend on schema_capnp which fails to generate
-  doCheck = false;
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+  __darwinAllowLocalNetworking = true;
+  # https://github.com/NixOS/nixpkgs/issues/255262
+  preCheck = ''
+    enabledTestPaths=$PWD/test
+    pushd "$out"
+  '';
+  postCheck = ''
+    popd
+  '';
 
-  pythonImportsCheck = [ "capnp" ];
-
-  meta = with lib; {
+  meta = {
+    description = "Cython wrapping of the C++ Cap'n Proto library";
     homepage = "https://capnproto.github.io/pycapnp/";
-    maintainers = [ ];
-    license = licenses.bsd2;
+    changelog = "https://github.com/capnproto/pycapnp/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ Liamolucko ];
   };
 }

--- a/pkgs/development/python-modules/pycapnp/include-paths.patch
+++ b/pkgs/development/python-modules/pycapnp/include-paths.patch
@@ -1,0 +1,14 @@
+--- a/capnp/lib/capnp.pyx
++++ b/capnp/lib/capnp.pyx
+@@ -4410,10 +4410,7 @@ def load(file_name, display_name=None, imports=[]):
+ # Automatically include the system and built-in capnp paths
+ # Highest priority at position 0
+ _capnp_paths = [
+-    # Common macOS brew location
+-    '/usr/local/include',
+-    # Common posix location
+-    '/usr/include',
++    '@capnproto@/include',
+ ]
+ 
+ class _Loader:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The upstream repo has already switched over to Cython 3, but they haven't released a version with that change yet; apply the patch that updates Cython for now.

This gets pycapnp to build with Python 3.13.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
