### PR TITLE
plover: unbork and move to by-name

### DIFF
--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -67,13 +67,16 @@
       pythonImportsCheck = [ "plover" ];
 
       meta = {
-        broken = stdenv.hostPlatform.isDarwin;
         description = "OpenSteno Plover stenography software";
+        homepage = "https://www.openstenoproject.org/plover/";
+        mainProgram = "plover";
         maintainers = with lib.maintainers; [
           twey
           kovirobi
         ];
         license = lib.licenses.gpl2Plus;
+        platforms = lib.platforms.unix;
+        broken = stdenv.hostPlatform.isDarwin;
       };
     }
   );

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -73,6 +73,7 @@
         maintainers = with lib.maintainers; [
           twey
           kovirobi
+          pandapip1
         ];
         license = lib.licenses.gpl2Plus;
         platforms = lib.platforms.unix;

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -73,7 +73,7 @@
           twey
           kovirobi
         ];
-        license = licenses.gpl2Plus;
+        license = lib.licenses.gpl2Plus;
       };
     }
   );

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -3,6 +3,7 @@
   config,
   stdenv,
   plover,
+  buildPythonPackage ? python3Packages.buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
   versionCheckHook,
@@ -32,79 +33,81 @@ let
     wrapQtAppsHook
     ;
 in
-{
-  dev = (
-    buildPythonPackage rec {
-      pname = "plover";
-      version = "4.0.2";
-      pyproject = true;
+buildPythonPackage rec {
+  pname = "plover";
+  version = "4.0.2";
+  pyproject = true;
 
-      src = fetchFromGitHub {
-        owner = "openstenoproject";
-        repo = "plover";
-        tag = "v${version}";
-        hash = "sha256-VpQT25bl8yPG4J9IwLkhSkBt31Y8BgPJdwa88WlreA8=";
-      };
+  src = fetchFromGitHub {
+    owner = "openstenoproject";
+    repo = "plover";
+    tag = "v${version}";
+    hash = "sha256-VpQT25bl8yPG4J9IwLkhSkBt31Y8BgPJdwa88WlreA8=";
+  };
 
-      postPatch = ''
-        sed -i 's/,<77//g' pyproject.toml # pythonRelaxDepsHook doesn't work for this for some reason
-      '';
+  postPatch = ''
+    sed -i 's/,<77//g' pyproject.toml # pythonRelaxDepsHook doesn't work for this for some reason
+  '';
 
-      build-system = [
-        babel
-        setuptools
-        pyqt5
-        wheel
-      ];
-      dependencies = [
-        appdirs
-        evdev
-        pyqt5
-        pyserial
-        plover-stroke
-        rtf-tokenize
-        setuptools
-        wcwidth
-        xlib
-      ];
-      nativeBuildInputs = [
-        wrapQtAppsHook
-      ];
+  build-system = [
+    babel
+    setuptools
+    pyqt5
+    wheel
+  ];
+  dependencies = [
+    appdirs
+    evdev
+    pyqt5
+    pyserial
+    plover-stroke
+    rtf-tokenize
+    setuptools
+    wcwidth
+    xlib
+  ];
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ];
 
-      nativeCheckInputs = [
-        pytestCheckHook
-        versionCheckHook
-        pytest-qt
-        mock
-      ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+    pytest-qt
+    mock
+  ];
 
-      # Segfaults?!
-      disabledTestPaths = [ "test/gui_qt/test_dictionaries_widget.py" ];
+  # Segfaults?!
+  disabledTestPaths = [ "test/gui_qt/test_dictionaries_widget.py" ];
 
-      preFixup = ''
-        makeWrapperArgs+=("''${qtWrapperArgs[@]}")
-      '';
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
 
-      dontWrapQtApps = true;
+  dontWrapQtApps = true;
 
-      pythonImportsCheck = [ "plover" ];
+  pythonImportsCheck = [ "plover" ];
 
-      meta = {
-        description = "OpenSteno Plover stenography software";
-        homepage = "https://www.openstenoproject.org/plover/";
-        mainProgram = "plover";
-        maintainers = with lib.maintainers; [
-          twey
-          kovirobi
-          pandapip1
-        ];
-        license = lib.licenses.gpl2Plus;
-        platforms = lib.platforms.unix;
-        broken = stdenv.hostPlatform.isDarwin;
-      };
-    }
-  );
+  meta = {
+    description = "OpenSteno Plover stenography software";
+    homepage = "https://www.openstenoproject.org/plover/";
+    mainProgram = "plover";
+    maintainers = with lib.maintainers; [
+      twey
+      kovirobi
+      pandapip1
+    ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
 }
 // lib.optionalAttrs config.allowAliases {
-  stable = throw "plover.stable was removed because it used Python 2. Use plover.dev instead."; # added 2022-06-05
+  # TODO: After 26.05 branch-off, remove these aliases
+  dev =
+    if lib.versionOlder "25.05" lib.version then
+      throw "plover.dev was renamed. Use plover-dev instead." # added 2025-06-05`
+    else
+      plover;
+  stable = throw "plover.stable was renamed. Use plover instead."; # added 2022-06-05; updated 2025-06-27
 }

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -2,13 +2,36 @@
   lib,
   config,
   stdenv,
-  buildPythonPackage ? python3Packages.buildPythonPackage,
+  plover,
   fetchFromGitHub,
+  fetchpatch,
   versionCheckHook,
   python3Packages,
   libsForQt5,
 }:
 
