### PR TITLE
ankiAddons.review-heatmap: init at 1.0.1 

### DIFF
--- a/pkgs/by-name/aa/aab/allow-manually-setting-modtime.patch
+++ b/pkgs/by-name/aa/aab/allow-manually-setting-modtime.patch
@@ -1,0 +1,124 @@
+diff --git a/aab/builder.py b/aab/builder.py
+index 5c3805c..7dfe595 100644
+--- a/aab/builder.py
++++ b/aab/builder.py
+@@ -77,7 +77,7 @@ class AddonBuilder:
+         self._config = Config()
+         self._path_dist_module = PATH_DIST / "src" / self._config["module_name"]
+
+-    def build(self, qt_versions: List[QtVersion], disttype="local", pyenv=None):
++    def build(self, qt_versions: List[QtVersion], disttype="local", pyenv=None, modtime=None):
+         logging.info(
+             "\n--- Building %s %s for %s ---\n",
+             self._config["display_name"],
+@@ -86,7 +86,7 @@ class AddonBuilder:
+         )
+
+         self.create_dist()
+-        self.build_dist(qt_versions=qt_versions, disttype=disttype, pyenv=pyenv)
++        self.build_dist(qt_versions=qt_versions, disttype=disttype, pyenv=pyenv, modtime=modtime)
+
+         return self.package_dist(qt_versions=qt_versions, disttype=disttype)
+
+@@ -102,7 +102,7 @@ class AddonBuilder:
+         PATH_DIST.mkdir(parents=True)
+         Git().archive(self._version, PATH_DIST)
+
+-    def build_dist(self, qt_versions: List[QtVersion], disttype="local", pyenv=None):
++    def build_dist(self, qt_versions: List[QtVersion], disttype="local", pyenv=None, modtime=None):
+         self._copy_licenses()
+         if self._path_changelog.exists():
+             self._copy_changelog()
+@@ -111,7 +111,7 @@ class AddonBuilder:
+         if self._callback_archive:
+             self._callback_archive()
+
+-        self._write_manifest(disttype)
++        self._write_manifest(disttype, modtime=modtime)
+
+         ui_builder = UIBuilder(dist=PATH_DIST, config=self._config)
+
+@@ -162,12 +162,13 @@ class AddonBuilder:
+
+         return out_path
+
+-    def _write_manifest(self, disttype):
++    def _write_manifest(self, disttype, modtime=None):
+         ManifestUtils.generate_and_write_manifest(
+             addon_properties=self._config,
+             version=self._version,
+             dist_type=disttype,
+             target_dir=self._path_dist_module,
++            modtime=modtime,
+         )
+
+     def _copy_licenses(self):
+diff --git a/aab/cli.py b/aab/cli.py
+index 2ce6425..0956e98 100644
+--- a/aab/cli.py
++++ b/aab/cli.py
+@@ -89,7 +89,7 @@ def build(args):
+     total = len(dists)
+     for dist in dists:
+         logging.info("\n=== Build task %s/%s ===", cnt, total)
+-        builder.build(qt_versions=qt_versions, disttype=dist)
++        builder.build(qt_versions=qt_versions, disttype=dist, modtime=args.modtime)
+         cnt += 1
+
+
+@@ -146,7 +146,7 @@ def build_dist(args):
+     total = len(dists)
+     for dist in dists:
+         logging.info("\n=== Build task %s/%s ===", cnt, total)
+-        builder.build_dist(qt_versions=qt_versions, disttype=dist)
++        builder.build_dist(qt_versions=qt_versions, disttype=dist, modtime=args.modtime)
+         cnt += 1
+
+
+@@ -204,6 +204,12 @@ def construct_parser():
+         default="local",
+         choices=["local", "ankiweb", "all"],
+     )
++    dist_parent.add_argument(
++        "--modtime",
++        help="Last modified timestamp",
++        type=int,
++        required=False,
++    )
+
+     build_parent = argparse.ArgumentParser(add_help=False)
+     build_parent.add_argument(
+diff --git a/aab/manifest.py b/aab/manifest.py
+index fc0038d..355e370 100644
+--- a/aab/manifest.py
++++ b/aab/manifest.py
+@@ -49,10 +49,11 @@ class ManifestUtils:
+         version: str,
+         dist_type: DistType,
+         target_dir: Path,
++        modtime=None,
+     ):
+         logging.info("Writing manifest...")
+         manifest = cls.generate_manifest_from_properties(
+-            addon_properties=addon_properties, version=version, dist_type=dist_type
++            addon_properties=addon_properties, version=version, dist_type=dist_type, modtime=modtime
+         )
+         cls.write_manifest(manifest=manifest, target_dir=target_dir)
+
+@@ -62,6 +63,7 @@ class ManifestUtils:
+         addon_properties: Config,
+         version: str,
+         dist_type: DistType,
++        modtime=None,
+     ) -> Dict[str, Any]:
+         manifest = {
+             "name": addon_properties["display_name"],
+@@ -71,7 +73,7 @@ class ManifestUtils:
+             "version": version,
+             "homepage": addon_properties.get("homepage", ""),
+             "conflicts": deepcopy(addon_properties["conflicts"]),
+-            "mod": Git().modtime(version),
++            "mod": modtime if modtime is not None else Git().modtime(version),
+         }
+
+         # Add version specifiers:

