### PR TITLE
python3Packages.mmengine: remove failing numpy.compat import

### DIFF
--- a/pkgs/development/python-modules/mmcv/default.nix
+++ b/pkgs/development/python-modules/mmcv/default.nix
@@ -48,10 +48,17 @@ buildPythonPackage rec {
     hash = "sha256-NNF9sLJWV1q6uBE73LUW4UWwYm4TBMTBJjJkFArBmsc=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "cpu_use = 4" "cpu_use = $NIX_BUILD_CORES"
-  '';
+  postPatch =
+    # Fails in python >= 3.13
+    # exec(compile(f.read(), version_file, "exec")) does not populate the locals() namesp
+    # In python 3.13, the locals() dictionary in a function does not automatically update with
+    # changes made by exec().
+    # https://peps.python.org/pep-0558/
+    ''
+      substituteInPlace setup.py \
+        --replace-fail "cpu_use = 4" "cpu_use = $NIX_BUILD_CORES" \
+        --replace-fail "return locals()['__version__']" "return '${version}'"
+    '';
 
   nativeBuildInputs = [
     ninja

--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -52,10 +52,22 @@ buildPythonPackage rec {
     })
   ];
 
-  postPatch = ''
-    substituteInPlace tests/test_config/test_lazy.py \
-      --replace-fail "import numpy.compat" ""
-  '';
+  postPatch =
+    # Fails in python >= 3.13
+    # exec(compile(f.read(), version_file, "exec")) does not populate the locals() namesp
+    # In python 3.13, the locals() dictionary in a function does not automatically update with
+    # changes made by exec().
+    # https://peps.python.org/pep-0558/
+    ''
+      substituteInPlace setup.py \
+        --replace-fail \
+          "return locals()['__version__']" \
+          "return '${version}'"
+    ''
+    + ''
+      substituteInPlace tests/test_config/test_lazy.py \
+        --replace-fail "import numpy.compat" ""
+    '';
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -52,6 +52,11 @@ buildPythonPackage rec {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace tests/test_config/test_lazy.py \
+      --replace-fail "import numpy.compat" ""
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @benxiao

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
