### PR TITLE
 python312Packages.tensorflow-datasets: adjust dependencies 

### DIFF
--- a/pkgs/development/python-modules/tensorflow-datasets/default.nix
+++ b/pkgs/development/python-modules/tensorflow-datasets/default.nix
@@ -76,30 +76,31 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  dependencies = [
-    absl-py
-    array-record
-    dm-tree
-    etils
-    immutabledict
-    numpy
-    promise
-    protobuf
-    psutil
-    pyarrow
-    requests
-    simple-parsing
-    tensorflow-metadata
-    termcolor
-    toml
-    tqdm
-    wrapt
-  ]
-  ++ etils.optional-dependencies.epath
-  ++ etils.optional-dependencies.etree
-  ++ lib.optionals (pythonOlder "3.9") [
-    importlib-resources
-  ];
+  dependencies =
+    [
+      absl-py
+      array-record
+      dm-tree
+      etils
+      immutabledict
+      numpy
+      promise
+      protobuf
+      psutil
+      pyarrow
+      requests
+      simple-parsing
+      tensorflow-metadata
+      termcolor
+      toml
+      tqdm
+      wrapt
+    ]
+    ++ etils.optional-dependencies.epath
+    ++ etils.optional-dependencies.etree
+    ++ lib.optionals (pythonOlder "3.9") [
+      importlib-resources
+    ];
 
   pythonImportsCheck = [ "tensorflow_datasets" ];
 

--- a/pkgs/development/python-modules/tensorflow-datasets/default.nix
+++ b/pkgs/development/python-modules/tensorflow-datasets/default.nix
@@ -3,23 +3,29 @@
   buildPythonPackage,
   fetchFromGitHub,
 
+  # build system
+  setuptools,
+
   # dependencies
+  absl-py,
   array-record,
-  dill,
   dm-tree,
-  future,
+  etils,
   immutabledict,
-  importlib-resources,
   numpy,
   promise,
   protobuf,
   psutil,
+  pyarrow,
   requests,
   simple-parsing,
-  six,
   tensorflow-metadata,
   termcolor,
+  toml,
   tqdm,
+  wrapt,
+  pythonOlder,
+  importlib-resources,
 
   # tests
   apache-beam,
@@ -27,6 +33,7 @@
   click,
   cloudpickle,
   datasets,
+  dill,
   ffmpeg,
   imagemagick,
   jax,
@@ -67,23 +74,31 @@ buildPythonPackage rec {
     hash = "sha256-ZXaPYmj8aozfe6ygzKybId8RZ1TqPuIOSpd8XxnRHus=";
   };
 
+  build-system = [ setuptools ];
+
   dependencies = [
+    absl-py
     array-record
-    dill
     dm-tree
-    future
+    etils
     immutabledict
-    importlib-resources
     numpy
     promise
     protobuf
     psutil
+    pyarrow
     requests
     simple-parsing
-    six
     tensorflow-metadata
     termcolor
+    toml
     tqdm
+    wrapt
+  ]
+  ++ etils.optional-dependencies.epath
+  ++ etils.optional-dependencies.etree
+  ++ lib.optionals (pythonOlder "3.9") [
+    importlib-resources
   ];
 
   pythonImportsCheck = [ "tensorflow_datasets" ];
@@ -94,6 +109,7 @@ buildPythonPackage rec {
     click
     cloudpickle
     datasets
+    dill
     ffmpeg
     imagemagick
     jax


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Building with `doCheck = false` causes errors because (1) `setuptools` is not declared as the build system and (2) `pyarrow` is not declared as a dependency. The rest of the changes are mostly cosmetic, to better align with the upstream [`setup.py`](https://github.com/tensorflow/datasets/blob/v4.9.9/setup.py#L50-L74). Note that for `etils[edc,enp,epath,epy,etree]`, `edc = epy` and `etree = array-types + epy + enp + etqdm` so `epath` and `etree` are sufficient and necessary. Practically speaking, there's so much redundancy that it doesn't really matter. Split into two commits just to make it slightly easier to see the diff.

The main motivation for building with  `doCheck = false` is that the tests pull in a substantial amount of dependencies, which can be unnecessary (when building with gpu, for example).

cc @GaetanLepage

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
