### PR TITLE
[Backport release-24.11] libxmp: 4.6.0 -> 4.6.3; cleanup

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13593,6 +13593,13 @@
     githubId = 34819524;
     name = "Marcel";
   };
+  marcin-serwin = {
+    name = "Marcin Serwin";
+    github = "marcin-serwin";
+    githubId = 12128106;
+    email = "marcin@serwin.dev";
+    keys = [ { fingerprint = "F311 FA15 1A66 1875 0C4D  A88D 82F5 C70C DC49 FD1D"; } ];
+  };
   marcovergueira = {
     email = "vergueira.marco@gmail.com";
     github = "marcovergueira";

--- a/pkgs/by-name/li/libxmp/package.nix
+++ b/pkgs/by-name/li/libxmp/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libxmp";
-  version = "4.6.2";
+  version = "4.6.3";
 
   src = fetchFromGitHub {
     owner = "libxmp";
     repo = "libxmp";
     tag = "libxmp-${finalAttrs.version}";
-    hash = "sha256-AfHathuBmF9OhtTyt8WabZKzFtnAkX1YeiYFF079z80=";
+    hash = "sha256-VTjS5bVu+jiswP4GCTxcAdhtVdtopy4A3hxlzIQlZVU=";
   };
 
   outputs = [

--- a/pkgs/by-name/li/libxmp/package.nix
+++ b/pkgs/by-name/li/libxmp/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libxmp";
-  version = "4.6.1";
+  version = "4.6.2";
 
   meta = with lib; {
     description = "Extended module player library";
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/xmp/libxmp/${pname}-${version}.tar.gz";
-    sha256 = "sha256-r2Becsg7JKuvAyaTR+JOvD/AbNe0lWUqLGGcH1FLxcs=";
+    sha256 = "sha256-rKwXBb4sT7TS1w3AV1mFO6aqt0eoPeV2sIJ4TUb1pLk=";
   };
 }

--- a/pkgs/by-name/li/libxmp/package.nix
+++ b/pkgs/by-name/li/libxmp/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libxmp";
-  version = "4.6.0";
+  version = "4.6.1";
 
   meta = with lib; {
     description = "Extended module player library";
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/xmp/libxmp/${pname}-${version}.tar.gz";
-    sha256 = "sha256-LTxF/lI7UJB+ieYPmjt/TMmquD7J27p3Q+r/vNyzXqY=";
+    sha256 = "sha256-r2Becsg7JKuvAyaTR+JOvD/AbNe0lWUqLGGcH1FLxcs=";
   };
 }

--- a/pkgs/by-name/li/libxmp/package.nix
+++ b/pkgs/by-name/li/libxmp/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
       over 90 mainstream and obscure module formats including Protracker (MOD),
       Scream Tracker 3 (S3M), Fast Tracker II (XM), and Impulse Tracker (IT).
     '';
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ marcin-serwin ];
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/li/libxmp/package.nix
+++ b/pkgs/by-name/li/libxmp/package.nix
@@ -1,27 +1,62 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  docutils,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libxmp";
   version = "4.6.2";
 
-  meta = with lib; {
+  src = fetchFromGitHub {
+    owner = "libxmp";
+    repo = "libxmp";
+    tag = "libxmp-${finalAttrs.version}";
+    hash = "sha256-AfHathuBmF9OhtTyt8WabZKzFtnAkX1YeiYFF079z80=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    docutils
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "BUILD_STATIC" stdenv.hostPlatform.isStatic)
+    (lib.cmakeBool "WITH_UNIT_TESTS" finalAttrs.doCheck)
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "libxmp-(.*)"
+    ];
+  };
+
+  meta = {
     description = "Extended module player library";
     homepage = "https://xmp.sourceforge.net/";
+    changelog = "https://github.com/libxmp/libxmp/releases/tag/${finalAttrs.src.tag}";
     longDescription = ''
       Libxmp is a library that renders module files to PCM data. It supports
       over 90 mainstream and obscure module formats including Protracker (MOD),
       Scream Tracker 3 (S3M), Fast Tracker II (XM), and Impulse Tracker (IT).
     '';
-    license = licenses.lgpl21Plus;
-    platforms = platforms.all;
+    maintainers = with lib.maintainers; [ ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
   };
-
-  src = fetchurl {
-    url = "mirror://sourceforge/xmp/libxmp/${pname}-${version}.tar.gz";
-    sha256 = "sha256-rKwXBb4sT7TS1w3AV1mFO6aqt0eoPeV2sIJ4TUb1pLk=";
-  };
-}
+})


### PR DESCRIPTION
Backport of #369944 #384918 #402124 #407247 to `release-24.11`. Fixes https://github.com/advisories/GHSA-vg32-cm75-rjr5.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.