### PR TITLE
kdePackages: backport kdepim fixes recommended by upstream

### DIFF
--- a/pkgs/kde/frameworks/kirigami/default.nix
+++ b/pkgs/kde/frameworks/kirigami/default.nix
@@ -1,5 +1,6 @@
 {
   stdenv,
+  fetchpatch,
   mkKdeDerivation,
   qtsvg,
   qttools,
@@ -16,6 +17,15 @@
 let
   unwrapped = mkKdeDerivation {
     pname = "kirigami";
+
+    # Backport patch recommended by upstream
+    # FIXME: remove in next update
+    patches = [
+      (fetchpatch {
+        url = "https://invent.kde.org/frameworks/kirigami/-/commit/21788be688de90d4f12edb9f45967a481801bd5e.patch";
+        hash = "sha256-BNp1Sc0qSXBJkyKSYW6sq0s2yN959iwnSxaZtOTmaNc=";
+      })
+    ];
 
     extraNativeBuildInputs = [
       qtsvg

--- a/pkgs/kde/gear/kdepim-runtime/default.nix
+++ b/pkgs/kde/gear/kdepim-runtime/default.nix
@@ -1,4 +1,5 @@
 {
+  fetchpatch,
   mkKdeDerivation,
   pkg-config,
   shared-mime-info,
@@ -13,6 +14,15 @@
 }:
 mkKdeDerivation {
   pname = "kdepim-runtime";
+
+  # Backport patch recommended by upstream
+  # FIXME: remove in next update
+  patches = [
+    (fetchpatch {
+      url = "https://invent.kde.org/pim/kdepim-runtime/-/commit/25202045186262a081c960461a8b791f84fccb5c.patch";
+      hash = "sha256-D769X/v16drueNNr4HfbIZPpjNul8qiKHpOu0BNcbc8=";
+    })
+  ];
 
   extraNativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
