### PR TITLE
jetbrains:2025.1.2 -> 2025.1.3

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -11,10 +11,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "3bdd0cd731bcdcd15de7ebee3ec36a13b82b72f68a77f6e6e780e36d88acd51e",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2.tar.gz",
-      "build_number": "251.26094.123"
+      "version": "2025.1.3",
+      "sha256": "4025fa892f214d4d55d658cb7390d1538d127286ec5aca1311fe9c5470336b45",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.3.tar.gz",
+      "build_number": "251.26927.39"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -43,26 +43,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "18d4465e8c50911d8f4ecd7ba75ee1aa14cf3d05eb4df39790729cf67bf2a638",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.2.tar.gz",
-      "build_number": "251.26094.127"
+      "version": "2025.1.3",
+      "sha256": "9dec99e036251696ded89abcb11a67a9f3869fc2bdad4ba0cc1297ca9ae4ebea",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.3.tar.gz",
+      "build_number": "251.26927.50"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "70dc870bd31fda67de30d3a132cfed543d5e67c15c7db52f6f4c4691a044930a",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.1.3",
+      "sha256": "f9f794a23cc623425bfef201c0a674c56090a24215fe71ebfaf6ba27226990c5",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.3.tar.gz",
+      "build_number": "251.26927.53"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "1e675bda1314ae914b64b31a22309ba2eba6f35e6659e53d4b291e73c2fb856b",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.1.3",
+      "sha256": "d9437e08f57cf6c3b695c2a5dc728b059c8e1523e056e21a101149440ea6dec2",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.3.tar.gz",
+      "build_number": "251.26927.53"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -100,18 +100,18 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "cdf8a824c7daa3247b09d76a29acb31cfa623b90643d3d2a814982cb0a32879d",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2.tar.gz",
-      "build_number": "251.25410.119"
+      "version": "2025.1.3",
+      "sha256": "7fce2077fbd3cb4c80e56af4607c2450db81a727b93cc41e155b3ab3779d7b90",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.3.tar.gz",
+      "build_number": "251.26094.147"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "2d4127e0284a262acb015c9d4247b654592e045b61664043a4de56029b45174f",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2.tar.gz",
-      "build_number": "251.26094.122"
+      "version": "2025.1.3",
+      "sha256": "9b640bf12efbfc1e6a97c7b749f85154ab64493ae5a51e195c8adca3e07507d9",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.3.tar.gz",
+      "build_number": "251.26927.47"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
@@ -124,10 +124,10 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "055510371e3c6a8d9fbfcd352645d847d2c092309c4746222babe4af240c2eac",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2.tar.gz",
-      "build_number": "251.26094.131"
+      "version": "2025.1.3",
+      "sha256": "dfb8836c7d09d61abdd57c85caf042b8c5e21bf730711b492d4932e6e55ec702",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.3.tar.gz",
+      "build_number": "251.26927.40"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -150,10 +150,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "911568cef55f23b134a4c316b5436214c2b51638c14a3b243785e19e354c2d4c",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.123"
+      "version": "2025.1.3",
+      "sha256": "62be26d09b1a7182a61aec032963b6264311cccd198cbb91121ca486c03639d3",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.3-aarch64.tar.gz",
+      "build_number": "251.26927.39"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -182,26 +182,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "71f8c4addac839823b9875e6f01f8ab98d7cf77ab9acf03c09e057cc5d030757",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.127"
+      "version": "2025.1.3",
+      "sha256": "6fdf298537395555f70ad34661e0c170564f5a3d2b395978749388be983e33fd",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.3-aarch64.tar.gz",
+      "build_number": "251.26927.50"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "d98c8d7bdc3e274d278b81ba2b6c1baa38f67be9407b4bfd3bad3413c6f128f1",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.1.3",
+      "sha256": "7a6d75ba101304fb2b416ae4ba6e04373a9c1c1a9419d2fff2dfb86d761d27fb",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.3-aarch64.tar.gz",
+      "build_number": "251.26927.53"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "0f982a4f4424bde5a33206c20df053a7afe174fe9d590943665504814a273c9d",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.1.3",
+      "sha256": "9586bd9c60da153634c8d66340959730cc80d3868e3b3d70472c07650dffefe4",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.3-aarch64.tar.gz",
+      "build_number": "251.26927.53"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -239,18 +239,18 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "c1ad139252fd3158aa86e9ac4532db5d9dd653807fc9f1dc4458170f3f1c3de6",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.25410.119"
+      "version": "2025.1.3",
+      "sha256": "ed6a185bf4768509febf4664e8577b518ce23f974a6b6d5a183d546d3da2d1a5",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.3-aarch64.tar.gz",
+      "build_number": "251.26094.147"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "13ed96cc82771ec49ce8e9f72179ac12829f4bc2ffae6a9ab553708aec47d4a9",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.122"
+      "version": "2025.1.3",
+      "sha256": "718f5a921d3659e8ebf903af50299c11a87acf1aa86ac213985c82e6226e48c5",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.3-aarch64.tar.gz",
+      "build_number": "251.26927.47"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
@@ -263,10 +263,10 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "c182bcd17ff4d0188c0e024952677dd21415456a421c5c1aaa356870f2efa009",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.131"
+      "version": "2025.1.3",
+      "sha256": "9f8f85426f23fc0f3ae9143f46cfaf2aae5c6766d51e3c853cf735db2e0339f8",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.3-aarch64.tar.gz",
+      "build_number": "251.26927.40"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -289,10 +289,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "f7dde8532ba52d4cfaab37828ba52fa2e159d82baf1fa555c1a0e65bb1186a86",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2.dmg",
-      "build_number": "251.26094.123"
+      "version": "2025.1.3",
+      "sha256": "8144071d2c4485b5fd2447a00be3577533a7bc5c510b4b4fdd5db68bb93607a1",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.3.dmg",
+      "build_number": "251.26927.39"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -321,26 +321,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "6d3c732fb3aadc7dad9bb6dafd294be04c82a4dd994223e4982b77213bf9a4b6",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.2.dmg",
-      "build_number": "251.26094.127"
+      "version": "2025.1.3",
+      "sha256": "daeab59912d6530605ac89b18d4cc462f273793153b557e4a06392bcc31de015",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.3.dmg",
+      "build_number": "251.26927.50"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "c64c7ff7fe2e73d7552f1727d912bb5f901d040c7269b4292f94190475580c2b",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.1.3",
+      "sha256": "1e640fc2bf96667240389e02e116e3a97c5c6d96060c4656a46bcda7b8440d0f",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.3.dmg",
+      "build_number": "251.26927.53"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "bacfa3bcf48d57d8e8ca8d352895025ffc42ce395b9b0074b3b566dc217324c9",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.1.3",
+      "sha256": "136a3114a3e33e18ad16226ba3b743f8139e113977b43242a0e127aaaa85786f",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.3.dmg",
+      "build_number": "251.26927.53"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -378,18 +378,18 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "23f3479d1cff5ee1726726bea866ff755b08930e9da43b7ad250e6cb620c1dcf",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2.dmg",
-      "build_number": "251.25410.119"
+      "version": "2025.1.3",
+      "sha256": "9b645982d017d896c46f9cd794807355c1fce90702ed561c121428edc1ec9e09",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.3.dmg",
+      "build_number": "251.26094.147"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "059d3d4c089b9277089bd7d64b8f6eedcf039fe791cddc694af434a1c5ad88c8",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2.dmg",
-      "build_number": "251.26094.122"
+      "version": "2025.1.3",
+      "sha256": "e0487e51ce73cc6f24c77cde6c5ab5104f6528b3c14b90488fae1845023b822f",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.3.dmg",
+      "build_number": "251.26927.47"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
@@ -402,10 +402,10 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "c33853a8d8a2dd47ce3a795202e2d802a9f1888b2c998c91cdfc9bc66f9bb19a",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2.dmg",
-      "build_number": "251.26094.131"
+      "version": "2025.1.3",
+      "sha256": "1e403680ee7eb9e4aa5c35d3138b0a95477b180e839b501e8b4b8a88878335cb",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.3.dmg",
+      "build_number": "251.26927.40"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -428,10 +428,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "9a47d3d86f2465f4b741408ad3a792d63a4dff486a05103825e479dae4d63932",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.123"
+      "version": "2025.1.3",
+      "sha256": "b415b03f8099cb4bcfd443562f9a88aecbe641ba387586d437031b5d2dc2726d",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.3-aarch64.dmg",
+      "build_number": "251.26927.39"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -460,26 +460,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "a30940d1b2659487ababc3a9ad8e4770236e90ad6c732cb1fd0c24690829a0ce",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.127"
+      "version": "2025.1.3",
+      "sha256": "f58070d3e49b61dccd8ce218f41558ad9904620860f58aa60fb4b683efed7aa9",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.3-aarch64.dmg",
+      "build_number": "251.26927.50"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "61a64b8abf0b350cb14f963975fc87ec574bc4b50ae7944980c43c816ffad5a8",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.1.3",
+      "sha256": "d912ba961141b315881c16805dd6684d1f0bae321c5baf84d851bdd80d7e9e87",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.3-aarch64.dmg",
+      "build_number": "251.26927.53"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "1c1afc32c8edcf1d2057a505f7f0b0dd1f1a20a6859172c1dd6a91a311a3167b",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.1.3",
+      "sha256": "88cb043b43d6da25269abae0fec2b41705b5ef72501f384ef4084091e461a1e8",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.3-aarch64.dmg",
+      "build_number": "251.26927.53"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -517,18 +517,18 @@
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "ab6645bba503f0a9d67b2838d1dd88a81ad81dd34e6015ccaea30400c35659e4",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2-aarch64.dmg",
-      "build_number": "251.25410.119"
+      "version": "2025.1.3",
+      "sha256": "04b5d3cd99bb3f04fb75ba115d7523db283a70a0410c9274a88ec888a62d8ca3",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.3-aarch64.dmg",
+      "build_number": "251.26094.147"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "1da265fa947d5d1cf3075495414b9e65ec519a5bd9bee5ca2fa7df67bafdc352",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.122"
+      "version": "2025.1.3",
+      "sha256": "06e9d70dd8f885526ff778df9c611e1e3b334a7cf313f769c7544936462056d1",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.3-aarch64.dmg",
+      "build_number": "251.26927.47"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
@@ -541,10 +541,10 @@
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "298d53fcd1a979e6910f97d9a29ac9bc0ed12386838a93a6d279bb415cf4708f",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.131"
+      "version": "2025.1.3",
+      "sha256": "2d65e2f9737fa436ad099b1d7a0034fe1143521df45ea785e7162d504175b4e9",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.3-aarch64.dmg",
+      "build_number": "251.26927.40"
     },
     "writerside": {
       "update-channel": "Writerside EAP",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -16,18 +16,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip"
       },
       "name": "ideavim"
     },
