### PR TITLE
[Backport release-25.05] qrencode: adopt, cleanup

### DIFF
--- a/pkgs/by-name/qr/qrencode/package.nix
+++ b/pkgs/by-name/qr/qrencode/package.nix
@@ -8,7 +8,7 @@
   autoreconfHook,
 }:
 
-stdenv.mkDerivation (finalAttrs: rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qrencode";
   version = "4.1.1";
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   src = fetchFromGitHub {
     owner = "fukuchi";
     repo = "libqrencode";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-nbrmg9SqCqMrLE7WCfNEzMV/eS9UVCKCrjBrGMzAsLk";
   };
 

--- a/pkgs/by-name/qr/qrencode/package.nix
+++ b/pkgs/by-name/qr/qrencode/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nix-update-script,
   pkg-config,
   libpng,
   libiconv,
@@ -22,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "fukuchi";
     repo = "libqrencode";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-nbrmg9SqCqMrLE7WCfNEzMV/eS9UVCKCrjBrGMzAsLk";
   };
 
@@ -48,22 +49,28 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postCheck
   '';
 
-  passthru.tests = finalAttrs.finalPackage.overrideAttrs (_: {
-    configureFlags = [ "--with-tests" ];
-    doCheck = true;
-  });
+  passthru = {
+    tests = finalAttrs.finalPackage.overrideAttrs {
+      configureFlags = [ "--with-tests" ];
+      doCheck = true;
+    };
+    updateScript = nix-update-script { };
+  };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://fukuchi.org/works/qrencode/";
-    description = "C library for encoding data in a QR Code symbol";
+    description = "C library and command line tool for encoding data in a QR Code symbol";
     longDescription = ''
       Libqrencode is a C library for encoding data in a QR Code symbol,
       a kind of 2D symbology that can be scanned by handy terminals
-      such as a mobile phone with CCD.
+      such as a smartphone.
+
+      The library also contains qrencode, a command-line utility to output
+      QR Code images in various formats.
     '';
-    license = licenses.lgpl21Plus;
-    maintainers = [ ];
-    platforms = platforms.all;
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.mdaniels5757 ];
+    platforms = lib.platforms.all;
     mainProgram = "qrencode";
   };
 })


### PR DESCRIPTION
Manual backport of #407835 (2 commits), https://github.com/NixOS/nixpkgs/pull/414239/commits/b8ade8b3a307d6eb665b8a407afec44f38ee242e#diff-f26ba77dc8656c487f887e926fa7f28c1aa0a8dd0916eb984919707b79f817a5 (just this file, which will probably set off the cherry-pick check), and #418487 to `release-25.05`. 

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.