### PR TITLE
python313Packages.punpy: init at 1.0.6

### DIFF
--- a/pkgs/development/python-modules/comet-maths/default.nix
+++ b/pkgs/development/python-modules/comet-maths/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  wheel,
+
+  # dependencies
+  matplotlib,
+  numdifftools,
+  numpy,
+  scikit-learn,
+  scipy,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "comet-maths";
+  version = "1.0.7";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "comet_maths";
+    inherit version;
+    hash = "sha256-emmkDEtmeLXayMnwFN3lg5cbtV7FrwLXm6Mn3GpbuPc=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    matplotlib
+    numdifftools
+    numpy
+    scikit-learn
+    scipy
+  ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+  disabledTestPaths = [
+    # Requires punpy, which depends on comet_maths. We _have_ to disable this
+    # test to avoid a circular dependency chain.
+    "comet_maths/interpolation/tests/test_interpolation.py"
+  ];
+
+  meta = {
+    description = "Mathematical algorithms and tools to use within CoMet toolkit";
+    homepage = "https://comet-maths.readthedocs.io/en/latest/";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/obsarray/default.nix
+++ b/pkgs/development/python-modules/obsarray/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  wheel,
+  versioneer,
+
+  # dependencies
+  comet-maths,
+  netcdf4,
+  xarray,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "obsarray";
+  version = "1.0.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-75bVIwB0ojKpNFdYsGIgRczCo0qHme20XZ12fzO+akQ=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+    versioneer
+  ];
+
+  dependencies = [
+    comet-maths
+    netcdf4
+    xarray
+  ];
+  pythonImportsCheck = [
+    "obsarray"
+  ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Measurement data handling in Python";
+    homepage = "https://obsarray.readthedocs.io/en/latest/";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/punpy/default.nix
+++ b/pkgs/development/python-modules/punpy/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  wheel,
+
+  # dependencies
+  comet-maths,
+  obsarray,
+
+  # tests
+  pytestCheckHook,
+  fetchFromGitHub,
+  punpy,
+}:
+
+buildPythonPackage rec {
+  pname = "punpy";
+  version = "1.0.6";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ynn01YcxIkM3tWaOBUZOvVRt3w7iRjPgcO22VakGTNM=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    comet-maths
+    obsarray
+  ];
+
+  pythonImportsCheck = [
+    "punpy"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+  passthru = {
+    # Tests data is not available on Pypi, and unfortunately we don't have a
+    # choice but to use Pypi and not GitHub for the src, because upstream
+    # donesn't tag properly the GitHub repository.
+    testsData = fetchFromGitHub {
+      owner = "comet-toolkit";
+      repo = "punpy";
+      rev = "257f2472c8dd1d3cb58084337824cae6aec1489a";
+      hash = "sha256-YW95EyxoTr1Sj8p3UYXTYk/UB1uLuq3A5W65WLE8E7U=";
+      sparseCheckout = [
+        "punpy/digital_effects_table/tests"
+      ];
+    };
+  };
+  preCheck = ''
+    for nc in ${punpy.passthru.testsData}/punpy/digital_effects_table/tests/*.nc; do
+      cp $nc punpy/digital_effects_table/tests/
+    done
+  '';
+
+  meta = {
+    description = "Propagating UNcertainties in PYthon";
+    homepage = "https://punpy.readthedocs.io/";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11953,6 +11953,8 @@ self: super: with self; {
 
   pulumi-random = pkgs.pulumiPackages.pulumi-random.sdks.python;
 
+  punpy = callPackage ../development/python-modules/punpy { };
+
   pure-cdb = callPackage ../development/python-modules/pure-cdb { };
 
   pure-eval = callPackage ../development/python-modules/pure-eval { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2771,6 +2771,8 @@ self: super: with self; {
 
   colout = callPackage ../development/python-modules/colout { };
 
+  comet-maths = callPackage ../development/python-modules/comet-maths { };
+
   cometblue-lite = callPackage ../development/python-modules/cometblue-lite { };
 
   comicapi = callPackage ../development/python-modules/comicapi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10423,6 +10423,8 @@ self: super: with self; {
 
   objsize = callPackage ../development/python-modules/objsize { };
 
+  obsarray = callPackage ../development/python-modules/obsarray { };
+
   obspy = callPackage ../development/python-modules/obspy { };
 
   oca-port = callPackage ../development/python-modules/oca-port { };


### PR DESCRIPTION
## Description of changes

~~A draft because I'm hesitant due to:~~ Not anymore, see [this discussion](https://discourse.nixos.org/t/python-package-available-only-on-pypi-with-outdated-github-repo/65973/3).

- https://github.com/comet-toolkit/comet_maths/issues/25
- https://github.com/comet-toolkit/punpy/issues/17
- https://github.com/comet-toolkit/obsarray/issues/37

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
