### PR TITLE
prometheus-tuya-smartplug-exporter: init at 1.0.4

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -128,6 +128,7 @@ let
         "surfboard"
         "systemd"
         "tibber"
+        "tuya-smartplug"
         "unbound"
         "unpoller"
         "v2ray"

--- a/nixos/modules/services/monitoring/prometheus/exporters/tuya-smartplug.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/tuya-smartplug.nix
@@ -1,0 +1,45 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.tuya-smartplug;
+in
+{
+  port = 9999;
+  extraOpts = {
+    configFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to the tuya-smartplug configuration file.
+      '';
+      example = lib.literalExpression "./config.yml";
+    };
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "debug"
+        "info"
+        "warn"
+        "error"
+      ];
+      default = "info";
+      description = ''
+        Detail level to log.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${lib.getExe pkgs.prometheus-tuya-smartplug-exporter} \
+          --log.level=${cfg.logLevel} \
+          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+          --config.file="${lib.escapeShellArg cfg.configFile}"
+      '';
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-tuya-smartplug-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-tuya-smartplug-exporter/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+let
+  version = "1.0.4";
+  src = fetchFromGitHub {
+    owner = "rkosegi";
+    repo = "tuya-smartplug-exporter";
+    rev = "v${version}";
+    hash = "sha256-6n14NLVV8jhg6a/WAR149px/nM0eKwgOIe5qBG8jbKA=";
+  };
+in
+buildGoModule {
+  pname = "prometheus-tuya-smartplug-exporter";
+  vendorHash = "sha256-ABIId1VSt3AgO4gHJakkmJrXClk0Q3dpY+DPLfmG3kw=";
+  inherit src version;
+
+  ldflags = [
+    "-X github.com/prometheus/common/version.Version=${version}"
+    "-X github.com/prometheus/common/version.Revision=${src.rev}"
+    "-X github.com/prometheus/common/version.Branch=unknown"
+  ];
+
+  meta = {
+    description = "Prometheus exporter for Tuya-based smartplug devices";
+    homepage = "https://github.com/rkosegi/tuya-smartplug-exporter";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ onny ];
+    mainProgram = "tuya-smartplug-exporter";
+  };
+}


### PR DESCRIPTION
Adding Prometheus exporter tuya-smartplug-exporter in version 1.0.4 https://github.com/rkosegi/tuya-smartplug-exporter

```
{ pkgs, config, ... }: let

  configFile = pkgs.writeText "config.yml" ''- name: Sauna Solarstrom
  id: ****
  key: ****
  ip: 10.250.0.2'';

in {

  services.prometheus.enable = true;

  services.prometheus = {
    exporters.tuya-smartplug = {
      enable = true;
      port = 9999;
      configFile = configFile;
    };
    scrapeConfigs = [
      {
        job_name = "solarsauna";
        static_configs = [{
          targets = [ "127.0.0.1:${toString config.services.prometheus.exporters.tuya-smartplug.port}" ];
        }];
      }
    ];

  };
}
```

check if running
```
systemctl status prometheus-tuya-smartplug-exporter.service
```

test query metrics from exporter directly
```
curl localhost:9999/metrics
```

query via prometheus
```
curl -s 'http://localhost:9090/api/v1/query?query=tuya_smartplug_voltage'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
