### PR TITLE
python3Packages.etils: adjust dependencies

### DIFF
--- a/pkgs/development/python-modules/etils/default.nix
+++ b/pkgs/development/python-modules/etils/default.nix
@@ -17,10 +17,17 @@
   jupyter,
   mediapy,
   numpy,
+  packaging,
+  protobuf,
+  fsspec,
   importlib-resources,
   typing-extensions,
   zipp,
   absl-py,
+  simple-parsing,
+  einops,
+  gcsfs,
+  s3fs,
   tqdm,
   dm-tree,
   jax,
@@ -44,23 +51,33 @@ buildPythonPackage rec {
   optional-dependencies = rec {
     array-types = enp;
     eapp = [
-      absl-py # FIXME package simple-parsing
+      absl-py
+      simple-parsing
     ] ++ epy;
     ecolab =
       [
         jupyter
         numpy
         mediapy
+        packaging
+        protobuf
       ]
       ++ enp
-      ++ epy;
+      ++ epy
+      ++ etree;
     edc = epy;
-    enp = [ numpy ] ++ epy;
+    enp = [
+      numpy
+      einops
+    ] ++ epy;
     epath = [
+      fsspec
       importlib-resources
       typing-extensions
       zipp
     ] ++ epy;
+    epath-gcs = [ gcsfs ] ++ epath;
+    epath-s3 = [ s3fs ] ++ epath;
     epy = [ typing-extensions ];
     etqdm = [
       absl-py
@@ -70,6 +87,7 @@ buildPythonPackage rec {
     etree-dm = [ dm-tree ] ++ etree;
     etree-jax = [ jax ] ++ etree;
     etree-tf = [ tensorflow ] ++ etree;
+    lazy-imports = ecolab;
     all =
       array-types
       ++ eapp
@@ -77,6 +95,8 @@ buildPythonPackage rec {
       ++ edc
       ++ enp
       ++ epath
+      ++ epath-gcs
+      ++ epath-s3
       ++ epy
       ++ etqdm
       ++ etree


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

No real motivation, just discovered while working on https://github.com/NixOS/nixpkgs/pull/419210. Direct port of the current upstream [`pyproject.toml`](https://github.com/google/etils/blob/d052212c91ddadd8d1d47116e3e578dea64b8fc3/pyproject.toml#L33-L121).

cc @GaetanLepage

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
