### PR TITLE
python3Packages.kmapper: add missing test dependency

### DIFF
--- a/pkgs/development/python-modules/kmapper/default.nix
+++ b/pkgs/development/python-modules/kmapper/default.nix
@@ -13,6 +13,7 @@
   scipy,
 
   # tests
+  anywidget,
   igraph,
   ipywidgets,
   matplotlib,
@@ -45,6 +46,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "kmapper" ];
 
   nativeCheckInputs = [
+    anywidget
     igraph
     ipywidgets
     matplotlib

--- a/pkgs/development/python-modules/kmapper/default.nix
+++ b/pkgs/development/python-modules/kmapper/default.nix
@@ -2,17 +2,23 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
-  scikit-learn,
-  numpy,
-  scipy,
+
+  # dependencies
   jinja2,
-  pytestCheckHook,
-  networkx,
-  matplotlib,
+  numpy,
+  scikit-learn,
+  scipy,
+
+  # tests
   igraph,
-  plotly,
   ipywidgets,
+  matplotlib,
+  networkx,
+  plotly,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -30,27 +36,28 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
-    scikit-learn
-    numpy
-    scipy
     jinja2
+    numpy
+    scikit-learn
+    scipy
   ];
 
   pythonImportsCheck = [ "kmapper" ];
 
   nativeCheckInputs = [
-    pytestCheckHook
-    networkx
-    matplotlib
     igraph
-    plotly
     ipywidgets
+    matplotlib
+    networkx
+    plotly
+    pytestCheckHook
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python implementation of Mapper algorithm for Topological Data Analysis";
     homepage = "https://kepler-mapper.scikit-tda.org/";
-    license = licenses.mit;
+    changelog = "https://github.com/scikit-tda/kepler-mapper/releases/tag/v${version}";
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.kmapper: cleanup**
- **python3Packages.kmapper: add missing test dependency**

---

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
