### PR TITLE
python3Packages.pytensor: 2.31.3 -> 2.31.4

### DIFF
--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -33,7 +33,7 @@
 
 buildPythonPackage rec {
   pname = "pytensor";
-  version = "2.31.3";
+  version = "2.31.4";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     postFetch = ''
       sed -i 's/git_refnames = "[^"]*"/git_refnames = " (tag: ${src.tag})"/' $out/pytensor/_version.py
     '';
-    hash = "sha256-tvK8UzJZvX9X2NKgqkyhi0ZzAb38Lu0ULze4L1Z3YfU=";
+    hash = "sha256-wHkEZqgnau8DaoOaSFg0Ma6EtjGLmc+y4fskNEyk7yg=";
   };
 
   build-system = [
@@ -82,81 +82,72 @@ buildPythonPackage rec {
     rm -rf pytensor
   '';
 
-  disabledTests =
-    [
-      # ValueError: dtype attribute is not a valid dtype instance
-      "test_AddDS"
-      "test_AddSD"
-      "test_add_sd"
-      "test_grad"
-      "test_rop"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # pytensor.link.c.exceptions.CompileError: Compilation failed (return status=1)
-      "OpFromGraph"
-      "add"
-      "cls_ofg1"
-      "direct"
-      "multiply"
-      "test_AddDS"
-      "test_AddSD"
-      "test_AddSS"
-      "test_MulDS"
-      "test_MulSD"
-      "test_MulSS"
-      "test_NoOutputFromInplace"
-      "test_OpFromGraph"
-      "test_adv_sub1_sparse_grad"
-      "test_alloc"
-      "test_binary"
-      "test_borrow_input"
-      "test_borrow_output"
-      "test_cache_race_condition"
-      "test_check_for_aliased_inputs"
-      "test_clinker_literal_cache"
-      "test_csm_grad"
-      "test_csm_unsorted"
-      "test_csr_dense_grad"
-      "test_debugprint"
-      "test_ellipsis_einsum"
-      "test_empty_elemwise"
-      "test_flatten"
-      "test_fprop"
-      "test_get_item_list_grad"
-      "test_grad"
-      "test_infer_shape"
-      "test_jax_pad"
-      "test_kron"
-      "test_masked_input"
-      "test_max"
-      "test_modes"
-      "test_mul_s_v_grad"
-      "test_multiple_outputs"
-      "test_not_inplace"
-      "test_numba_Cholesky_grad"
-      "test_numba_pad"
-      "test_optimizations_preserved"
-      "test_overided_function"
-      "test_potential_output_aliasing_induced_by_updates"
-      "test_profiling"
-      "test_rebuild_strict"
-      "test_runtime_broadcast_c"
-      "test_scan_err1"
-      "test_scan_err2"
-      "test_shared"
-      "test_size_implied_by_broadcasted_parameters"
-      "test_solve_triangular_grad"
-      "test_structured_add_s_v_grad"
-      "test_structureddot_csc_grad"
-      "test_structureddot_csr_grad"
-      "test_sum"
-      "test_swap_SharedVariable_with_given"
-      "test_test_value_op"
-      "test_unary"
-      "test_unbroadcast"
-      "test_update_equiv"
-      "test_update_same"
-    ];
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # pytensor.link.c.exceptions.CompileError: Compilation failed (return status=1)
+    "OpFromGraph"
+    "add"
+    "cls_ofg1"
+    "direct"
+    "multiply"
+    "test_AddDS"
+    "test_AddSD"
+    "test_AddSS"
+    "test_MulDS"
+    "test_MulSD"
+    "test_MulSS"
+    "test_NoOutputFromInplace"
+    "test_OpFromGraph"
+    "test_adv_sub1_sparse_grad"
+    "test_alloc"
+    "test_binary"
+    "test_borrow_input"
+    "test_borrow_output"
+    "test_cache_race_condition"
+    "test_check_for_aliased_inputs"
+    "test_clinker_literal_cache"
+    "test_csm_grad"
+    "test_csm_unsorted"
+    "test_csr_dense_grad"
+    "test_debugprint"
+    "test_ellipsis_einsum"
+    "test_empty_elemwise"
+    "test_flatten"
+    "test_fprop"
+    "test_get_item_list_grad"
+    "test_grad"
+    "test_infer_shape"
+    "test_jax_pad"
+    "test_kron"
+    "test_masked_input"
+    "test_max"
+    "test_modes"
+    "test_mul_s_v_grad"
+    "test_multiple_outputs"
+    "test_not_inplace"
+    "test_numba_Cholesky_grad"
+    "test_numba_pad"
+    "test_optimizations_preserved"
+    "test_overided_function"
+    "test_potential_output_aliasing_induced_by_updates"
+    "test_profiling"
+    "test_rebuild_strict"
+    "test_runtime_broadcast_c"
+    "test_scan_err1"
+    "test_scan_err2"
+    "test_shared"
+    "test_size_implied_by_broadcasted_parameters"
+    "test_solve_triangular_grad"
+    "test_structured_add_s_v_grad"
+    "test_structureddot_csc_grad"
+    "test_structureddot_csr_grad"
+    "test_sum"
+    "test_swap_SharedVariable_with_given"
+    "test_test_value_op"
+    "test_unary"
+    "test_unbroadcast"
+    "test_update_equiv"
+    "test_update_same"
+  ];
 
   disabledTestPaths = [
     # Don't run the most compute-intense tests


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/pymc-devs/pytensor/compare/refs/tags/rel-2.31.3...rel-2.31.4
Changelog: https://github.com/pymc-devs/pytensor/releases/tag/rel-2.31.4

cc @bcdarwin @ferrine

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
