### PR TITLE
seafile: remove myself from maintainers

### DIFF
--- a/nixos/modules/services/networking/seafile.nix
+++ b/nixos/modules/services/networking/seafile.nix
@@ -542,7 +542,6 @@ in
   };
 
   meta.maintainers = with lib.maintainers; [
-    greizgh
     schmittlauch
   ];
 }

--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [
       schmittlauch
-      greizgh
     ];
     mainProgram = "seafile-applet";
   };

--- a/pkgs/by-name/li/libsearpc/package.nix
+++ b/pkgs/by-name/li/libsearpc/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     mainProgram = "searpc-codegen.py";
     license = lib.licenses.lgpl3;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ greizgh ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/se/seafile-server/libevhtp.nix
+++ b/pkgs/by-name/se/seafile-server/libevhtp.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/criticalstack/libevhtp";
     license = licenses.bsd3;
     maintainers = with maintainers; [
-      greizgh
       schmittlauch
       melvyn2
     ];

--- a/pkgs/by-name/se/seafile-server/package.nix
+++ b/pkgs/by-name/se/seafile-server/package.nix
@@ -94,7 +94,6 @@ stdenv.mkDerivation {
     license = licenses.agpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      greizgh
       schmittlauch
       melvyn2
     ];

--- a/pkgs/by-name/se/seafile-shared/package.nix
+++ b/pkgs/by-name/se/seafile-shared/package.nix
@@ -62,7 +62,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      greizgh
       schmittlauch
     ];
   };

--- a/pkgs/by-name/se/seahub/package.nix
+++ b/pkgs/by-name/se/seahub/package.nix
@@ -79,7 +79,6 @@ python3.pkgs.buildPythonApplication rec {
     homepage = "https://github.com/haiwen/seahub";
     license = licenses.asl20;
     maintainers = with maintainers; [
-      greizgh
       schmittlauch
       melvyn2
     ];

--- a/pkgs/development/python-modules/django-formtools/default.nix
+++ b/pkgs/development/python-modules/django-formtools/default.nix
@@ -40,7 +40,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/jazzband/django-formtools/blob/master/docs/changelog.rst";
     license = licenses.bsd3;
     maintainers = with maintainers; [
-      greizgh
       schmittlauch
     ];
   };

--- a/pkgs/development/python-modules/django-statici18n/default.nix
+++ b/pkgs/development/python-modules/django-statici18n/default.nix
@@ -48,7 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/zyegfryed/django-statici18n";
     license = licenses.bsd3;
     maintainers = with maintainers; [
-      greizgh
       schmittlauch
     ];
   };


### PR DESCRIPTION
I do not use seafile anymore and won't spend energy working on it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
