### PR TITLE
nixos/ollama: add option to download models at build time

### DIFF
--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -161,6 +161,38 @@ in
           Search for models of your choice from: <https://ollama.com/library>
         '';
       };
+      preloadModels = lib.mkOption {
+        type = lib.types.listOf (
+          lib.types.submodule {
+            options = {
+              model = lib.mkOption {
+                type = types.str;
+                description = ''
+                  The name of the model to download.
+                  It may include the size, otherwise Ollama's default will be usedi.
+                '';
+              };
+              hash = lib.mkOption {
+                type = types.str;
+                description = ''
+                  The hash of the downloaded model.
+                  This hash is computed by Nix, not by Ollama.
+                '';
+              };
+            };
+          }
+        );
+        default = [ ];
+        example = [
+          {
+            model = "qwen3:0.6b";
+            hash = "sha256-jSZRsRY6nghyWUf2ishb7cYawD79+jcLu+f1CejjOk0=";
+          }
+        ];
+        description = ''
+          Download these models into the Nix store at build time.
+        '';
+      };
       openFirewall = lib.mkOption {
         type = types.bool;
         default = false;
@@ -307,6 +339,46 @@ in
           exit 1
         fi
       '';
+    };
+
+    systemd.services.ollama-model-preloader = lib.mkIf (cfg.preloadModels != [ ]) {
+      wantedBy = [
+        "multi-user.target"
+        "ollama.service"
+      ];
+      before = [ "ollama.service" ];
+      serviceConfig = {
+        Type = "exec";
+      };
+      script =
+        let
+          fetchModel =
+            { model, hash }:
+            pkgs.runCommand model
+              {
+                outputHashAlgo = "sha256";
+                outputHashMode = "recursive";
+                outputHash = hash;
+              }
+              ''
+                mkdir -p $out
+                ${lib.getExe pkgs.omdd} get ${model} \
+                  | grep -o 'https://.*' \
+                  | sed 's|https://\(.*\)/v[0-9]\+/\(.*\)/manifests/\(.*\)$|&\n out=manifests/\1/\2/\3|; s|https://.*/blobs/\([^/]*\)$|&\n out=blobs/\1|' \
+                  | ${lib.getExe pkgs.aria2} -x16 -s16 -d$out -i-
+              '';
+        in
+        ''
+          for model in ${lib.concatMapStringsSep " " fetchModel cfg.preloadModels}; do
+            cd $model
+            find . -type f | while read f; do
+              if ! [ -e "${cfg.models}/$f" ]; then
+                mkdir -p "${cfg.models}/$(dirname $f)"
+                ln -s "$PWD/$f" "${cfg.models}/$f"
+              fi
+            done
+          done
+        '';
     };
 
     networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.port ]; };

--- a/nixos/tests/ollama.nix
+++ b/nixos/tests/ollama.nix
@@ -9,16 +9,25 @@ in
 
   nodes = {
     cpu =
-      { ... }:
       {
         services.ollama.enable = true;
       };
 
     altAddress =
-      { ... }:
       {
         services.ollama.enable = true;
         services.ollama.port = altPort;
+      };
+
+    preload =
+      {
+        services.ollama.enable = true;
+        services.ollama.preloadModels = [
+          {
+            model = "tinydolphin";
+            hash = "sha256-Y4TJJ76Y3P0T00aoha2ldtXs2I6QHvMxNOUwp8KJmtY=";
+          }
+        ];
       };
   };
 
@@ -42,6 +51,7 @@ in
     vms = [
       (cpu, ${toString mainPort}),
       (altAddress, ${toString altPort}),
+      (preload, ${toString mainPort}),
     ]
 
     start_all()

--- a/pkgs/by-name/om/omdd/package.nix
+++ b/pkgs/by-name/om/omdd/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "omdd";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "amirrezaDev1378";
+    repo = "ollama-model-direct-download";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kEDI22af9+xSpwWouuR+KA/vofbOj5E0BDubjzRbwh0=";
+  };
+
+  vendorHash = null;
+
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/omdd
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/amirrezaDev1378/ollama-model-direct-download/releases/tag/v${finalAttrs.version}";
+    description = " Ollama model direct link generator and installer";
+    homepage = "https://github.com/amirrezaDev1378/ollama-model-direct-download";
+    license = with lib.licenses; [ mit ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ners ];
+    mainProgram = "omdd";
+  };
+})


### PR DESCRIPTION
With this, users may specify models with hashes which will be downloaded into the Nix store at build time. These models are then linked into ollama's model directory at service start time.

This does not touch ollama's logic at all, but is a step towards reproducible provisioning.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
