### PR TITLE
morewaita-icon-theme: 48.1 -> 48.2, remove build-related files from $out

### DIFF
--- a/pkgs/by-name/mo/morewaita-icon-theme/fix-broken-symlinks.patch
+++ b/pkgs/by-name/mo/morewaita-icon-theme/fix-broken-symlinks.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kenichi Kamiya <kachick1@gmail.com>
+Date: Sun, 15 Jun 2025 10:35:51 +0900
+Subject: [PATCH] Fix broken symlinks
+
+---
+ scalable/apps/gnome-character-map.svg    | 2 +-
+ symbolic/apps/pamac-manager-symbolic.svg | 2 +-
+ symbolic/apps/pamac-symbolic.svg         | 2 +-
+ symbolic/apps/pamac-updater-symbolic.svg | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/scalable/apps/gnome-character-map.svg b/scalable/apps/gnome-character-map.svg
+index f04d4679adb66b897b42396e75896f4c46199c24..d400f7677eefaa10db958bb324247825d8c3578e 120000
+--- a/scalable/apps/gnome-character-map.svg
++++ b/scalable/apps/gnome-character-map.svg
+@@ -1 +1 @@
+-accessories-character-map.svg
+\ No newline at end of file
++../legacy/accessories-character-map.svg
+\ No newline at end of file
+diff --git a/symbolic/apps/pamac-manager-symbolic.svg b/symbolic/apps/pamac-manager-symbolic.svg
+index 758557a5c791b43de172d29f466fe6b6cb9d5207..106458e72401668bca4b9457cd6c2eff9ea7e4e2 120000
+--- a/symbolic/apps/pamac-manager-symbolic.svg
++++ b/symbolic/apps/pamac-manager-symbolic.svg
+@@ -1 +1 @@
+-system-software-install-symbolic.svg
+\ No newline at end of file
++../legacy/system-software-install-symbolic.svg
+\ No newline at end of file
+diff --git a/symbolic/apps/pamac-symbolic.svg b/symbolic/apps/pamac-symbolic.svg
+index 758557a5c791b43de172d29f466fe6b6cb9d5207..106458e72401668bca4b9457cd6c2eff9ea7e4e2 120000
+--- a/symbolic/apps/pamac-symbolic.svg
++++ b/symbolic/apps/pamac-symbolic.svg
+@@ -1 +1 @@
+-system-software-install-symbolic.svg
+\ No newline at end of file
++../legacy/system-software-install-symbolic.svg
+\ No newline at end of file
+diff --git a/symbolic/apps/pamac-updater-symbolic.svg b/symbolic/apps/pamac-updater-symbolic.svg
+index 758557a5c791b43de172d29f466fe6b6cb9d5207..106458e72401668bca4b9457cd6c2eff9ea7e4e2 120000
+--- a/symbolic/apps/pamac-updater-symbolic.svg
++++ b/symbolic/apps/pamac-updater-symbolic.svg
+@@ -1 +1 @@
+-system-software-install-symbolic.svg
+\ No newline at end of file
++../legacy/system-software-install-symbolic.svg
+\ No newline at end of file

--- a/pkgs/by-name/mo/morewaita-icon-theme/package.nix
+++ b/pkgs/by-name/mo/morewaita-icon-theme/package.nix
@@ -4,15 +4,16 @@
   fetchFromGitHub,
   gtk3,
   xdg-utils,
+  nix-update-script,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "morewaita-icon-theme";
   version = "48.1";
 
   src = fetchFromGitHub {
     owner = "somepaulo";
     repo = "MoreWaita";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-18jI4hADVHC/WCmMTlA+VBuZ1jNGSxL+lO3GwWDiNoU=";
   };
 
@@ -31,11 +32,15 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
     description = "Adwaita style extra icons theme for Gnome Shell";
     homepage = "https://github.com/somepaulo/MoreWaita";
-    license = with licenses; [ gpl3Only ];
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ pkosel ];
+    license = with lib.licenses; [ gpl3Only ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ pkosel ];
   };
-}
+})

--- a/pkgs/by-name/mo/morewaita-icon-theme/package.nix
+++ b/pkgs/by-name/mo/morewaita-icon-theme/package.nix
@@ -41,6 +41,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/somepaulo/MoreWaita";
     license = with lib.licenses; [ gpl3Only ];
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ pkosel ];
+    maintainers = with lib.maintainers; [
+      pkosel
+      kachick
+    ];
   };
 })

--- a/pkgs/by-name/mo/morewaita-icon-theme/package.nix
+++ b/pkgs/by-name/mo/morewaita-icon-theme/package.nix
@@ -8,14 +8,19 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "morewaita-icon-theme";
-  version = "48.1";
+  version = "48.2";
 
   src = fetchFromGitHub {
     owner = "somepaulo";
     repo = "MoreWaita";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-18jI4hADVHC/WCmMTlA+VBuZ1jNGSxL+lO3GwWDiNoU=";
+    hash = "sha256-eCMU5RNlqHN6tImGd2ur+rSC+kR5xQ8Zh4BaRgjBHVc=";
   };
+
+  patches = [
+    # Avoiding "ERROR: noBrokenSymlinks". ref: https://github.com/somepaulo/MoreWaita/pull/335
+    ./fix-broken-symlinks.patch
+  ];
 
   postPatch = ''
     patchShebangs install.sh

--- a/pkgs/by-name/mo/morewaita-icon-theme/package.nix
+++ b/pkgs/by-name/mo/morewaita-icon-theme/package.nix
@@ -17,6 +17,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-18jI4hADVHC/WCmMTlA+VBuZ1jNGSxL+lO3GwWDiNoU=";
   };
 
