### PR TITLE
nixos/immich: assert postgresql is below v17

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -228,6 +228,11 @@ in
         assertion = !isPostgresUnixSocket -> cfg.secretsFile != null;
         message = "A secrets file containing at least the database password must be provided when unix sockets are not used.";
       }
+      {
+        # When removing this assertion, please adjust the nixosTests accordingly.
+        assertion = cfg.database.enable -> lib.versionOlder config.services.postgresql.package.version "17";
+        message = "Immich doesn't support PostgreSQL 17+, yet.";
+      }
     ];
 
     services.postgresql = mkIf cfg.database.enable {

--- a/nixos/tests/web-apps/immich-public-proxy.nix
+++ b/nixos/tests/web-apps/immich-public-proxy.nix
@@ -30,6 +30,9 @@
         port = 8002;
         settings.ipp.responseHeaders."X-NixOS" = "Rules";
       };
+
+      # TODO: Remove when PostgreSQL 17 is supported.
+      services.postgresql.package = pkgs.postgresql_16;
     };
 
   testScript = ''

--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -18,6 +18,9 @@
         enable = true;
         environment.IMMICH_LOG_LEVEL = "verbose";
       };
+
+      # TODO: Remove when PostgreSQL 17 is supported.
+      services.postgresql.package = pkgs.postgresql_16;
     };
 
   testScript = ''


### PR DESCRIPTION
We recently bumped the default PostgreSQL version to v17 in the NixOS module. This breaks immich, which still needs PostgreSQL 16.

I'm not exactly sure whether we should pin v16 in the module or in the test, though.

## Things done

- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
