### PR TITLE
postgresql.withPackages.pg_config: fix paths

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/omnigres.nix
+++ b/pkgs/servers/sql/postgresql/ext/omnigres.nix
@@ -12,6 +12,7 @@
   postgresqlBuildExtension,
   postgresqlTestExtension,
   python3,
+  stdenv,
   unstableGitUpdater,
 }:
 
@@ -28,6 +29,16 @@ postgresqlBuildExtension (finalAttrs: {
     rev = "d347be5ae1d79645ac277d19080eacba7b229cf8";
     hash = "sha256-LKsH+aeLg7v2RfK80D3mgXdPB8jMIv5uFdf+3c5Z0vA=";
   };
+
+  # This matches postInstall of PostgreSQL's generic.nix, which does this for the PGXS Makefile.
+  # Since omnigres uses a CMake file, which tries to replicate the things that PGXS does, we need
+  # to apply the same fix for darwin.
+  # The reason we need to do this is, because PG_BINARY will point at the postgres wrapper of
+  # postgresql.withPackages, which does not contain the same symbols as the original file, ofc.
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace "cmake/PostgreSQLExtension.cmake" \
+      --replace-fail '-bundle_loader ''${PG_BINARY}' "-bundle_loader ${postgresql}/bin/postgres"
+  '';
 
   strictDeps = true;
 
@@ -48,8 +59,6 @@ postgresqlBuildExtension (finalAttrs: {
   cmakeFlags = [
     "-DOPENSSL_CONFIGURED=1"
     "-DPG_CONFIG=${pgWithExtensions.pg_config}/bin/pg_config"
-    "-DPostgreSQL_EXTENSION_DIR=${pgWithExtensions}/share/postgresql/extension/"
-    "-DPostgreSQL_PACKAGE_LIBRARY_DIR=${pgWithExtensions}/lib/"
     "-DPostgreSQL_TARGET_EXTENSION_DIR=${builtins.placeholder "out"}/share/postgresql/extension/"
     "-DPostgreSQL_TARGET_PACKAGE_LIBRARY_DIR=${builtins.placeholder "out"}/lib/"
   ];

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -610,66 +610,78 @@ let
     f:
     let
       installedExtensions = f postgresql.pkgs;
-    in
-    buildEnv {
-      name = "${postgresql.pname}-and-plugins-${postgresql.version}";
-      paths = installedExtensions ++ [
-        postgresql
-        postgresql.man # in case user installs this into environment
-      ];
+      finalPackage = buildEnv {
+        name = "${postgresql.pname}-and-plugins-${postgresql.version}";
+        paths = installedExtensions ++ [
+          # consider keeping in-sync with `postBuild` below
+          postgresql
+          postgresql.man # in case user installs this into environment
+        ];
 
-      pathsToLink = [
-        "/"
-        "/bin"
-      ];
+        pathsToLink = [
+          "/"
+          "/bin"
+          "/share/postgresql/extension"
+          # Unbreaks Omnigres' build system
+          "/share/postgresql/timezonesets"
+          "/share/postgresql/tsearch_data"
+        ];
 
-      nativeBuildInputs = [ makeBinaryWrapper ];
-      postBuild =
-        let
-          args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
-        in
-        ''
-          wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
-        '';
+        nativeBuildInputs = [ makeBinaryWrapper ];
+        postBuild =
+          let
+            args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
+          in
+          ''
+            wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
 
-      passthru = {
-        inherit installedExtensions;
-        inherit (postgresql)
-          pg_config
-          pkgs
-          psqlSchema
-          version
-          ;
+            mkdir -p "$out/nix-support"
+            substitute "${lib.getDev postgresql}/nix-support/pg_config.env" "$out/nix-support/pg_config.env" \
+              --replace-fail "${postgresql}" "$out" \
+              --replace-fail "${postgresql.man}" "$out"
+          '';
 
-        withJIT = postgresqlWithPackages {
-          inherit
-            buildEnv
-            lib
-            makeBinaryWrapper
-            postgresql
+        passthru = {
+          inherit installedExtensions;
+          inherit (postgresql)
+            pkgs
+            psqlSchema
+            version
             ;
-        } (_: installedExtensions ++ [ postgresql.jit ]);
-        withoutJIT = postgresqlWithPackages {
-          inherit
-            buildEnv
-            lib
-            makeBinaryWrapper
-            postgresql
-            ;
-        } (_: lib.remove postgresql.jit installedExtensions);
 
-        withPackages =
-          f':
-          postgresqlWithPackages {
+          pg_config = postgresql.pg_config.override { inherit finalPackage; };
+
+          withJIT = postgresqlWithPackages {
             inherit
               buildEnv
               lib
               makeBinaryWrapper
               postgresql
               ;
-          } (ps: installedExtensions ++ f' ps);
+          } (_: installedExtensions ++ [ postgresql.jit ]);
+          withoutJIT = postgresqlWithPackages {
+            inherit
+              buildEnv
+              lib
+              makeBinaryWrapper
+              postgresql
+              ;
+          } (_: lib.remove postgresql.jit installedExtensions);
+
+          withPackages =
+            f':
+            postgresqlWithPackages {
+              inherit
+                buildEnv
+                lib
+                makeBinaryWrapper
+                postgresql
+                ;
+            } (ps: installedExtensions ++ f' ps);
+        };
       };
-    };
+    in
+    finalPackage;
 
 in
 # passed by <major>.nix

--- a/pkgs/servers/sql/postgresql/pg_config.env.mk
+++ b/pkgs/servers/sql/postgresql/pg_config.env.mk
@@ -9,5 +9,6 @@ pg_config.env: $(top_builddir)/src/port/pg_config_paths.h | $(top_builddir)/src/
 	echo "LDFLAGS_EX=\"$(LDFLAGS_EX)\"" >>$@
 	echo "LDFLAGS_SL=\"$(LDFLAGS_SL)\"" >>$@
 	echo "LIBS=\"$(LIBS)\"" >>$@
+	echo "PGXS=\"$(dev)/lib/pgxs/src/makefiles/pgxs.mk\"" >>$@
 	cat $(top_builddir)/src/port/pg_config_paths.h $(top_builddir)/src/include/pg_config.h \
 	  | sed -nE 's/^#define ([^ ]+) ("?)(.*)\2$$/\1="\3"/p' >>$@

--- a/pkgs/servers/sql/postgresql/pg_config.sh
+++ b/pkgs/servers/sql/postgresql/pg_config.sh
@@ -70,7 +70,7 @@ for opt; do
         --mandir)               show+=("$MANDIR") ;;
         --sharedir)             show+=("$PGSHAREDIR") ;;
         --sysconfdir)           show+=("$SYSCONFDIR") ;;
-        --pgxs)                 show+=("@postgresql-dev@/lib/pgxs/src/makefiles/pgxs.mk") ;;
+        --pgxs)                 show+=("$PGXS") ;;
         --configure)            show+=("$CONFIGURE_ARGS") ;;
         --cc)                   show+=("$CC") ;;
         --cppflags)             show+=("$CPPFLAGS") ;;
@@ -108,7 +108,7 @@ LOCALEDIR = $LOCALEDIR
 MANDIR = $MANDIR
 SHAREDIR = $PGSHAREDIR
 SYSCONFDIR = $SYSCONFDIR
-PGXS = @postgresql-dev@/lib/pgxs/src/makefiles/pgxs.mk
+PGXS = $PGXS
 CONFIGURE = $CONFIGURE_ARGS
 CC = $CC
 CPPFLAGS = $CPPFLAGS


### PR DESCRIPTION
Continuation of #407920, which can't be re-opened anymore, retargeting staging.

I consider the state of this ready-to-go.

## Things done

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
