### PR TITLE
nixos/systemd: Drop kbrequest.target symlink

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -153,6 +153,8 @@
 
 - `command-not-found` package is now disabled by default; it works only for nix-channels based systems, and requires setup for it to work.
 
+- The systemd target `kbrequest.target` is now unset by default, instead of being forcibly symlinked to `rescue.target`. In case you were relying on this behavior (Alt + ArrowUp on the tty causing the current target to be changed to `rescue.target`), you can restore it by setting `systemd.targets.rescue.aliases = [ "kbrequest.target" ];` in your configuration.
+
 ## Other Notable Changes {#sec-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -524,7 +524,6 @@ rec {
           # Stupid misc. symlinks.
           ln -s ${cfg.defaultUnit} $out/default.target
           ln -s ${cfg.ctrlAltDelUnit} $out/ctrl-alt-del.target
-          ln -s rescue.target $out/kbrequest.target
 
           ln -s ../remote-fs.target $out/multi-user.target.wants/
         ''}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Successor to #181783 (the original PR), #299310 (my last attempt to get this merged, which I abandoned).

~~Adds an option for `kbrequest.target` rather than hard-coding a symlink to `rescue.target`, and changes the old default from `rescue.target` to null (which causes there not to be a symlink).~~ Removes the `kbrequest.target` symlink to `rescue.target`.

Rationale:
In short: **No other noteworthy Linux distro has this set by default anymore**, **systemd does not recommend this anymore since 2017**, and **it genuinely disrupts usage** (Alt+ArrowUp is a common keyboard shortcut in text editors to move lines upward, and such text editors may be used on the tty).

nixpkgs apparently sets this since 2013 in commit f4a3bdd6afa31671bfc18fd22417b04914dfa0a8.

https://github.com/NixOS/nixpkgs/blob/f4a3bdd6afa31671bfc18fd22417b04914dfa0a8/modules/system/boot/systemd.nix#L328

The commit message refers to systemd recommending this.

systemd changed their stance on this in 2017.
  - https://github.com/systemd/systemd/issues/6451
  - https://github.com/systemd/systemd/issues/6493
  - https://github.com/systemd/systemd/commit/44ec14e13b94beebd17a1b4d0be28954dd197593
  - https://github.com/systemd/systemd/commit/f48077762390d0d189985fe710e2af140dc05964

Other Linux distributions mostly followed suit. Just NixOS did not.

My prior attempt to get this merged had someone convince me to change the default back to the current behaviour instead of `null`.
I am no longer open to a different default than `null`, so this PR will stay as-is in this regard. Having it be set to any target is simply a bad default setting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
