### PR TITLE
garage: remove 0.8, mark 0.9 eol, rename 1.0

### DIFF
--- a/nixos/modules/services/web-servers/garage.md
+++ b/nixos/modules/services/web-servers/garage.md
@@ -23,18 +23,12 @@ In all cases, you should read the changelog and ideally test the upgrade on a st
 Checking the health of your cluster can be achieved using `garage-manage repair`.
 :::
 
-::: {.warning}
-Until 1.0 is released, patch-level upgrades are considered as minor version upgrades.
-Minor version upgrades are considered as major version upgrades.
-i.e. 0.6 to 0.7 is a major version upgrade.
-:::
-
   - **Straightforward upgrades (patch-level upgrades).**
     Upgrades must be performed one by one, i.e. for each node, stop it, upgrade it : change [stateVersion](#opt-system.stateVersion) or [services.garage.package](#opt-services.garage.package), restart it if it was not already by switching.
   - **Multiple version upgrades.**
     Garage do not provide any guarantee on moving more than one major-version forward.
-    E.g., if you're on `0.7`, you cannot upgrade to `0.9`.
-    You need to upgrade to `0.8` first.
+    E.g., if you're on `0.9`, you cannot upgrade to `2.0`.
+    You need to upgrade to `1.2` first.
     As long as [stateVersion](#opt-system.stateVersion) is declared properly,
     this is enforced automatically. The module will issue a warning to remind the user to upgrade to latest
     Garage *after* that deploy.
@@ -67,8 +61,8 @@ This is inspired from how Nextcloud does it.
 
 While patch-level updates are no problem and can be done directly in the
 package-expression (and should be backported to supported stable branches after that),
-major-releases should be added in a new attribute (e.g. Garage `v0.8.0`
-should be available in `nixpkgs` as `pkgs.garage_0_8_0`).
+major-releases should be added in a new attribute (e.g. Garage `v3.0.0`
+should be available in `nixpkgs` as `pkgs.garage_3`).
 To provide simple upgrade paths it's generally useful to backport those as well to stable
 branches. As long as the package-default isn't altered, this won't break existing setups.
 After that, the versioning-warning in the `garage`-module should be

--- a/nixos/modules/services/web-servers/garage.md
+++ b/nixos/modules/services/web-servers/garage.md
@@ -7,9 +7,6 @@ The server setup can be automated using
  client configured to your local Garage instance is available in
  the global environment as `garage-manage`.
 
-The current default by NixOS is `garage_0_8` which is also the latest
-major version available.
-
 ## General considerations on upgrades {#module-services-garage-upgrade-scenarios}
 
 Garage provides a cookbook documentation on how to upgrade:
@@ -45,7 +42,7 @@ Here are some baseline instructions to handle advanced upgrades in Garage, when 
   - Run `systemctl stop garage` to stop the actual Garage version.
   - Backup the metadata folder of ALL your nodes, e.g. for a metadata directory (the default one) in `/var/lib/garage/meta`,
     you can run `pushd /var/lib/garage; tar -acf meta-v0.7.tar.zst meta/; popd`.
-  - Run the offline migration: `nix-shell -p garage_0_8 --run "garage offline-repair --yes"`, this can take some time depending on how many objects are stored in your cluster.
+  - Run the offline migration: `nix-shell -p garage_1 --run "garage offline-repair --yes"`, this can take some time depending on how many objects are stored in your cluster.
   - Bump Garage version in your NixOS configuration, either by changing [stateVersion](#opt-system.stateVersion) or bumping [services.garage.package](#opt-services.garage.package), this should restart Garage automatically.
   - Perform `garage-manage repair --all-nodes --yes tables` and `garage-manage repair --all-nodes --yes blocks`.
   - Wait for a full table sync to run.
@@ -77,8 +74,8 @@ packages, but mark them as insecure in an expression like this (in
 ```nix
 /* ... */
 {
-  garage_0_7_3 = generic {
-    version = "0.7.3";
+  garage_1_2_0 = generic {
+    version = "1.2.0";
     sha256 = "0000000000000000000000000000000000000000000000000000";
     eol = true;
   };

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -111,19 +111,6 @@ let
     };
 in
 rec {
-  # Until Garage hits 1.0, 0.7.3 is equivalent to 7.3.0 for now, therefore
-  # we have to keep all the numbers in the version to handle major/minor/patch level.
-  # for <1.0.
-  # Please add new versions to nixos/tests/garage/default.nix as well.
-
-  garage_0_8_7 = generic {
-    version = "0.8.7";
-    hash = "sha256-2QGbR6YvMQeMxN3n1MMJ5qfBcEJ5hjXARUOfEn+m4Jc=";
-    cargoHash = "sha256-NmeAkm35Su4o5JEn75pZmxhVHh+VMwKwULKY0eCVlYo=";
-    cargoPatches = [ ./update-time-0.8.patch ];
-    broken = stdenv.hostPlatform.isDarwin;
-  };
-
   garage_0_9_4 = generic {
     version = "0.9.4";
     hash = "sha256-2ZaxenwaVGYYUjUJaGgnGpZNQprQV9+Jns2sXM6cowk=";
@@ -142,8 +129,6 @@ rec {
     hash = "sha256-dn7FoouF+5qmW6fcC20bKQSc6D2G9yrWdBK3uN3bF58=";
     cargoHash = "sha256-6VM/EesrUIaQOeDGqzb0kOqMz4hW7zBJUnaRQ9C3cqc=";
   };
-
-  garage_0_8 = garage_0_8_7;
 
   garage_0_9 = garage_0_9_4;
 

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -133,10 +133,9 @@ rec {
 
   garage_0_9 = garage_0_9_4;
 
-  garage_1_x = garage_1_2_0;
-  garage_1 = garage_1_x;
+  garage_1 = garage_1_2_0;
 
   garage_2 = garage_2_0_0;
 
-  garage = garage_1_x;
+  garage = garage_1;
 }

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -116,6 +116,7 @@ rec {
     hash = "sha256-2ZaxenwaVGYYUjUJaGgnGpZNQprQV9+Jns2sXM6cowk=";
     cargoHash = "sha256-ittesFz1GUGipQecsmMA+GEaVoUY+C9DtEvsO0HFNCc=";
     cargoPatches = [ ./update-time.patch ];
+    eol = true;
   };
 
   garage_1_2_0 = generic {

--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -100,6 +100,7 @@ let
         homepage = "https://garagehq.deuxfleurs.fr";
         license = lib.licenses.agpl3Only;
         maintainers = with lib.maintainers; [
+          adamcstephens
           nickcao
           _0x4A6F
           teutat3s

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -729,6 +729,8 @@ mapAliases {
   g4music = gapless; # Added 2024-07-26
   g4py = throw "'g4py' has been renamed to/replaced by 'python3Packages.geant4'"; # Converted to throw 2024-10-17
   gamin = throw "'gamin' has been removed as it is unmaintained upstream"; # Added 2024-04-19
+  garage_0_8 = throw "'garage_0_8' has been removed as it is unmaintained upstream"; # Added 2025-06-23
+  garage_0_8_7 = throw "'garage_0_8_7' has been removed as it is unmaintained upstream"; # Added 2025-06-23
   gbl = throw "'gbl' has been removed because the upstream repository no longer exists"; # Added 2025-01-26
   gcc48 = throw "gcc48 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2024-09-10
   gcc49 = throw "gcc49 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2024-09-11

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -731,6 +731,7 @@ mapAliases {
   gamin = throw "'gamin' has been removed as it is unmaintained upstream"; # Added 2024-04-19
   garage_0_8 = throw "'garage_0_8' has been removed as it is unmaintained upstream"; # Added 2025-06-23
   garage_0_8_7 = throw "'garage_0_8_7' has been removed as it is unmaintained upstream"; # Added 2025-06-23
+  garage_1_x = lib.warnOnInstantiate "'garage_1_x' has been renamed to 'garage_1'" garage_1; # Added 2025-06-23
   gbl = throw "'gbl' has been removed because the upstream repository no longer exists"; # Added 2025-01-26
   gcc48 = throw "gcc48 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2024-09-10
   gcc49 = throw "gcc49 has been removed from Nixpkgs, as it is unmaintained and obsolete"; # Added 2024-09-11

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3025,7 +3025,6 @@ with pkgs;
 
   inherit (callPackages ../tools/filesystems/garage { })
     garage
-    garage_0_8
     garage_0_9
     garage_0_8_7
     garage_0_9_4

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3029,7 +3029,6 @@ with pkgs;
     garage_0_9_4
 
     garage_1_2_0
-    garage_1_x
     garage_1
 
     garage_2_0_0

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3026,7 +3026,6 @@ with pkgs;
   inherit (callPackages ../tools/filesystems/garage { })
     garage
     garage_0_9
-    garage_0_8_7
     garage_0_9_4
 
     garage_1_2_0


### PR DESCRIPTION
- [x] Should we remove 0.9 now instead of marking EOL? - No, leaving 0.9 to see if anybody shows up with issues.
- [x] What is the backport? Mark both as EOL? Do not backport? - No backport.
- [x] Do we want to keep a top-level `garage` or remove this as well, forcing everyone to specify a version? - No, leave as-is.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
