### PR TITLE
tidal-hifi: improve quality of the desktop entry

### DIFF
--- a/pkgs/by-name/ti/tidal-hifi/package.nix
+++ b/pkgs/by-name/ti/tidal-hifi/package.nix
@@ -125,15 +125,15 @@ buildNpmPackage {
 
   desktopItems = [
     (makeDesktopItem {
-      exec = "tidal-hifi";
+      type = "Application";
       name = "TIDAL Hi-Fi";
       desktopName = "tidal-hifi";
       genericName = "TIDAL Hi-Fi";
       comment = "The web version of listen.tidal.com running in electron with hifi support thanks to widevine.";
       icon = "tidal-hifi";
-      startupNotify = true;
+      exec = "tidal-hifi";
       terminal = false;
-      type = "Application";
+      mimeTypes = [ "x-scheme-handler/tidal" ];
       categories = [
         "Network"
         "Application"
@@ -141,8 +141,8 @@ buildNpmPackage {
         "Audio"
         "Video"
       ];
+      startupNotify = true;
       startupWMClass = "tidal-hifi";
-      mimeTypes = [ "x-scheme-handler/tidal" ];
       extraConfig.X-PulseAudio-Properties = "media.role=music";
     })
   ];

--- a/pkgs/by-name/ti/tidal-hifi/package.nix
+++ b/pkgs/by-name/ti/tidal-hifi/package.nix
@@ -87,7 +87,7 @@ let
     vulkan-loader
   ];
 in
-buildNpmPackage {
+buildNpmPackage (self: {
   pname = "tidal-hifi";
   inherit version;
 
@@ -125,21 +125,20 @@ buildNpmPackage {
 
   desktopItems = [
     (makeDesktopItem {
-      type = "Application";
-      name = "TIDAL Hi-Fi";
-      desktopName = "tidal-hifi";
-      genericName = "TIDAL Hi-Fi";
-      comment = "The web version of listen.tidal.com running in electron with hifi support thanks to widevine.";
+      name = self.pname;
+      desktopName = "TIDAL Hi-Fi";
+      genericName = "Music Player";
+      comment = self.meta.description;
       icon = "tidal-hifi";
-      exec = "tidal-hifi";
+      exec = self.meta.mainProgram;
       terminal = false;
       mimeTypes = [ "x-scheme-handler/tidal" ];
       categories = [
-        "Network"
-        "Application"
-        "AudioVideo"
         "Audio"
-        "Video"
+        "Music"
+        "Player"
+        "Network"
+        "AudioVideo"
       ];
       startupNotify = true;
       startupWMClass = "tidal-hifi";
@@ -190,7 +189,7 @@ buildNpmPackage {
 
   meta = {
     changelog = "https://github.com/Mastermindzh/tidal-hifi/releases/tag/${version}";
-    description = "Web version of Tidal running in electron with hifi support thanks to widevine";
+    description = "Web version of Tidal running in Electron with Hi-Fi support thanks to Widevine";
     homepage = "https://github.com/Mastermindzh/tidal-hifi";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
@@ -201,4 +200,4 @@ buildNpmPackage {
     platforms = lib.platforms.linux;
     mainProgram = "tidal-hifi";
   };
-}
+})


### PR DESCRIPTION
This PR improves the desktop entry for `tidal-hifi` because I noticed it looked a little funny.

Summary:
 - Changed the file name to `tidal-hifi` (to remove the whitespace).
 - Change the `desktopName` (aesthetic name) to "TIDAL Hi-Fi".
 - Change the generic name to "Music Player" because "TIDAL Hi-Fi" is not generic.
 - Make `comment` and `exec` (and `name`) follow the values used for `meta` attributes to reduce maintenance overhead slightly.
 - Fix capitalization errors in `meta.description`.
 - Change the `categories` slightly to be more similar to other streaming service programs.
 - Re-ordered the attributes to make it easier to read along with <https://specifications.freedesktop.org/desktop-entry-spec/1.4/recognized-keys.html>.

Each commit has a justification in its summary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
