### PR TITLE
perlPackages.ImagePNGLibpng: 0.57 -> 0.59

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16950,12 +16950,12 @@ with self;
     };
   };
 
-  ImagePNGLibpng = buildPerlPackage {
+  ImagePNGLibpng = buildPerlPackage rec {
     pname = "Image-PNG-Libpng";
-    version = "0.57";
+    version = "0.59";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BK/BKB/Image-PNG-Libpng-0.56.tar.gz";
-      hash = "sha256-+vu/6/9CP3u4XvJ6MEH7YpG1AzbHpYIiSlysQzHDx9k=";
+      url = "mirror://cpan/authors/id/B/BK/BKB/Image-PNG-Libpng-${version}.tar.gz";
+      hash = "sha256-4fn19YqM6YhwUp9WgIQfsz4wQnLzn6rtXC95Kc5vWNc=";
     };
     buildInputs = [ pkgs.libpng ];
     meta = {


### PR DESCRIPTION
update ImagePNGLibpng since it failed with

```
Running phase: unpackPhase
unpacking source archive /nix/store/zsi7lq4xmbwpa7k7hwzc6fyn3ys22byk-Image-PNG-Libpng-0.56.tar.gz
source root is Image-PNG-Libpng-0.56
setting SOURCE_DATE_EPOCH to timestamp 1608677235 of file "Image-PNG-Libpng-0.56/MANIFEST"
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
patching ./script/pnginspect...
patching ./examples/supports.pl...
patching ./examples/synopsis.pl...
patching ./examples/set-background.pl...
patching ./examples/get-www-png.pl...
patching ./examples/set-unknown-chunk.pl...
patching ./examples/q.pl...
patching ./examples/copy-png.pl...
patching ./examples/color-type-name.pl...
patching ./examples/xkcd.pl...
patching ./examples/png-cgi.pl...
patching ./examples/set-text.pl...
patching ./examples/synopsis-easy.pl...
patching ./examples/libpng-write.pl...
patching ./examples/rgb-to-gray.pl...
/nix/store/380ibq4l01y2bphpsdxp5q9w5szmj3y1-builder.sh: line 15: warning: command substitution: ignored null byte in input
/nix/store/380ibq4l01y2bphpsdxp5q9w5szmj3y1-builder.sh: line 15: warning: command substitution: ignored null byte in input
/nix/store/380ibq4l01y2bphpsdxp5q9w5szmj3y1-builder.sh: line 15: warning: command substitution: ignored null byte in input
/nix/store/380ibq4l01y2bphpsdxp5q9w5szmj3y1-builder.sh: line 15: warning: command substitution: ignored null byte in input
/nix/store/380ibq4l01y2bphpsdxp5q9w5szmj3y1-builder.sh: line 15: warning: command substitution: ignored null byte in input
/nix/store/380ibq4l01y2bphpsdxp5q9w5szmj3y1-builder.sh: line 15: warning: command substitution: ignored null byte in input
/nix/store/380ibq4l01y2bphpsdxp5q9w5szmj3y1-builder.sh: line 15: warning: command substitution: ignored null byte in input
patching ./t/gAMA.t...
patching ./t/make-tEXT.pl...
png-compile-test.c:17: IMAGE-PNG LIBPNG VERSION: <<1.6.47>>
Checking if your kit is complete...
Looks good
Warning (mostly harmless): No library found for -lpng
Warning (mostly harmless): No library found for -lz
Warning (mostly harmless): No library found for -lm
Generating a Unix-style Makefile
Writing Makefile for Image::PNG::Libpng
Writing MYMETA.yml and MYMETA.json
no configure script, doing nothing
Running phase: buildPhase
build flags: SHELL=/nix/store/00zrahbb32nzawrmv9sjxn36h7qk9vrs-bash-5.2p37/bin/bash
cp lib/Image/PNG/Libpng.pod blib/lib/Image/PNG/Libpng.pod
cp lib/Image/PNG/Libpng.pm blib/lib/Image/PNG/Libpng.pm
cp lib/Image/PNG/Const.pm blib/lib/Image/PNG/Const.pm
Running Mkbootstrap for Libpng ()
chmod 644 "Libpng.bs"
"/nix/store/gy10hw004rl2xfbfq41vnw0yb1w8rvbl-perl-5.40.0/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- Libpng.bs blib/arch/auto/Image/PNG/Libpng/Libpng.bs 644
"/nix/store/gy10hw004rl2xfbfq41vnw0yb1w8rvbl-perl-5.40.0/bin/perl" "/nix/store/gy10hw004rl2xfbfq41vnw0yb1w8rvbl-perl-5.40.0/lib/perl5/5.40.0/ExtUtils/xsubpp"  -typemap '/nix/store/gy10hw004rl2xfbfq41vnw0yb1w8rvbl-perl-5.40.0/lib/perl5/5.40.0/ExtUtils/typemap' -typemap '/build/Image-PNG-Libpng-0.56/typemap'  Libpng.xs > Libpng.xsc
mv Libpng.xsc Libpng.c
gcc -c   -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/no-such-path/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2   -DVERSION=\"0.56\" -DXS_VERSION=\"0.56\" -fPIC "-I/nix/store/gy10hw004rl2xfbfq41vnw0yb1w8rvbl-perl-5.40.0/lib/perl5/5.40.0/x86_64-linux-thread-multi/CORE"   Libpng.c
rm -f blib/arch/auto/Image/PNG/Libpng/Libpng.so
gcc  -lpng -lz -lm -shared -O2 -L/nix/store/q4wq65gl3r8fy746v9bbwgx4gzn0r2kl-glibc-2.40-66/lib -fstack-protector-strong  Libpng.o  -o blib/arch/auto/Image/PNG/Libpng/Libpng.so  \
      \
  
chmod 755 blib/arch/auto/Image/PNG/Libpng/Libpng.so
cp script/pnginspect blib/script/pnginspect
"/nix/store/gy10hw004rl2xfbfq41vnw0yb1w8rvbl-perl-5.40.0/bin/perl" -MExtUtils::MY -e 'MY->fixin(shift)' -- blib/script/pnginspect
Manifying 1 pod document
Manifying 2 pod documents
Running phase: checkPhase
check flags: SHELL=/nix/store/00zrahbb32nzawrmv9sjxn36h7qk9vrs-bash-5.2p37/bin/bash VERBOSE=y test
"/nix/store/gy10hw004rl2xfbfq41vnw0yb1w8rvbl-perl-5.40.0/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- Libpng.bs blib/arch/auto/Image/PNG/Libpng/Libpng.bs 644
PERL_DL_NONLAZY=1 "/nix/store/gy10hw004rl2xfbfq41vnw0yb1w8rvbl-perl-5.40.0/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/any2gray8.t ......... ok   
t/bKGD.t .............. ok    
t/bogus.t ............. skipped: libpng version is 1.6.47
t/chrm-xyz.t .......... ok    
t/cHRM.t .............. ok   
t/chunk-cache-max.t ... ok   
t/chunk-malloc-max.t .. ok   
t/comp-buff.t ......... ok   
t/compress-level.t .... ok    
t/Const.t ............. ok   
t/copy-all-png.t ...... 1/? libpng warning: hIST: out of place
libpng warning: hIST: out of place
libpng warning: hIST: out of place
libpng warning: hIST: out of place
t/copy-all-png.t ...... ok     
t/daft.t .............. ok   
t/exif.t .............. 1/? libpng warning: eXIf: invalid

#   Failed test 'Round trip of eXIf chunk'
#   at t/exif.t line 46.
#          got: undef
#     expected: 'MM random garbage'
# Looks like you failed 1 test of 2.
t/exif.t .............. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests 
t/functions.t ......... ok   
t/gAMA.t .............. ok   
t/get-internals.t ..... ok   
t/get-palette-max.t ... ok   
t/get-text.t .......... ok   
t/header.t ............ ok   
t/hIST.t .............. libpng warning: hIST: out of place
t/hIST.t .............. 1/? 
#   Failed test 'Valid hist in ch1n3p04'
#   at t/hIST.t line 27.

#   Failed test 'Right histogram size in ch1n3p04'
#   at t/hIST.t line 29.
#          got: '0'
#     expected: '15'

#   Failed test 'Round trip of hIST chunk'
#   at t/hIST.t line 32.
#     Structures begin differing at:
#          $got = undef
#     $expected = ARRAY(0xc6aaa0)
libpng warning: hIST: out of place

#   Failed test 'Valid hist in ch2n3p08'
#   at t/hIST.t line 27.

#   Failed test 'Right histogram size in ch2n3p08'
#   at t/hIST.t line 29.
#          got: '0'
#     expected: '256'

#   Failed test 'Round trip of hIST chunk'
#   at t/hIST.t line 32.
#     Structures begin differing at:
#          $got = undef
#     $expected = ARRAY(0xc6a638)
# Looks like you failed 6 tests of 6.
t/hIST.t .............. Dubious, test returned 6 (wstat 1536, 0x600)
Failed 6/6 subtests 
t/io-read.t ........... ok   
t/io.t ................ ok   
t/Libpng.t ............ ok   
t/oFFs.t .............. ok   
t/pCAL.t .............. ok   
t/pHYs.t .............. ok   
t/PLTE.t .............. ok   
t/read-from-scalar.t .. ok   
t/sBIT.t .............. ok   
t/sCAL.t .............. ok   
t/set-itxt.t .......... ok    
t/set-text.t .......... ok    
t/split-alpha.t ....... ok    
t/sPLT.t .............. ok    
t/supports.t .......... ok    
t/tIME.t .............. ok    
t/transformations.t ... ok   
t/tRNS.t .............. ok   
t/user-limits.t ....... ok   

Test Summary Report
-------------------
t/exif.t            (Wstat: 256 (exited 1) Tests: 2 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
t/hIST.t            (Wstat: 1536 (exited 6) Tests: 6 Failed: 6)
  Failed tests:  1-6
  Non-zero exit status: 6
Files=39, Tests=405,  5 wallclock secs ( 0.16 usr  0.09 sys +  2.84 cusr  0.99 csys =  4.08 CPU)
Result: FAIL
Failed 2/39 test programs. 7/405 subtests failed.
make: *** [Makefile:1102: test_dynamic] Error 255
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
