### PR TITLE
[release-25.05] exploitdb: 2025-05-10 -> 2025-06-21

### DIFF
--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2025-06-14";
+  version = "2025-06-21";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
     rev = "refs/tags/${version}";
-    hash = "sha256-znJZK7EhLFg2ImxWqEfvt7Em+M8lAly+oPzrmaGznRU=";
+    hash = "sha256-6mXku+SW6xmSYxd40Ilis8H/2Ozm6eUecLQHy1xeKtM=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2025-05-26";
+  version = "2025-05-30";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
     rev = "refs/tags/${version}";
-    hash = "sha256-e9a0bzlyqI3lR87X+S9XIVTpEv1a9RxlfKqyk6CsDGU=";
+    hash = "sha256-X90stp4BiHOHoh030eqGeUGiWytF5ryY08/VYEsbnIw=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2025-05-30";
+  version = "2025-06-06";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
     rev = "refs/tags/${version}";
-    hash = "sha256-X90stp4BiHOHoh030eqGeUGiWytF5ryY08/VYEsbnIw=";
+    hash = "sha256-DOzhxZZ66p49tECn0z1lGSNHq3GEpEbayhwsiJ6IGG4=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2025-05-22";
+  version = "2025-05-26";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
     rev = "refs/tags/${version}";
-    hash = "sha256-2dnIchOJJrqqePgOxb7tWw0j1neTlXFyxT30qwTOkrc=";
+    hash = "sha256-e9a0bzlyqI3lR87X+S9XIVTpEv1a9RxlfKqyk6CsDGU=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2025-05-19";
+  version = "2025-05-22";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
     rev = "refs/tags/${version}";
-    hash = "sha256-Tk2iPWiybUlsmiHbjJTNEMkCuXVeam49PiWrl4mVzhY=";
+    hash = "sha256-2dnIchOJJrqqePgOxb7tWw0j1neTlXFyxT30qwTOkrc=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2025-05-10";
+  version = "2025-05-19";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
     rev = "refs/tags/${version}";
-    hash = "sha256-YcSkBnzw3iMuD0MtpqtUq1gOBoj2ptigI63cI1wBibY=";
+    hash = "sha256-Tk2iPWiybUlsmiHbjJTNEMkCuXVeam49PiWrl4mVzhY=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2025-06-10";
+  version = "2025-06-14";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
     rev = "refs/tags/${version}";
-    hash = "sha256-add3ejm6rtyvzNbXzdLqCL9Ho131FDJ41aHm3L8LmVg=";
+    hash = "sha256-znJZK7EhLFg2ImxWqEfvt7Em+M8lAly+oPzrmaGznRU=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2025-06-06";
+  version = "2025-06-10";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
     rev = "refs/tags/${version}";
-    hash = "sha256-DOzhxZZ66p49tECn0z1lGSNHq3GEpEbayhwsiJ6IGG4=";
+    hash = "sha256-add3ejm6rtyvzNbXzdLqCL9Ho131FDJ41aHm3L8LmVg=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Backports to `release-25.05` of: #409201 #410101 #411291 #412264 #414515 #417320 #418758.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.