### PR TITLE
resholve: 0.10.5 -> 0.10.6

### DIFF
--- a/pkgs/development/misc/resholve/README.md
+++ b/pkgs/development/misc/resholve/README.md
@@ -41,25 +41,20 @@ Here's a simple example of how `resholve.mkDerivation` is already used in nixpkg
 <!-- TODO: figure out how to pull this externally? -->
 
 ```nix
-{ lib
-, fetchFromGitHub
-, resholve
-, bash
-, coreutils
-, goss
-, which
+{
+  bash,
+  coreutils,
+  gnused,
+  goss,
+  lib,
+  resholve,
+  which,
 }:
 
 resholve.mkDerivation rec {
   pname = "dgoss";
-  version = "0.4.2";
-
-  src = fetchFromGitHub {
-    owner = "goss-org";
-    repo = "goss";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-FDn1OETkYIpMenk8QAAHvfNZcSzqGl5xrD0fAZPVmRM=";
-  };
+  version = goss.version;
+  src = goss.src;
 
   dontConfigure = true;
   dontBuild = true;
@@ -73,20 +68,27 @@ resholve.mkDerivation rec {
     default = {
       scripts = [ "bin/dgoss" ];
       interpreter = "${bash}/bin/bash";
-      inputs = [ coreutils which ];
+      inputs = [
+        coreutils
+        gnused
+        which
+      ];
       keep = {
         "$CONTAINER_RUNTIME" = true;
       };
     };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/goss-org/goss/blob/v${version}/extras/dgoss/README.md";
     changelog = "https://github.com/goss-org/goss/releases/tag/v${version}";
     description = "Convenience wrapper around goss that aims to bring the simplicity of goss to docker containers";
-    license = licenses.asl20;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ hyzual anthonyroussel ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      hyzual
+      anthonyroussel
+    ];
     mainProgram = "dgoss";
   };
 }
@@ -101,20 +103,26 @@ trivial, so I'll also link to some real-world examples:
 
 ```nix
 {
-  resholvedScript = resholve.writeScript "name" {
-    inputs = [ file ];
-    interpreter = "${bash}/bin/bash";
-  } ''
-    echo "Hello"
-    file .
-  '';
-  resholvedScriptBin = resholve.writeScriptBin "name" {
-    inputs = [ file ];
-    interpreter = "${bash}/bin/bash";
-  } ''
-    echo "Hello"
-    file .
-  '';
+  resholvedScript =
+    resholve.writeScript "name"
+      {
+        inputs = [ file ];
+        interpreter = "${bash}/bin/bash";
+      }
+      ''
+        echo "Hello"
+        file .
+      '';
+  resholvedScriptBin =
+    resholve.writeScriptBin "name"
+      {
+        inputs = [ file ];
+        interpreter = "${bash}/bin/bash";
+      }
+      ''
+        echo "Hello"
+        file .
+      '';
 }
 ```
 
@@ -125,7 +133,11 @@ This function has a similar API to `writeScript` and `writeScriptBin`, except it
 trivial for now. If you have a real usage that you find helpful, please PR it.
 
 ```nix
-{ stdenv, resholve, module1 }:
+{
+  stdenv,
+  resholve,
+  module1,
+}:
 
 stdenv.mkDerivation {
   # pname = "testmod3";
@@ -140,7 +152,10 @@ stdenv.mkDerivation {
       interpreter = "${bash}/bin/bash";
       inputs = [ module1 ];
       fake = {
-        external = [ "jq" "openssl" ];
+        external = [
+          "jq"
+          "openssl"
+        ];
       };
     }}
   '';
@@ -220,7 +235,10 @@ from the manpage, and the Nix equivalents:
   fake = {
     # fake accepts the initial of valid identifier types as a CLI convenience.
     # Use full names in the Nix API.
-    function = [ "setUp" "tearDown" ];
+    function = [
+      "setUp"
+      "tearDown"
+    ];
     builtin = [ "setopt" ];
     source = [ "/etc/bashrc" ];
   };

--- a/pkgs/development/misc/resholve/resholve-utils.nix
+++ b/pkgs/development/misc/resholve/resholve-utils.nix
@@ -39,7 +39,11 @@ rec {
     else if builtins.isList val then
       "${name}:${semicolons (map lib.escapeShellArg val)}"
     else
-      nope [ solution env name ] "unexpected type: ${builtins.typeOf val}";
+      nope [
+        solution
+        env
+        name
+      ] "unexpected type: ${builtins.typeOf val}";
 
   # Build fake/fix/keep directives from Nix types
   phraseDirectives =
@@ -68,7 +72,10 @@ rec {
     else if builtins.isAttrs val then
       spaces (phraseDirectives solution env val)
     else
-      nope [ solution env ] "unexpected type: ${builtins.typeOf val}";
+      nope [
+        solution
+        env
+      ] "unexpected type: ${builtins.typeOf val}";
 
   # Shell-format each env value
   shellEnv =

--- a/pkgs/development/misc/resholve/source.nix
+++ b/pkgs/development/misc/resholve/source.nix
@@ -4,11 +4,11 @@
 }:
 
 rec {
-  version = "0.10.5";
+  version = "0.10.6";
   rSrc = fetchFromGitHub {
     owner = "abathur";
     repo = "resholve";
     rev = "v${version}";
-    hash = "sha256-SzJbA0wLeSwvXnAE4bTNqh0tnpFPkn6N1hp7sZGAkB4=";
+    hash = "sha256-iJEkfW60QO4nFp+ib2+DeDRsZviYFhWRQoBw1VAhzJY=";
   };
 }

--- a/pkgs/development/misc/resholve/test.nix
+++ b/pkgs/development/misc/resholve/test.nix
@@ -42,7 +42,6 @@
   bashup-events32,
   dgoss,
   git-ftp,
-  ix,
   lesspipe,
   locate-dominating-file,
   mons,
@@ -77,6 +76,7 @@ let
     rlwrap
     gnutar
     bc
+    msmtp
   ];
 in
 rec {
@@ -326,7 +326,6 @@ rec {
   inherit bashup-events32;
   inherit bats;
   inherit git-ftp;
-  inherit ix;
   inherit lesspipe;
   inherit locate-dominating-file;
   inherit mons;


### PR DESCRIPTION
Release mainly adds msmtp/msmtpq syntax parsing rules (https://github.com/abathur/resholve/blob/master/CHANGELOG.md#v0106-jun-21-2025).

Also:
- use nixfmt style for examples in README.md
- drop passthru consumer test for ix removed in #397949


## Things done

## `nixpkgs-review` result (just a few immediate deps)

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --package bats --package xdg-utils --package lesspipe --package yadm`
Commit: `8a1b029672ae04fc836cdfc468452c4e5615eefb`

---
### `x86_64-darwin`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>bats</li>
    <li>lesspipe</li>
    <li>xdg-utils</li>
    <li>yadm</li>
  </ul>
</details>

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>bats</li>
    <li>lesspipe</li>
    <li>xdg-utils</li>
    <li>yadm</li>
  </ul>
</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
