### PR TITLE
fusesoc: Updated to 2.4.3

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -35,6 +35,8 @@
   of the [4.3 release](https://github.com/netbox-community/netbox/releases/tag/v4.2.0),
   make the required changes to your database, if needed, then upgrade by setting `services.netbox.package = pkgs.netbox_4_3;` in your configuration.
 
+- `fusesoc` has been updated from `2.2.1` to `2.4.3`. This new version should be completely backwards compatible, but introduces new features such as 'mappings'.
+
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/tools/package-management/fusesoc/default.nix
+++ b/pkgs/tools/package-management/fusesoc/default.nix
@@ -2,9 +2,6 @@
   buildPythonPackage,
   fetchPypi,
   lib,
-  iverilog,
-  verilator,
-  gnumake,
   edalize,
   fastjsonschema,
   pyparsing,
@@ -34,16 +31,6 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "fusesoc" ];
-
-  makeWrapperArgs = [
-    "--suffix PATH : ${
-      lib.makeBinPath [
-        iverilog
-        verilator
-        gnumake
-      ]
-    }"
-  ];
 
   meta = with lib; {
     homepage = "https://github.com/olofk/fusesoc";

--- a/pkgs/tools/package-management/fusesoc/default.nix
+++ b/pkgs/tools/package-management/fusesoc/default.nix
@@ -8,17 +8,21 @@
   pyyaml,
   simplesat,
   ipyxact,
+  argcomplete,
   setuptools-scm,
 }:
 buildPythonPackage rec {
   pname = "fusesoc";
-  version = "2.2.1";
+  version = "2.4.3";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-M36bXBgY8hR33AVDlHoH8PZJG2Bi0KOEI07IMns7R4w=";
+    hash = "sha256-/CWwbLUvUWzQDG0EyfY4IF5G8+NehA/D+OwAuzpkBdU=";
   };
 
+  patches = [ ./fusesoc-without-jsonschema2md.patch ];
+
+  pyproject = true;
   nativeBuildInputs = [ setuptools-scm ];
 
   propagatedBuildInputs = [
@@ -28,6 +32,7 @@ buildPythonPackage rec {
     pyyaml
     simplesat
     ipyxact
+    argcomplete
   ];
 
   pythonImportsCheck = [ "fusesoc" ];

--- a/pkgs/tools/package-management/fusesoc/fusesoc-without-jsonschema2md.patch
+++ b/pkgs/tools/package-management/fusesoc/fusesoc-without-jsonschema2md.patch
@@ -1,0 +1,12 @@
+diff --git i/pyproject.toml w/pyproject.toml
+index 5c80b63..d216fd4 100644
+--- i/pyproject.toml
++++ w/pyproject.toml
+@@ -30,7 +30,6 @@ dependencies = [
+   "pyyaml>=6.0",
+   "simplesat>=0.9.1",
+   "fastjsonschema",
+-  "jsonschema2md",
+   "argcomplete",
+ ]
+ requires-python = ">=3.6, <4"


### PR DESCRIPTION
The new `jsonschema2md` dependency isn't actually needed for FuseSoC but rather it's documentation build, so was removed rather than being packaged in nixpkgs. This should be fixed upstream in future versions.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
