### PR TITLE
python312Packages.scipy: 1.15.3 -> 1.16.0

### DIFF
--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -59,7 +59,7 @@ let
 in
 buildPythonPackage rec {
   pname = "numpy";
-  version = "2.3.0";
+  version = "2.3.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -67,7 +67,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     extension = "tar.gz";
-    hash = "sha256-WB+H+enp2yy6IUFADhYOndZE7iSHiNb5BjbuuP2SYKY=";
+    hash = "sha256-HsmuIKQibaN0NizKPGLNdT+vL5UUQLDjuY6TwjVEHSs=";
   };
 
   patches = lib.optionals python.hasDistutilsCxxPatch [

--- a/pkgs/development/python-modules/pythran/default.nix
+++ b/pkgs/development/python-modules/pythran/default.nix
@@ -24,14 +24,14 @@ let
 in
 buildPythonPackage rec {
   pname = "pythran";
-  version = "0.17.0";
+  version = "0.18.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "serge-sans-paille";
     repo = "pythran";
     tag = version;
-    hash = "sha256-JG1FH2UAekFF9Vv7wCn/L7gJlVKv5AxqgGrj8pejqeY=";
+    hash = "sha256-GZSVcB4JIx02eiUb9d7o5cUAyICIoH6m0mz4TL7a9PY=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -48,8 +48,8 @@ let
   #     nix-shell maintainers/scripts/update.nix --argstr package python3.pkgs.scipy
   #
   # The update script uses sed regexes to replace them with the updated hashes.
-  version = "1.15.3";
-  srcHash = "sha256-97z5CLRq/2kWjL2+ewHRA71vSfvCLHVJdOUZfDFnyhM=";
+  version = "1.16.0";
+  srcHash = "sha256-PFWUq7RsqMgBK1bTw52y1renoPygWNreikNTFHWE2Ig=";
   datasetsHashes = {
     ascent = "1qjp35ncrniq9rhzb14icwwykqg2208hcssznn3hz27w39615kh3";
     ecg = "1bwbjp43b7znnwha5hv6wiz3g0bhwrpqpi75s12zidxrbwvd62pj";
@@ -104,7 +104,7 @@ buildPythonPackage {
   # that override globally the `numpy` attribute to point to `numpy_1`.
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "numpy>=2.0.0,<2.5" numpy
+      --replace-fail "numpy>=2.0.0,<2.6" numpy
   '';
 
   build-system =
@@ -119,7 +119,7 @@ buildPythonPackage {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # Minimal version required according to:
-      # https://github.com/scipy/scipy/blob/v1.14.0/scipy/meson.build#L185-L188
+      # https://github.com/scipy/scipy/blob/v1.16.0/scipy/meson.build#L238-L244
       (xcbuild.override {
         sdkVer = "13.3";
       })

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -143,23 +143,17 @@ buildPythonPackage {
     pytest-xdist
   ];
 
-  disabledTests =
-    [
-      "test_cumulative_simpson_against_simpson_with_default_dx"
-      # https://github.com/scipy/scipy/issues/22789
-      "test_funcs"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-      # The following tests are broken on aarch64-darwin with newer compilers and library versions.
-      # See https://github.com/scipy/scipy/issues/18308
-      "test_a_b_neg_int_after_euler_hypergeometric_transformation"
-      "test_dst4_definition_ortho"
-      "test_load_mat4_le"
-      "hyp2f1_test_case47"
-      "hyp2f1_test_case3"
-      "test_uint64_max"
-      "test_large_m4" # https://github.com/scipy/scipy/issues/22466
-    ];
+  disabledTests = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # The following tests are broken on aarch64-darwin with newer compilers and library versions.
+    # See https://github.com/scipy/scipy/issues/18308
+    "test_a_b_neg_int_after_euler_hypergeometric_transformation"
+    "test_dst4_definition_ortho"
+    "test_load_mat4_le"
+    "hyp2f1_test_case47"
+    "hyp2f1_test_case3"
+    "test_uint64_max"
+    "test_large_m4" # https://github.com/scipy/scipy/issues/22466
+  ];
 
   doCheck = !(stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isDarwin);
 


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
