### PR TITLE
[Backport release-25.05] wavebox: 10.135.21-2 -> 10.137.9-2

### DIFF
--- a/pkgs/by-name/wa/wavebox/package.nix
+++ b/pkgs/by-name/wa/wavebox/package.nix
@@ -156,11 +156,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wavebox";
-  version = "10.136.15-2";
+  version = "10.137.9-2";
 
   src = fetchurl {
     url = "https://download.wavebox.app/stable/linux/deb/amd64/wavebox_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-VY8SIFg4aN5dH3CXB6r/mv1lh2KWNSPDHZkNFXptQJo=";
+    hash = "sha256-knJKdBegAeC2xQWnkdvx2Xyyfr3Q9uHaXlD62PnMngs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/wa/wavebox/package.nix
+++ b/pkgs/by-name/wa/wavebox/package.nix
@@ -156,11 +156,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wavebox";
-  version = "10.135.21-2";
+  version = "10.136.15-2";
 
   src = fetchurl {
     url = "https://download.wavebox.app/stable/linux/deb/amd64/wavebox_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-NnJ+pP6JrMiMmoXS/yYm5qMLmv5oyguhmYF/M0Pv4/g=";
+    hash = "sha256-VY8SIFg4aN5dH3CXB6r/mv1lh2KWNSPDHZkNFXptQJo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Manual backport of #407906 #414750 to `release-25.05`. Contains security fixes.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.