### PR TITLE
libajantv2: 17.1.3 -> 17.5.0

### DIFF
--- a/pkgs/by-name/li/libajantv2/demos-ntv2overlay-no-makefile.patch
+++ b/pkgs/by-name/li/libajantv2/demos-ntv2overlay-no-makefile.patch
@@ -1,0 +1,23 @@
+From f822ffa9f886b668fe0a6269f0ba8bf48043d190 Mon Sep 17 00:00:00 2001
+From: Luke Granger-Brown <git@lukegb.com>
+Date: Sun, 22 Jun 2025 14:12:08 +0100
+Subject: [PATCH 4/4] Don't attempt to install a non-existent Makefile
+
+---
+ demos/ntv2overlay/CMakeLists.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/demos/ntv2overlay/CMakeLists.txt b/demos/ntv2overlay/CMakeLists.txt
+index 4520e795..ae94906f 100644
+--- a/demos/ntv2overlay/CMakeLists.txt
++++ b/demos/ntv2overlay/CMakeLists.txt
+@@ -48,6 +48,3 @@ endif()
+ if (AJA_INSTALL_CMAKE)
+ 	install(FILES CMakeLists.txt DESTINATION ${CMAKE_INSTALL_PREFIX}/libajantv2/demos/ntv2overlay)
+ endif()
+-if (AJA_INSTALL_MISC)
+-	install(FILES Makefile DESTINATION ${CMAKE_INSTALL_PREFIX}/libajantv2/demos/ntv2overlay)
+-endif()
+-- 
+2.49.0
+

--- a/pkgs/by-name/li/libajantv2/device-info-list.patch
+++ b/pkgs/by-name/li/libajantv2/device-info-list.patch
@@ -1,8 +1,18 @@
+From 5d6984729190139ddcbefb825e4d59a8bdfc3551 Mon Sep 17 00:00:00 2001
+From: Luke Granger-Brown <git@lukegb.com>
+Date: Sun, 22 Jun 2025 14:05:49 +0100
+Subject: [PATCH 2/3] Properly mark CNTV2DeviceScanner::GetDeviceInfoList as a
+ class member method
+
+---
+ ajantv2/src/ntv2devicescanner.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/ajantv2/src/ntv2devicescanner.cpp b/ajantv2/src/ntv2devicescanner.cpp
-index 448e48d372..6b46f9f69d 100644
+index 11d145be..1fb0b433 100644
 --- a/ajantv2/src/ntv2devicescanner.cpp
 +++ b/ajantv2/src/ntv2devicescanner.cpp
-@@ -137,7 +137,7 @@
+@@ -117,7 +117,7 @@ CNTV2DeviceScanner::CNTV2DeviceScanner (const bool inScanNow)
  		}
  	#endif	//	!defined(NTV2_DEPRECATE_16_3)
  