@@ -36,7 +36,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/631/766544/python-251.26094.121.zip"
+        "251.26927.53": "https://plugins.jetbrains.com/files/631/780469/python-251.26927.53.zip"
       },
       "name": "python"
     },
@@ -46,8 +46,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.26094.121": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip"
       },
       "name": "scala"
     },
@@ -67,18 +67,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
       },
       "name": "string-manipulation"
     },
@@ -98,18 +98,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip"
       },
       "name": "handlebars-mustache"
     },
@@ -129,18 +129,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.119": null,
+        "251.25410.129": null,
         "251.25410.170": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
         "251.26094.133": null,
         "251.26094.141": null,
-        "251.26094.87": null
+        "251.26094.147": null,
+        "251.26094.87": null,
+        "251.26927.39": null,
+        "251.26927.40": null,
+        "251.26927.47": null,
+        "251.26927.50": null,
+        "251.26927.53": null
       },
       "name": "kotlin"
     },
@@ -160,18 +160,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/6981/724264/ini-251.23774.466.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.23774.423": null,
+        "251.25410.129": null,
+        "251.25410.170": null,
         "251.26094.133": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip"
       },
       "name": "ini"
     },
@@ -191,18 +191,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -222,18 +222,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
       },
       "name": "grep-console"
     },