+  postPatch = ''
+    patchShebangs install.sh
+
+    # Replace this workaround if https://github.com/somepaulo/MoreWaita/pull/339 is merged
+    substituteInPlace install.sh \
+      --replace-fail '"''${HOME}/.local/share/' '"$out/share/'
+  '';
+
   nativeBuildInputs = [
     gtk3
     xdg-utils
@@ -25,9 +33,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -d $out/share/icons/MoreWaita
-    cp -r . $out/share/icons/MoreWaita
-    gtk-update-icon-cache -f -t $out/share/icons/MoreWaita && xdg-desktop-menu forceupdate
+    ./install.sh
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR mainly aims to fix 2 problems.

* failing automatic update: https://nixpkgs-update-logs.nix-community.org/morewaita-icon-theme/2025-06-04.log
  Changes: https://github.com/somepaulo/MoreWaita/compare/v48.1...v48.2
* package including unnecessary build-related files.


<details>

<summary>Diff for file tree.</summary>

```diff
diff --git a/dev/fd/63 b/dev/fd/62
--- a/dev/fd/63
+++ b/dev/fd/62
@@ -1,18 +1,10 @@
-/nix/store/fdi24ixy8lqma39bk3jj6ndssrdfrqb5-morewaita-icon-theme-48.1
+nixpkgs/result
 ├── share
     ├── icons
         ├── MoreWaita
             ├── AUTHORS
-            ├── CONTRIBUTING.md
             ├── LICENSE
-            ├── PACKAGING.md
-            ├── README.md
-            ├── _dev
-            │   ├── dump_groups.py
-            ├── custom_folder_icons.sh
             ├── index.theme
-            ├── install.sh
-            ├── meson.build
             ├── scalable
             │   ├── apps
             │   │   ├── 0ad.svg
@@ -37,6 +29,8 @@
             │   │   ├── OpenBoard.svg -> openboard.svg
             │   │   ├── OpenRGB.svg -> openrgb.svg
             │   │   ├── ProtonMail_Bridge.svg -> protonmail-bridge.svg
+            │   │   ├── PrusaSlicer-gcodeviewer.svg
+            │   │   ├── PrusaSlicer.svg
             │   │   ├── QtProject-assistant.svg -> assistant.svg
             │   │   ├── QtProject-designer.svg -> designer.svg
             │   │   ├── QtProject-linguist.svg -> linguist.svg
@@ -48,7 +42,6 @@
             │   │   ├── TeamViewer.svg
             │   │   ├── Zoom.svg
             │   │   ├── abiword.svg
-            │   │   ├── accessories-character-map.svg
             │   │   ├── alacarte.svg
             │   │   ├── alacritty.svg
             │   │   ├── android-studio-beta.svg -> android-studio-canary.svg
@@ -94,6 +87,9 @@
             │   │   ├── appimagekit-unityhub.svg -> unityhub.svg
             │   │   ├── appimagekit-yuzu.svg -> yuzu.svg
             │   │   ├── appimagekit-zen-browser.svg -> zen-browser.svg
+            │   │   ├── appimagekit-zoho-mail-desktop.svg -> zoho-mail.svg
+            │   │   ├── apple-music.svg
+            │   │   ├── application-x-zoom.svg -> Zoom.svg
             │   │   ├── applications-java.svg -> java-openjdk.svg
             │   │   ├── ardour.svg
             │   │   ├── ardour6.svg -> ardour.svg
@@ -114,6 +110,7 @@
             │   │   ├── avogadro.svg
             │   │   ├── avogadro2.svg -> avogadro.svg
             │   │   ├── balena-etcher-electron.svg -> etcher.svg
+            │   │   ├── bambustudio.svg
             │   │   ├── bashtop.svg -> btop.svg
             │   │   ├── betterbird.svg
             │   │   ├── bitwarden.svg
@@ -128,6 +125,7 @@
             │   │   ├── brave-browser.svg -> brave-desktop.svg
             │   │   ├── brave-cifhbcnohmdccbgoicgdjpfamggdegmo-Default.svg -> teams.svg
             │   │   ├── brave-desktop.svg
+            │   │   ├── briar.svg
             │   │   ├── bsnes.svg -> dev.bsnes.bsnes.svg
             │   │   ├── btop.svg
             │   │   ├── buzz.svg
@@ -168,6 +166,7 @@
             │   │   ├── com.alacritty.Alacritty.svg -> alacritty.svg
             │   │   ├── com.anydesk.Anydesk.svg -> anydesk.svg
             │   │   ├── com.axosoft.GitKraken.svg -> gitkraken.svg
+            │   │   ├── com.bambulab.BambuStudio.svg -> bambustudio.svg
             │   │   ├── com.bitwarden.desktop.svg -> bitwarden.svg
             │   │   ├── com.bitwig.BitwigStudio.svg -> bitwig-studio.svg
             │   │   ├── com.boxy_svg.BoxySVG.svg -> boxy-svg.svg
@@ -180,6 +179,7 @@
             │   │   ├── com.discordapp.Discord.svg -> discord.svg
             │   │   ├── com.discordapp.DiscordCanary.svg -> discord-canary.svg
             │   │   ├── com.dropbox.Client.svg -> dropbox.svg
+            │   │   ├── com.fender.studio.svg
             │   │   ├── com.getmailspring.Mailspring.svg -> mailspring.svg
             │   │   ├── com.getpostman.Postman.svg -> postman.svg
             │   │   ├── com.gigitux.gtkwhats.svg -> com.github.eneshecan.WhatsAppForLinux.svg
@@ -200,6 +200,7 @@
             │   │   ├── com.google.Chrome.svg -> google-chrome.svg
             │   │   ├── com.hamrick.VueScan.svg -> xsane.svg
             │   │   ├── com.heroicgameslauncher.hgl.svg -> heroic.svg
+            │   │   ├── com.icons8.Lunacy.svg -> lunacy.svg
             │   │   ├── com.jetbrains.CLion.svg -> clion.svg
             │   │   ├── com.jetbrains.DataGrip.svg -> datagrip.svg
             │   │   ├── com.jetbrains.DataSpell.svg -> dataspell.svg
@@ -216,6 +217,8 @@
             │   │   ├── com.jetbrains.ToolBox.svg -> jetbrains-toolbox.svg
             │   │   ├── com.jetbrains.WebStorm.svg -> webstorm.svg
             │   │   ├── com.jetbrains.dataspell.svg -> dataspell.svg
+            │   │   ├── com.jgraph.drawio.desktop.svg -> drawio.svg
+            │   │   ├── com.lablicate.OpenChrom.svg -> openchrom.svg
             │   │   ├── com.logseq.Logseq.svg -> logseq.svg
             │   │   ├── com.lunarclient.LunarClient.svg -> lunarclient.svg
             │   │   ├── com.mastermindzh.tidal-hifi.svg -> tidal-hifi.svg
@@ -230,6 +233,8 @@
             │   │   ├── com.opera.Opera.svg -> opera.svg
             │   │   ├── com.play0ad.zeroad.svg -> 0ad.svg
             │   │   ├── com.protonvpn.www.svg -> protonvpn-gui.svg
+            │   │   ├── com.prusa3d.PrusaSlicer.GCodeViewer.svg -> PrusaSlicer-gcodeviewer.svg
+            │   │   ├── com.prusa3d.PrusaSlicer.svg -> PrusaSlicer.svg
             │   │   ├── com.qq.QQ.svg -> qq.svg
             │   │   ├── com.rawtherapee.RawTherapee.svg -> rawtherapee.svg
             │   │   ├── com.sindresorhus.Caprine.svg -> facebook-messenger.svg
@@ -251,6 +256,7 @@
             │   │   ├── com.visualstudio.code.svg -> visual-studio-code.svg
             │   │   ├── com.vivaldi.Vivaldi.svg -> vivaldi.svg
             │   │   ├── com.vscodium.codium.svg -> vscodium.svg
+            │   │   ├── coolercontrol.svg
             │   │   ├── coppwr.svg
             │   │   ├── corectrl.svg
             │   │   ├── cudatext-512.svg
@@ -271,13 +277,16 @@
             │   │   ├── designer.svg
             │   │   ├── dev.aunetx.deezer.svg -> deezer.svg
             │   │   ├── dev.bsnes.bsnes.svg
+            │   │   ├── dev.deedles.Trayscale.svg
             │   │   ├── dev.neovide.neovide.svg -> neovide.svg
             │   │   ├── dev.pulsar_edit.Pulsar.svg -> pulsar.svg
             │   │   ├── dev.vencord.Vesktop.svg -> vesktop.svg
             │   │   ├── dev.zed.Zed.svg -> zed.svg
             │   │   ├── discord-canary.svg
             │   │   ├── discord.svg
+            │   │   ├── drawio.svg
             │   │   ├── dropbox.svg
+            │   │   ├── dune3d.svg
             │   │   ├── eclipse-cdt.svg -> eclipse.svg
             │   │   ├── eclipse.svg
             │   │   ├── electron.svg
@@ -328,6 +337,7 @@
             │   │   ├── fleet.svg
             │   │   ├── flightgear.svg
             │   │   ├── floorp.svg
+            │   │   ├── flowblade.svg
             │   │   ├── fm.helio.Worksatation.svg -> helio-workstation.svg
             │   │   ├── foobar2000.svg
             │   │   ├── foot.svg
@@ -343,6 +353,7 @@
             │   │   ├── fuse.svg -> fuse-emulator.svg
             │   │   ├── gda-browser-5.0.svg
             │   │   ├── gda-control-center.svg
+            │   │   ├── gdevelop.svg
             │   │   ├── geany.svg
             │   │   ├── geneious.svg
             │   │   ├── genymotion-bin.svg -> genymotion.svg
@@ -355,7 +366,7 @@
             │   │   ├── github-desktop.svg
             │   │   ├── gitkraken.svg
             │   │   ├── gnome-aisleriot.svg
-            │   │   ├── gnome-character-map.svg -> accessories-character-map.svg
+            │   │   ├── gnome-character-map.svg -> ../legacy/accessories-character-map.svg
             │   │   ├── gnome-emacs.svg -> emacs.svg
             │   │   ├── gnome-nettool.svg
             │   │   ├── gnome-nettools.svg -> gnome-nettool.svg
@@ -367,8 +378,11 @@
             │   │   ├── goland.svg
             │   │   ├── google-chrome.svg
             │   │   ├── google-chrome2.svg -> google-chrome.svg
+            │   │   ├── google-docs.svg
             │   │   ├── google-earth-pro.svg -> google-earth.svg
             │   │   ├── google-earth.svg
+            │   │   ├── google-sheets.svg
+            │   │   ├── google-slides.svg
             │   │   ├── googlechrome.svg -> google-chrome.svg
             │   │   ├── googleearth.svg -> google-earth.svg
             │   │   ├── gparted.svg
@@ -409,6 +423,7 @@
             │   │   ├── input-remapper.svg
             │   │   ├── insomnia.svg
             │   │   ├── intellij.svg
+            │   │   ├── interstellar.svg
             │   │   ├── io.anytype.anytype.svg -> anytype.svg
             │   │   ├── io.appflowy.AppFlowy.svg -> appflowy.svg
             │   │   ├── io.atom.electron.BaseApp.svg -> electron.svg
@@ -417,20 +432,27 @@
             │   │   ├── io.element.Element.svg
             │   │   ├── io.frappe.books.svg -> frappe-books.svg
             │   │   ├── io.freetubeapp.FreeTube.svg -> freetube.svg
+            │   │   ├── io.gdevelop.ide.svg -> gdevelop.svg
             │   │   ├── io.github.Figma_Linux.figma_linux.svg -> figma.svg
             │   │   ├── io.github.NhekoReborn.Nheko.svg -> nheko.svg
             │   │   ├── io.github.OpenToonz.svg -> opentoonz.svg
             │   │   ├── io.github.alainm23.planify.svg
+            │   │   ├── io.github.amit9838.mousam.svg -> mousam.svg
             │   │   ├── io.github.chidiwilliams.Buzz.svg -> buzz.svg
             │   │   ├── io.github.cudatext.CudaText-Qt.svg -> cudatext-512.svg
             │   │   ├── io.github.cudatext.CudaText-Qt5.svg -> cudatext-512.svg
             │   │   ├── io.github.dimtpap.coppwr.svg -> coppwr.svg
             │   │   ├── io.github.dvlv.boxbuddyrs.svg -> boxbuddyrs.svg
             │   │   ├── io.github.endless_sky.endless_sky.svg -> endless-sky.svg
+            │   │   ├── io.github.jean28518.Linux-Assistant.svg -> linux-assistant.svg
+            │   │   ├── io.github.jliljebl.Flowblade.svg -> flowblade.svg
+            │   │   ├── io.github.kotatogram.svg -> kotatogram.svg
             │   │   ├── io.github.manisandro.gImageReader.svg -> gimagereader.svg
             │   │   ├── io.github.mimbrero.WhatsAppDesktop.svg -> com.github.eneshecan.WhatsAppForLinux.svg
+            │   │   ├── io.github.plrigaux.sysd-manager.svg -> sysd-manager.svg
             │   │   ├── io.github.quodlibet.ExFalso.svg
             │   │   ├── io.github.quodlibet.QuodLibet.svg
+            │   │   ├── io.github.ra3xdh.qucs_s.svg -> qucs-s.svg
             │   │   ├── io.github.rinigus.OSMScoutServer.svg -> osmscout-server.svg
             │   │   ├── io.github.rinigus.PureMaps.svg -> pure-maps.svg
             │   │   ├── io.github.shiftey.Desktop.svg -> github-desktop.svg
@@ -506,6 +528,7 @@
             │   │   ├── kitty.svg
             │   │   ├── kodi.svg
             │   │   ├── kolourpaint.svg
+            │   │   ├── kotatogram.svg
             │   │   ├── krita.svg
             │   │   ├── kruler.svg
             │   │   ├── kvantum.svg
@@ -675,9 +698,11 @@
             │   │   ├── linguist-qt5.svg -> linguist.svg
             │   │   ├── linguist.svg
             │   │   ├── linguist5.svg -> linguist.svg
+            │   │   ├── linux-assistant.svg
             │   │   ├── localsend.svg
             │   │   ├── logseq.svg
             │   │   ├── lpub3d.svg
+            │   │   ├── lunacy.svg
             │   │   ├── lunar-client.svg -> lunarclient.svg
             │   │   ├── lunarclient.svg
             │   │   ├── lutris_blender.svg -> blender.svg
@@ -711,7 +736,6 @@
             │   │   ├── menulibre.svg
             │   │   ├── mercury-browser.svg -> mercury.svg
             │   │   ├── mercury.svg
-            │   │   ├── meson.build
             │   │   ├── micro.svg
             │   │   ├── microsoft-edge.svg
             │   │   ├── minecraft-launcher.svg -> minecraft.svg
@@ -725,6 +749,7 @@
             │   │   ├── mockoon.svg
             │   │   ├── monero-gui.svg -> monero.svg
             │   │   ├── monero.svg
+            │   │   ├── mousam.svg
             │   │   ├── mozilla-firefox.svg -> firefox.svg
             │   │   ├── mpv-icon-8bit-64x64.svg -> mpv.svg
             │   │   ├── mpv.svg
@@ -787,10 +812,12 @@
             │   │   ├── okular.svg
             │   │   ├── one.ablaze.floorp.svg -> floorp.svg
             │   │   ├── one.alynx.showmethekey.svg
+            │   │   ├── one.jwr.interstellar.svg -> interstellar.svg
             │   │   ├── onetagger.svg
             │   │   ├── onlyoffice-desktopeditors.svg -> org.onlyoffice.desktopeditors.svg
             │   │   ├── openbabel.svg
             │   │   ├── openboard.svg
+            │   │   ├── openchrom.svg
             │   │   ├── openra-cnc.svg
             │   │   ├── openra-d2k.svg
             │   │   ├── openra-ra.svg
@@ -812,13 +839,16 @@
             │   │   ├── org.bleachbit.BleachBit.svg -> bleachbit.svg
             │   │   ├── org.blender.Blender.svg -> blender.svg
             │   │   ├── org.bluesabre.MenuLibre.svg -> menulibre.svg
+            │   │   ├── org.briarproject.Briar.svg -> briar.svg
             │   │   ├── org.chromium.Chromium.svg -> chromium-browser.svg
             │   │   ├── org.cockpit_project.CockpitClient.svg
             │   │   ├── org.codeberg.dnkl.foot.svg -> foot.svg
             │   │   ├── org.codeblocks.codeblocks.svg -> codeblocks.svg
+            │   │   ├── org.coolercontrol.CoolerControl.svg -> coolercontrol.svg
             │   │   ├── org.cvfosammmm.Setzer.svg -> setzer.svg
             │   │   ├── org.daa.NeovimGtk.svg -> nvim.svg
             │   │   ├── org.darktable.Darktable.svg -> darktable.svg
+            │   │   ├── org.dune3d.dune3d.svg -> dune3d.svg
             │   │   ├── org.eclipse.Committers.svg -> eclipse.svg
             │   │   ├── org.eclipse.Java.svg -> eclipse.svg
             │   │   ├── org.eclipse.Javascript.svg -> eclipse.svg
@@ -897,6 +927,7 @@
             │   │   ├── org.qutebrowser.qutebrowser.svg -> qutebrowser.svg
             │   │   ├── org.raspberrypi.rpi-imager.svg -> rpi-imager.svg
             │   │   ├── org.ryujinx.Ryujinx.svg -> ryujinx.svg
+            │   │   ├── org.shotcut.Shotcut.svg -> shotcut.svg
             │   │   ├── org.signal.Signal.svg -> signal-desktop.svg
             │   │   ├── org.soundconverter.SoundConverter.svg -> soundconverter.svg
             │   │   ├── org.sqlitebrowser.sqlitebrowser.svg -> sqlitebrowser.svg
@@ -930,6 +961,8 @@
             │   │   ├── parsehub.svg
             │   │   ├── pavucontrol.svg
             │   │   ├── phpstorm.svg
+            │   │   ├── pianoteq-stage.svg -> pianoteq.svg
+            │   │   ├── pianoteq.svg
             │   │   ├── pidgin.svg
             │   │   ├── pinta.svg
             │   │   ├── poedit.svg -> net.poedit.Poedit.svg
@@ -940,8 +973,6 @@
             │   │   ├── popcorntime.svg
             │   │   ├── portmaster.svg
             │   │   ├── postman.svg
-            │   │   ├── preferences-desktop-theme.svg
-            │   │   ├── preferences-system-network.svg
             │   │   ├── prismlauncher.svg
             │   │   ├── projectM.svg
             │   │   ├── proton-mail.svg
@@ -951,6 +982,8 @@
             │   │   ├── protonmail-ie.svg
             │   │   ├── protonvpn-gui.svg
             │   │   ├── protonvpn-logo.svg -> protonvpn-gui.svg
+            │   │   ├── prusa-slicer-gcodeviewer.svg -> PrusaSlicer-gcodeviewer.svg
+            │   │   ├── prusa-slicer.svg -> PrusaSlicer.svg
             │   │   ├── pulsar.svg
             │   │   ├── pure-maps.svg
             │   │   ├── pycharm-community.svg -> pycharm.svg
@@ -983,6 +1016,7 @@
             │   │   ├── qtlinguist.svg -> linguist.svg
             │   │   ├── qtoctave.svg -> octave.svg
             │   │   ├── qtscrcpy.svg -> scrcpy.svg
+            │   │   ├── qucs-s.svg
             │   │   ├── qutebrowser.svg
             │   │   ├── qv4l2.svg
             │   │   ├── qvidcap.svg -> qv4l2.svg
@@ -997,6 +1031,7 @@
             │   │   ├── rocketchat.svg
             │   │   ├── rpi-imager.svg
             │   │   ├── rpi.svg -> rpi-imager.svg
+            │   │   ├── rpminstall.svg
             │   │   ├── rstudio.svg
             │   │   ├── ru.yandex.Browser.svg -> yandex-browser.svg
             │   │   ├── rubymine.svg
@@ -1014,6 +1049,7 @@
             │   │   ├── setzer.svg
             │   │   ├── sh.cider.Cider.svg -> cider.svg
             │   │   ├── sh.ppy.osu.svg -> osu.svg
+            │   │   ├── shotcut.svg
             │   │   ├── shotwell.svg
             │   │   ├── signal-desktop.svg
             │   │   ├── sioyek-icon-linux.svg -> sioyek.svg
@@ -1075,13 +1111,10 @@
             │   │   ├── sun-javaws32-jdk8.svg -> java-openjdk.svg
             │   │   ├── surfshark.svg
             │   │   ├── suyu.svg
-            │   │   ├── synaptic.svg -> system-software-install.svg
             │   │   ├── syncthing-gtk.svg
             │   │   ├── syncthing.svg -> syncthing-gtk.svg
             │   │   ├── syncthingtray.svg -> syncthing-gtk.svg
-            │   │   ├── system-software-install.svg
-            │   │   ├── system-software-installer.svg -> system-software-install.svg
-            │   │   ├── system-software-update.svg -> system-software-install.svg
+            │   │   ├── sysd-manager.svg
             │   │   ├── teams-for-linux.svg -> teams.svg
             │   │   ├── teams.svg
             │   │   ├── teamviewer.svg -> TeamViewer.svg
@@ -1098,6 +1131,7 @@
             │   │   ├── thunderbird-mozilla-build.svg -> thunderbird.svg
             │   │   ├── thunderbird.svg
             │   │   ├── tidal-hifi.svg
+            │   │   ├── timeshift.svg
             │   │   ├── todoist.svg
             │   │   ├── toolbox.svg -> jetbrains-toolbox.svg
             │   │   ├── tor-browser-en.svg -> tor-browser.svg
@@ -1145,6 +1179,7 @@
             │   │   ├── webcord.svg
             │   │   ├── webstorm.svg
             │   │   ├── wezterm.svg
+            │   │   ├── whatsapp-business.svg
             │   │   ├── whatsapp-desktop.svg -> com.github.eneshecan.WhatsAppForLinux.svg
             │   │   ├── whatsapp-for-linux.svg -> com.github.eneshecan.WhatsAppForLinux.svg
             │   │   ├── whatsapp-nativefier.svg -> com.github.eneshecan.WhatsAppForLinux.svg
@@ -1168,6 +1203,11 @@
             │   │   ├── zed.svg
             │   │   ├── zen-browser.svg
             │   │   ├── zim.svg
+            │   │   ├── zoho-mail-desktop.svg -> zoho-mail.svg
+            │   │   ├── zoho-mail.svg
+            │   │   ├── zoho-sheet.svg
+            │   │   ├── zoho-show.svg
+            │   │   ├── zoho-writer.svg
             │   │   ├── zoom-desktop.svg -> Zoom.svg
             │   │   ├── zoom-icon.svg -> Zoom.svg
             │   │   ├── zrythm.svg
@@ -1186,7 +1226,6 @@
             │   │   ├── keyboard.svg
             │   │   ├── media-tape.svg
             │   │   ├── memory.svg
-            │   │   ├── meson.build
             │   │   ├── network-card.svg
             │   │   ├── processor.svg -> cpu.svg
             │   │   ├── soundcard.svg -> audio-card.svg
@@ -1194,6 +1233,7 @@
             │   │   ├── vmware-memory.svg -> memory.svg
             │   │   ├── yast_soundcard.svg -> audio-card.svg
             │   ├── legacy
+            │   │   ├── accessories-character-map.svg
             │   │   ├── accessories-text-editor.svg
             │   │   ├── applications-accessories.svg
             │   │   ├── applications-all.svg
@@ -1212,23 +1252,29 @@
             │   │   ├── applications-system.svg
             │   │   ├── applications-utilities.svg
             │   │   ├── gnome-applications.svg -> applications-all.svg
-            │   │   ├── meson.build
             │   │   ├── package.svg
             │   │   ├── preferences-desktop-accessibility.svg
             │   │   ├── preferences-desktop-locale.svg
             │   │   ├── preferences-desktop-screensaver.svg
+            │   │   ├── preferences-desktop-theme.svg
             │   │   ├── preferences-desktop-wallpaper.svg
             │   │   ├── preferences-desktop.svg
+            │   │   ├── preferences-system-network.svg
             │   │   ├── preferences-system.svg -> applications-system.svg
+            │   │   ├── software-sources.svg
+            │   │   ├── synaptic.svg
             │   │   ├── system-file-manager.svg
             │   │   ├── system-lock-screen.svg
             │   │   ├── system-log-out.svg
             │   │   ├── system-reboot.svg
             │   │   ├── system-shutdown.svg
+            │   │   ├── system-software-install.svg
+            │   │   ├── system-software-installer.svg -> system-software-install.svg
+            │   │   ├── system-software-update.svg
             │   │   ├── system-suspend-hibernate.svg
             │   │   ├── system-suspend.svg
             │   │   ├── system-users.svg
-            │   ├── meson.build
+            │   │   ├── x-system-software-sources.svg -> software-sources.svg
             │   ├── mimetypes
             │   │   ├── android-package-archive.svg
             │   │   ├── application-apk.svg -> android-package-archive.svg
@@ -1254,6 +1300,7 @@
             │   │   ├── application-metalink4+xml.svg -> application-xml.svg
             │   │   ├── application-octet-stream.svg
             │   │   ├── application-owl+xml.svg -> application-xml.svg
+            │   │   ├── application-pdf.svg
             │   │   ├── application-pgp-encrypted.svg
             │   │   ├── application-pgp-keys.svg
             │   │   ├── application-pgp-signature.svg
@@ -1384,6 +1431,7 @@
             │   │   ├── application-x-godot-shader.svg -> application-x-godot-project.svg
             │   │   ├── application-x-gpx+xml.svg -> application-loc+xml.svg
             │   │   ├── application-x-gpx.svg -> application-loc+xml.svg
+            │   │   ├── application-x-gzpdf.svg -> application-pdf.svg
             │   │   ├── application-x-gzpostscript.svg -> application-postscript.svg
             │   │   ├── application-x-hwp.svg
             │   │   ├── application-x-hwpx.svg -> application-x-hwp.svg
@@ -1411,6 +1459,7 @@
             │   │   ├── application-x-krita-paintoppresent.svg -> oasis-drawing.svg
             │   │   ├── application-x-krita.svg -> oasis-drawing.svg
             │   │   ├── application-x-ktheme.svg -> application-x-theme.svg
+            │   │   ├── application-x-lzpdf.svg -> application-pdf.svg
             │   │   ├── application-x-mobi8-ebook.svg -> application-epub+zip.svg
             │   │   ├── application-x-mobipocket-ebook.svg -> application-epub+zip.svg
             │   │   ├── application-x-model.svg
@@ -1455,6 +1504,7 @@
             │   │   ├── application-x-x509-user-cert.svg -> application-pkix-cert.svg
             │   │   ├── application-x-xopp.svg
             │   │   ├── application-x-xopt.svg -> application-x-xopp.svg
+            │   │   ├── application-x-xzpdf.svg -> application-pdf.svg
             │   │   ├── application-x-yaml.svg
             │   │   ├── application-x-zip-compressed-fb2.svg -> application-epub+zip.svg
             │   │   ├── application-xml.svg
@@ -1471,6 +1521,8 @@
             │   │   ├── com.bitwig.BitwigStudio.application-bitwig-project.svg -> application-x-bitwig-studio.svg
             │   │   ├── com.bitwig.BitwigStudio.application-bitwig-remote-controls.svg -> application-x-bitwig-studio.svg
             │   │   ├── com.bitwig.BitwigStudio.audio-x.dawproject.svg
+            │   │   ├── com.fender.studio.application-x.fender-fenderstudio.svg
+            │   │   ├── com.fender.studio.application-x.fender-jamtrack.svg
             │   │   ├── gddoc.svg -> oasis-text.svg
             │   │   ├── gddraw.svg -> oasis-drawing.svg
             │   │   ├── gdform.svg -> oasis-database.svg
@@ -1481,6 +1533,7 @@
             │   │   ├── gnome-mime-application-x-xopt.svg -> application-x-xopp.svg
             │   │   ├── gnome-mime-text-x-makefile.svg -> text-x-makefile.svg
             │   │   ├── image-vnd.adobe.photoshop.svg -> application-x-photoshop.svg
+            │   │   ├── image-vnd.djvu+multipage.svg -> image-vnd.djvu.svg
             │   │   ├── image-vnd.djvu.svg
             │   │   ├── image-x-djvu.svg -> image-vnd.djvu.svg
             │   │   ├── image-x-krita.svg -> oasis-drawing.svg
@@ -1521,7 +1574,6 @@
             │   │   ├── libreoffice-text.svg -> oasis-text.svg
             │   │   ├── libreoffice-web-template.svg -> oasis-web-template.svg
             │   │   ├── libreoffice-web.svg -> oasis-web.svg
-            │   │   ├── meson.build
             │   │   ├── model-obj.svg -> application-x-model.svg
             │   │   ├── model-stl.svg -> application-x-model.svg
             │   │   ├── model-x-stl-binary.svg -> application-x-model.svg
@@ -1786,6 +1838,8 @@
             │       ├── folder-syncthing.svg
             │       ├── folder-temp-legacy.svg
             │       ├── folder-temp.svg
+            │       ├── folder-torrent-legacy.svg
+            │       ├── folder-torrent.svg
             │       ├── folder-translation-legacy.svg
             │       ├── folder-translation.svg
             │       ├── folder-ubuntu-legacy.svg
@@ -1799,7 +1853,6 @@
             │       ├── folder-work-legacy.svg
             │       ├── folder-work.svg
             │       ├── go-home.svg
-            │       ├── meson.build
             ├── symbolic
                 ├── apps
                 │   ├── 0ad-symbolic.svg
@@ -1824,6 +1877,8 @@
                 │   ├── OpenBoard-symbolic.svg -> openboard-symbolic.svg
                 │   ├── OpenRGB-symbolic.svg -> openrgb-symbolic.svg
                 │   ├── ProtonMail_Bridge-symbolic.svg -> protonmail-bridge-symbolic.svg
+                │   ├── PrusaSlicer-gcodeviewer-symbolic.svg
+                │   ├── PrusaSlicer-symbolic.svg
                 │   ├── QtProject-assistant-symbolic.svg -> assistant-symbolic.svg
                 │   ├── QtProject-designer-symbolic.svg -> designer-symbolic.svg
                 │   ├── QtProject-linguist-symbolic.svg -> linguist-symbolic.svg
@@ -1880,6 +1935,9 @@
                 │   ├── appimagekit-unityhub-symbolic.svg -> unityhub-symbolic.svg
                 │   ├── appimagekit-yuzu-symbolic.svg -> yuzu-symbolic.svg
                 │   ├── appimagekit-zen-browser-symbolic.svg -> zen-browser-symbolic.svg
+                │   ├── appimagekit-zoho-mail-desktop-symbolic.svg -> zoho-mail-symbolic.svg
+                │   ├── apple-music-symbolic.svg
+                │   ├── application-x-zoom-symbolic.svg -> Zoom-symbolic.svg
                 │   ├── applications-java-symbolic.svg -> java-openjdk-symbolic.svg
                 │   ├── ardour-symbolic.svg
                 │   ├── ardour6-symbolic.svg -> ardour-symbolic.svg
@@ -1900,6 +1958,7 @@
                 │   ├── avogadro-symbolic.svg
                 │   ├── avogadro2-symbolic.svg -> avogadro-symbolic.svg
                 │   ├── balena-etcher-electron-symbolic.svg -> etcher-symbolic.svg
+                │   ├── bambustudio-symbolic.svg
                 │   ├── betterbird-symbolic.svg
                 │   ├── bitwarden-symbolic.svg
                 │   ├── bitwig-studio-symbolic.svg
@@ -1914,6 +1973,7 @@
                 │   ├── brave-browser-symbolic.svg -> brave-desktop-symbolic.svg
                 │   ├── brave-cifhbcnohmdccbgoicgdjpfamggdegmo-Default-symbolic.svg -> teams-symbolic.svg
                 │   ├── brave-desktop-symbolic.svg
+                │   ├── briar-symbolic.svg
                 │   ├── bsnes-symbolic.svg -> dev.bsnes.bsnes-symbolic.svg
                 │   ├── btop-symbolic.svg
                 │   ├── buzz-symbolic.svg
@@ -1953,6 +2013,7 @@
                 │   ├── com.alacritty.Alacritty-symbolic.svg -> alacritty-symbolic.svg
                 │   ├── com.anydesk.Anydesk-symbolic.svg -> anydesk-symbolic.svg
                 │   ├── com.axosoft.GitKraken-symbolic.svg -> gitkraken-symbolic.svg
+                │   ├── com.bambulab.BambuStudio-symbolic.svg -> bambustudio-symbolic.svg
                 │   ├── com.bitwarden.desktop-symbolic.svg -> bitwarden-symbolic.svg
                 │   ├── com.bitwig.BitwigStudio-symbolic.svg -> bitwig-studio-symbolic.svg
                 │   ├── com.boxy_svg.BoxySVG-symbolic.svg -> boxy-svg-symbolic.svg
@@ -1965,6 +2026,7 @@
                 │   ├── com.discordapp.Discord-symbolic.svg -> discord-symbolic.svg
                 │   ├── com.discordapp.DiscordCanary-symbolic.svg -> discord-canary-symbolic.svg
                 │   ├── com.dropbox.Client-symbolic.svg -> dropbox-symbolic.svg
+                │   ├── com.fender.studio-symbolic.svg
                 │   ├── com.getmailspring.Mailspring-symbolic.svg -> mailspring-symbolic.svg
                 │   ├── com.gigitux.gtkwhats-symbolic.svg -> com.github.eneshecan.WhatsAppForLinux-symbolic.svg
                 │   ├── com.github.Eloston.UngoogledChromium-symbolic.svg -> ungoogled-chromium-symbolic.svg
@@ -1982,6 +2044,7 @@
                 │   ├── com.google.Chrome-symbolic.svg -> google-chrome-symbolic.svg
                 │   ├── com.hamrick.VueScan-symbolic.svg -> xsane-symbolic.svg
                 │   ├── com.heroicgameslauncher.hgl-symbolic.svg -> heroic-symbolic.svg
+                │   ├── com.icons8.Lunacy-symbolic.svg -> lunacy-symbolic.svg
                 │   ├── com.jetbrains.CLion-symbolic.svg -> clion-symbolic.svg
                 │   ├── com.jetbrains.DataGrip-symbolic.svg -> datagrip-symbolic.svg
                 │   ├── com.jetbrains.DataSpell-symbolic.svg -> dataspell-symbolic.svg
@@ -1998,6 +2061,8 @@
                 │   ├── com.jetbrains.ToolBox-symbolic.svg -> jetbrains-toolbox-symbolic.svg
                 │   ├── com.jetbrains.WebStorm-symbolic.svg -> webstorm-symbolic.svg
                 │   ├── com.jetbrains.dataspell-symbolic.svg -> dataspell-symbolic.svg
+                │   ├── com.jgraph.drawio.desktop-symbolic.svg -> drawio-symbolic.svg
+                │   ├── com.lablicate.OpenChrom-symbolic.svg -> openchrom-symbolic.svg
                 │   ├── com.logseq.Logseq-symbolic.svg -> logseq-symbolic.svg
                 │   ├── com.lunarclient.LunarClient-symbolic.svg -> lunarclient-symbolic.svg
                 │   ├── com.mastermindzh.tidal-hifi-symbolic.svg -> tidal-hifi-symbolic.svg
@@ -2012,6 +2077,8 @@
                 │   ├── com.opera.Opera-symbolic.svg -> opera-symbolic.svg
                 │   ├── com.play0ad.zeroad-symbolic.svg -> 0ad-symbolic.svg
                 │   ├── com.protonvpn.www-symbolic.svg -> protonvpn-gui-symbolic.svg
+                │   ├── com.prusa3d.PrusaSlicer-symbolic.svg -> PrusaSlicer-symbolic.svg
+                │   ├── com.prusa3d.PrusaSlicer.GCodeViewer-symbolic.svg -> PrusaSlicer-gcodeviewer-symbolic.svg
                 │   ├── com.qq.QQ-symbolic.svg -> qq-symbolic.svg
                 │   ├── com.rawtherapee.RawTherapee-symbolic.svg -> rawtherapee-symbolic.svg
                 │   ├── com.sindresorhus.Caprine-symbolic.svg -> facebook-messenger-symbolic.svg
@@ -2032,6 +2099,7 @@
                 │   ├── com.visualstudio.code-symbolic.svg -> visual-studio-code-symbolic.svg
                 │   ├── com.visualstudio.code.oss-symbolic.svg -> code-oss-symbolic.svg
                 │   ├── com.vscodium.codium-symbolic.svg -> vscodium-symbolic.svg
+                │   ├── coolercontrol-symbolic.svg
                 │   ├── coppwr-symbolic.svg
                 │   ├── corectrl-symbolic.svg
                 │   ├── cudatext-512-symbolic.svg
@@ -2052,13 +2120,16 @@
                 │   ├── designer-symbolic.svg
                 │   ├── dev.aunetx.deezer-symbolic.svg -> deezer-symbolic.svg
                 │   ├── dev.bsnes.bsnes-symbolic.svg
+                │   ├── dev.deedles.Trayscale-symbolic.svg
                 │   ├── dev.neovide.neovide-symbolic.svg -> neovide-symbolic.svg
                 │   ├── dev.pulsar_edit.Pulsar-symbolic.svg -> pulsar-symbolic.svg
                 │   ├── dev.vencord.Vesktop-symbolic.svg -> vesktop-symbolic.svg
                 │   ├── dev.zed.Zed-symbolic.svg -> zed-symbolic.svg
                 │   ├── discord-canary-symbolic.svg -> discord-symbolic.svg
                 │   ├── discord-symbolic.svg
+                │   ├── drawio-symbolic.svg
                 │   ├── dropbox-symbolic.svg
+                │   ├── dune3d-symbolic.svg
                 │   ├── eclipse-cdt-symbolic.svg -> eclipse-symbolic.svg
                 │   ├── eclipse-symbolic.svg
                 │   ├── electron-symbolic.svg
@@ -2109,6 +2180,7 @@
                 │   ├── fleet-symbolic.svg
                 │   ├── flightgear-symbolic.svg
                 │   ├── floorp-symbolic.svg
+                │   ├── flowblade-symbolic.svg
                 │   ├── fm.helio.Worksatation-symbolic.svg -> helio-workstation-symbolic.svg
                 │   ├── foobar2000-symbolic.svg
                 │   ├── foot-symbolic.svg
@@ -2124,6 +2196,7 @@
                 │   ├── fuse-symbolic.svg -> fuse-emulator-symbolic.svg
                 │   ├── gda-browser-5.0-symbolic.svg -> gda-control-center-symbolic.svg
                 │   ├── gda-control-center-symbolic.svg
+                │   ├── gdevelop-symbolic.svg
                 │   ├── geany-symbolic.svg
                 │   ├── geneious-symbolic.svg
                 │   ├── genymotion-bin-symbolic.svg -> genymotion-symbolic.svg
@@ -2145,8 +2218,11 @@
                 │   ├── goland-symbolic.svg
                 │   ├── google-chrome-symbolic.svg
                 │   ├── google-chrome2-symbolic.svg -> google-chrome-symbolic.svg
+                │   ├── google-docs-symbolic.svg
                 │   ├── google-earth-pro-symbolic.svg -> google-earth-symbolic.svg
                 │   ├── google-earth-symbolic.svg
+                │   ├── google-sheets-symbolic.svg
+                │   ├── google-slides-symbolic.svg
                 │   ├── googlechrome-symbolic.svg -> google-chrome-symbolic.svg
                 │   ├── googleearth-symbolic.svg -> google-earth-symbolic.svg
                 │   ├── gparted-symbolic.svg
@@ -2187,6 +2263,7 @@
                 │   ├── input-remapper-symbolic.svg
                 │   ├── insomnia-symbolic.svg
                 │   ├── intellij-symbolic.svg
+                │   ├── interstellar-symbolic.svg
                 │   ├── io.anytype.anytype-symbolic.svg -> anytype-symbolic.svg
                 │   ├── io.appflowy.AppFlowy-symbolic.svg -> appflowy-symbolic.svg
                 │   ├── io.atom.electron.BaseApp-symbolic.svg -> electron-symbolic.svg
@@ -2195,6 +2272,7 @@
                 │   ├── io.element.Element-symbolic.svg
                 │   ├── io.frappe.books-symbolic.svg -> frappe-books-symbolic.svg
                 │   ├── io.freetubeapp.FreeTube-symbolic.svg -> freetube-symbolic.svg
+                │   ├── io.gdevelop.ide-symbolic.svg -> gdevelop-symbolic.svg
                 │   ├── io.github.Figma_Linux.figma_linux-symbolic.svg -> figma-symbolic.svg
                 │   ├── io.github.NhekoReborn.Nheko-symbolic.svg -> nheko-symbolic.svg
                 │   ├── io.github.OpenToonz-symbolic.svg -> opentoonz-symbolic.svg
@@ -2204,8 +2282,13 @@
                 │   ├── io.github.dimtpap.coppwr-symbolic.svg -> coppwr-symbolic.svg
                 │   ├── io.github.dvlv.boxbuddyrs-symbolic.svg -> boxbuddyrs-symbolic.svg
                 │   ├── io.github.endless_sky.endless_sky-symbolic.svg -> endless-sky-symbolic.svg
+                │   ├── io.github.jean28518.Linux-Assistant-symbolic.svg -> linux-assistant-symbolic.svg
+                │   ├── io.github.jliljebl.Flowblade-symbolic.svg -> flowblade-symbolic.svg
+                │   ├── io.github.kotatogram-symbolic.svg -> kotatogram-symbolic.svg
                 │   ├── io.github.manisandro.gImageReader-symbolic.svg -> gimagereader-symbolic.svg
                 │   ├── io.github.mimbrero.WhatsAppDesktop-symbolic.svg -> com.github.eneshecan.WhatsAppForLinux-symbolic.svg
+                │   ├── io.github.plrigaux.sysd-manager-symbolic.svg -> sysd-manager-symbolic.svg
+                │   ├── io.github.ra3xdh.qucs_s-symbolic.svg -> qucs-s-symbolic.svg
                 │   ├── io.github.rinigus.OSMScoutServer-symbolic.svg -> osmscout-server-symbolic.svg
                 │   ├── io.github.rinigus.PureMaps-symbolic.svg -> pure-maps-symbolic.svg
                 │   ├── io.github.shiftey.Desktop-symbolic.svg -> github-desktop-symbolic.svg
@@ -2281,6 +2364,7 @@
                 │   ├── kitty-symbolic.svg
                 │   ├── kodi-symbolic.svg
                 │   ├── kolourpaint-symbolic.svg
+                │   ├── kotatogram-symbolic.svg
                 │   ├── krita-symbolic.svg
                 │   ├── kruler-symbolic.svg
                 │   ├── kvantum-symbolic.svg
@@ -2450,9 +2534,11 @@
                 │   ├── linguist-qt5-symbolic.svg -> linguist-symbolic.svg
                 │   ├── linguist-symbolic.svg
                 │   ├── linguist5-symbolic.svg -> linguist-symbolic.svg
+                │   ├── linux-assistant-symbolic.svg
                 │   ├── localsend-symbolic.svg
                 │   ├── logseq-symbolic.svg
                 │   ├── lpub3d-symbolic.svg
+                │   ├── lunacy-symbolic.svg
                 │   ├── lunar-client-symbolic.svg -> lunarclient-symbolic.svg
                 │   ├── lunarclient-symbolic.svg
                 │   ├── lutris_blender-symbolic.svg -> blender-symbolic.svg
@@ -2486,7 +2572,6 @@
                 │   ├── menulibre-symbolic.svg
                 │   ├── mercury-browser-symbolic.svg -> mercury-symbolic.svg
                 │   ├── mercury-symbolic.svg
-                │   ├── meson.build
                 │   ├── micro-symbolic.svg
                 │   ├── microsoft-edge-symbolic.svg
                 │   ├── minecraft-launcher-symbolic.svg -> minecraft-symbolic.svg
@@ -2559,10 +2644,12 @@
                 │   ├── om.getpostman.Postman-symbolic.svg -> postman-symbolic.svg
                 │   ├── one.ablaze.floorp-symbolic.svg -> floorp-symbolic.svg
                 │   ├── one.alynx.showmethekey-symbolic.svg
+                │   ├── one.jwr.interstellar-symbolic.svg -> interstellar-symbolic.svg
                 │   ├── onetagger-symbolic.svg
                 │   ├── onlyoffice-desktopeditors-symbolic.svg -> org.onlyoffice.desktopeditors-symbolic.svg
                 │   ├── openbabel-symbolic.svg
                 │   ├── openboard-symbolic.svg
+                │   ├── openchrom-symbolic.svg
                 │   ├── openra-cnc-symbolic.svg
                 │   ├── openra-d2k-symbolic.svg
                 │   ├── openra-ra-symbolic.svg
@@ -2584,13 +2671,16 @@
                 │   ├── org.bleachbit.BleachBit-symbolic.svg -> bleachbit-symbolic.svg
                 │   ├── org.blender.Blender-symbolic.svg -> blender-symbolic.svg
                 │   ├── org.bluesabre.MenuLibre-symbolic.svg -> menulibre-symbolic.svg
+                │   ├── org.briarproject.Briar-symbolic.svg -> briar-symbolic.svg
                 │   ├── org.chromium.Chromium-symbolic.svg -> google-chrome-symbolic.svg
                 │   ├── org.cockpit_project.CockpitClient-symbolic.svg
                 │   ├── org.codeberg.dnkl.foot-symbolic.svg -> foot-symbolic.svg
                 │   ├── org.codeblocks.codeblocks-symbolic.svg -> codeblocks-symbolic.svg
+                │   ├── org.coolercontrol.CoolerControl-symbolic.svg -> coolercontrol-symbolic.svg
                 │   ├── org.cvfosammmm.Setzer-symbolic.svg -> setzer-symbolic.svg
                 │   ├── org.daa.NeovimGtk-symbolic.svg -> nvim-symbolic.svg
                 │   ├── org.darktable.Darktable-symbolic.svg -> darktable-symbolic.svg
+                │   ├── org.dune3d.dune3d-symbolic.svg -> dune3d-symbolic.svg
                 │   ├── org.eclipse.Committers-symbolic.svg -> eclipse-symbolic.svg
                 │   ├── org.eclipse.Java-symbolic.svg -> eclipse-symbolic.svg
                 │   ├── org.eclipse.Javascript-symbolic.svg -> eclipse-symbolic.svg
@@ -2664,6 +2754,7 @@
                 │   ├── org.qutebrowser.qutebrowser-symbolic.svg -> qutebrowser-symbolic.svg
                 │   ├── org.raspberrypi.rpi-imager-symbolic.svg -> rpi-imager-symbolic.svg
                 │   ├── org.ryujinx.Ryujinx-symbolic.svg -> ryujinx-symbolic.svg
+                │   ├── org.shotcut.Shotcut-symbolic.svg -> shotcut-symbolic.svg
                 │   ├── org.signal.Signal-symbolic.svg -> signal-desktop-symbolic.svg
                 │   ├── org.soundconverter.SoundConverter-symbolic.svg -> soundconverter-symbolic.svg
                 │   ├── org.sqlitebrowser.sqlitebrowser-symbolic.svg -> gda-control-center-symbolic.svg
@@ -2690,11 +2781,13 @@
                 │   ├── osu-symbolic.svg
                 │   ├── pacseek-symbolic.svg
                 │   ├── page.codeberg.libre_menu_editor.LibreMenuEditor-symbolic.svg -> menulibre-symbolic.svg
-                │   ├── pamac-manager-symbolic.svg -> system-software-install-symbolic.svg
-                │   ├── pamac-symbolic.svg -> system-software-install-symbolic.svg
-                │   ├── pamac-updater-symbolic.svg -> system-software-install-symbolic.svg
+                │   ├── pamac-manager-symbolic.svg -> ../legacy/system-software-install-symbolic.svg
+                │   ├── pamac-symbolic.svg -> ../legacy/system-software-install-symbolic.svg
+                │   ├── pamac-updater-symbolic.svg -> ../legacy/system-software-install-symbolic.svg
                 │   ├── parsehub-symbolic.svg
                 │   ├── phpstorm-symbolic.svg
+                │   ├── pianoteq-stage-symbolic.svg -> pianoteq-symbolic.svg
+                │   ├── pianoteq-symbolic.svg
                 │   ├── pidgin-symbolic.svg
                 │   ├── pinta-symbolic.svg
                 │   ├── poedit-symbolic.svg -> net.poedit.Poedit-symbolic.svg
@@ -2705,8 +2798,6 @@
                 │   ├── popcorntime-symbolic.svg
                 │   ├── portmaster-symbolic.svg
                 │   ├── postman-symbolic.svg
-                │   ├── preferences-desktop-theme-symbolic.svg
-                │   ├── preferences-system-network-symbolic.svg
                 │   ├── prismlauncher-symbolic.svg
                 │   ├── projectM-symbolic.svg
                 │   ├── proton-mail-symbolic.svg
@@ -2716,6 +2807,8 @@
                 │   ├── protonmail-ie-symbolic.svg
                 │   ├── protonvpn-gui-symbolic.svg
                 │   ├── protonvpn-logo-symbolic.svg -> protonvpn-gui-symbolic.svg
+                │   ├── prusa-slicer-gcodeviewer-symbolic.svg -> PrusaSlicer-gcodeviewer-symbolic.svg
+                │   ├── prusa-slicer-symbolic.svg -> PrusaSlicer-symbolic.svg
                 │   ├── pulsar-symbolic.svg
                 │   ├── pure-maps-symbolic.svg
                 │   ├── pycharm-community-symbolic.svg -> pycharm-symbolic.svg
@@ -2748,6 +2841,7 @@
                 │   ├── qtlinguist-symbolic.svg -> linguist-symbolic.svg
                 │   ├── qtoctave-symbolic.svg -> octave-symbolic.svg
                 │   ├── qtscrcpy-symbolic.svg -> scrcpy-symbolic.svg
+                │   ├── qucs-s-symbolic.svg
                 │   ├── qutebrowser-symbolic.svg
                 │   ├── qv4l2-symbolic.svg
                 │   ├── qvidcap-symbolic.svg -> qv4l2-symbolic.svg
@@ -2762,6 +2856,7 @@
                 │   ├── rocketchat-symbolic.svg
                 │   ├── rpi-imager-symbolic.svg
                 │   ├── rpi-symbolic.svg -> rpi-imager-symbolic.svg
+                │   ├── rpminstall-symbolic.svg
                 │   ├── rstudio-symbolic.svg
                 │   ├── ru.yandex.Browser-symbolic.svg -> yandex-browser-symbolic.svg
                 │   ├── rubymine-symbolic.svg
@@ -2779,6 +2874,7 @@
                 │   ├── setzer-symbolic.svg
                 │   ├── sh.cider.Cider-symbolic.svg -> cider-symbolic.svg
                 │   ├── sh.ppy.osu-symbolic.svg -> osu-symbolic.svg
+                │   ├── shotcut-symbolic.svg
                 │   ├── shotwell-symbolic.svg
                 │   ├── signal-desktop-symbolic.svg
                 │   ├── sioyek-icon-linux-symbolic.svg -> sioyek-symbolic.svg
@@ -2843,9 +2939,7 @@
                 │   ├── syncthing-gtk-symbolic.svg
                 │   ├── syncthing-symbolic.svg -> syncthing-gtk-symbolic.svg
                 │   ├── syncthingtray-symbolic.svg -> syncthing-gtk-symbolic.svg
-                │   ├── system-software-install-symbolic.svg
-                │   ├── system-software-installer-symbolic.svg -> system-software-install-symbolic.svg
-                │   ├── system-software-update-symbolic.svg -> system-software-install-symbolic.svg
+                │   ├── sysd-manager-symbolic.svg
                 │   ├── teams-for-linux-symbolic.svg -> teams-symbolic.svg
                 │   ├── teams-symbolic.svg
                 │   ├── teamviewer-symbolic.svg -> TeamViewer-symbolic.svg
@@ -2862,6 +2956,7 @@
                 │   ├── thunderbird-mozilla-buld-symbolic.svg -> thunderbird-symbolic.svg
                 │   ├── thunderbird-symbolic.svg
                 │   ├── tidal-hifi-symbolic.svg
+                │   ├── timeshift-symbolic.svg
                 │   ├── todoist-symbolic.svg
                 │   ├── toolbox-symbolic.svg -> jetbrains-toolbox-symbolic.svg
                 │   ├── tor-browser-en-symbolic.svg -> tor-browser-symbolic.svg
@@ -2908,6 +3003,7 @@
                 │   ├── webcord-symbolic.svg
                 │   ├── webstorm-symbolic.svg
                 │   ├── wezterm-symbolic.svg
+                │   ├── whatsapp-business-symbolic.svg
                 │   ├── whatsapp-desktop-symbolic.svg -> com.github.eneshecan.WhatsAppForLinux-symbolic.svg
                 │   ├── whatsapp-for-linux-symbolic.svg -> com.github.eneshecan.WhatsAppForLinux-symbolic.svg
                 │   ├── whatsapp-nativefier-symbolic.svg -> com.github.eneshecan.WhatsAppForLinux-symbolic.svg
@@ -2931,6 +3027,11 @@
                 │   ├── zed-symbolic.svg
                 │   ├── zen-browser-symbolic.svg
                 │   ├── zim-symbolic.svg
+                │   ├── zoho-mail-desktop-symbolic.svg -> zoho-mail-symbolic.svg
+                │   ├── zoho-mail-symbolic.svg
+                │   ├── zoho-sheet-symbolic.svg
+                │   ├── zoho-show-symbolic.svg
+                │   ├── zoho-writer-symbolic.svg
                 │   ├── zoom-desktop-symbolic.svg -> Zoom-symbolic.svg
                 │   ├── zoom-icon-symbolic.svg -> Zoom-symbolic.svg
                 │   ├── zrythm-symbolic.svg
@@ -2944,10 +3045,16 @@
                 │   ├── applications-office-symbolic.svg -> ../places/folder-work-symbolic.svg
                 │   ├── applications-other-symbolic.svg
                 │   ├── gnome-applications-symbolic.svg -> applications-all-symbolic.svg
-                │   ├── meson.build
                 │   ├── package-symbolic.svg
                 │   ├── preferences-desktop-symbolic.svg
-                ├── meson.build
+                │   ├── preferences-desktop-theme-symbolic.svg
+                │   ├── preferences-system-network-symbolic.svg
+                │   ├── software-sources-symbolic.svg
+                │   ├── synaptic-symbolic.svg
+                │   ├── system-software-install-symbolic.svg
+                │   ├── system-software-installer-symbolic.svg -> system-software-install-symbolic.svg
+                │   ├── system-software-update-symbolic.svg
+                │   ├── x-system-software-sources-symbolic.svg -> software-sources-symbolic.svg
                 ├── places
                 │   ├── com.bitwig.BitwigStudio.application-bitwig-project-folder-symbolic.svg -> folder-bitwig-symbolic.svg
                 │   ├── folder-3dbenchy-legacy-symbolic.svg -> folder-3dbenchy-symbolic.svg
@@ -3077,6 +3184,8 @@
                 │   ├── folder-syncthing-symbolic.svg
                 │   ├── folder-temp-legacy-symbolic.svg
                 │   ├── folder-temp-symbolic.svg
+                │   ├── folder-torrent-legacy-symbolic.svg -> folder-torrent-symbolic.svg
+                │   ├── folder-torrent-symbolic.svg
                 │   ├── folder-translation-legacy-symbolic.svg -> folder-translation-symbolic.svg
                 │   ├── folder-translation-symbolic.svg
                 │   ├── folder-ubuntu-legacy-symbolic.svg -> folder-ubuntu-symbolic.svg
@@ -3089,7 +3198,6 @@
                 │   ├── folder-wine-symbolic.svg
                 │   ├── folder-work-legacy-symbolic.svg
                 │   ├── folder-work-symbolic.svg
-                │   ├── meson.build
                 ├── status
                     ├── TeamViewer-indicator-away.svg
                     ├── TeamViewer-indicator-busy.svg
@@ -3107,7 +3215,6 @@
                     ├── jdownloader-indicator.svg
                     ├── keepassxc-locked.svg
                     ├── keepassxc-unlocked.svg
-                    ├── meson.build
                     ├── org.keepassxc.KeePassXC-locked.svg -> keepassxc-locked.svg
                     ├── org.keepassxc.KeePassXC-unlocked.svg -> keepassxc-unlocked.svg
                     ├── pamac-tray-no-update.svg
@@ -3146,4 +3253,4 @@
                     ├── user-status-pending.svg
                     ├── vlc-panel.svg
 
-16 directories, 3131 files
+15 directories, 3239 files
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
