### PR TITLE
coqPackages_8_20: fix sort instability

### DIFF
--- a/pkgs/development/coq-modules/bignums/default.nix
+++ b/pkgs/development/coq-modules/bignums/default.nix
@@ -13,7 +13,7 @@
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "9.0.0+rocq${coq.coq-version}" = range "9.0" "9.0";
         "9.0.0+coq${coq.coq-version}" = range "8.13" "8.20";

--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -39,7 +39,7 @@ let
     inherit version;
     defaultVersion =
       with lib.versions;
-      lib.switch coq.coq-version (lib.lists.sort (x: y: lib.versions.isLe x.out y.out) (
+      lib.switch coq.coq-version (lib.lists.sort (x: y: lib.versions.isLt x.out y.out) (
         lib.mapAttrsToList (out: case: { inherit case out; }) {
           "2.5.2" = range "8.20" "9.0";
           "2.0.1" = "8.19";

--- a/pkgs/development/coq-modules/coqeal/default.nix
+++ b/pkgs/development/coq-modules/coqeal/default.nix
@@ -24,7 +24,7 @@ let
           mc
         ];
       in
-      lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+      lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
         lib.mapAttrsToList (out: cases: { inherit cases out; }) {
           "2.1.0" = cmc (range "8.20" "9.0") (isGe "2.3.0");
           "2.0.3" = cmc (range "8.16" "8.20") (isGe "2.1.0");

--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -15,7 +15,7 @@ mkCoqDerivation {
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "3.4.3" = range "8.12" "9.0";
         "3.4.2" = range "8.12" "8.20";

--- a/pkgs/development/coq-modules/deriving/default.nix
+++ b/pkgs/development/coq-modules/deriving/default.nix
@@ -20,7 +20,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version ssreflect.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version ssreflect.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "0.2.2" = cmc (range "8.17" "9.0") (range "2.0.0" "2.4.0");
         "0.2.1" = cmc (range "8.17" "9.0") (range "2.0.0" "2.3.0");

--- a/pkgs/development/coq-modules/dpdgraph/default.nix
+++ b/pkgs/development/coq-modules/dpdgraph/default.nix
@@ -15,7 +15,7 @@ mkCoqDerivation {
   owner = "Karmaki";
   repo = "coq-dpdgraph";
   inherit version;
-  defaultVersion = lib.switch coq.coq-version (lib.lists.sort (x: y: lib.versions.isLe x.out y.out) (
+  defaultVersion = lib.switch coq.coq-version (lib.lists.sort (x: y: lib.versions.isLt x.out y.out) (
     lib.mapAttrsToList (out: case: { inherit case out; }) {
       "1.0+8.20" = "8.20";
       "1.0+8.19" = "8.19";

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -12,7 +12,7 @@
   repo = "Coq-Equations";
   opam-name = "rocq-equations";
   inherit version;
-  defaultVersion = lib.switch coq.coq-version (lib.lists.sort (x: y: lib.versions.isLe x.out y.out) (
+  defaultVersion = lib.switch coq.coq-version (lib.lists.sort (x: y: lib.versions.isLt x.out y.out) (
     lib.mapAttrsToList (out: case: { inherit case out; }) {
       "1.3.1+9.0" = "9.0";
       "1.3.1+8.20" = "8.20";

--- a/pkgs/development/coq-modules/extructures/default.nix
+++ b/pkgs/development/coq-modules/extructures/default.nix
@@ -20,7 +20,7 @@
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp-boot.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp-boot.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "0.5.0" = cmc (range "8.17" "9.0") (range "2.0.0" "2.4.0");
         "0.4.0" = cmc (range "8.17" "8.20") (range "2.0.0" "2.3.0");

--- a/pkgs/development/coq-modules/flocq/default.nix
+++ b/pkgs/development/coq-modules/flocq/default.nix
@@ -15,7 +15,7 @@ mkCoqDerivation {
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "4.2.1" = range "8.15" "9.0";
         "4.2.0" = range "8.14" "8.20";

--- a/pkgs/development/coq-modules/fourcolor/default.nix
+++ b/pkgs/development/coq-modules/fourcolor/default.nix
@@ -29,7 +29,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "1.4.1" = cmc (isGe "8.16") (isGe "2.0");
         "1.3.0" = cmc (isGe "8.16") "2.0.0";

--- a/pkgs/development/coq-modules/gaia/default.nix
+++ b/pkgs/development/coq-modules/gaia/default.nix
@@ -29,7 +29,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "2.3" = cmc (range "8.16" "9.0") (range "2.0" "2.4");
         "2.2" = cmc (range "8.16" "9.0") (range "2.0" "2.3");

--- a/pkgs/development/coq-modules/graph-theory/default.nix
+++ b/pkgs/development/coq-modules/graph-theory/default.nix
@@ -31,7 +31,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "0.9.6" = cmc (range "8.18" "9.0") (range "2.0.0" "2.4.0");
         "0.9.4" = cmc (range "8.16" "8.19") (range "2.0.0" "2.3.0");

--- a/pkgs/development/coq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/coq-modules/hierarchy-builder/default.nix
@@ -15,7 +15,7 @@ let
     inherit version;
     defaultVersion =
       with lib.versions;
-      lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+      lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
         lib.mapAttrsToList (out: case: { inherit case out; }) {
           "1.9.1" = range "8.20" "9.0";
           "1.8.0" = range "8.19" "8.20";

--- a/pkgs/development/coq-modules/hydra-battles/default.nix
+++ b/pkgs/development/coq-modules/hydra-battles/default.nix
@@ -20,7 +20,7 @@
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "0.9" = range "8.13" "8.16";
         "0.4" = range "8.11" "8.12";

--- a/pkgs/development/coq-modules/interval/default.nix
+++ b/pkgs/development/coq-modules/interval/default.nix
@@ -19,7 +19,7 @@ mkCoqDerivation rec {
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "4.11.1" = range "8.13" "8.20";
         "4.10.0" = range "8.12" "8.19";

--- a/pkgs/development/coq-modules/iris/default.nix
+++ b/pkgs/development/coq-modules/iris/default.nix
@@ -13,7 +13,7 @@ mkCoqDerivation {
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "4.3.0" = range "8.19" "9.0";
         "4.2.0" = range "8.18" "8.19";

--- a/pkgs/development/coq-modules/itauto/default.nix
+++ b/pkgs/development/coq-modules/itauto/default.nix
@@ -23,7 +23,7 @@
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "8.20.0" = isEq "8.20";
         "8.19.0" = isEq "8.19";

--- a/pkgs/development/coq-modules/jasmin/default.nix
+++ b/pkgs/development/coq-modules/jasmin/default.nix
@@ -21,7 +21,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "2025.02.0" = cmc (range "8.19" "9.0") (range "2.2" "2.4");
         "2024.07.2" = cmc (isEq "8.18") (isEq "2.2");

--- a/pkgs/development/coq-modules/json/default.nix
+++ b/pkgs/development/coq-modules/json/default.nix
@@ -15,9 +15,9 @@
 
   defaultVersion =
     let
-      inherit (lib.versions) isLe range;
+      inherit (lib.versions) isLt range;
     in
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "0.2.0" = range "8.14" "9.0";
         "0.1.3" = range "8.14" "8.20";

--- a/pkgs/development/coq-modules/mathcomp-abel/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-abel/default.nix
@@ -25,7 +25,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "1.2.1" = cmc (range "8.10" "8.16") (range "1.12.0" "1.15.0");
         "1.2.0" = cmc (range "8.10" "8.15") (range "1.12.0" "1.14.0");

--- a/pkgs/development/coq-modules/mathcomp-algebra-tactics/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-algebra-tactics/default.nix
@@ -26,7 +26,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp-algebra.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp-algebra.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "1.2.5" = cmc (range "8.20" "9.0") (isGe "2.4");
         "1.2.4" = cmc (range "8.16" "9.0") (isGe "2.0");

--- a/pkgs/development/coq-modules/mathcomp-analysis/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-analysis/default.nix
@@ -51,7 +51,7 @@ let
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "1.11.0" = cmc (range "8.20" "9.0") (range "2.1.0" "2.4.0");
         "1.9.0" = cmc (range "8.19" "8.20") (range "2.1.0" "2.3.0");

--- a/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
@@ -23,7 +23,7 @@ mkCoqDerivation {
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "1.0.2" = range "8.10" "9.0";
         "1.0.0" = range "8.5" "8.14";

--- a/pkgs/development/coq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-finmap/default.nix
@@ -23,7 +23,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp-boot.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp-boot.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "2.2.0" = cmc (range "8.20" "9.0") (range "2.3" "2.4");
         "2.1.0" = cmc (range "8.16" "9.0") (range "2.0" "2.3");

--- a/pkgs/development/coq-modules/mathcomp-infotheo/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-infotheo/default.nix
@@ -26,7 +26,7 @@
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp-analysis.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp-analysis.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "0.9.3" = cmc (range "8.20" "8.20") (isGe "1.10");
         "0.9.1" = cmc (range "8.19" "8.20") (isGe "1.9");

--- a/pkgs/development/coq-modules/mathcomp-tarjan/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-tarjan/default.nix
@@ -25,7 +25,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp-ssreflect.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp-ssreflect.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "1.0.3" = cmc (range "8.16" "9.0") (range "2.0.0" "2.4.0");
         "1.0.2" = cmc (range "8.16" "9.0") (range "2.0.0" "2.3.0");

--- a/pkgs/development/coq-modules/mathcomp-word/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-word/default.nix
@@ -63,7 +63,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "3.2" = cmc (range "8.16" "9.0") (isGe "2.0");
         "2.4" = cmc (range "8.12" "8.20") (range "1.12" "1.19");

--- a/pkgs/development/coq-modules/mathcomp-zify/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-zify/default.nix
@@ -27,7 +27,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp-algebra.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp-algebra.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "1.5.0+2.0+8.16" = cmc (range "8.16" "9.0") (isGe "2.0.0");
         "1.3.0+1.12+8.13" = cmc (range "8.13" "8.20") (range "1.12" "1.19.0");

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -31,9 +31,9 @@ let
   withDoc = single && (args.withDoc or false);
   defaultVersion =
     let
-      inherit (lib.versions) isLe range;
+      inherit (lib.versions) isLt range;
     in
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "2.4.0" = range "8.20" "9.0";
         "2.3.0" = range "8.19" "9.0";

--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -10,7 +10,7 @@
 let
   repo = "metacoq";
   owner = "MetaCoq";
-  defaultVersion = lib.switch coq.coq-version (lib.lists.sort (x: y: lib.versions.isLe x.out y.out) (
+  defaultVersion = lib.switch coq.coq-version (lib.lists.sort (x: y: lib.versions.isLt x.out y.out) (
     lib.mapAttrsToList (out: case: { inherit case out; }) {
       "1.0-beta2-8.11" = "8.11";
       "1.0-beta2-8.12" = "8.12";

--- a/pkgs/development/coq-modules/multinomials/default.nix
+++ b/pkgs/development/coq-modules/multinomials/default.nix
@@ -27,7 +27,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "2.4.0" = cmc (range "8.18" "9.0") (range "2.1.0" "2.4.0");
         "2.3.0" = cmc (range "8.17" "9.0") (range "2.1.0" "2.3.0");

--- a/pkgs/development/coq-modules/odd-order/default.nix
+++ b/pkgs/development/coq-modules/odd-order/default.nix
@@ -19,7 +19,7 @@ mkCoqDerivation {
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch mathcomp.character.version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch mathcomp.character.version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "2.2.0" = (range "2.2.0" "2.4.0");
         "2.1.0" = (range "2.1.0" "2.3.0");

--- a/pkgs/development/coq-modules/reglang/default.nix
+++ b/pkgs/development/coq-modules/reglang/default.nix
@@ -27,7 +27,7 @@ mkCoqDerivation {
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "1.2.2" = cmc (range "8.16" "9.0") (range "2.0.0" "2.4.0");
         "1.2.1" = cmc (range "8.16" "9.0") (range "2.0.0" "2.3.0");

--- a/pkgs/development/coq-modules/relation-algebra/default.nix
+++ b/pkgs/development/coq-modules/relation-algebra/default.nix
@@ -28,7 +28,7 @@ mkCoqDerivation {
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "1.7.11" = isEq "8.20";
         "1.7.10" = range "8.18" "8.19";

--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -14,7 +14,7 @@
   inherit version;
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "1.10.0" = range "8.17" "9.0";
         "1.8.0" = range "8.11" "8.19";

--- a/pkgs/development/coq-modules/ssprove/default.nix
+++ b/pkgs/development/coq-modules/ssprove/default.nix
@@ -25,7 +25,7 @@
         mc
       ];
     in
-    lib.switch [ coq.coq-version mathcomp-boot.version ] (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch [ coq.coq-version mathcomp-boot.version ] (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: cases: { inherit cases out; }) {
         "0.2.4" = cmc (range "8.18" "9.0") (range "2.3.0" "2.4.0");
         "0.2.3" = cmc (range "8.18" "8.20") (range "2.3.0" "2.3.0");

--- a/pkgs/development/coq-modules/stdpp/default.nix
+++ b/pkgs/development/coq-modules/stdpp/default.nix
@@ -13,7 +13,7 @@ mkCoqDerivation {
   owner = "iris";
   defaultVersion =
     with lib.versions;
-    lib.switch coq.coq-version (lib.lists.sort (x: y: isLe x.out y.out) (
+    lib.switch coq.coq-version (lib.lists.sort (x: y: isLt x.out y.out) (
       lib.mapAttrsToList (out: case: { inherit case out; }) {
         "1.11.0" = range "8.19" "9.0";
         "1.10.0" = range "8.18" "8.19";


### PR DESCRIPTION
Without the change `builtins.sort` is not guaranteed to produce stable results across `nix` implementations or even `std::sort` implementations.

With a small patch from https://github.com/NixOS/nix/issues/12106#issuecomment-2562897421 `nix` shows predicate instability as:

    $ nix eval --impure --expr 'with import ./. {};  coqPackages_8_20' --show-trace
    error:
       … while evaluating the attribute 'coqPackages_8_20'
    ...
       … while calling the 'sort' builtin
         at pkgs/development/coq-modules/metacoq/default.nix:13:48:
           12|   owner = "MetaCoq";
           13|   defaultVersion = lib.switch coq.coq-version (lib.lists.sort (x: y: lib.versions.isLe x.out y.out) (
             |                                                ^
           14|     lib.mapAttrsToList (out: case: { inherit case out; }) {

       error: !(a < a) assert failed

The fix is to use strict `<` comparison rather than non-strict `<=` one.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
