### PR TITLE
[Backport release-25.05] vcsh: 2.0.8 -> 2.0.10

### DIFF
--- a/pkgs/by-name/vc/vcsh/package.nix
+++ b/pkgs/by-name/vc/vcsh/package.nix
@@ -2,24 +2,30 @@
   lib,
   stdenv,
   fetchurl,
+  autoconf,
+  automake,
   makeWrapper,
   pkg-config,
+  unzip,
   git,
   perlPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vcsh";
-  version = "2.0.8";
+  version = "2.0.10";
 
   src = fetchurl {
-    url = "https://github.com/RichiH/vcsh/releases/download/v${finalAttrs.version}/vcsh-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-VgRA3v5PIKwizmXoc8f/YMoMCDGFJK/m2uhq3EsT1xQ=";
+    url = "https://github.com/RichiH/vcsh/releases/download/v${finalAttrs.version}/vcsh-${finalAttrs.version}.zip";
+    hash = "sha256-M/UME2kNCxwzngKXMYp0cdps7LWVwoS2I/mTrvPts7g=";
   };
 
   nativeBuildInputs = [
-    pkg-config
+    autoconf
+    automake
     makeWrapper
+    pkg-config
+    unzip
   ];
 
   buildInputs = [ git ];

--- a/pkgs/by-name/vc/vcsh/package.nix
+++ b/pkgs/by-name/vc/vcsh/package.nix
@@ -8,12 +8,12 @@
   perlPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vcsh";
   version = "2.0.8";
 
   src = fetchurl {
-    url = "https://github.com/RichiH/vcsh/releases/download/v${version}/${pname}-${version}.tar.xz";
+    url = "https://github.com/RichiH/vcsh/releases/download/v${finalAttrs.version}/vcsh-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-VgRA3v5PIKwizmXoc8f/YMoMCDGFJK/m2uhq3EsT1xQ=";
   };
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Version Control System for $HOME";
     homepage = "https://github.com/RichiH/vcsh";
-    changelog = "https://github.com/RichiH/vcsh/blob/v${version}/changelog";
+    changelog = "https://github.com/RichiH/vcsh/blob/v${finalAttrs.version}/changelog";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [
       ttuegel
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     mainProgram = "vcsh";
   };
-}
+})


### PR DESCRIPTION
Manual backport of #417075 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
