### PR TITLE
workflows/labels: run with app token & much higher rate limit

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -33,6 +33,8 @@ concurrency:
 
 # This is used as fallback without app only.
 # This happens when testing in forks without setting up that app.
+# Labels will most likely not exist in forks, yet. For this case,
+# we add the issues permission only here.
 permissions:
   issues: write # needed to create *new* labels
   pull-requests: write
@@ -56,6 +58,8 @@ jobs:
         with:
           app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
           private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+          # No issues: write permission here, because labels in Nixpkgs should
+          # be created explicitly via the UI with color and description.
           permission-pull-requests: write
 
       - name: Log current API rate limits
@@ -89,21 +93,40 @@ jobs:
             const allLimits = new Bottleneck({
               // Avoid concurrent requests
               maxConcurrent: 1,
-              // Hourly limit is at 5000, but other jobs need some, too!
-              // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
-              reservoir: 500,
-              reservoirRefreshAmount: 500,
-              reservoirRefreshInterval: 60 * 60 * 1000
+              // Will be updated with first `updateReservoir()` call below.
+              reservoir: 0
             })
             // Pause between mutative requests
             const writeLimits = new Bottleneck({ minTime: 1000 }).chain(allLimits)
             github.hook.wrap('request', async (request, options) => {
+              // Requests to the /rate_limit endpoint do not count against the rate limit.
+              if (options.url == '/rate_limit') return request(options)
               stats.requests++
               if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(options.method))
                 return writeLimits.schedule(request.bind(null, options))
               else
                 return allLimits.schedule(request.bind(null, options))
             })
+
+            async function updateReservoir() {
+              let response
+              try {
+                response = await github.rest.rateLimit.get()
+              } catch (err) {
+                core.error(`Failed updating reservoir:\n${err}`)
+                // Keep retrying on failed rate limit requests instead of exiting the script early.
+                return
+              }
+              // Always keep 1000 spare requests for other jobs to do their regular duty.
+              // They normally use below 100, so 1000 is *plenty* of room to work with.
+              const reservoir = Math.max(0, response.data.resources.core.remaining - 1000)
+              core.info(`Updating reservoir to: ${reservoir}`)
+              allLimits.updateSettings({ reservoir })
+            }
+            await updateReservoir()
+            // Update remaining requests every minute to account for other jobs running in parallel.
+            const reservoirUpdater = setInterval(updateReservoir, 60 * 1000)
+            process.on('uncaughtException', () => clearInterval(reservoirUpdater))
 
             if (process.env.UPDATED_WITHIN && !/^\d+$/.test(process.env.UPDATED_WITHIN))
               throw new Error('Please enter "updated within" as integer in hours.')
@@ -284,6 +307,7 @@ jobs:
               .map(({ reason }) => core.setFailed(`${reason.message}\n${reason.cause.stack}`))
 
             core.notice(`Processed ${stats.prs} PRs, made ${stats.requests + stats.artifacts} API requests and downloaded ${stats.artifacts} artifacts.`)
+            clearInterval(reservoirUpdater)
 
       - name: Log current API rate limits
         env:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,6 +13,9 @@ on:
       headBranch:
         required: true
         type: string
+    secrets:
+      NIXPKGS_CI_APP_PRIVATE_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       updatedWithin:
@@ -28,6 +31,8 @@ concurrency:
   # PR- and manually-triggered runs will be cancelled, but scheduled runs will be queued.
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
+# This is used as fallback without app only.
+# This happens when testing in forks without setting up that app.
 permissions:
   issues: write # needed to create *new* labels
   pull-requests: write
@@ -44,9 +49,18 @@ jobs:
       - name: Install dependencies
         run: npm install @actions/artifact bottleneck
 
+      # Use a GitHub App, because it has much higher rate limits: 12,500 instead of 5,000 req / hour.
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        if: vars.NIXPKGS_CI_APP_ID
+        id: app-token
+        with:
+          app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
       - name: Log current API rate limits
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: gh api /rate_limit | jq
 
       - name: Labels from API data and Eval results
@@ -54,6 +68,7 @@ jobs:
         env:
           UPDATED_WITHIN: ${{ inputs.updatedWithin }}
         with:
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const Bottleneck = require('bottleneck')
             const path = require('node:path')
@@ -272,7 +287,7 @@ jobs:
 
       - name: Log current API rate limits
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: gh api /rate_limit | jq
 
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
@@ -281,7 +296,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           !contains(fromJSON(inputs.headBranch).type, 'development')
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           configuration-path: .github/labeler.yml # default
           sync-labels: true
 
@@ -291,7 +306,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           !contains(fromJSON(inputs.headBranch).type, 'development')
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           configuration-path: .github/labeler-no-sync.yml
           sync-labels: false
 
@@ -304,11 +319,11 @@ jobs:
           github.event_name == 'pull_request_target' &&
           contains(fromJSON(inputs.headBranch).type, 'development')
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           configuration-path: .github/labeler-development-branches.yml
           sync-labels: true
 
       - name: Log current API rate limits
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: gh api /rate_limit | jq

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,6 +103,8 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    secrets:
+      NIXPKGS_CI_APP_PRIVATE_KEY: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
     with:
       headBranch: ${{ needs.prepare.outputs.headBranch }}
 


### PR DESCRIPTION
With the data from https://github.com/NixOS/nixpkgs/pull/419080#issuecomment-2995188881, we can allow many more requests for manually triggered workflows. This will allow us to back fill multiple days of labeling, if needed.

## Things done

- [x] Tested in my fork.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