+let
+  inherit (python3Packages)
+    buildPythonPackage
+    appdirs
+    babel
+    evdev
+    mock
+    pyqt5
+    pyserial
+    pytestCheckHook
+    pytest-qt
+    plover-stroke
+    rtf-tokenize
+    setuptools
+    wcwidth
+    wheel
+    xlib
+    ;
+  inherit (libsForQt5)
+    wrapQtAppsHook
+    ;
+in
 {
   dev = (
     buildPythonPackage rec {
@@ -27,13 +50,13 @@
         sed -i 's/,<77//g' pyproject.toml # pythonRelaxDepsHook doesn't work for this for some reason
       '';
 
-      build-system = with python3Packages; [
+      build-system = [
         babel
         setuptools
         pyqt5
         wheel
       ];
-      dependencies = with python3Packages; [
+      dependencies = [
         appdirs
         evdev
         pyqt5
@@ -44,11 +67,11 @@
         wcwidth
         xlib
       ];
-      nativeBuildInputs = with libsForQt5; [
+      nativeBuildInputs = [
         wrapQtAppsHook
       ];
 
-      nativeCheckInputs = with python3Packages; [
+      nativeCheckInputs = [
         pytestCheckHook
         versionCheckHook
         pytest-qt

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -73,7 +73,7 @@
           twey
           kovirobi
         ];
-        license = lib.licenses.gpl2;
+        license = licenses.gpl2Plus;
       };
     }
   );

--- a/pkgs/development/python-modules/plover-dev/default.nix
+++ b/pkgs/development/python-modules/plover-dev/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchFromGitHub,
+  writeShellScriptBin,
+  plover,
+  python3Packages,
+  pkginfo,
+  packaging,
+  psutil,
+  pygments,
+  readme-renderer,
+  requests-cache,
+  requests-futures,
+  # Qt
+  pyqt,
+  qtbase,
+  wrapQtAppsHook,
+}:
+
+(plover.override {
+  inherit wrapQtAppsHook pyqt;
+}).overridePythonAttrs
+  (oldAttrs: rec {
+    version = "5.0.0.dev2";
+
+    src = fetchFromGitHub {
+      owner = "openstenoproject";
+      repo = "plover";
+      tag = "v${version}";
+      hash = "sha256-PZwxVrdQPhgbj+YmWZIUETngeJGs6IQty0hY43tLQO0=";
+    };
+
+    # pythonRelaxDeps seemingly doesn't work here
+    postPatch = oldAttrs.postPatch + ''
+      sed -i /PySide6-Essentials/d pyproject.toml
+    '';
+
+    build-system = oldAttrs.build-system ++ [
+      # Replacement for missing pyside6-essentials tools,
+      # workaround for https://github.com/NixOS/nixpkgs/issues/277849.
+      # Ideally this would be solved in pyside6 itself but I spent four
+      # hours trying to untangle its build system before giving up. If
+      # anyone wants to spend the time fixing it feel free to request
+      # me (@Pandapip1) as a reviewer.
+      (writeShellScriptBin "pyside6-uic" ''
+        exec ${qtbase}/libexec/uic -g python "$@"
+      '')
+      (writeShellScriptBin "pyside6-rcc" ''
+        exec ${qtbase}/libexec/rcc -g python "$@"
+      '')
+    ];
+
+    dependencies =
+      oldAttrs.dependencies
+      ++ [
+        packaging
+        pkginfo
+        psutil
+        pygments
+        qtbase
+        readme-renderer
+        requests-cache
+        requests-futures
+      ]
+      ++ readme-renderer.optional-dependencies.md;
+
+    meta.description = oldAttrs.meta.description + " (Development version)";
+  })

--- a/pkgs/development/python-modules/plover-stroke/default.nix
+++ b/pkgs/development/python-modules/plover-stroke/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  pytest-qt,
+  pyside6,
+}:
+
+buildPythonPackage rec {
+  pname = "plover-stroke";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "openstenoproject";
+    repo = "plover_stroke";
+    tag = version;
+    hash = "sha256-A75OMzmEn0VmDAvmQCp6/7uptxzwWJTwsih3kWlYioA=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-qt
+    pyside6
+  ];
+
+  pythonImportsCheck = [ "plover_stroke" ];
+
+  meta = {
+    description = "Helper class for working with steno strokes";
+    homepage = "https://github.com/openstenoproject/plover_stroke";
+    license = lib.licenses.gpl2Plus; # https://github.com/openstenoproject/plover_stroke/issues/4
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+}

--- a/pkgs/development/python-modules/plover/default.nix
+++ b/pkgs/development/python-modules/plover/default.nix
@@ -3,36 +3,27 @@
   config,
   stdenv,
   plover,
-  buildPythonPackage ? python3Packages.buildPythonPackage,
+  buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
   versionCheckHook,
-  python3Packages,
-  libsForQt5,
+  appdirs,
+  babel,
+  evdev,
+  mock,
+  pyqt5,
+  pyserial,
+  pytestCheckHook,
+  pytest-qt,
+  plover-stroke,
+  rtf-tokenize,
+  setuptools,
+  wcwidth,
+  wheel,
+  xlib,
+  wrapQtAppsHook,
 }:
 
-let
-  inherit (python3Packages)
-    buildPythonPackage
-    appdirs
-    babel
-    evdev
-    mock
-    pyqt5
-    pyserial
-    pytestCheckHook
-    pytest-qt
-    plover-stroke
-    rtf-tokenize
-    setuptools
-    wcwidth
-    wheel
-    xlib
-    ;
-  inherit (libsForQt5)
-    wrapQtAppsHook
-    ;
-in
 buildPythonPackage rec {
   pname = "plover";
   version = "4.0.2";

--- a/pkgs/development/python-modules/plover/default.nix
+++ b/pkgs/development/python-modules/plover/default.nix
@@ -94,12 +94,3 @@ buildPythonPackage rec {
     broken = stdenv.hostPlatform.isDarwin;
   };
 }
-// lib.optionalAttrs config.allowAliases {
-  # TODO: After 26.05 branch-off, remove these aliases
-  dev =
-    if lib.versionOlder "25.05" lib.version then
-      throw "plover.dev was renamed. Use plover-dev instead." # added 2025-06-05`
-    else
-      plover;
-  stable = throw "plover.stable was renamed. Use plover instead."; # added 2022-06-05; updated 2025-06-27
-}

