### PR TITLE
lp_solve: fix cross-compilation

### DIFF
--- a/pkgs/applications/science/math/lp_solve/0001-fix-cross-compilation.patch
+++ b/pkgs/applications/science/math/lp_solve/0001-fix-cross-compilation.patch
@@ -1,0 +1,53 @@
+diff --git a/lp_solve/ccc b/lp_solve/ccc
+index bd5a938..7fe0427 100644
+--- a/lp_solve/ccc
++++ b/lp_solve/ccc
+@@ -1,6 +1,6 @@
+ :
+ src='../lp_MDO.c ../shared/commonlib.c ../colamd/colamd.c ../shared/mmio.c ../shared/myblas.c ../ini.c ../fortify.c ../lp_rlp.c ../lp_crash.c ../bfp/bfp_LUSOL/lp_LUSOL.c ../bfp/bfp_LUSOL/LUSOL/lusol.c ../lp_Hash.c ../lp_lib.c ../lp_wlp.c ../lp_matrix.c ../lp_mipbb.c ../lp_MPS.c ../lp_params.c ../lp_presolve.c ../lp_price.c ../lp_pricePSE.c ../lp_report.c ../lp_scale.c ../lp_simplex.c lp_solve.c ../lp_SOS.c ../lp_utils.c ../yacc_read.c'
+-c=cc
++c=$CC
+ 
+ MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+ 
+@@ -10,7 +10,7 @@ echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+ echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+ echo 'main(){printf("ux%d", (int) (sizeof(void *)*8));}'>>"$MYTMP"/platform.c
+ $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+-PLATFORM=`"$MYTMP"/platform`
++PLATFORM=`@emulator@ "$MYTMP"/platform`
+ rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+ 
+ mkdir bin bin/$PLATFORM >/dev/null 2>&1
+diff --git a/lpsolve55/ccc b/lpsolve55/ccc
+index 999f5f6..ff69b17 100644
+--- a/lpsolve55/ccc
++++ b/lpsolve55/ccc
+@@ -1,6 +1,6 @@
+ :
+ src='../lp_MDO.c ../shared/commonlib.c ../shared/mmio.c ../shared/myblas.c ../ini.c ../fortify.c ../colamd/colamd.c ../lp_rlp.c ../lp_crash.c ../bfp/bfp_LUSOL/lp_LUSOL.c ../bfp/bfp_LUSOL/LUSOL/lusol.c ../lp_Hash.c ../lp_lib.c ../lp_wlp.c ../lp_matrix.c ../lp_mipbb.c ../lp_MPS.c ../lp_params.c ../lp_presolve.c ../lp_price.c ../lp_pricePSE.c ../lp_report.c ../lp_scale.c ../lp_simplex.c ../lp_SOS.c ../lp_utils.c ../yacc_read.c'
+-c=cc
++c=$CC
+ 
+ MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
+ 
+@@ -10,7 +10,7 @@ echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
+ echo '#include <stdio.h>'>>"$MYTMP"/platform.c
+ echo 'main(){printf("ux%d", (int) (sizeof(void *)*8));}'>>"$MYTMP"/platform.c
+ $c "$MYTMP"/platform.c -o "$MYTMP"/platform
+-PLATFORM=`"$MYTMP"/platform`
++PLATFORM=`@emulator@ "$MYTMP"/platform`
+ rm "$MYTMP"/platform "$MYTMP"/platform.c >/dev/null 2>&1
+ 
+ mkdir bin bin/$PLATFORM >/dev/null 2>&1
+@@ -42,8 +42,8 @@ fi
+ opts='-O3'
+ 
+ $c -s -c -I.. -I../shared -I../bfp -I../bfp/bfp_LUSOL -I../bfp/bfp_LUSOL/LUSOL -I../colamd $opts $def $NOISNAN -DYY_NEVER_INTERACTIVE -DPARSER_LP -DINVERSE_ACTIVE=INVERSE_LUSOL -DRoleIsExternalInvEngine $src
+-ar rv bin/$PLATFORM/liblpsolve55.a `echo $src|sed s/[.]c/.o/g|sed 's/[^ ]*\///g'`
+-ranlib bin/$PLATFORM/liblpsolve55.a
++$AR rv bin/$PLATFORM/liblpsolve55.a `echo $src|sed s/[.]c/.o/g|sed 's/[^ ]*\///g'`
++$RANLIB bin/$PLATFORM/liblpsolve55.a
+ 
+ if [ "$so" != "" ]
+ then

--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -5,6 +5,9 @@
   cctools,
   fixDarwinDylibNames,
   autoSignDarwinBinariesHook,
+  replaceVars,
+  buildPackages,
+  binutils,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +20,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs =
-    lib.optionals stdenv.hostPlatform.isDarwin [
+    [
+      binutils
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       cctools
       fixDarwinDylibNames
     ]
@@ -34,6 +40,12 @@ stdenv.mkDerivation rec {
     };
 
   dontConfigure = true;
+
+  patches = [
+    (replaceVars ./0001-fix-cross-compilation.patch {
+      emulator = "${stdenv.hostPlatform.emulator buildPackages}";
+    })
+  ];
 
   buildPhase =
     let


### PR DESCRIPTION
Fixed failing cross-compilation. Closes #419102.

Tested with:

`x86_64-linux` > `x86_64-linux`

```
nix-build -I nixpkgs=channel:nixos-unstable -E 'with import <nixpkgs> {}; callPackage ./pkgs/applications/science/math/lp_solve/default.nix { inherit (darwin) autoSignDarwinBinariesHook; }'
```

`x86_64-linux` > `aarch64-unknown-linux-gnu`

```
nix-build -I nixpkgs=channel:nixos-unstable -E 'with import <nixpkgs> { crossSystem = { config = "aarch64-unknown-linux-gnu"; }; }; callPackage ./pkgs/applications/science/math/lp_solve/default.nix { inherit (darwin) autoSignDarwinBinariesHook; }'
```

I also tried `armv7l-unknown-linux-gnueabi` and `riscv64-linux`, but there was no gcc and it tried building `armv7l-unknown-linux-gnueabi-nolibc-gcc-14.3.0` which I assume is a lost cause (I don't have 8 hours to build gcc :skull:).

Is there any way I can check what architectures/channels have a precompiled gcc toolchain?

> - [x] Tested compilation of all packages that depend on this change using nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD". Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

The only failing package is shogun-6.1.4, but it has nothing to do with my change — https://github.com/NixOS/nixpkgs/issues/419311.

Besides that I think everything else was rebuilding successfully. Unfortunately my laptop ran out of all 32 GB of memory while trying to build libreoffice, so I could not complete the whole process, lol.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
