### PR TITLE
vscode-extensions.jjk.jjk: init at 0.8.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2771,6 +2771,8 @@ let
         };
       };
 
+      jjk.jjk = callPackage ./jjk.jjk { };
+
       jroesch.lean = buildVscodeMarketplaceExtension rec {
         mktplcRef = {
           name = "lean";

--- a/pkgs/applications/editors/vscode/extensions/jjk.jjk/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/jjk.jjk/default.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  npmHooks,
+  fetchNpmDeps,
+  typescript,
+  nodejs,
+  vsce,
+  zig,
+  unzip,
+  moreutils,
+}:
+
+let
+  name = "jjk";
+  publisher = "jjk";
+  owner = "keanemind";
+  version = "0.8.1";
+  releaseTag = "v${version}";
+  extId = "${publisher}.${name}";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = name;
+    tag = releaseTag;
+    hash = "sha256-zB3CflSUNmNfTijl37AXsGww2LuFEONQQA43bfku3f8=";
+  };
+
+  fakeeditorPkg = stdenv.mkDerivation {
+    pname = "fakeeditor";
+    inherit version src;
+    nativeBuildInputs = [
+      zig.hook
+    ];
+    sourceRoot = "${src.name}/src/fakeeditor";
+    meta.mainProgram = "fakeeditor";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vscode-extension-${publisher}-${name}";
+  inherit version src;
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-er2Sy1NSnTSEbFH7w3Kcr3/+vkc8n1ju72n+LtjrR2Y=";
+  };
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    typescript
+    nodejs
+    vsce
+    unzip
+    moreutils
+  ];
+
+  postPatch = ''
+    sed 's/&& npm run build-fakeeditor[^"]*//g' package.json | sponge package.json
+    substituteInPlace src/repository.ts \
+      --replace-fail 'const fakeEditorExecutables' 'const _fakeEditorExecutables' \
+      --replace-fail 'fakeEditorExecutables[process.platform]?.[process.arch];' 'null; fakeEditorPath = "${lib.getExe fakeeditorPkg}";'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    node esbuild.js --production
+    cp -r src/webview dist/
+    cp src/config.toml dist/
+    mkdir -p dist/codicons
+    cp -r node_modules/@vscode/codicons/dist/* dist/codicons/
+
+    vsce package --allow-star-activation --out ./${name}-${version}.vsix
+
+    mkdir -p unpacked
+    unzip ./${name}-${version}.vsix 'extension/*' -d ./unpacked
+
+    echo ${fakeeditorPkg}
+
+    runHook postBuild
+  '';
+
+  installPrefix = "share/vscode/extensions/${extId}";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/$installPrefix
+    mv ./unpacked/extension/* $out/$installPrefix
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    vscodeExtPublisher = publisher;
+    vscodeExtName = name;
+    vscodeExtUniqueId = extId;
+  };
+
+  meta = {
+    description = "VS Code Extension for Jujutsu (jj) VCS support";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=${extId}";
+    homepage = "https://github.com/${owner}/${name}";
+    changelog = "https://github.com/${owner}/${name}/releases/tag/${releaseTag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ timon ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Jujutsu (jj) VCS support for VS Code

https://github.com/keanemind/jjk

<img width="1678" alt="diff" src="https://github.com/user-attachments/assets/baa308fe-898b-4bbd-a828-bdee1a0bf420" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