--- a/pkgs/by-name/aa/aab/fix-flaky-tests.patch
+++ b/pkgs/by-name/aa/aab/fix-flaky-tests.patch
@@ -1,0 +1,75 @@
+diff --git a/tests/test_legacy.py b/tests/test_legacy.py
+index 33790b9..0577262 100644
+--- a/tests/test_legacy.py
++++ b/tests/test_legacy.py
+@@ -101,8 +101,8 @@ gui/
+         sample-project/
+             icons/
+                 coffee.svg
+-                heart.svg
+                 email.svg
++                heart.svg
+                 help.svg\
+ """
+
+diff --git a/tests/test_ui.py b/tests/test_ui.py
+index 0774672..3764fda 100644
+--- a/tests/test_ui.py
++++ b/tests/test_ui.py
+@@ -60,22 +60,22 @@ def test_ui_builder(tmp_path: Path):
+
+     expected_file_structure = """\
+ gui/
++    forms/
++        __init__.py
++        qt5/
++            __init__.py
++            dialog.py
++        qt6/
++            __init__.py
++            dialog.py
+     resources/
+         __init__.py
+         sample-project/
+             icons/
+                 coffee.svg
+-                heart.svg
+                 email.svg
+-                help.svg
+-    forms/
+-        __init__.py
+-        qt6/
+-            __init__.py
+-            dialog.py
+-        qt5/
+-            __init__.py
+-            dialog.py\
++                heart.svg
++                help.svg\
+ """
+
+     config = Config(test_project_root / "addon.json")
+@@ -136,8 +136,8 @@ gui/
+         sample-project/
+             icons/
+                 coffee.svg
+-                heart.svg
+                 email.svg
++                heart.svg
+                 help.svg\
+ """
+
+diff --git a/tests/util.py b/tests/util.py
+index a682bcd..a4aa7de 100644
+--- a/tests/util.py
++++ b/tests/util.py
+@@ -40,6 +40,9 @@ def list_files(startpath: Path):
+     ret = []
+
+     for root, dirs, files in os.walk(path):
++        dirs.sort()
++        files.sort()
++
+         level = root.replace(path, "").count(os.sep)
+         indent = " " * 4 * (level)
+         ret.append("{}{}/".format(indent, os.path.basename(root)))

--- a/pkgs/by-name/aa/aab/only-call-git-when-necessary.patch
+++ b/pkgs/by-name/aa/aab/only-call-git-when-necessary.patch
@@ -1,0 +1,14 @@
+diff --git a/aab/builder.py b/aab/builder.py
+index 5c3805c..a181b27 100644
+--- a/aab/builder.py
++++ b/aab/builder.py
+@@ -67,8 +67,7 @@ class AddonBuilder:
+         self._version = Git().parse_version(version)
+         # git stash create comes up empty when no changes were made since the
+         # last commit. Don't use 'dev' as version in these cases.
+-        git_status = call_shell("git status --porcelain")
+-        if self._version == "dev" and git_status == "":
++        if self._version == "dev" and call_shell("git status --porcelain") == "":
+             self._version = Git().parse_version("current")
+         if not self._version:
+             logging.error("Error: Version could not be determined through Git")