@@ -11,3 +21,6 @@ index 448e48d372..6b46f9f69d 100644
  {
  	AJAAutoLock tmpLock(&sDevInfoListLock);
  	return sDevInfoList;
+-- 
+2.49.0
+

--- a/pkgs/by-name/li/libajantv2/musl.patch
+++ b/pkgs/by-name/li/libajantv2/musl.patch
@@ -1,7 +1,7 @@
-From 6b27c75125f2b2c66d5d6dd8d35569260ac72f17 Mon Sep 17 00:00:00 2001
+From 8312398dbc1f0a960c0e64c2faaa756277c0f67c Mon Sep 17 00:00:00 2001
 From: Alyssa Ross <hi@alyssa.is>
 Date: Fri, 3 Jan 2025 12:21:28 +0100
-Subject: [PATCH] Don't use non-standard ACCESSPERMS macro
+Subject: [PATCH 3/3] Don't use non-standard ACCESSPERMS macro
 
 This macro is non-standard, and is not defined by e.g. musl libc.
 It's just a define for 0777, so just use that instead.
@@ -28,5 +28,5 @@ index 78196446..e18b10a3 100644
  				char* result = getcwd(cwdBuf, AJA_MAX_PATH);
  				AJA_UNUSED(result);
 -- 
-2.47.0
+2.49.0
 

--- a/pkgs/by-name/li/libajantv2/package.nix
+++ b/pkgs/by-name/li/libajantv2/package.nix
@@ -12,18 +12,19 @@
 
 stdenv.mkDerivation rec {
   pname = "libajantv2";
-  version = "17.1.3";
+  version = "17.5.0";
 
   src = fetchFromGitHub {
     owner = "aja-video";
     repo = "libajantv2";
     rev = "ntv2_${builtins.replaceStrings [ "." ] [ "_" ] version}";
-    hash = "sha256-7APoPj2LnvdwfuVforoJz0YxKU1WmAgRqIfXao4IZmY=";
+    hash = "sha256-/BfFbBScS75TpUZEeYzAHd1PtnZgnCNfGtjwYPJJjkg=";
   };
   patches = [
     ./use-system-mbedtls.patch
     ./device-info-list.patch
     ./musl.patch
+    ./demos-ntv2overlay-no-makefile.patch
   ];
 
   outputs = [

--- a/pkgs/by-name/li/libajantv2/use-system-mbedtls.patch
+++ b/pkgs/by-name/li/libajantv2/use-system-mbedtls.patch
@@ -1,16 +1,19 @@
-Commit ID: 1aeee534119a22e717ce3d0e9f62c8791cd825b9
-Change ID: pzyrusopmyvtvnwnruvrltqtpqtzxrpo
-Author: Luke Granger-Brown <git@lukegb.com> (2024-12-20 18:03:16)
-Committer: Luke Granger-Brown <git@lukegb.com> (2024-12-20 18:03:25)
+From 6c8dca24e48b0bbeb11e9611fe547246167030ab Mon Sep 17 00:00:00 2001
+From: Luke Granger-Brown <git@lukegb.com>
+Date: Fri, 20 Dec 2024 18:03:16 +0000
+Subject: [PATCH 1/3] Use system mbedtls, rather than downloading from a random
+ Git branch...
 
-    Use system mbedtls, rather than downloading from a random Git branch...
+---
+ ajantv2/CMakeLists.txt | 50 +++---------------------------------------
+ 1 file changed, 3 insertions(+), 47 deletions(-)
 
 diff --git a/ajantv2/CMakeLists.txt b/ajantv2/CMakeLists.txt
-index ffa572e9c8..74c23e8e4e 100644
+index 8037dd4b..aa6e6577 100644
 --- a/ajantv2/CMakeLists.txt
 +++ b/ajantv2/CMakeLists.txt
-@@ -52,49 +52,13 @@
- else()
+@@ -55,49 +55,13 @@ else()
+     endif()
      message(STATUS "NTV2 SDK will load signed 3rd-party plugins")
  
 -    set(MBEDTLS_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/mbedtls-install)
@@ -23,7 +26,6 @@ index ffa572e9c8..74c23e8e4e 100644
 -        set(MBEDCRYPTO_LIBRARY ${MBEDTLS_LIBRARY_DIR}/mbedcrypto.lib)
 -        set(MBEDTLS_EXTRA_CONFIG_FLAGS
 -                "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
--                "-DMSVC_STATIC_RUNTIME=ON"
 -                "-DCMAKE_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}")
 -    elseif (CMAKE_SYSTEM_NAME MATCHES "^(Linux|Darwin)$")
 -        set(MBEDTLS_LIBRARY ${MBEDTLS_LIBRARY_DIR}/libmbedtls.a)
@@ -35,7 +37,7 @@ index ffa572e9c8..74c23e8e4e 100644
 -    # BUILD_BYPRODUCTS informing CMake where the .a files are located is required to make Ninja build work
 -    ExternalProject_Add(
 -        mbedtls
--        GIT_REPOSITORY https://github.com/aja-video/mbedtls.git
+-        GIT_REPOSITORY ${AJANTV2_MBEDTLS_URL}
 -        GIT_TAG fix-win-dll-cmake
 -        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${MBEDTLS_INSTALL_DIR}
 -                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -46,6 +48,7 @@ index ffa572e9c8..74c23e8e4e 100644
 -                    -DUSE_STATIC_MBEDTLS_LIBRARY=ON
 -                    -DUSE_SHARED_MBEDTLS_LIBRARY=OFF
 -                    ${MBEDTLS_EXTRA_CONFIG_FLAGS}
+-		CMAKE_CACHE_ARGS "-DCMAKE_OSX_ARCHITECTURES:STRING=${CMAKE_OSX_ARCHITECTURES}"
 -        BUILD_ALWAYS TRUE
 -        BUILD_BYPRODUCTS ${MBEDTLS_LIBRARY} ${MBEDX509_LIBRARY} ${MBEDCRYPTO_LIBRARY}
 -    )
@@ -62,7 +65,7 @@ index ffa572e9c8..74c23e8e4e 100644
  endif()
  
  
-@@ -668,10 +632,6 @@
+@@ -671,10 +635,6 @@ if (NOT TARGET ${PROJECT_NAME})
          aja_ntv2_log_build_info()
  
          add_library(${PROJECT_NAME} SHARED ${TARGET_SOURCES})
@@ -73,7 +76,7 @@ index ffa572e9c8..74c23e8e4e 100644
  
          target_compile_definitions(${PROJECT_NAME} PUBLIC
              ${TARGET_COMPILE_DEFS_DYNAMIC}
-@@ -687,10 +647,6 @@
+@@ -690,10 +650,6 @@ if (NOT TARGET ${PROJECT_NAME})
  
          add_library(${PROJECT_NAME} STATIC ${TARGET_SOURCES})
  
@@ -84,3 +87,6 @@ index ffa572e9c8..74c23e8e4e 100644
          target_compile_definitions(${PROJECT_NAME} PUBLIC
              ${TARGET_COMPILE_DEFS_STATIC}
              ${AJANTV2_TARGET_COMPILE_DEFS})
+-- 
+2.49.0
+

--- a/pkgs/os-specific/linux/ajantv2/default.nix
+++ b/pkgs/os-specific/linux/ajantv2/default.nix
@@ -9,6 +9,11 @@ stdenv.mkDerivation {
   inherit (libajantv2) src;
   sourceRoot = "${libajantv2.src.name}/driver/linux";
 
+  patches = [
+    ./fix-linux-6.15.patch
+  ];
+  patchFlags = "-p3";
+
   hardeningDisable = [ "pic" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/ajantv2/default.nix
+++ b/pkgs/os-specific/linux/ajantv2/default.nix
@@ -35,5 +35,7 @@ stdenv.mkDerivation {
       "aarch64-linux"
     ];
     description = "AJA video driver";
+    # FTB for hardened 5.10/5.15 kernels
+    broken = kernel.kernelOlder "6" && kernel.isHardened;
   };
 }

--- a/pkgs/os-specific/linux/ajantv2/fix-linux-6.15.patch
+++ b/pkgs/os-specific/linux/ajantv2/fix-linux-6.15.patch
@@ -1,0 +1,61 @@
+From 8eacfa908f7d9b366d68e0ea0516fdd867a1e492 Mon Sep 17 00:00:00 2001
+From: Luke Granger-Brown <git@lukegb.com>
+Date: Sun, 22 Jun 2025 19:38:10 +0100
+Subject: [PATCH 5/5] Use ccflags-y instead of EXTRA_CFLAGS, which stopped
+ working in Linux 6.15
+
+---
+ driver/linux/Makefile | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/driver/linux/Makefile b/driver/linux/Makefile
+index f714ff9b..da4ee90b 100644
+--- a/driver/linux/Makefile
++++ b/driver/linux/Makefile
+@@ -25,10 +25,10 @@ VERSIONING 	 = -DSDKVER_MAJ=$(SDKVER_MAJ) -DSDKVER_MIN=$(SDKVER_MIN) -DSDKVER_PN
+ DISTRO_INFO  = -DDISTRO_TYPE=$(DISTRO_TYPE) -DDISTRO_IS_RHEL_LIKE=$(DISTRO_IS_RHEL_LIKE) \
+ 			   -DDISTRO_MAJ_VERSION=$(DISTRO_MAJ_VERSION) -DDISTRO_MIN_VERSION=$(DISTRO_MIN_VERSION)  \
+ 			   -DDISTRO_KERNEL_PKG_MAJ=$(DISTRO_KERNEL_PKG_MAJ) -DDISTRO_KERNEL_PKG_MIN=$(DISTRO_KERNEL_PKG_MIN) -DDISTRO_KERNEL_PKG_PNT=$(DISTRO_KERNEL_PKG_PNT)
+-EXTRA_CFLAGS += -DAJALinux -DXENA2 $(DBG) -D$(NTV2TARGET) -D$(A_ARCH) $(EXTRA_DEPS) $(VERSIONING) $(DISTRO_INFO) $(INCLUDES) -Wall -Wno-implicit-fallthrough
++ccflags-y += -DAJALinux -DXENA2 $(DBG) -D$(NTV2TARGET) -D$(A_ARCH) $(EXTRA_DEPS) $(VERSIONING) $(DISTRO_INFO) $(INCLUDES) -Wall -Wno-implicit-fallthrough
+ 
+ ifdef AJA_HEVC
+-	EXTRA_CFLAGS += -DAJA_HEVC=$(AJA_HEVC)
++	ccflags-y += -DAJA_HEVC=$(AJA_HEVC)
+ endif
+ 
+ # if rdma is set
+@@ -73,7 +73,7 @@ ifeq ($(NVIDIA_KO),)
+ endif
+ 
+ ifdef NVIDIA_IGPU
+-	EXTRA_CFLAGS += -DAJA_IGPU=1
++	ccflags-y += -DAJA_IGPU=1
+ ifneq ($(NVIDIA_KO),)
+ ifeq ($(NVIDIA_SYMVERS),)
+ 	NVIDIA_GEN_SYMVERS := ./nvidia-ko-to-module-symvers $(NVIDIA_KO) $(A_LINUX_DRIVER_PATH)/nvidia.symvers
+@@ -91,17 +91,17 @@ endif
+ 
+ # determine if the ko is gpl - no ko is proprietary igpu
+ ifeq ($(NVIDIA_KO),)
+-	EXTRA_CFLAGS += -I$(NVIDIA_SRC_DIR) -DAJA_RDMA=1 -DNVIDIA_PROPRIETARY=1
++	ccflags-y += -I$(NVIDIA_SRC_DIR) -DAJA_RDMA=1 -DNVIDIA_PROPRIETARY=1
+ else
+ ifeq ($(shell modinfo $(NVIDIA_KO) | grep license: | grep GPL),)
+-	EXTRA_CFLAGS += -I$(NVIDIA_SRC_DIR) -DAJA_RDMA=1 -DNVIDIA_PROPRIETARY=1
++	ccflags-y += -I$(NVIDIA_SRC_DIR) -DAJA_RDMA=1 -DNVIDIA_PROPRIETARY=1
+ else
+-	EXTRA_CFLAGS += -I$(NVIDIA_SRC_DIR) -DAJA_RDMA=1
++	ccflags-y += -I$(NVIDIA_SRC_DIR) -DAJA_RDMA=1
+ endif
+ endif
+ 
+ ifdef AJA_CREATE_DEVICE_NODES
+-	EXTRA_CFLAGS += -DAJA_CREATE_DEVICE_NODES=$(AJA_CREATE_DEVICE_NODES)
++	ccflags-y += -DAJA_CREATE_DEVICE_NODES=$(AJA_CREATE_DEVICE_NODES)
+ endif
+ 
+ AJANTV2INCS = $(A_LIB_NTV2_INC)/ajaexport.h \
+-- 
+2.49.0
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Disable the kernel module from building on older -hardened kernels
* Bump to 17.5.0 (https://github.com/aja-video/libajantv2/compare/ntv2_17_1_3...ntv2_17_5_0)
* Make the kernel module build under Linux 6.15 (https://github.com/aja-video/libajantv2/issues/54)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
