### PR TITLE
html2text, wavpack, pinentry_mac, dosfstools: fix build with gettext 0.24.1+

### DIFF
--- a/pkgs/by-name/do/dosfstools/package.nix
+++ b/pkgs/by-name/do/dosfstools/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
   autoreconfHook,
+  gettextAutoreconfCompatHook,
   pkg-config,
   libiconv,
   gettext,
@@ -43,6 +44,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
+    gettextAutoreconfCompatHook
     pkg-config
   ] ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
 

--- a/pkgs/by-name/ge/gettextAutoreconfCompatHook/package.nix
+++ b/pkgs/by-name/ge/gettextAutoreconfCompatHook/package.nix
@@ -1,0 +1,32 @@
+{
+  makeSetupHook,
+  writeText,
+  gettext,
+}:
+
+# Since gettext 0.24.1, m4 macros are installed in ${gettext}/share/gettext/m4
+# instead of ${gettext}/share/aclocal.
+# As a result, packages depending on gettext m4 macros but without
+# AM_GNU_GETTEXT_VERSION in configure.ac will fail to build during autoreconf,
+# with errors like:
+#   AC_LIB_PREPARE_PREFIX: command not found
+#   error: possibly undefined macro: AC_LIB_PREPARE_PREFIX
+#   error: possibly undefined macro: AM_ICONV
+#
+# For the intention of this breaking change, see:
+#   https://savannah.gnu.org/bugs/index.php?67090
+#
+# This hook restores the old behavior by adding ${gettext}/share/gettext/m4
+# to ACLOCAL_PATH.
+# It should only be used for packages that use autoreconf and without
+# upstream fixes for gettext 0.24.1+.
+
+makeSetupHook { name = "gettext-autoreconf-compat-hook"; } (
+  writeText "setup-hook.sh" ''
+    addGettextAclocalHook() {
+        addToSearchPath "ACLOCAL_PATH" "${gettext}/share/gettext/m4"
+    }
+
+    prependToVar preConfigurePhases addGettextAclocalHook
+  ''
+)

--- a/pkgs/by-name/ht/html2text/package.nix
+++ b/pkgs/by-name/ht/html2text/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  gettextAutoreconfCompatHook,
   autoreconfHook,
   libiconv,
 }:
@@ -17,7 +18,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-7Ch51nJ5BeRqs4PEIPnjCGk+Nm2ydgJQCtkcpihXun8=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    gettextAutoreconfCompatHook
+  ];
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin libiconv;
 

--- a/pkgs/by-name/wa/wavpack/package.nix
+++ b/pkgs/by-name/wa/wavpack/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   gettext,
   autoreconfHook,
+  gettextAutoreconfCompatHook,
   libiconv,
 }:
 
@@ -13,7 +14,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    gettextAutoreconfCompatHook
+  ];
   buildInputs = [ libiconv ];
 
   # autogen.sh:9

--- a/pkgs/tools/security/pinentry/mac.nix
+++ b/pkgs/tools/security/pinentry/mac.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  gettextAutoreconfCompatHook,
   libassuan,
   libgpg-error,
   makeBinaryWrapper,
@@ -42,6 +43,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
   nativeBuildInputs = [
     autoreconfHook
+    gettextAutoreconfCompatHook
     makeBinaryWrapper
     texinfo
   ];


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/405793#issuecomment-2996266430

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
