### PR TITLE
python3Packages.exscript: init at 2.6-unstable-2025-08-05

### DIFF
--- a/pkgs/development/python-modules/exscript/default.nix
+++ b/pkgs/development/python-modules/exscript/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  configparser,
+  paramiko,
+  pycryptodomex,
+  setuptools,
+}:
+buildPythonPackage {
+  pname = "exscript";
+  version = "2.6-unstable-2025-08-05";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "knipknap";
+    repo = "exscript";
+    rev = "6fd60076e2b56875faf65ea63de272aba223d40b";
+    hash = "sha256-EUkE4BK17NoQJenIibfz4junYiJ4uVHRK4xqfCae/AQ=";
+  };
+
+  build-tools = [ setuptools ];
+
+  dependencies = [
+    configparser
+    paramiko
+    pycryptodomex
+    setuptools
+  ];
+
+  pythonRemoveDeps = [ "future" ];
+
+  postPatch = ''
+    substituteInPlace Exscript/version.py \
+      --replace-fail "DEVELOPMENT" "2.6"
+
+    substituteInPlace Exscript/servers/sshd.py \
+      --replace-fail "base64.decodestring" "base64.decodebytes"
+
+    substituteInPlace Exscript/emulators/command.py \
+      --replace-fail "from past.builtins import execfile" "" \
+      --replace-fail "execfile(filename, args)" "exec(open(filename).read(), args)"
+
+    substituteInPlace \
+      Exscript/logger.py \
+      Exscript/protocols/dummy.py \
+      Exscript/protocols/protocol.py \
+      Exscript/protocols/telnet.py \
+      Exscript/protocols/telnetlib.py \
+      Exscript/servers/httpd.py \
+      Exscript/util/collections.py \
+      Exscript/util/file.py \
+      Exscript/util/interact.py \
+      Exscript/util/url.py \
+      tests/Exscript/protocols/ProtocolTest.py \
+      tests/Exscript/workqueue/JobTest.py \
+      tests/Exscript/workqueue/PipelineTest.py \
+        --replace-fail "from future import standard_library" "" \
+        --replace-fail "standard_library.install_aliases()" ""
+  '';
+
+  # Included tests require internet
+  doCheck = false;
+  pythonImportsCheck = [ "Exscript" ];
+
+  meta = {
+    description = "Automating Telnet and SSH";
+    homepage = "https://github.com/knipknap/exscript";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4876,6 +4876,8 @@ self: super: with self; {
 
   exrex = callPackage ../development/python-modules/exrex { };
 
+  exscript = callPackage ../development/python-modules/exscript { };
+
   extension-helpers = callPackage ../development/python-modules/extension-helpers { };
 
   extract-msg = callPackage ../development/python-modules/extract-msg { };


### PR DESCRIPTION
Add exscript, a Python module for automating SSH and Telnet

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
