### PR TITLE
opencv4: protobuf_21 -> protobuf

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -468,6 +468,7 @@ effectiveStdenv.mkDerivation {
       (cmakeBool "OPENCV_GENERATE_PKGCONFIG" true)
       (cmakeBool "WITH_OPENMP" true)
       (cmakeBool "BUILD_PROTOBUF" false)
+      (cmakeFeature "CMAKE_CXX_STANDARD" "17") # required to enable protobuf
       (cmakeBool "WITH_PROTOBUF" true)
       (cmakeBool "PROTOBUF_UPDATE_FILES" true)
       (cmakeBool "OPENCV_ENABLE_NONFREE" enableUnfree)

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -13,7 +13,7 @@
   glib,
   glog,
   gflags,
-  protobuf_21,
+  protobuf,
   config,
   ocl-icd,
   qimgv,
@@ -335,7 +335,7 @@ effectiveStdenv.mkDerivation {
       glib
       glog
       pcre2
-      protobuf_21
+      protobuf
       zlib
     ]
     ++ optionals enablePython [


### PR DESCRIPTION
Updates the OpenCV derivation expression to use the default version of `protobuf` and updates the language standard used by OpenCV to C++17.

`protobuf_29` was briefly made the default (https://github.com/NixOS/nixpkgs/pull/370155), but reverted in https://github.com/NixOS/nixpkgs/commit/c312f6f8187eefb9c860bc54d1e508490f20c94a due to language standard requirements (C++17) and concerns about possible linking breakage as a result (https://github.com/NixOS/nixpkgs/pull/375774#issuecomment-2819729232).

https://github.com/NixOS/nixpkgs/pull/386339 raises the language standard to C++17 -- this ~~appears unnecessary given the default language standard for GCC and Clang has been C++17 since versions 11 and 16, respectively (https://gcc.gnu.org/projects/cxx-status.html#cxx17 and https://clang.llvm.org/cxx_status.html)~~ is necessary given OpenCV sets the default language standard in several places (https://github.com/NixOS/nixpkgs/pull/419335#issuecomment-3023141693).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