@@ -253,18 +253,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip"
       },
       "name": "file-watchers"
     },
@@ -274,8 +274,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip"
       },
       "name": "maven-helper"
     },
@@ -295,18 +295,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip"
       },
       "name": "cucumber-for-java"
     },
@@ -316,8 +316,8 @@
         "phpstorm"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip"
+        "251.26094.133": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip"
       },
       "name": "symfony-plugin"
     },
@@ -327,8 +327,8 @@
         "phpstorm"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip"
+        "251.26094.133": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip"
       },
       "name": "php-annotations"
     },
@@ -345,15 +345,15 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.25410.119": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/7322/780482/python-ce-251.26927.53.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/7322/780482/python-ce-251.26927.53.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/7322/780482/python-ce-251.26927.53.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7322/780482/python-ce-251.26927.53.zip"
       },
       "name": "python-community-edition"
     },
@@ -373,18 +373,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip"
       },
       "name": "asciidoc"
     },
@@ -404,18 +404,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "251.25410.170": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "251.26094.133": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "251.26094.141": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
+        "251.26094.147": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26927.39": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26927.40": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26927.47": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26927.50": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
       },
       "name": "wakatime"
     },
@@ -435,18 +435,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip"
       },
       "name": "gittoolbox"
     },
@@ -466,18 +466,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/7724/724240/clouds-docker-impl-251.23774.466.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.23774.423": null,
+        "251.25410.129": null,
+        "251.25410.170": null,
         "251.26094.133": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/7724/780474/clouds-docker-impl-251.26927.53.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/7724/780474/clouds-docker-impl-251.26927.53.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/7724/780474/clouds-docker-impl-251.26927.53.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/7724/780474/clouds-docker-impl-251.26927.53.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/7724/780474/clouds-docker-impl-251.26927.53.zip"
       },
       "name": "docker"
     },
@@ -497,18 +497,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip"
       },
       "name": "graphql"
     },
@@ -527,17 +527,17 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.119": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
+        "251.25410.129": null,
         "251.26094.133": null,
         "251.26094.141": null,
