### PR TITLE
lcov: set correct version

### DIFF
--- a/pkgs/by-name/lc/lcov/package.nix
+++ b/pkgs/by-name/lc/lcov/package.nix
@@ -6,6 +6,7 @@
   python3,
   perlPackages,
   makeWrapper,
+  versionCheckHook,
 }:
 
 let
@@ -57,6 +58,12 @@ stdenv.mkDerivation (finalAttrs: {
       wrapProgram "$f" --set PERL5LIB ${perlPackages.makeFullPerlPath perlDeps}
     done
   '';
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "--version";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Code coverage tool that enhances GNU gcov";

--- a/pkgs/by-name/lc/lcov/package.nix
+++ b/pkgs/by-name/lc/lcov/package.nix
@@ -44,8 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preBuild = ''
     patchShebangs --build bin/{fix.pl,get_version.sh} tests/*/*
-    patchShebangs --host bin/{gen*,lcov,perl2lcov}
-    makeFlagsArray=(PREFIX=$out LCOV_PERL_PATH=${lib.getExe perl})
+    makeFlagsArray=(PREFIX=$out)
   '';
 
   postInstall = ''

--- a/pkgs/by-name/lc/lcov/package.nix
+++ b/pkgs/by-name/lc/lcov/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall = ''
-    for f in "$out"/bin/{gen*,lcov,perl2lcov}; do
+    for f in "$out"/bin/{gen*,lcov,llvm2lcov,perl2lcov}; do
       wrapProgram "$f" --set PERL5LIB ${perlPackages.makeFullPerlPath perlDeps}
     done
   '';

--- a/pkgs/by-name/lc/lcov/package.nix
+++ b/pkgs/by-name/lc/lcov/package.nix
@@ -19,14 +19,14 @@ let
     perlPackages.PathTools
   ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ perlPackages.MemoryProcess ];
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lcov";
   version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "linux-test-project";
     repo = "lcov";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-31318or9AQ7iyu9DNQEvf5jaDzrneOOqOXu0HF1eag4=";
   };
 
@@ -67,9 +67,10 @@ stdenv.mkDerivation rec {
     '';
 
     homepage = "https://github.com/linux-test-project/lcov";
+    changelog = "https://github.com/linux-test-project/lcov/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
 
     maintainers = with lib.maintainers; [ dezgeg ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/lc/lcov/package.nix
+++ b/pkgs/by-name/lc/lcov/package.nix
@@ -42,9 +42,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
+  makeFlags = [
+    "PREFIX=$(out)"
+    "VERSION=${finalAttrs.version}"
+    "RELEASE=1"
+  ];
+
   preBuild = ''
     patchShebangs --build bin/{fix.pl,get_version.sh} tests/*/*
-    makeFlagsArray=(PREFIX=$out)
   '';
 
   postInstall = ''


### PR DESCRIPTION
lcov currently reports its version incorrectly as 2.4-beta

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `6f4dccb5ac7cf998cbceed54c4cb83f8f7067d8c`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>bpfilter</li>
    <li>bpfilter.dev</li>
    <li>bpfilter.lib</li>
    <li>lcov</li>
    <li>makeGCOVReport</li>
    <li>openroad</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc