### PR TITLE
nhentai: 0.5.3 -> 0.5.25

### DIFF
--- a/pkgs/by-name/nh/nhentai/package.nix
+++ b/pkgs/by-name/nh/nhentai/package.nix
@@ -1,32 +1,67 @@
 {
   lib,
-  python3Packages,
+  python3,
   fetchFromGitHub,
+  fetchPypi,
 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  python =
+    let
+      packageOverrides = self: super: {
+        iso8601 = super.iso8601.overridePythonAttrs (old: rec {
+          version = "1.1.0";
+          src = fetchPypi {
+            pname = "iso8601";
+            inherit version;
+            hash = "sha256-MoEee4He7iBj6m0ulPiBmobR84EeSdI2I6QfqDK+8D8=";
+          };
+        });
+        urllib3 = super.urllib3.overridePythonAttrs (old: rec {
+          version = "1.26.20";
+          src = fetchPypi {
+            pname = "urllib3";
+            inherit version;
+            hash = "sha256-QMLcDGgeR+uPkOfie/b/ffLmd0If1GdW2hFhw5ynDTI=";
+          };
+        });
+      };
+    in
+    python3.override {
+      inherit packageOverrides;
+      self = python;
+    };
+
+in
+python.pkgs.buildPythonApplication rec {
   pname = "nhentai";
-  version = "0.5.3";
-  format = "setuptools";
+  version = "0.5.25";
 
   src = fetchFromGitHub {
     owner = "RicterZ";
     repo = "nhentai";
     rev = version;
-    hash = "sha256-SjWIctAyczjYGP4buXQBA/RcrdikMSuSBtfhORNmXMc=";
+    hash = "sha256-KwcaCeeGeR6qSfraSYyf4VEims9YWB6j3HmpT8XSePo=";
   };
 
   # tests require a network connection
   doCheck = false;
 
-  propagatedBuildInputs = with python3Packages; [
+  pyproject = true;
+
+  build-system = with python.pkgs; [
+    poetry-core
+  ];
+
+  dependencies = with python.pkgs; [
     requests
-    img2pdf
-    iso8601
-    beautifulsoup4
     soupsieve
+    beautifulsoup4
     tabulate
-    future
+    iso8601
+    urllib3
+    httpx
+    chardet
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Update version from `0.5.3` to `0.5.25`
- Enable `pyproject` build system
- Remove old dependencies that are no longer needed
- Pin `iso8601` dependency to version `1.1.0`
- Pin `urllib3` dependency to version `1.26.20`

I bring with me the highly-demanded update of the most important piece of software in nixpkgs. Nix users, we can all rest well now.

Jokes aside, the nhentai CLI package was outdated and broken because of the recent update from Python 3.12 to 3.13 in the nixpkgs repo. Some dependencies of the previous version are not compatible with Python 3.13, breaking the build process. Luckily, those dependencies have since been replaced in the newer version of nhentai CLI. It builds again by just updating the version and dependencies. The project also switched to the pyproject build-system, which is now enabled for this package. The `iso8601` and `urllib3` dependencies have to be pinned to older versions for now, as their nixpkgs version is too new for nhentai CLI.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
