### PR TITLE
nixos/amdgpu: add kernelModule.patches option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -27,7 +27,7 @@
   These versions only work with old compiler versions that will be unsupported by the time of the Nixpkgs 25.05 release.
   In the future, users should expect CUDA versions to be dropped as the compiler versions they require leave upstream support windows.
 
-- Convenience options for `amdgpu`, the open source driver for Radeon cards, are now available under [`hardware.amdgpu`](#opt-hardware.amdgpu.initrd.enable).
+- Convenience options for `amdgpu`, the open source driver for Radeon cards, are now available under [`hardware.amdgpu`](#opt-hardware.amdgpu.kernelModule.inInitrd).
 
 - [AMDVLK](https://github.com/GPUOpen-Drivers/AMDVLK), AMD's open source Vulkan driver, is now available to be configured under the [`hardware.amdgpu.amdvlk`](#opt-hardware.amdgpu.amdvlk.enable) option.
   This also allows configuring runtime settings for AMDVLK, including enabling experimental features.

--- a/nixos/modules/services/hardware/amdgpu-kernel-module.nix
+++ b/nixos/modules/services/hardware/amdgpu-kernel-module.nix
@@ -1,0 +1,42 @@
+# TODO there should probably be a generic mechanism to patch any in-kernel module like this
+{
+  stdenv,
+  kernel, # The kernel to patch
+  patches ? [ ],
+}:
+
+stdenv.mkDerivation {
+  pname = "amdgpu-kernel-module-customised";
+  inherit (kernel)
+    src
+    version
+    postPatch
+    nativeBuildInputs
+    modDirVersion
+    ;
+  patches = kernel.patches or [ ] ++ patches;
+
+  modulePath = "drivers/gpu/drm/amd/amdgpu";
+
+  buildPhase = ''
+    BUILT_KERNEL=${kernel.dev}/lib/modules/$modDirVersion/build
+
+    cp $BUILT_KERNEL/Module.symvers $BUILT_KERNEL/.config ${kernel.dev}/vmlinux ./
+
+    make "-j$NIX_BUILD_CORES" modules_prepare
+    make "-j$NIX_BUILD_CORES" M=$modulePath modules
+  '';
+
+  installPhase = ''
+    make \
+      INSTALL_MOD_PATH="$out" \
+      XZ="xz -T$NIX_BUILD_CORES" \
+      M="$modulePath" \
+      modules_install
+  '';
+
+  meta = {
+    description = "AMDGPU kernel module";
+    inherit (kernel.meta) license;
+  };
+}

--- a/nixos/modules/services/hardware/amdgpu.nix
+++ b/nixos/modules/services/hardware/amdgpu.nix
@@ -42,6 +42,36 @@ in
         This allows for an earlier modeset to apply the preferred resolution in
         the beginning of the initramfs phase rather than after it.
       '';
+
+      patches = lib.mkOption {
+        type = with lib.types; listOf path;
+        default = [ ];
+        description = ''
+          Patches to apply to the kernel for the `amdgpu` kernel module build.
+
+          This is intended for applying small patches concerning only the
+          `amdgpu` module's internals without needing to rebuild the entire
+          kernel.
+
+          The patches are applied to the entire kernel tree but only the
+          `amdgpu` module will actually be built and used. You should therefore
+          not touch anything outside of `drivers/gpu/drm/amd/amdgpu` using the
+          patches as those modifications will not be present in the actual
+          kernel you will be running which might cause undefined and likely
+          erroneous behaviour.
+          Use {option}`boot.kernelPatches` instead for such cases.
+
+          A reboot is required for the patched module to be loaded.
+        '';
+        example = lib.literalExpression ''
+          [
+            (pkgs.fetchpatch2 {
+              url = "https://lore.kernel.org/lkml/20240610-amdgpu-min-backlight-quirk-v1-1-8459895a5b2a@weissschuh.net/raw";
+              hash = "";
+            })
+          ]
+        '';
+      };
     };
 
     opencl.enable = lib.mkEnableOption ''OpenCL support using ROCM runtime library'';
@@ -69,6 +99,13 @@ in
       ];
 
     boot.initrd.kernelModules = lib.optionals cfg.kernelModule.inInitrd [ "amdgpu" ];
+
+    boot.extraModulePackages = lib.mkIf (cfg.kernelModule.patches != [ ]) [
+      (pkgs.callPackage ./amdgpu-kernel-module.nix {
+        inherit (config.boot.kernelPackages) kernel;
+        inherit (cfg.kernelModule) patches;
+      })
+    ];
 
     hardware.graphics = lib.mkIf cfg.opencl.enable {
       enable = lib.mkDefault true;

--- a/nixos/modules/services/hardware/amdgpu.nix
+++ b/nixos/modules/services/hardware/amdgpu.nix
@@ -117,6 +117,9 @@ in
   };
 
   meta = {
-    maintainers = with lib.maintainers; [ johnrtitor ];
+    maintainers = with lib.maintainers; [
+      johnrtitor
+      Scrumplex
+    ];
   };
 }

--- a/nixos/modules/system/boot/unl0kr.nix
+++ b/nixos/modules/system/boot/unl0kr.nix
@@ -55,7 +55,7 @@ in
     ];
 
     warnings = lib.mkMerge [
-      (lib.mkIf (config.hardware.amdgpu.initrd.enable) [
+      (lib.mkIf (config.hardware.amdgpu.kernelModule.inInitrd) [
         ''Use early video loading at your risk. It's not guaranteed to work with unl0kr.''
       ])
       (lib.mkIf (config.boot.plymouth.enable) [


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/321663
Closes https://github.com/NixOS/nixpkgs/pull/321663

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
