### PR TITLE
kardolus-chatgpt-cli: init at 1.8.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20833,6 +20833,11 @@
     githubId = 104558;
     name = "Benjamin Saunders";
   };
+  ralleka = {
+    name = "RalleKa";
+    github = "RalleKa";
+    githubId = 46349331;
+  };
   ramblurr = {
     name = "Casey Link";
     email = "nix@caseylink.com";

--- a/pkgs/by-name/ka/kardolus-chatgpt-cli/package.nix
+++ b/pkgs/by-name/ka/kardolus-chatgpt-cli/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+}:
+
+buildGoModule (finalAttrs: {
+  # "chatgpt-cli" is taken by another package with the same upsteam name.
+  # To keep "pname" and "package attribute name" identical, the owners name (kardolus) gets prefixed as identifier.
+  pname = "kardolus-chatgpt-cli";
+  version = "1.8.4";
+
+  src = fetchFromGitHub {
+    owner = "kardolus";
+    repo = "chatgpt-cli";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-vr61SrIYun6KUB9u+ZtUmdGO/ks2aQnAMAQ0g6QPaho=";
+  };
+
+  vendorHash = null;
+  # The tests of kardolus/chatgpt-cli require an OpenAI API Key to be present in the environment,
+  # (e.g. https://github.com/kardolus/chatgpt-cli/blob/v1.8.4/test/contract/contract_test.go#L35)
+  # which will not be the case in the pipeline.
+  # Therefore, tests must be skipped.
+  doCheck = false;
+
+  nativeBuildInputs = [ makeWrapper ];
+  postFixup = ''
+    wrapProgram $out/bin/chatgpt \
+      --run "mkdir -p ~/.chatgpt-cli" \
+      --set-default CHATGPT_CLI_HISTORY_DIR ~/.chatgpt-cli
+  '';
+
+  meta = {
+    description = "Command-line interface for ChatGPT";
+    longDescription = ''
+      ChatGPT CLI is a versatile tool for interacting with LLMs through OpenAI, Azure, and other popular providers like Perplexity AI and Llama.
+      It supports prompt files, history tracking, and live data injection via MCP (Model Context Protocol),
+      making it ideal for both casual users and developers seeking a powerful, customizable GPT experience.
+    '';
+    homepage = "https://github.com/kardolus/chatgpt-cli";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ralleka ];
+    mainProgram = "chatgpt";
+  };
+})


### PR DESCRIPTION
Added [`chatgpt-cli`](https://github.com/kardolus/chatgpt-cli) from [`kardolus`](https://github.com/kardolus) as a package in version 1.8.4 (currently latest).

There is already a package called [`chatgpt-cli`](https://github.com/j178/chatgpt) from [`j178`](https://github.com/j178), but it does not seem to be as actively maintained (and it does not work for me). `kardolus`s `chatgpt-cli` appears to be more actively maintained and it has more active users.

Though I compared both programs, they do not share the same code base. They are not forks of each other and work differently.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