-        "251.26094.87": null
+        "251.26094.147": null,
+        "251.26094.87": null,
+        "251.26927.39": null,
+        "251.26927.40": null,
+        "251.26927.47": null,
+        "251.26927.50": null,
+        "251.26927.53": null
       },
       "name": "-deprecated-rust"
     },
@@ -556,17 +556,17 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.119": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
+        "251.25410.129": null,
         "251.26094.133": null,
         "251.26094.141": null,
-        "251.26094.87": null
+        "251.26094.147": null,
+        "251.26094.87": null,
+        "251.26927.39": null,
+        "251.26927.40": null,
+        "251.26927.47": null,
+        "251.26927.50": null,
+        "251.26927.53": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -586,18 +586,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/8195/715934/toml-251.23774.429.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
+        "251.23774.423": null,
+        "251.25410.129": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip"
       },
       "name": "toml"
     },
@@ -607,8 +607,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip"
       },
       "name": "minecraft-development"
     },
@@ -628,18 +628,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/8554/716074/featuresTrainer-251.23774.436.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -659,18 +659,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
       },
       "name": "nixidea"
     },
@@ -690,18 +690,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip"
       },
       "name": "gherkin"
     },
@@ -721,18 +721,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip"
       },
       "name": "-env-files"
     },
@@ -742,8 +742,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip"
+        "251.26927.50": "https://plugins.jetbrains.com/files/9568/780515/go-plugin-251.26927.53.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/9568/780515/go-plugin-251.26927.53.zip"
       },
       "name": "go"
     },
@@ -763,18 +763,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9707/702582/ANSI_Highlighter_Premium-24.3.4.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
         "251.25410.170": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
         "251.26094.133": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
         "251.26094.141": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar"
+        "251.26094.147": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26927.39": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26927.40": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26927.47": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26927.50": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26927.53": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar"
       },
       "name": "ansi-highlighter-premium"
     },
@@ -794,18 +794,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
     },
@@ -825,18 +825,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
       },
       "name": "randomness"
     },
@@ -856,18 +856,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
       },
       "name": "csv-editor"
     },
@@ -887,18 +887,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.26094.147": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip"
       },
       "name": "rainbow-brackets"
     },
@@ -918,18 +918,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
     },
@@ -949,18 +949,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
       },
       "name": "hocon"
     },
@@ -979,17 +979,17 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip"
       },
       "name": "go-template"
     },
@@ -1009,18 +1009,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.26094.147": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip"
       },
       "name": "extra-icons"
     },
@@ -1040,18 +1040,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/11349/768106/aws-toolkit-jetbrains-standalone-3.74.243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.26094.147": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1060,7 +1060,7 @@
         "rider"
       ],
       "builds": {
-        "251.25410.119": "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip"
       },
       "name": "cognitivecomplexity"
     },
@@ -1080,18 +1080,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip"
       },
       "name": "vscode-keymap"
     },
@@ -1111,18 +1111,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -1142,18 +1142,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
     },
@@ -1173,18 +1173,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -1204,18 +1204,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
     },
@@ -1235,18 +1235,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip"
       },
       "name": "protocol-buffers"
     },
@@ -1266,18 +1266,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "251.25410.170": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "251.26094.133": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "251.26094.141": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "251.26094.147": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26927.39": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26927.40": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26927.47": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26927.50": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26927.53": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -1297,18 +1297,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "251.25410.170": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "251.26094.133": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "251.26094.141": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "251.26094.147": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26927.39": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26927.40": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26927.47": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26927.50": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26927.53": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
     },
@@ -1328,18 +1328,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "251.25410.170": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "251.26094.133": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
         "251.26094.141": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar"
+        "251.26094.147": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26927.39": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26927.40": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26927.47": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26927.50": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26927.53": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar"
       },
       "name": "which-key"
     },
@@ -1359,18 +1359,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.26094.147": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1390,18 +1390,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.26094.147": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip"
       },
       "name": "github-copilot"
     },
@@ -1421,18 +1421,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1452,18 +1452,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1483,18 +1483,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18824/694222/CodeGlancePro-1.9.7-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
       },
       "name": "codeglance-pro"
     },
@@ -1514,18 +1514,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.23774.423": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar"
+        "251.23774.423": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.25410.170": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.26094.133": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.26094.141": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.26094.147": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.26927.39": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.26927.40": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.26927.47": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.26927.50": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar",
+        "251.26927.53": "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1545,18 +1545,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
     },
@@ -1576,18 +1576,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip"
       },
       "name": "mermaid"
     },
@@ -1607,18 +1607,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
     },
@@ -1638,18 +1638,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip"
       },
       "name": "code-complexity"
     },