--- a/pkgs/by-name/aa/aab/package.nix
+++ b/pkgs/by-name/aa/aab/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "aab";
+  version = "1.0.0-dev.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "glutanimate";
+    repo = "anki-addon-builder";
+    tag = "v${version}";
+    hash = "sha256-92Xqxgb9MLhSIa5EN3Rdk4aJlRfzEWqKmXFe604Q354=";
+  };
+
+  patches = [
+    ./fix-flaky-tests.patch
+    ./only-call-git-when-necessary.patch
+    ./allow-manually-setting-modtime.patch
+  ];
+
+  build-system = [ python3.pkgs.poetry-core ];
+
+  dependencies = with python3.pkgs; [
+    jsonschema
+    whichcraft
+    pyqt5
+    pyqt6
+  ];
+
+  nativeCheckInputs = [
+    python3.pkgs.pytestCheckHook
+    python3.pkgs.pyqt5
+    python3.pkgs.pyqt6
+  ];
+
+  pythonImportsCheck = [ "aab" ];
+
+  meta = {
+    description = "Build tool for Anki add-ons";
+    homepage = "https://github.com/glutanimate/anki-addon-builder";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ eljamm ];
+  };
+}

--- a/pkgs/games/anki/addons/default.nix
+++ b/pkgs/games/anki/addons/default.nix
@@ -14,5 +14,7 @@
 
   reviewer-refocus-card = callPackage ./reviewer-refocus-card { };
 
+  review-heatmap = callPackage ./review-heatmap { };
+
   yomichan-forvo-server = callPackage ./yomichan-forvo-server { };
 }

--- a/pkgs/games/anki/addons/review-heatmap/0001-Apply-vite-style-to-anki-review-heatmap.js.patch
+++ b/pkgs/games/anki/addons/review-heatmap/0001-Apply-vite-style-to-anki-review-heatmap.js.patch
@@ -1,0 +1,26 @@
+---
+ src/web/main.ts | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/web/main.ts b/src/web/main.ts
+index 389c7fc..0b7c702 100644
+--- a/src/web/main.ts
++++ b/src/web/main.ts
+@@ -29,8 +29,12 @@ listed here: <https://glutanimate.com/contact/>.
+ Any modifications to this file must keep this entire header intact.
+ */
+
+-import "./_vendor/cal-heatmap.css";
+-import "./css/review-heatmap.css";
++import calHeatmapCss from "./_vendor/cal-heatmap.css";
++import reviewHeatmapCss from "./css/review-heatmap.css";
++
++var __vite_style__ = document.createElement('style');
++__vite_style__.textContent = calHeatmapCss + "\n" + reviewHeatmapCss;
++document.head.appendChild(__vite_style__);
+
+ import { CalHeatMap } from "./_vendor/cal-heatmap.js";
+ import { ReviewHeatmapOptions, ReviewHeatmapData } from "./types";
+--
+2.49.0
+

--- a/pkgs/games/anki/addons/review-heatmap/default.nix
+++ b/pkgs/games/anki/addons/review-heatmap/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  esbuild,
+  aab,
+}:
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "review-heatmap";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "glutanimate";
+    repo = "review-heatmap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CL98DYikumoPR/QTWcMMwpd/tEpKLIDVC1Rj5NEvWJ8=";
+    # Needed files are set to export-ignore in .gitattributes
+    forceFetchGit = true;
+  };
+
+  patches = [ ./0001-Apply-vite-style-to-anki-review-heatmap.js.patch ];
+
+  nativeBuildInputs = [
+    aab
+    esbuild
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Work around missing icons
+    mkdir resources/icons/optional
+    touch resources/icons/optional/{patreon.svg,thanks.svg,twitter.svg,youtube.svg}
+
+    mkdir -p build/dist
+    cp -r src resources designer --target-directory build/dist
+    aab build_dist ${finalAttrs.version} --modtime -1
+
+    # build anki-review-heatmap.js
+    esbuild \
+      src/web/main.ts \
+      --bundle \
+      --minify \
+      --target=es2015 \
+      --loader:.css=text \
+      --outfile=build/dist/src/review_heatmap/web/anki-review-heatmap.js
+
+    cd build/dist/src/review_heatmap
+
+    runHook postBuild
+  '';
+
+  meta = {
+    description = "Anki add-on to help you keep track of your review activity";
+    homepage = "https://github.com/glutanimate/review-heatmap";
+    changelog = "https://github.com/glutanimate/review-heatmap/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ eljamm ];
+  };
+})


### PR DESCRIPTION
## Test

```shellSession
nix-build -E 'with import ./. {}; anki.withAddons [ ankiAddons.review-heatmap ]' && ./result/bin/anki
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
