### PR TITLE
lib.types.attrTag: expose suboptions at correct level

### DIFF
--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -7,7 +7,7 @@
 let
   inherit (lib) mkOption types;
   forceDeep = x: builtins.deepSeq x x;
-  mergedSubOption = (options.merged.type.getSubOptions options.merged.loc).extensible."merged.<name>";
+  mergedSubOption = (options.merged.type.getSubOptions options.merged.loc).extensible;
 in
 {
   options = {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -919,12 +919,7 @@ let
           description = "attribute-tagged union";
           descriptionClass = "noun";
           getSubOptions =
-            prefix:
-            mapAttrs (tagName: tagOption: {
-              "${lib.showOption prefix}" = tagOption // {
-                loc = prefix ++ [ tagName ];
-              };
-            }) tags;
+            prefix: mapAttrs (tagName: tagOption: tagOption // { loc = prefix ++ [ tagName ]; }) tags;
           check = v: isAttrs v && length (attrNames v) == 1 && tags ? ${head (attrNames v)};
           merge =
             loc: defs:


### PR DESCRIPTION
Currently, `attrTag` does a really weird thing when you get its suboptions

https://github.com/NixOS/nixpkgs/blob/459f07632933eef424cb06cf35617aeebc6e637b/lib/types.nix#L921-L927

For each tag, it will emit a option tree that is 2 deep, each with a single extra intermediate node of `"${showOption prefix}"` containing the actual option.

Let's see how this looks in practice, by inspecting the only option in nixpkgs that currently uses `attrTag`.

<details>

<summary>(repl snippet)</summary>

```nix
let
  nixpkgs = builtins.getFlake "nixpkgs";

  system = nixpkgs.lib.nixosSystem {
    system = "x86_64-linux";
    modules = [ ];
  };

  opt = system.options.services.misskey.reverseProxy.webserver;

in
opt.type.getSubOptions opt.loc
```

</details>

These are the suboptions of `services.misskey.reverseProxy.webserver`:

```nix
{
  caddy = {
    "services.misskey.reverseProxy.webserver" = {
      _type = "option";
      loc = [
        "services"
        "misskey"
        "reverseProxy"
        "webserver"
        "caddy"
      ];
      declarationPositions = <...>;
      declarations = <...>;
      default = <...>;
      description = <...>;
      type = <...>;
    };
  };
  nginx = {
    "services.misskey.reverseProxy.webserver" = {
      _type = "option";
      loc = [
        "services"
        "misskey"
        "reverseProxy"
        "webserver"
        "nginx"
      ];
      declarationPositions = <...>;
      declarations = <...>;
      default = <...>;
      description = <...>;
      type = <...>;
    };
  };
}
```

That looks obviously wrong. If we want to look at the structure of the `nginx` option, we must specify the **full path to the option** as a *rendered path location from the eval root* and access `(suboptions).nginx."services.misskey.reverseProxy.webserver"`, which contains the actual `nginx` option.

This is clearly not done in order to emit `prefix` somewhere either, because that belongs in the `loc` of the suboptions, which is already set correctly.

So this extra nesting is just, very strange, and serves no purpose. But it did trip me up when using `attrTag` on my own (and specifically, i got some strange results when trying to render docs using the output from this exact function)

The change simply removes that extra level of nesting. Since it only touches `getSubOptions`, it doesn't affect actual usage of the type, only how it's exposed to documentation tooling (and the reason it didn't look weird at all in official nixos docs is because that ignores the entire shape of the options tree and only ever uses `loc`, which IS handled correctly)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