@@ -1669,18 +1669,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1696,14 +1696,14 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.119": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip"
+        "251.26094.133": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26094.147": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip"
       },
       "name": "dev-containers"
     },
@@ -1715,8 +1715,8 @@
       ],
       "builds": {
         "251.25410.170": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip"
+        "251.26927.39": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip"
       },
       "name": "rust"
     },
@@ -1736,18 +1736,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip"
       },
       "name": "continue"
     },
@@ -1767,18 +1767,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip"
       },
       "name": "gitlab"
     },
@@ -1798,18 +1798,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
       },
       "name": "catppuccin-icons"
     },
@@ -1829,18 +1829,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
     },
@@ -1860,18 +1860,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23806/664310/Oxocarbon-1.4.5.zip",
         "251.23774.423": null,
-        "251.25410.119": null,
+        "251.25410.129": null,
         "251.25410.170": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
         "251.26094.133": null,
         "251.26094.141": null,
-        "251.26094.87": null
+        "251.26094.147": null,
+        "251.26094.87": null,
+        "251.26927.39": null,
+        "251.26927.40": null,
+        "251.26927.47": null,
+        "251.26927.50": null,
+        "251.26927.53": null
       },
       "name": "oxocarbon"
     },
@@ -1891,18 +1891,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.26094.147": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip"
       },
       "name": "extra-ide-tweaks"
     },
@@ -1922,18 +1922,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.26094.147": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip"
       },
       "name": "extra-tools-pack"
     },
@@ -1950,15 +1950,15 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.119": null,
         "251.25410.170": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
         "251.26094.133": null,
-        "251.26094.87": null
+        "251.26094.147": null,
+        "251.26094.87": null,
+        "251.26927.39": null,
+        "251.26927.40": null,
+        "251.26927.47": null,
+        "251.26927.50": null,
+        "251.26927.53": null
       },
       "name": "nix-lsp"
     },
@@ -1977,59 +1977,48 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
         "251.25410.170": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
         "251.26094.133": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
         "251.26094.141": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip"
