### PR TITLE
fosrl-pangolin: 1.2.0 -> 1.8.0

### DIFF
--- a/pkgs/by-name/fo/fosrl-pangolin/package.nix
+++ b/pkgs/by-name/fo/fosrl-pangolin/package.nix
@@ -3,28 +3,58 @@
   fetchFromGitHub,
   esbuild,
   buildNpmPackage,
+  makeWrapper,
+  formats,
   inter,
+  databaseType ? "sqlite",
+  environmentVariables ? { },
 }:
 
-buildNpmPackage rec {
+assert lib.assertOneOf "databaseType" databaseType [
+  "sqlite"
+  "pg"
+];
+
+let
+  db =
+    isLong:
+    if (databaseType == "sqlite") then
+      "sqlite"
+    else if isLong then
+      "postgresql"
+    else
+      "pg";
+in
+
+buildNpmPackage (finalAttrs: {
   pname = "pangolin";
-  version = "1.2.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "fosrl";
     repo = "pangolin";
-    tag = version;
-    hash = "sha256-2yrim4pr8cgIh/FBuGIuK+ycwImpMiz+m21H5qYARmU=";
+    tag = finalAttrs.version;
+    hash = "sha256-Cy5COyZAH0NPQDMpKUmweYWkyupDC2sNf2CP+EJ5GiE=";
   };
 
-  npmDepsHash = "sha256-fi4e79Bk1LC/LizBJ+EhCjDzLR5ZocgVyWbSXsEJKdw=";
-  nativeBuildInputs = [ esbuild ];
-  # Replace the googleapis.com Inter font with a local copy from nixpkgs
-  # based on
-  # https://github.com/NixOS/nixpkgs/blob/f7bf574774e466b984063a44330384cdbca67d6c/pkgs/by-name/ne/nextjs-ollama-llm-ui/package.nix
+  npmDepsHash = "sha256-OGqYmOO6pizcOrdaoSGgjDQgqpjU0SIw3ceh57eyjr4=";
+
+  nativeBuildInputs = [
+    esbuild
+    makeWrapper
+  ];
+
+  prePatch = ''
+    cat > server/db/index.ts << EOF
+    export * from "./${db false}";
+    EOF
+  '';
+
+  # Replace the googleapis.com Inter font with a local copy from Nixpkgs.
+  # Based on pkgs.nextjs-ollama-llm-ui.
   postPatch = ''
     substituteInPlace src/app/layout.tsx --replace-fail \
-      "{ Figtree, Inter } from \"next/font/google\"" \
+      "{ Inter } from \"next/font/google\"" \
       "localFont from \"next/font/local\""
 
     substituteInPlace src/app/layout.tsx --replace-fail \
@@ -34,33 +64,105 @@ buildNpmPackage rec {
     cp "${inter}/share/fonts/truetype/InterVariable.ttf" src/app/Inter.ttf
   '';
 
-  preBuild = ''
-    npx drizzle-kit generate --dialect sqlite --schema ./server/db/schemas/ --out init
-  '';
+  preBuild = "npx drizzle-kit generate --dialect ${db true} --schema ./server/db/${db false}/schema.ts --name migration --out init";
+
+  npmBuildScript = "build:${db false}";
+
+  postBuild = "npm run build:cli";
+
+  preInstall = "mkdir -p $out/{bin,share/pangolin}";
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/
 
-    cp -r .next/standalone/* $out/
-    cp -r .next/standalone/.next $out/
+    cp -r node_modules $out/share/pangolin
 
-    cp -r .next/static $out/.next/static
-    cp -r dist $out/dist
-    cp -r init $out/dist/init
+    cp -r .next/standalone/.next $out/share/pangolin
+    cp .next/standalone/package.json $out/share/pangolin
 
-    cp server/db/names.json $out/dist/names.json
-    cp -r public $out/public
-    cp -r node_modules $out/
+    cp -r .next/static $out/share/pangolin/.next/static
+    cp -r public $out/share/pangolin/public
+
+    cp -r dist $out/share/pangolin/dist
+    cp -r init $out/share/pangolin/dist/init
+
+    cp server/db/names.json $out/share/pangolin/dist/names.json
+
     runHook postInstall
   '';
+
+  preFixup =
+    let
+      defaultConfig = (formats.yaml { }).generate "pangolin-default-config" {
+        app.dashboard_url = "https://pangolin.example.test";
+        domains.domain1.base_domain = "example.test";
+        gerbil.base_endpoint = "pangolin.example.test";
+        server.secret = "A secret string used for encrypting sensitive data. Must be at least 8 characters long.";
+      };
+      variablesMapped =
+        isServer:
+        (lib.concatMapAttrsStringSep " " (name: value: "--set ${name} ${value}") (
+          {
+            NODE_OPTIONS = "enable-source-maps";
+            NODE_ENV = "development";
+            ENVIRONMENT = "prod";
+          }
+          // environmentVariables
+        ))
+        # If we're running Pangolin, test if we have a .nix_skip_setup file in the public
+        # and .next directories. If we don't, clean them up and re-create them.
+        + lib.optionalString isServer " --run '${
+           (lib.concatMapStringsSep " && "
+             (
+               dir:
+               "test -f ${dir}/.nix_skip_setup || { rm -${lib.optionalString (dir == ".next") "r"}f ${dir} && ${
+                 if (dir == ".next") then "cp -rd" else "ln -s"
+               } ${placeholder "out"}/share/pangolin/${dir} .; }"
+             )
+             [
+               ".next"
+               "public"
+               "node_modules"
+             ]
+           )
+           # Also deploy a small config (if none exists) and run the
+           # database migrations before running the server.
+         } && test -f config/config.yml || { install -Dm600 ${defaultConfig} config/config.yml && { test -z $EDITOR && { echo \"Please edit $(pwd)/config/config.yml\" and run the server again. && exit 255; } || $EDITOR config/config.yml; }; } && command ${placeholder "out"}/bin/migrate-pangolin-database'";
+    in
+    lib.concatMapStrings
+      (
+        attr:
+        "makeWrapper $out/share/pangolin/dist/${attr.mjs}.mjs $out/bin/${attr.command} ${
+          variablesMapped (attr.mjs == "server")
+        }\n"
+      )
+      [
+        {
+          mjs = "cli";
+          command = "pangctl";
+        }
+        {
+          mjs = "migrations";
+          command = "migrate-pangolin-database";
+        }
+        {
+          mjs = "server";
+          command = "pangolin";
+        }
+      ];
+
+  passthru = { inherit databaseType; };
 
   meta = {
     description = "Tunneled reverse proxy server with identity and access control";
     homepage = "https://github.com/fosrl/pangolin";
-    changelog = "https://github.com/fosrl/pangolin/releases/tag/${version}";
+    changelog = "https://github.com/fosrl/pangolin/releases/tag/${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ jackr ];
+    maintainers = with lib.maintainers; [
+      jackr
+      sigmasquadron
+    ];
     platforms = lib.platforms.linux;
+    mainProgram = "pangolin";
   };
-}
+})


### PR DESCRIPTION
Changelogs: [1.3.0](https://github.com/fosrl/pangolin/releases/tag/1.3.0), [1.3.1](https://github.com/fosrl/pangolin/releases/tag/1.3.1), [1.3.2](https://github.com/fosrl/pangolin/releases/tag/1.3.2), [1.4.0](https://github.com/fosrl/pangolin/releases/tag/1.4.0), [1.5.0](https://github.com/fosrl/pangolin/releases/tag/1.5.0), [1.5.1](https://github.com/fosrl/pangolin/releases/tag/1.5.1), [1.6.0](https://github.com/fosrl/pangolin/releases/tag/1.6.0), [1.6.1](https://github.com/fosrl/pangolin/releases/tag/1.6.1), [1.6.2](https://github.com/fosrl/pangolin/releases/tag/1.6.2), [1.7.0](https://github.com/fosrl/pangolin/releases/tag/1.7.0), [1.7.1](https://github.com/fosrl/pangolin/releases/tag/1.7.1), [1.7.2](https://github.com/fosrl/pangolin/releases/tag/1.7.2), [1.7.3](https://github.com/fosrl/pangolin/releases/tag/1.7.3), [1.8.0](https://github.com/fosrl/pangolin/releases/tag/1.8.0).

This combined update introduces a new database type for Pangolin: PostgreSQL. The module for it will come at a later date, so no separate package for it right now.

1.6.0 also introduces the `pangctl` command, which has inspired me to write the spaghetti you see in the `preFixup` section of the diff. By wrapping the `*.mjs` files to actual commands in `$out/bin`, we can simplify the NixOS module, make it easier to access `pangctl`, and allow non-NixOS users to start a Pangolin server without much hassle.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
