### PR TITLE
sshwifty: init at 0.4.0-beta-release

### DIFF
--- a/pkgs/by-name/ss/sshwifty/package.nix
+++ b/pkgs/by-name/ss/sshwifty/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildGo125Module,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  go_1_25,
+}:
+buildGo125Module (finalAttrs: {
+  pname = "sshwifty";
+  version = "0.4.0-beta-release";
+
+  src = fetchFromGitHub {
+    owner = "nirui";
+    repo = "sshwifty";
+    tag = finalAttrs.version;
+    hash = "sha256-7ZfS46+aflKIQ8S9T18JjCb7bY8mB6cJl/lgJi5Hukg=";
+  };
+
+  sshwifty-ui = buildNpmPackage {
+    pname = "sshwifty-ui";
+    inherit (finalAttrs) version src;
+
+    npmDepsHash = "sha256-I96VixL21cF2kp9AK6q0ipjphjdWuSETKakbsprGek0=";
+
+    npmBuildScript = "generate";
+
+    postInstall = ''
+      cp -r application/controller/{static_pages,static_pages.go} \
+        $out/lib/node_modules/sshwifty-ui/application/controller
+    '';
+
+    nativeBuildInputs = [ go_1_25 ];
+  };
+
+  postPatch = ''
+    cp -r ${finalAttrs.sshwifty-ui}/lib/node_modules/sshwifty-ui/* .
+  '';
+
+  vendorHash = "sha256-kLKydjvZtFEY7vjqxK1cCwZSTbdqYWPRmxYSN0LYqsg=";
+
+  ldflags = [
+    "-s"
+    "-X github.com/nirui/sshwifty/application.version=${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    find $out/bin ! -name sshwifty -type f -exec rm -rf {} \;
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "WebSSH & WebTelnet client";
+    homepage = "https://github.com/nirui/sshwifty";
+    changelog = "https://github.com/nirui/sshwifty/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.agpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "sshwifty";
+  };
+})


### PR DESCRIPTION
Add sshwifty, a WebSSH and WebTelnet client
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