+        "251.26094.147": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26927.39": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26927.40": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26927.47": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26927.50": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26927.53": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip"
       },
       "name": "markdtask"
     }
   },
   "files": {
     "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip": "sha256-frvQ+Dm1ueID6+vNlja0HtecGyn+ppq9GTgmU3kQ+58=",
-    "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip": "sha256-ekeCyyUhzP32v8nu+U/LS0a/eW6onhBX0qCQmNQ/pgg=",
+    "https://plugins.jetbrains.com/files/10080/770998/intellij-rainbow-brackets-2024.2.15-241.zip": "sha256-CM76oAiI4APHHlPgiMnEp75HUjVqEdxODNMmCAdlhAs=",
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
-    "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip": "sha256-Bnnvy+HDNkx2DQM7N+JUa8hQzIA3H/5Y0WpWAjPmhUI=",
     "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip": "sha256-GO0bXJsHx9O1A6M9NUCv9m4JwKHs5plwSssgx+InNqE=",
-    "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip": "sha256-6pZ8vHw8C08IUvU76meMTGShoSMntQABv/KBX4BRDYs=",
     "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip": "sha256-zX1nEdq84wwQvGhV664V5bNBPVTI4zWo306JtjXcGkE=",
-    "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip": "sha256-trVQyV4PcxI1BeLtIg3fP1dOITiFRheIGpxU3GuA83w=",
-    "https://plugins.jetbrains.com/files/11349/768106/aws-toolkit-jetbrains-standalone-3.74.243.zip": "sha256-eWAEs18QSUate1bvO1412v+XniVEhjykgNsEn/rhGH0=",
-    "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip": "sha256-yklhTCVPh6vJo/ppVh3W6d7Cy8mfzfHbfOiXZT/vyI4=",
+    "https://plugins.jetbrains.com/files/11058/773844/Extra_Icons-2025.1.6.zip": "sha256-VXw3DwhHZZrSrkB290xxZOHCh3Q879BD4X3dz0eaEK0=",
+    "https://plugins.jetbrains.com/files/11349/778277/aws-toolkit-jetbrains-standalone-3.78.251.zip": "sha256-qDajuAtPcVOPLTN/ltUOjf/YEM5ESa1mkVDJKUwYtcw=",
     "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip": "sha256-SWIXjxnwAf9dju1oOgzePrTY0lPNNX54Afp5OIkGGi4=",
-    "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
     "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip": "sha256-obbLL8n6gK8oFw8NnJbdAylPHfTv4GheBDnVFOUpwL0=",
-    "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip": "sha256-/g1ucT18ywVJnCePH7WyMWKgM9umowBz5wFObmO7cws=",
     "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip": "sha256-HC1s5FqSLVgPNKc5Wiw0RFC6KpozxmjKzbh9rS9nFwc=",
     "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip": "sha256-Q+gqKG/2bHD49Xtn9MNlYJQGtNF/7tIay9F7ndi8uwA=",
-    "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip": "sha256-VQqK0Cm9ddXN63KYIqimuGOh7EB9VvdlErp/VrWx8SA=",
     "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip": "sha256-DKkgt0z/ui0bOLSbnKy51RL7+9HIqeriroi2otZ64mQ=",
     "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip": "sha256-eKwDE+PMtYhrGbDDZPS5cimssH+1xV4GF6RXXg/3urU=",
     "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip": "sha256-h9GNGjqTc+h+x/0TRilKmqGoPsxhPmXIKoGC/s4/PKg=",
-    "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip": "sha256-Tgu8CfDhO6KugfuLNhmxe89dMm+Qo3fmAg/8hwjUaoc=",
     "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip": "sha256-ZYn365EY8+VP1TKM4wBotMj1hYbSSr4J1K5oIZlE2SE=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar": "sha256-mB09zvUg1hLXl9lgW1NEU+DyVel1utZv6s+mFykckYY=",
-    "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar": "sha256-2FlEaHf2rO6xgG3LnZIPt/XKgRGjpLSiEXCncfAf3bI=",
     "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar": "sha256-Z3q0d4jCqeBwzW0jSSM3q4MTAPaTqQuwnV3ZVHfOMR4=",
-    "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip": "sha256-yKpWQZGxfsKwPVTJLHpF4KGJ5ANCd73uxHlfdFE4Qf4=",
     "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip": "sha256-W5CtJqmejx2braLiJEYGPU29fCSOZNSQG0HZxqdOJIk=",
-    "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip": "sha256-9DLY2HIyQR2w8xPVVKa2l7OZWqfoTvHkLGZYEnDV7/A=",
-    "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip": "sha256-GKCOuZJerzhkhbl4zXWukonkygCT/Dm/tV4zRxFAP+g=",
+    "https://plugins.jetbrains.com/files/16604/773849/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.8.zip": "sha256-Dk4S09hBnL8Hx1rcFt1u5AHD78IUUn8fGc7QLtHolAc=",
+    "https://plugins.jetbrains.com/files/17718/776694/github-copilot-intellij-1.5.47-243.zip": "sha256-9mI8Lo/jmQkIa4LKJKtAKmkeCjPtDqf6lxpz10xkQOE=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip": "sha256-fa9GiD/PNGy8AEao99vW3DBF1FKSulu3t+wO7mdr5fk=",
-    "https://plugins.jetbrains.com/files/18824/694222/CodeGlancePro-1.9.7-signed.zip": "sha256-8RjKjmadd1o/M+WTLtKPn354bbKgEht4nvWnMcRPN9w=",
     "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip": "sha256-/1lyQq7JANhcKmIaaBHZ8ZCR4p23sLjLTTq9/68Fz+c=",
-    "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar": "sha256-NjhQX8TY9B+aOPm3RrR42OyPM2GnZ5d0/+L83fcaGM0=",
+    "https://plugins.jetbrains.com/files/18922/779484/GerryThemes.jar": "sha256-R9txnGxxkAFnO49WUCwaMzLAPLpnMtwKMb2ZZKbldcI=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
-    "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip": "sha256-jGWRU0g120qYvvFiUFI10zvprTsemuIq3XmIjYxZGts=",
     "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip": "sha256-QqEjnN6lUUtHkDRFWPeV3vqgGB/ZfWGVDqtk8gwJEqY=",
     "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip": "sha256-N66Bh0AwHmg5N9PNguRAGtpJ/dLMWMp3rxjTgz9poFo=",
     "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip": "sha256-TZPup3EJ0cBv4i2eVAQwVmmzy0rmt4KptEsk3C7baEM=",
@@ -2041,55 +2030,45 @@
     "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip": "sha256-zNNFPPPnYLkSzXX3CA1IMA0cjeXMcPY58+v80/KjVkg=",
     "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip": "sha256-PwxExt+Dlq11Y5UdEwFr/2BJPST3EYY7r/3gsXoxGzo=",
     "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip": "sha256-0x7t3Lo29Bwmo5pItUD/D+na2yIfd2shPiAVCZp9j/w=",
+    "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip": "sha256-pLB6vIl7bgtu2tu/7OpcnAkMFEc+iEVyRJgxmSl35hk=",
     "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip": "sha256-TZNCi4kRc7NNcV89j2UhT6y1+l1L512xTN/yTztjQfY=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
-    "https://plugins.jetbrains.com/files/23806/664310/Oxocarbon-1.4.5.zip": "sha256-zF89Q1LE6xwBeDKv4FSQ6H6cbABjz74Z/qGwddRWp7M=",
-    "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip": "sha256-bwZSaUkfJ2D6XLr0e7EoismsTmvNCyRzGd4OWu6u9n0=",
-    "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip": "sha256-SC8IMca0EYEmZFrMsaK3oadaemM4FQnYiTxOTt1zQGg=",
+    "https://plugins.jetbrains.com/files/23927/773851/Extra_IDE_Tweaks-2025.1.6.zip": "sha256-YDHbiq94sCzD7zlKz7pm4w0Aa35lxV2jVzoYGnPnu+U=",
+    "https://plugins.jetbrains.com/files/24559/773842/Extra_Tools_Pack-2025.1.7.zip": "sha256-jHz450cWWFxxB1a6wEMAnDrbg0GZ5SlTewO79KAw8AM=",
     "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip": "sha256-rRSyr7nShG1q9tVSO7VRo3KoGnBcrND4D4+38gNBtqI=",
-    "https://plugins.jetbrains.com/files/631/766544/python-251.26094.121.zip": "sha256-gj3s+D04AcmPxzhKDWdYFED8Ab+iHIp6fpZhxasofUQ=",
-    "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip": "sha256-pFKAZ8xFNfUh7/Hi4NYPDQAhRRYm4WKTpCQELqBfb40=",
+    "https://plugins.jetbrains.com/files/631/780469/python-251.26927.53.zip": "sha256-VP035AwZJ3mt4MLqIIq3ZKeiSJpFOEqjCf9EoR6Wlyw=",
     "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip": "sha256-34s7pOsqMaGoVYhCuAZtylNwplQOtNQJUppepsl4F4Q=",
-    "https://plugins.jetbrains.com/files/6981/724264/ini-251.23774.466.zip": "sha256-CnoNNfcsbP9IipuqsBV1OZu+l3h7Yrs6MSofriDvI34=",
-    "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip": "sha256-dcFDO0/mzbjkrsgM+RdHBAA5davTqD5is2D7JYQiTxc=",
     "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip": "sha256-pyB9/Rutax3lp69NcvbVKy4b4OpZZ3cJst6UrrsQCho=",
     "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip": "sha256-BW47ZEUINVnhV0RZ1np7Dkf3lfyrtKoZ9ej/SVct2Xs=",
     "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip": "sha256-KY5VRiLJJwa9OVVog1W3MboZjwVboYwYm+i4eqooo44=",
-    "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip": "sha256-8IHS3kmmbL8uQYnaMW7NgBIpBKT+XDJ4QDiiPZa5pzo=",
     "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip": "sha256-jNHP/vaCaolmvNUQRGmIgSR1ykjDtKqyJ69UIn5cz70=",
     "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip": "sha256-Xsw4P/KddgOuwcNBzT3UWkaQBYXLqGop+fQhoL65Dfg=",
-    "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip": "sha256-q8LjYzKuTK5da+A/29Z2+bHhWKmvsIUVG1MprbsIoLM=",
     "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip": "sha256-I7gwjCnW8OXzM5eioM7h6RW9qYaQX0MWJPfHOOL9KJA=",
     "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip": "sha256-SgldikXjVx6hUw3LqcN8/NxLLBfnr/LUc/SrIIACl7k=",
     "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip": "sha256-HfTd3zT/7sOrYutEkEzpFAu6AijrFrpHJg1ftP3N87Y=",
     "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip": "sha256-gN9XqO/x41scgJ9dzTdC4i4hIZJpwSeR7OjU2BG8gzU=",
     "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip": "sha256-8om1u4KfXRkMUV8YzXWa1cgMeqTCRKSvDUh86ZBzPTE=",
-    "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip": "sha256-3RJ7YVFtynyqeLIzdrirCMbWNZmUkJ+DT/9my71H0Dk=",
+    "https://plugins.jetbrains.com/files/7322/780482/python-ce-251.26927.53.zip": "sha256-R2guKcBjP8XVPzFjCPEOey9kgrr750WF2GP7KCKH+yY=",
     "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip": "sha256-//bXaBJI+eIAYCuXek0pl9h7Utmrtui68QC1vrxPY8c=",
     "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar": "sha256-DobKZKokueqq0z75d2Fo3BD8mWX9+LpGdT9C7Eu2fHc=",
     "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip": "sha256-cnVK5tsExjEAqP3cuh1PgNjrZYt2dVGQ/RL/jr89Zew=",
-    "https://plugins.jetbrains.com/files/7724/724240/clouds-docker-impl-251.23774.466.zip": "sha256-2o1CaX3Xe86ZksIMW9ZqvnuvfvnqSddDDxEU/SFWER8=",
-    "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip": "sha256-p+7U17bTsrxGFVR+Kguma43FOHW0d3NQKRjwxONqL1g=",
     "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip": "sha256-+WJP3tXjIC4eGkssPrNf+tGEIKGQeLP3CcFtyXYUlQg=",
-    "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip": "sha256-rr2pO0mIsqWXYZgwEhcQJlk0lQabxnIPxqRCGdTFaTw=",
+    "https://plugins.jetbrains.com/files/7724/780474/clouds-docker-impl-251.26927.53.zip": "sha256-LBxYHevaGEV7iXy45BO2ZCENlhFak9LLkrP0tNoOG78=",
     "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip": "sha256-O+gSW36MwqQqUiZBQl8J4NFNK+jFowtT9k1ykhSraxM=",
     "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip": "sha256-5QQ3zmfgtcy4cSyGale9GvENuiWV8cQmzTEfxPkox2A=",
-    "https://plugins.jetbrains.com/files/8195/715934/toml-251.23774.429.zip": "sha256-cNWs+ycKlqednnqJAm4AkqF3LTdMt8jhwWWiEDdKQE4=",
+    "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip": "sha256-zPSBubfibs8dTxOLzJusinLn0ejkHNwEO1E4Ryi72HI=",
     "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip": "sha256-DYgGpnlqpr/d/hJXD6uYsa2tzErM4uCofgok/3WayYs=",
     "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip": "sha256-l1dKtjk1YkO2Bd5H/4MDIGAyqi3tNMsDIrVNoMDwzEs=",
-    "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip": "sha256-4c1nxjbEsNs9twmQnJllk1OIVmm0nnUYZ0R7f/6bJt4=",
+    "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip": "sha256-WGGDyxE1ElguDMm7dONA2f0k3u+Tl1vZp3HMLkr5bFw=",
     "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip": "sha256-JD/OcG0B/KUMNmNsnRmiWzZ3QWVcFjaqNnQW8WbV1zc=",
     "https://plugins.jetbrains.com/files/8554/716074/featuresTrainer-251.23774.436.zip": "sha256-P6ux6UgbjeJW3lF4w696bZ73zumY8hEm1iM98IsKgTQ=",
     "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip": "sha256-iK3cy0Nf87rLV0m/t3LJv65Klij/9L5l9ad2UW9O00w=",
     "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip": "sha256-qcMxLM2Y/Q18r718VasRMAlKppbH+ra/6eKCkmVL88s=",
     "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip": "sha256-OFisV6Vs/xlbDvchxfrREDVgVh7wcfGnot+zUrgQU6M=",
-    "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip": "sha256-aG15ecfrsvNkpLjHclJEVKEW95GvBH+dEaqa+VCRkUo=",
     "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip": "sha256-Boy61dRieXmWrnTMfqqYZbdG/DNQ24KdguKN2fcZ+eg=",
-    "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip": "sha256-hR7hC2phDJnHXxPy80WlEDFAhZHtMCu7nqYvAb0VeTI=",
     "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip": "sha256-0c/2qbuu+M6z0gvpme+Mkv23JlQKNTUU+9GL9mh2IFw=",
-    "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip": "sha256-P6XLFObtTrnxNWvNZag73hFVVY82t3+YQ2G31cwAVgg=",
+    "https://plugins.jetbrains.com/files/9568/780515/go-plugin-251.26927.53.zip": "sha256-68Q6r7G+uEvPxYg9o0ceyJbIkZkavmBUeM0BYD3z198=",
     "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar": "sha256-XYCD4kOHDeIKhti0T175xhBHR8uscaFN4c9CNlUaCDs=",
-    "https://plugins.jetbrains.com/files/9707/702582/ANSI_Highlighter_Premium-24.3.4.jar": "sha256-STDhSOshNJU8YOjd1ZMxNl4WaHEp81t9TimFVQGZgWw=",
     "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip": "sha256-Mzmmq0RzMKZeKfBSo7FHvzeEtPGIrwqEDLAONQEsR1M=",
     "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip": "sha256-ArwC2HO2cHlTcFKXQBuKzZTuOiiIDEc/SGDsDQUCZmI="
   }


### PR DESCRIPTION
    jetbrains: 2025.1.2 -> 2025.1.3
    
    jetbrains.clion: 2025.1.2 -> 2025.1.3
    jetbrains.goland: 2025.1.2 -> 2025.1.3
    jetbrains.idea-community: 2025.1.2 -> 2025.1.3
    jetbrains.idea-ultimate: 2025.1.2 -> 2025.1.3
    jetbrains.rider: 2025.1.2 -> 2025.1.3
    jetbrains.ruby-mine: 2025.1.2 -> 2025.1.3
    jetbrains.webstorm: 2025.1.2 -> 2025.1.3

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
