### PR TITLE
workflows: log rate limits consistently

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,6 +43,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Log current API rate limits
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /rate_limit | jq
+
       - name: Create backport PRs
         id: backport
         uses: korthout/backport-action@436145e922f9561fc5ea157ff406f21af2d6b363 # v3.2.0
@@ -55,6 +60,11 @@ jobs:
 
             * [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
               * Even as a non-committer, if you find that it is not acceptable, leave a comment.
+
+      - name: Log current API rate limits
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /rate_limit | jq
 
       - name: "Add 'has: port to stable' label"
         if: steps.backport.outputs.created_pull_numbers != ''

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,6 +50,11 @@ jobs:
         run: |
           ./trusted/ci/check-cherry-picks.sh "$BASE_SHA" "$HEAD_SHA" checked-cherry-picks.md
 
+      - name: Log current API rate limits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq
+
       - name: Prepare review
         if: steps.check.outcome == 'failure'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -148,3 +153,8 @@ jobs:
                 }`, { node_id: review.node_id })
               })
             )
+
+      - name: Log current API rate limits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -79,6 +79,12 @@ jobs:
           permission-administration: read
           permission-members: read
 
+      - name: Log current API rate limits
+        if: steps.app-token.outputs.token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /rate_limit | jq
+
       - name: Validate codeowners
         if: steps.app-token.outputs.token
         env:
@@ -89,6 +95,12 @@ jobs:
           # Set this to "notowned,avoid-shadowing" to check that all files are owned by somebody
           EXPERIMENTAL_CHECKS: "avoid-shadowing"
         run: result/bin/codeowners-validator
+
+      - name: Log current API rate limits
+        if: steps.app-token.outputs.token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /rate_limit | jq
 
   # Request reviews from code owners
   request:
@@ -116,8 +128,20 @@ jobs:
           permission-members: read
           permission-pull-requests: write
 
+      - name: Log current API rate limits
+        if: steps.app-token.outputs.token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /rate_limit | jq
+
       - name: Request reviews
         if: steps.app-token.outputs.token
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: result/bin/request-code-owner-reviews.sh ${{ github.repository }} ${{ github.event.number }} "$OWNERS_FILE"
+
+      - name: Log current API rate limits
+        if: steps.app-token.outputs.token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /rate_limit | jq

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -66,6 +66,11 @@ jobs:
           name: merged-${{ matrix.system }}
           path: merged/*
 
+      - name: Log current API rate limits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq
+
       - name: Get target run id
         if: inputs.targetSha
         id: targetRunId
@@ -107,6 +112,11 @@ jobs:
             // No artifact found at this stage. This usually means that Eval failed on the target branch.
             // This should only happen when Eval is broken on the target branch and this PR fixes it.
             // Continue without targetRunId to skip the remaining steps, but pass the job.
+
+      - name: Log current API rate limits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq
 
       - uses: actions/download-artifact@v4
         if: steps.targetRunId.outputs.targetRunId

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -266,6 +266,11 @@ jobs:
 
             core.notice(`Processed ${stats.prs} PRs, made ${stats.requests + stats.artifacts} API requests and downloaded ${stats.artifacts} artifacts.`)
 
+      - name: Log current API rate limits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq
+
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         name: Labels from touched files
         if: |
@@ -313,3 +318,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler-development-branches.yml
           sync-labels: true
+
+      - name: Log current API rate limits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -54,6 +54,10 @@ jobs:
           permission-members: read
           permission-pull-requests: write
 
+      - name: Log current API rate limits (github.token)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq
 
       # In the regular case, this workflow is called via workflow_call from the eval workflow directly.
       # In the more special case, when a PR is undrafted an eval run will have started already.
@@ -87,6 +91,11 @@ jobs:
             }
             throw new Error("No comparison artifact found.")
 
+      - name: Log current API rate limits (github.token)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq
+
       - name: Download the comparison results
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
@@ -95,6 +104,17 @@ jobs:
           pattern: comparison
           path: comparison
           merge-multiple: true
+
+      - name: Log current API rate limits (app-token)
+        if: ${{ steps.app-token.outputs.token }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /rate_limit | jq
+
+      - name: Log current API rate limits (github.token)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq
 
       - name: Requesting maintainer reviews
         if: ${{ steps.app-token.outputs.token }}
@@ -111,3 +131,14 @@ jobs:
           jq -r 'keys[]' comparison/maintainers.json \
             | while read -r id; do gh api /user/"$id" --jq .login; done \
             | GH_TOKEN=${{ steps.app-token.outputs.token }} result/bin/request-reviewers.sh "$REPOSITORY" "$NUMBER" "$AUTHOR"
+
+      - name: Log current API rate limits (app-token)
+        if: ${{ steps.app-token.outputs.token }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api /rate_limit | jq
+
+      - name: Log current API rate limits (github.token)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api /rate_limit | jq


### PR DESCRIPTION
This will give us a better idea about:
- Which jobs use the most API calls and can possibly be made more efficient.
- Which rate limits apply exactly to which tokens.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
