### PR TITLE
python3Packages.nampa: 1.0 -> 1.0-unstable-2024-12-18

### DIFF
--- a/pkgs/development/python-modules/nampa/default.nix
+++ b/pkgs/development/python-modules/nampa/default.nix
@@ -2,14 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  future,
   pythonOlder,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "nampa";
-  version = "1.0";
+  version = "1.0-unstable-2024-12-18";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -17,19 +16,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "thebabush";
     repo = "nampa";
-    tag = version;
-    hash = "sha256-ylDthh6fO0jKiYib0bed31Dxt4afiD0Jd5mfRKrsZpE=";
+    rev = "cb6a63aae64324f57bdc296064bc6aa2b99ff99a";
+    hash = "sha256-4NEfrx5cR6Zk713oBRZBe52mrbHKhs1doJFAdjnobig=";
   };
 
-  postPatch = ''
-    # https://github.com/thebabush/nampa/pull/13
-    substituteInPlace setup.py \
-      --replace "0.1.1" "${version}"
-  '';
-
   build-system = [ setuptools ];
-
-  dependencies = [ future ];
 
   # Not used for binaryninja as plugin
   doCheck = false;
@@ -39,7 +30,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python implementation of the FLIRT technology";
     homepage = "https://github.com/thebabush/nampa";
-    changelog = "https://github.com/thebabush/nampa/releases/tag/${version}";
+    changelog = "https://github.com/thebabush/nampa/commits/cb6a63aae64324f57bdc296064bc6aa2b99ff99a/";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
With the recent shift to Python 3.13 the `nampa` package has stopped building with the following:

```
error: future-1.0.0 not supported for interpreter python3.13
```

The respective fix has been submitted in thebabush/nampa@cb6a63aae64324f57bdc296064bc6aa2b99ff99a back in December of 2024, but no new release had been cut since.

Since only four commits have happened since the tagging point of 1.0 (one of which had already been cherry-picked as a patch and one is the fix for the `future` compatibility issue), I deemed it manageable to just fast-forward our base source instead. The remaining two commits are the following, which are relatively small correctness fixes:

- [Use BytesIO to load compressed FLIRT files](https://github.com/thebabush/nampa/commit/b8f25435221ddc073c48c6ca24f2f53cf55a9699)
- [Decompress with wbits=-MAX_WBITS for FLIRT versions \[5, 7)](https://github.com/thebabush/nampa/commit/ff30add0b8733e84fd089e58ca0fbd962e12c9f9)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves #427333.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
