### PR TITLE
pter: init at 3.20.1

### DIFF
--- a/pkgs/by-name/pt/pter/package.nix
+++ b/pkgs/by-name/pt/pter/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  python311Packages,
+  python3Packages,
+  qt5,
+  withQt ? false,
+}:
+let
+  # Use python311Packages on Darwin due to ncurses being disabled in newer versions
+  pythonPkgs = if stdenv.isDarwin then python311Packages else python3Packages;
+in
+pythonPkgs.buildPythonApplication rec {
+  pname = "pter";
+  version = "3.20.1";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "vonshednob";
+    repo = "pter";
+    tag = "v${version}";
+    hash = "sha256-1TJ3MembAMB3sewlZE0G8vI8HFrSjEIdIKq5J51P40g=";
+  };
+
+  build-system = with pythonPkgs; [
+    docutils
+    setuptools
+  ];
+
+  nativeBuildInputs = lib.optionals withQt [ qt5.wrapQtAppsHook ];
+
+  dependencies =
+    with pythonPkgs;
+    [
+      cursedspace
+      pytodotxt
+    ]
+    ++ lib.optionals withQt [ pyqt5 ];
+
+  nativeCheckInputs = [ pythonPkgs.unittestCheckHook ];
+
+  unittestFlagsArray = [
+    "-s"
+    "tests"
+  ];
+
+  dontWrapQtApps = true;
+
+  preFixup = lib.optionalString withQt ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  meta = {
+    description = "Manage your todo.txt in a commandline user interface";
+    homepage = "https://vonshednob.cc/pter/";
+    license = lib.licenses.mit;
+    mainProgram = if withQt then "qpter" else "pter";
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+}

--- a/pkgs/development/python-modules/cursedspace/default.nix
+++ b/pkgs/development/python-modules/cursedspace/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  docutils,
+  setuptools,
+  unittestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "cursedspace";
+  version = "1.5.2";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "vonshednob";
+    repo = "cursedspace";
+    tag = "v${version}";
+    hash = "sha256-aqjVdjijfrmjeNsjHyYuWIbX9v65bGbQMcK0NahYKpc=";
+  };
+
+  build-system = [
+    docutils
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  unittestFlagsArray = [
+    "-s"
+    "tests"
+  ];
+
+  pythonImportsCheck = [ "cursedspace" ];
+
+  meta = {
+    description = "Python library/framework for TUI application on the basis of the curses package";
+    homepage = "https://vonshednob.cc/cursedspace/";
+    changelog = "https://codeberg.org/vonshednob/cursedspace/src/branch/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+}

--- a/pkgs/development/python-modules/pytodotxt/default.nix
+++ b/pkgs/development/python-modules/pytodotxt/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+  setuptools,
+  unittestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pytodotxt";
+  version = "3.0.0";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "vonshednob";
+    repo = "pytodotxt";
+    tag = "v${version}";
+    hash = "sha256-f85PgMIMoR/HPPqTdwjymF1mE19pWaPMtSJNQ8UfvP0=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  unittestFlagsArray = [
+    "-s"
+    "tests"
+  ];
+
+  pythonImportsCheck = [ "pytodotxt" ];
+
+  meta = {
+    description = "Python library to access todo.txt-like task lists";
+    homepage = "https://vonshednob.cc/pytodotxt/";
+    changelog = "https://codeberg.org/vonshednob/pytodotxt/src/branch/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14717,6 +14717,8 @@ self: super: with self; {
 
   pytmx = callPackage ../development/python-modules/pytmx { };
 
+  pytodotxt = callPackage ../development/python-modules/pytodotxt { };
+
   pytomlpp = callPackage ../development/python-modules/pytomlpp { };
 
   pytomorrowio = callPackage ../development/python-modules/pytomorrowio { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3108,6 +3108,8 @@ self: super: with self; {
 
   curlify = callPackage ../development/python-modules/curlify { };
 
+  cursedspace = callPackage ../development/python-modules/cursedspace { };
+
   curtsies = callPackage ../development/python-modules/curtsies { };
 
   curvefitgui = callPackage ../development/python-modules/curvefitgui { };


### PR DESCRIPTION
Closes #419502

Also had to add two new python packages that pter depends on:
- cursedspace
- pytodotxt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
