### PR TITLE
python312Packages.pybind11: 2.13.6 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -100,7 +100,7 @@ buildPythonPackage rec {
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/pybind/pybind11";
     changelog = "https://github.com/pybind/pybind11/blob/${src.rev}/docs/changelog.rst";
     description = "Seamless operability between C++11 and Python";
@@ -110,8 +110,8 @@ buildPythonPackage rec {
       C++ types in Python and vice versa, mainly to create Python
       bindings of existing C++ code.
     '';
-    license = licenses.bsd3;
-    maintainers = with maintainers; [
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
       yuriaisaka
       dotlambda
     ];

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -50,16 +50,12 @@ buildPythonPackage rec {
 
   dontUseCmakeBuildDir = true;
 
-  # Don't build tests if not needed, read the doInstallCheck value at runtime
-  preConfigure = ''
-    if [ -n "$doInstallCheck" ]; then
-      cmakeFlagsArray+=("-DBUILD_TESTING=ON")
-    fi
-  '';
-
   cmakeFlags = [
     "-DBoost_INCLUDE_DIR=${lib.getDev boost}/include"
     "-DEIGEN3_INCLUDE_DIR=${lib.getDev eigen}/include/eigen3"
+    # Always build tests, because even when cross compiling building the tests
+    # is another confirmation that everything is OK.
+    "-DBUILD_TESTING=ON"
   ] ++ lib.optionals (python.isPy3k && !stdenv.cc.isClang) [ "-DPYBIND11_CXX_STANDARD=-std=c++17" ];
 
   postBuild = ''

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -10,7 +10,7 @@
   boost,
   eigen,
   python,
-  catch,
+  catch2,
   numpy,
   pytestCheckHook,
   libxcrypt,
@@ -45,7 +45,15 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  buildInputs = lib.optionals (pythonOlder "3.9") [ libxcrypt ];
+  buildInputs =
+    [
+      # Used only for building tests - something we do even when cross
+      # compiling.
+      catch2
+    ]
+    ++ lib.optionals (pythonOlder "3.9") [
+      libxcrypt
+    ];
   propagatedNativeBuildInputs = [ setupHook ];
 
   dontUseCmakeBuildDir = true;
@@ -71,7 +79,6 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
-    catch
     numpy
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -50,6 +50,8 @@ buildPythonPackage rec {
       # Used only for building tests - something we do even when cross
       # compiling.
       catch2
+      boost
+      eigen
     ]
     ++ lib.optionals (pythonOlder "3.9") [
       libxcrypt
@@ -59,8 +61,6 @@ buildPythonPackage rec {
   dontUseCmakeBuildDir = true;
 
   cmakeFlags = [
-    "-DBoost_INCLUDE_DIR=${lib.getDev boost}/include"
-    "-DEIGEN3_INCLUDE_DIR=${lib.getDev eigen}/include/eigen3"
     # Always build tests, because even when cross compiling building the tests
     # is another confirmation that everything is OK.
     "-DBUILD_TESTING=ON"

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -88,23 +88,23 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTestPaths = [
-    # require dependencies not available in nixpkgs
-    "tests/test_embed/test_trampoline.py"
-    "tests/test_embed/test_interpreter.py"
-    # numpy changed __repr__ output of numpy dtypes
-    "tests/test_numpy_dtypes.py"
-    # no need to test internal packaging
-    "tests/extra_python_package/test_files.py"
-    # tests that try to parse setuptools stdout
-    "tests/extra_setuptools/test_setuphelper.py"
-  ];
+  #disabledTestPaths = [
+  #  # require dependencies not available in nixpkgs
+  #  "tests/test_embed/test_trampoline.py"
+  #  "tests/test_embed/test_interpreter.py"
+  #  # numpy changed __repr__ output of numpy dtypes
+  #  "tests/test_numpy_dtypes.py"
+  #  # no need to test internal packaging
+  #  "tests/extra_python_package/test_files.py"
+  #  # tests that try to parse setuptools stdout
+  #  "tests/extra_setuptools/test_setuphelper.py"
+  #];
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # expects KeyError, gets RuntimeError
-    # https://github.com/pybind/pybind11/issues/4243
-    "test_cross_module_exception_translator"
-  ];
+  #disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+  #  # expects KeyError, gets RuntimeError
+  #  # https://github.com/pybind/pybind11/issues/4243
+  #  "test_cross_module_exception_translator"
+  #];
   passthru = {
     # scikit-build-core's tests depend upon pybind11, and hence introduce
     # infinite recursion. To avoid this, we define here a scikit-build-core


### PR DESCRIPTION
## Description of changes

Preparing for the version 3 release, I found a few fixes that are relevant even for version 2. Currently the build fails with:

```
Executing pytestCheckPhase
pytest flags: -m pytest
Traceback (most recent call last):
  File "/build/source/tests/conftest.py", line 25, in <module>
    import pybind11_tests
ModuleNotFoundError: No module named 'pybind11_tests'
ImportError while loading conftest '/build/source/tests/conftest.py'.
tests/conftest.py:25: in <module>
    import pybind11_tests
E   ModuleNotFoundError: No module named 'pybind11_tests'
```

See also:

- https://github.com/pybind/pybind11/discussions/5741
- https://github.com/matplotlib/matplotlib/pull/30291

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
