### PR TITLE
ci/eval/compare: fix unbounded rebuild labels

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -5,6 +5,8 @@
 
 name: Labels
 
+# TEST
+
 on:
   schedule:
     - cron: '07,17,27,37,47,57 * * * *'

--- a/ci/eval/compare/utils.nix
+++ b/ci/eval/compare/utils.nix
@@ -176,7 +176,7 @@ rec {
       lib.mapAttrsToList (
         kernel: rebuildCount:
         let
-          range = from: to: from <= rebuildCount && (rebuildCount <= to || to == null);
+          range = from: to: from <= rebuildCount && (to == null || rebuildCount <= to);
         in
         lib.mapAttrs' (number: lib.nameValuePair "10.rebuild-${kernel}: ${number}") {
           "0" = range 0 0;

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -4,6 +4,8 @@ __nixpkgs_setup_set_original=$-
 set -eu
 set -o pipefail
 
+# TEST
+
 if [[ -n "${BASH_VERSINFO-}" && "${BASH_VERSINFO-}" -lt 5 ]]; then
     echo "Detected Bash version that isn't supported by Nixpkgs (${BASH_VERSION})"
     echo "Please install Bash 5 or greater to continue."


### PR DESCRIPTION
With enough rebuilds, this will currently lead to:

```
error: cannot compare null with an integer
```

Fixes https://github.com/NixOS/nixpkgs/pull/417916#issuecomment-2994385409

## Things done

- [ ] Test in this PR with temporary stdenv change.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
