### PR TITLE
 qdirstat: patch missed lsblk, wrap cache writer later to prevent double wrapping

### DIFF
--- a/pkgs/by-name/qd/qdirstat/package.nix
+++ b/pkgs/by-name/qd/qdirstat/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   qmakeFlags = [ "INSTALL_PREFIX=${placeholder "out"}" ];
 
-  postInstall = ''
+  postFixup = ''
     wrapProgram $out/bin/qdirstat-cache-writer \
       --set PERL5LIB "${perlPackages.makePerlPath [ perlPackages.URI ]}"
   '';

--- a/pkgs/by-name/qd/qdirstat/package.nix
+++ b/pkgs/by-name/qd/qdirstat/package.nix
@@ -8,6 +8,7 @@
   bash,
   makeWrapper,
   perlPackages,
+  util-linux,
 }:
 
 stdenv.mkDerivation rec {
@@ -38,6 +39,8 @@ stdenv.mkDerivation rec {
     substituteInPlace src/Cleanup.cpp src/cleanup-config-page.ui \
       --replace-fail /bin/bash ${bash}/bin/bash \
       --replace-fail /bin/sh ${bash}/bin/sh
+    substituteInPlace src/MountPoints.cpp \
+      --replace-fail /bin/lsblk ${util-linux}/bin/lsblk
     substituteInPlace src/StdCleanup.cpp \
       --replace-fail /bin/bash ${bash}/bin/bash
   '';

--- a/pkgs/by-name/qd/qdirstat/package.nix
+++ b/pkgs/by-name/qd/qdirstat/package.nix
@@ -32,21 +32,14 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace scripts/scripts.pro \
-      --replace /bin/true ${coreutils}/bin/true
-
-    for i in src/SysUtil.cpp src/FileSizeStatsWindow.cpp
-    do
-      substituteInPlace $i \
-        --replace /usr/bin/xdg-open ${xdg-utils}/bin/xdg-open
-    done
-    for i in src/Cleanup.cpp src/cleanup-config-page.ui
-    do
-      substituteInPlace $i \
-        --replace /bin/bash ${bash}/bin/bash \
-        --replace /bin/sh ${bash}/bin/sh
-    done
+      --replace-fail /bin/true ${coreutils}/bin/true
+    substituteInPlace src/SysUtil.cpp src/FileSizeStatsWindow.cpp \
+      --replace-fail /usr/bin/xdg-open ${xdg-utils}/bin/xdg-open
+    substituteInPlace src/Cleanup.cpp src/cleanup-config-page.ui \
+      --replace-fail /bin/bash ${bash}/bin/bash \
+      --replace-fail /bin/sh ${bash}/bin/sh
     substituteInPlace src/StdCleanup.cpp \
-      --replace /bin/bash ${bash}/bin/bash
+      --replace-fail /bin/bash ${bash}/bin/bash
   '';
 
   qmakeFlags = [ "INSTALL_PREFIX=${placeholder "out"}" ];


### PR DESCRIPTION
see invididual commits

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
