### PR TITLE
pyroveil: init at 0-unstable-2025-05-28

### DIFF
--- a/pkgs/by-name/py/pyroveil/init.sh
+++ b/pkgs/by-name/py/pyroveil/init.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z "${pyroveil_package_path:-}" ]; then
+  echo "No pyroveil_package_path variable set" >&2
+  exit
+fi
+
+mkdir -p "$HOME/.local/share/"
+cp -r --no-preserve=mode,ownership \
+  "$pyroveil_package_path/share/vulkan/implicit_layer.d/VkLayer_pyroveil_64.json" \
+  "$HOME/.local/share/vulkan/implicit_layer.d/"
+
+rm -f "$HOME/.local/share/pyroveil"
+ln -sf "$pyroveil_package_path/share/pyroveil" "$HOME/.local/share/"

--- a/pkgs/by-name/py/pyroveil/package.nix
+++ b/pkgs/by-name/py/pyroveil/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  python3,
+  makeWrapper,
+}:
+stdenv.mkDerivation (final: {
+  pname = "pyroveil";
+  version = "0-unstable-2025-06-24";
+
+  src = fetchFromGitHub {
+    owner = "HansKristian-Work";
+    repo = "pyroveil";
+    rev = "6b8adb0b0ed2cbdbd8c69e848280890a041bc7dc";
+    fetchSubmodules = true;
+    hash = "sha256-G5scUXWrDcLXouWOrHfl4vUIl6baQIOHNFQRgXL7UVg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+    makeWrapper
+  ];
+
+  postInstall = ''
+    mkdir -p "$out/share/pyroveil"
+    cp -r ../hacks "$out/share/pyroveil"
+    install -D '${./init.sh}' "$out/bin/pyroveil-init"
+
+    wrapProgram "$out/bin/pyroveil-init" \
+      --inherit-argv0 \
+      --set-default pyroveil_package_path "$out"
+  '';
+
+  meta = {
+    description = "Vulkan layer to replace shaders or roundtrip them to workaround driver bugs";
+    homepage = "https://github.com/HansKristian-Work/pyroveil";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ shved ];
+    mainProgram = "pyroveil-init";
+  };
+})


### PR DESCRIPTION
Vulkan layer to replace shaders or roundtrip them to workaround driver bugs. This compiles package and produce an init script.

The init script puts the layer's json to right place and reference to hacks file to local/share path. So launch option may looks like `PYROVEIL=1
PYROVEIL_CONFIG=$HOME/.local/share/pyroveil/hacks/monster-hunter-wilds-nv/pyroveil.json`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