--- a/pkgs/development/python-modules/plover/default.nix
+++ b/pkgs/development/python-modules/plover/default.nix
@@ -11,7 +11,6 @@
   babel,
   evdev,
   mock,
-  pyqt5,
   pyserial,
   pytestCheckHook,
   pytest-qt,
@@ -21,6 +20,8 @@
   wcwidth,
   wheel,
   xlib,
+  # Qt dependencies
+  pyqt,
   wrapQtAppsHook,
 }:
 
@@ -43,13 +44,13 @@ buildPythonPackage rec {
   build-system = [
     babel
     setuptools
-    pyqt5
+    pyqt
     wheel
   ];
   dependencies = [
     appdirs
     evdev
-    pyqt5
+    pyqt
     pyserial
     plover-stroke
     rtf-tokenize

--- a/pkgs/development/python-modules/rtf-tokenize/default.nix
+++ b/pkgs/development/python-modules/rtf-tokenize/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "rtf-tokenize";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "openstenoproject";
+    repo = "rtf_tokenize";
+    tag = version;
+    hash = "sha256-zwD2sRYTY1Kmm/Ag2hps9VRdUyQoi4zKtDPR+F52t9A=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "rtf_tokenize" ];
+
+  meta = {
+    description = "Simple RTF tokenizer package for Python";
+    homepage = "https://github.com/openstenoproject/rtf_tokenize";
+    license = lib.licenses.gpl2Plus; # https://github.com/openstenoproject/rtf_tokenize/issues/1
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1351,6 +1351,12 @@ mapAliases {
   platformioPackages.platformio-core = platformio-core; # Added 2025-09-04
   plex-media-player = throw "'plex-media-player' has been discontinued, the new official client is available as 'plex-desktop'"; # Added 2025-05-28
   PlistCpp = throw "'PlistCpp' has been renamed to/replaced by 'plistcpp'"; # Converted to throw 2025-10-27
+  plover.dev =
+    if lib.versionOlder "25.11" lib.version then
+      throw "plover.dev was renamed. Use python3Packages.plover-dev instead." # Added 2025-11-15
+    else
+      python3Packages.plover-dev;
+  plover.stable = throw "plover.stable was renamed. Use python3Packages.plover instead."; # Added 2022-06-05; Updated 2025-11-15
   pltScheme = throw "'pltScheme' has been renamed to/replaced by 'racket'"; # Converted to throw 2025-10-27
   plv8 = throw "'plv8' has been removed. Use 'postgresqlPackages.plv8' instead."; # Added 2025-07-19
   pn = throw "'pn' has been removed as upstream was archived in 2020"; # Added 2025-10-17

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11514,8 +11514,6 @@ with pkgs;
 
   plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };
 
-  plover = callPackage ../applications/misc/plover { };
-
   pokefinder = qt6Packages.callPackage ../tools/games/pokefinder { };
 
   pothos = libsForQt5.callPackage ../applications/radio/pothos { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11514,7 +11514,7 @@ with pkgs;
 
   plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };
 
-  plover = recurseIntoAttrs (libsForQt5.callPackage ../applications/misc/plover { });
+  plover = callPackage ../applications/misc/plover { };
 
   pokefinder = qt6Packages.callPackage ../tools/games/pokefinder { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16723,6 +16723,8 @@ self: super: with self; {
 
   rtb-data = callPackage ../development/python-modules/rtb-data { };
 
+  rtf-tokenize = callPackage ../development/python-modules/rtf-tokenize { };
+
   rtfde = callPackage ../development/python-modules/rtfde { };
 
   rtfunicode = callPackage ../development/python-modules/rtfunicode { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12344,6 +12344,10 @@ self: super: with self; {
 
   plotpy = callPackage ../development/python-modules/plotpy { };
 
+  plover = callPackage ../development/python-modules/plover {
+    inherit (pkgs.libsForQt5) wrapQtAppsHook;
+  };
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   pluggy = callPackage ../development/python-modules/pluggy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12344,6 +12344,8 @@ self: super: with self; {
 
   plotpy = callPackage ../development/python-modules/plotpy { };
 
+  plover-stroke = callPackage ../development/python-modules/plover-stroke { };
+
   pluggy = callPackage ../development/python-modules/pluggy { };
 
   pluginbase = callPackage ../development/python-modules/pluginbase { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12349,6 +12349,11 @@ self: super: with self; {
     pyqt = self.pyqt5;
   };
 
+  plover-dev = callPackage ../development/python-modules/plover-dev {
+    inherit (pkgs.qt6) wrapQtAppsHook qtbase;
+    pyqt = self.pyside6;
+  };
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   pluggy = callPackage ../development/python-modules/pluggy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12346,6 +12346,7 @@ self: super: with self; {
 
   plover = callPackage ../development/python-modules/plover {
     inherit (pkgs.libsForQt5) wrapQtAppsHook;
+    pyqt = self.pyqt5;
   };
 
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/419420
Fixes https://github.com/NixOS/nixpkgs/issues/141797
Makes progress on https://github.com/NixOS/nixpkgs/issues/180841
Supersedes https://github.com/NixOS/nixpkgs/pull/426075
(sort of) Supersedes https://github.com/NixOS/nixpkgs/pull/119702
(sort of) Supersedes https://github.com/NixOS/nixpkgs/pull/110658

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

CC @natsukium @Twey @KoviRobi

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
