### PR TITLE
fluffychat: 1.27.0 -> 2.0.0

### DIFF
--- a/pkgs/by-name/fl/fluffychat/package.nix
+++ b/pkgs/by-name/fl/fluffychat/package.nix
@@ -1,15 +1,16 @@
 {
   lib,
-  fetchzip,
   fetchFromGitHub,
-  fetchpatch,
   imagemagick,
   libgbm,
   libdrm,
   flutter332,
   pulseaudio,
+  copyDesktopItems,
   makeDesktopItem,
-  olm,
+
+  callPackage,
+  vodozemac-wasm ? callPackage ./vodozemac-wasm.nix { flutter = flutter332; },
 
   targetFlutterPlatform ? "linux",
 }:
@@ -24,81 +25,72 @@ in
 flutter332.buildFlutterApplication (
   rec {
     pname = "fluffychat-${targetFlutterPlatform}";
-    version = "1.27.0";
+    version = "2.0.0";
 
     src = fetchFromGitHub {
       owner = "krille-chan";
       repo = "fluffychat";
       tag = "v${version}";
-      hash = "sha256-kt4VpegxcZ+d0NIKan2A0AUqFLdYNcU9HY/4zyd2eSU=";
+      hash = "sha256-fFc6nIVQUY9OiGkEc7jrzXnBQPDWC5x5A4/XHUhu6hs=";
     };
-
-    # https://github.com/krille-chan/fluffychat/pull/1965
-    patches = [
-      (fetchpatch {
-        name = "fix_compilation_mxc_image.patch";
-        url = "https://github.com/krille-chan/fluffychat/commit/e1ec87d3aaae00eb030bcfda28ec8f247e2c3346.patch";
-        hash = "sha256-/cd3geNVPifAC7iTcx8V1l2WY9Y/mEw+VPl2B4HSJKY=";
-      })
-    ];
 
     inherit pubspecLock;
 
     gitHashes = {
-      flutter_secure_storage_linux = "sha256-cFNHW7dAaX8BV7arwbn68GgkkBeiAgPfhMOAFSJWlyY=";
       flutter_web_auth_2 = "sha256-3aci73SP8eXg6++IQTQoyS+erUUuSiuXymvR32sxHFw=";
       flutter_typeahead = "sha256-ZGXbbEeSddrdZOHcXE47h3Yu3w6oV7q+ZnO6GyW7Zg8=";
+      flutter_secure_storage_linux = "sha256-cFNHW7dAaX8BV7arwbn68GgkkBeiAgPfhMOAFSJWlyY=";
     };
 
     inherit targetFlutterPlatform;
 
-    meta = {
-      description = "Chat with your friends (matrix client)";
-      homepage = "https://fluffychat.im/";
-      license = lib.licenses.agpl3Plus;
-      mainProgram = "fluffychat";
-      maintainers = with lib.maintainers; [
-        mkg20001
-        tebriel
-        aleksana
-      ];
-      platforms = [
-        "x86_64-linux"
-        "aarch64-linux"
-      ];
-      sourceProvenance = [ lib.sourceTypes.fromSource ];
-      inherit (olm.meta) knownVulnerabilities;
-    };
+    meta =
+      {
+        description = "Chat with your friends (matrix client)";
+        homepage = "https://fluffychat.im/";
+        license = lib.licenses.agpl3Plus;
+        maintainers = with lib.maintainers; [
+          mkg20001
+          tebriel
+          aleksana
+        ];
+        badPlatforms = lib.platforms.darwin;
+      }
+      // lib.optionalAttrs (targetFlutterPlatform == "linux") {
+        mainProgram = "fluffychat";
+      };
   }
   // lib.optionalAttrs (targetFlutterPlatform == "linux") {
-    nativeBuildInputs = [ imagemagick ];
+    nativeBuildInputs = [
+      imagemagick
+      copyDesktopItems
+    ];
 
     runtimeDependencies = [ pulseaudio ];
 
     env.NIX_LDFLAGS = "-rpath-link ${libwebrtcRpath}";
 
-    desktopItem = makeDesktopItem {
-      name = "Fluffychat";
-      exec = "fluffychat";
-      icon = "fluffychat";
-      desktopName = "Fluffychat";
-      genericName = "Chat with your friends (matrix client)";
-      categories = [
-        "Chat"
-        "Network"
-        "InstantMessaging"
-      ];
-    };
+    desktopItems = [
+      (makeDesktopItem {
+        name = "Fluffychat";
+        exec = "fluffychat";
+        icon = "fluffychat";
+        desktopName = "Fluffychat";
+        genericName = "Chat with your friends (matrix client)";
+        categories = [
+          "Chat"
+          "Network"
+          "InstantMessaging"
+        ];
+      })
+    ];
 
     postInstall = ''
       FAV=$out/app/fluffychat-linux/data/flutter_assets/assets/favicon.png
       ICO=$out/share/icons
 
-      install -D $FAV $ICO/fluffychat.png
-      mkdir $out/share/applications
-      cp $desktopItem/share/applications/*.desktop $out/share/applications
       for size in 24 32 42 64 128 256 512; do
-        D=$ICO/hicolor/''${s}x''${s}/apps
+        D=$ICO/hicolor/''${size}x''${size}/apps
         mkdir -p $D
         magick $FAV -resize ''${size}x''${size} $D/fluffychat.png
       done
@@ -107,20 +99,8 @@ flutter332.buildFlutterApplication (
     '';
   }
   // lib.optionalAttrs (targetFlutterPlatform == "web") {
-    prePatch =
-      # https://github.com/krille-chan/fluffychat/blob/v1.17.1/scripts/prepare-web.sh
-      let
-        # Use Olm 1.3.2, the oldest version, for FluffyChat 1.14.1 which depends on olm_flutter 1.2.0.
-        olmVersion = pubspecLock.packages.flutter_olm.version;
-        olmJs = fetchzip {
-          url = "https://github.com/famedly/olm/releases/download/v${olmVersion}/olm.zip";
-          stripRoot = false;
-          hash = "sha256-Vl3Cp2OaYzM5CPOOtTHtUb1W48VXePzOV6FeiIzyD1Y=";
-        };
-      in
-      ''
-        rm -r assets/js/package
-        cp -r '${olmJs}/javascript' assets/js/package
-      '';
+    preBuild = ''
+      cp -r ${vodozemac-wasm}/* ./assets/vodozemac/
+    '';
   }
 )

--- a/pkgs/by-name/fl/fluffychat/pubspec.lock.json
+++ b/pkgs/by-name/fl/fluffychat/pubspec.lock.json
@@ -176,6 +176,16 @@
       "source": "hosted",
       "version": "2.1.2"
     },
+    "build_cli_annotations": {
+      "dependency": "transitive",
+      "description": {
+        "name": "build_cli_annotations",
+        "sha256": "b59d2769769efd6c9ff6d4c4cede0be115a566afc591705c2040b707534b1172",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.0"
+    },
     "canonical_json": {
       "dependency": "transitive",
       "description": {
@@ -764,16 +774,6 @@
       "source": "hosted",
       "version": "1.1.1"
     },
-    "flutter_olm": {
-      "dependency": "direct main",
-      "description": {
-        "name": "flutter_olm",
-        "sha256": "5e6211af8cba1abf7d1f92e543f6d573dfe6017fe4742e0d04ba84beab47f940",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "2.0.0"
-    },
     "flutter_openssl_crypto": {
       "dependency": "direct main",
       "description": {
@@ -793,6 +793,16 @@
       },
       "source": "hosted",
       "version": "2.0.28"
+    },
+    "flutter_rust_bridge": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_rust_bridge",
+        "sha256": "b416ff56002789e636244fb4cc449f587656eff995e5a7169457eb0593fcaddb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.10.0"
     },
     "flutter_secure_storage": {
       "dependency": "direct main",
@@ -881,6 +891,16 @@
       },
       "source": "git",
       "version": "5.2.0"
+    },
+    "flutter_vodozemac": {
+      "dependency": "direct main",
+      "description": {
+        "name": "flutter_vodozemac",
+        "sha256": "2405ca121b84d1cd83200a14021022e1691b123a23bcefc36adc7740cefbc1f9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.2"
     },
     "flutter_web_auth_2": {
       "dependency": "direct main",
@@ -1445,11 +1465,11 @@
       "dependency": "direct main",
       "description": {
         "name": "matrix",
-        "sha256": "f8f78700f967de4333a0c9ca609dac2ae05914a27faa60c5530026b7aca6ae78",
+        "sha256": "996e3b1560959afaa3118ec2b5a06734ad29acf64f9c3c09a605c3ddef22039f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.40.2"
+      "version": "1.0.1"
     },
     "meta": {
       "dependency": "transitive",
@@ -1520,16 +1540,6 @@
       },
       "source": "hosted",
       "version": "2.0.2"
-    },
-    "olm": {
-      "dependency": "transitive",
-      "description": {
-        "name": "olm",
-        "sha256": "6a3fe1e5170b954dd9e4ba3b27513e6aa9b7591eb7bb0d7f6f32140b7f140c6f",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.1.0"
     },
     "opus_caf_converter_dart": {
       "dependency": "direct main",
@@ -2746,6 +2756,16 @@
       },
       "source": "hosted",
       "version": "15.0.0"
+    },
+    "vodozemac": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vodozemac",
+        "sha256": "dba14017e042748fb22d270e8ab1d3e46965b89788dd3857dba938ec07571968",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
     },
     "wakelock_plus": {
       "dependency": "direct main",

--- a/pkgs/by-name/fl/fluffychat/vodozemac-wasm.nix
+++ b/pkgs/by-name/fl/fluffychat/vodozemac-wasm.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  stdenv,
+  fluffychat-web,
+  symlinkJoin,
+  buildPackages,
+  rustc,
+  rustPlatform,
+  cargo,
+  flutter,
+  flutter_rust_bridge_codegen,
+  which,
+  wasm-pack,
+  wasm-bindgen-cli_0_2_100,
+  binaryen,
+  writableTmpDirAsHomeHook,
+  runCommand,
+}:
+
+let
+  pubSources = fluffychat-web.pubspecLock.dependencySources;
+
+  # wasm-pack doesn't take 'RUST_SRC_PATH' into consideration
+  rustcWithLibSrc = buildPackages.rustc.override {
+    sysroot = symlinkJoin {
+      name = "rustc_unwrapped_with_libsrc";
+      paths = [
+        buildPackages.rustc.unwrapped
+      ];
+      postBuild = ''
+        mkdir -p $out/lib/rustlib/src/rust
+        ln -s ${rustPlatform.rustLibSrc} $out/lib/rustlib/src/rust/library
+      '';
+    };
+  };
+in
+
+# https://github.com/krille-chan/fluffychat/blob/main/scripts/prepare-web.sh
+stdenv.mkDerivation {
+  pname = "vodozemac-wasm";
+  inherit (pubSources.vodozemac) version;
+
+  # These two were in the same repository, so just reuse them
+  unpackPhase = ''
+    runHook preUnpack
+
+    cp -r ${pubSources.flutter_vodozemac}/rust ./rust
+    cp -r ${pubSources.vodozemac} ./dart
+    chmod -R +rwx .
+
+    runHook postUnpack
+  '';
+
+  # Remove dev_dependencies to avoid downloading them
+  postPatch = ''
+    sed -i '/^dev_dependencies:/,/^$/d' dart/pubspec.yaml
+  '';
+
+  cargoRoot = "rust";
+
+  cargoDeps = symlinkJoin {
+    name = "vodozemac-wasm-cargodeps";
+    paths = [
+      pubSources.flutter_vodozemac.passthru.cargoDeps
+      # Pull in rust vendor so we don't have to vendor rustLibSrc again
+      # This is required because `-Z build-std=std,panic_abort` rebuilds std
+      rustPlatform.rustVendorSrc
+    ];
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustcWithLibSrc
+    rustc.llvmPackages.lld
+    cargo
+    flutter
+    flutter_rust_bridge_codegen
+    which
+    wasm-pack
+    wasm-bindgen-cli_0_2_100
+    binaryen
+    writableTmpDirAsHomeHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd dart
+      dart pub get --offline
+    popd
+    RUST_LOG=info flutter_rust_bridge_codegen build-web \
+      --dart-root $(realpath ./dart) --rust-root $(realpath ./rust) --release
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r dart/web/pkg/vodozemac_bindings_dart* $out/
+
+    runHook postInstall
+  '';
+
+  env = {
+    # Build a pub cache from fluffychat, as dart-vodozemac should be a subset
+    # This is required because dart-vodozemac, as a pub, doesn't have a pubspec.lock
+    # But flutter_rust_bridge_codegen still requires all dependencies of it
+    PUB_CACHE = runCommand "fluffychat-pub-cache" { } ''
+      mkdir -p $out/hosted/pub.dev
+      pushd $out/hosted/pub.dev
+        ${lib.concatMapAttrsStringSep "; " (
+          _: p:
+          "ln -s ${p} ./${if lib.hasPrefix "pub-" p.name then lib.removePrefix "pub-" p.name else p.name}"
+        ) pubSources}
+      popd
+    '';
+    RUSTC_BOOTSTRAP = 1; # `-Z build-std=std,panic_abort` requires nightly toolchain
+  };
+
+  inherit (fluffychat-web) meta;
+}

--- a/pkgs/by-name/fl/flutter_rust_bridge_codegen/package.nix
+++ b/pkgs/by-name/fl/flutter_rust_bridge_codegen/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   rustPlatform,
   cargo-expand,
+  stdenv,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "flutter_rust_bridge_codegen";
@@ -26,11 +27,17 @@ rustPlatform.buildRustPackage rec {
 
   # needed to run text (see https://github.com/fzyzcjy/flutter_rust_bridge/blob/ae970bfafdf80b9eb283a2167b972fb2e6504511/frb_codegen/src/library/utils/logs.rs#L43)
   logLevel = "debug";
-  checkFlags = [
-    # Disabled because these tests need a different version of anyhow than the package itself
-    "--skip=tests::test_execute_generate_on_frb_example_dart_minimal"
-    "--skip=tests::test_execute_generate_on_frb_example_pure_dart"
-  ];
+  checkFlags =
+    [
+      # Disabled because these tests need a different version of anyhow than the package itself
+      "--skip=tests::test_execute_generate_on_frb_example_dart_minimal"
+      "--skip=tests::test_execute_generate_on_frb_example_pure_dart"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Timeout on darwin, not related to networking in sandbox
+      "--skip=library::codegen::controller::tests::test_run_with_watch"
+      "--skip=library::codegen::generator::api_dart::tests::test_functions"
+    ];
 
   meta = {
     mainProgram = "flutter_rust_bridge_codegen";

--- a/pkgs/development/compilers/dart/package-source-builders/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/default.nix
@@ -5,6 +5,7 @@
   file_picker = callPackage ./file_picker { };
   flutter_discord_rpc = callPackage ./flutter_discord_rpc { };
   flutter_secure_storage_linux = callPackage ./flutter-secure-storage-linux { };
+  flutter_vodozemac = callPackage ./flutter_vodozemac { };
   flutter_volume_controller = callPackage ./flutter_volume_controller { };
   fvp = callPackage ./fvp { };
   handy_window = callPackage ./handy-window { };

--- a/pkgs/development/compilers/dart/package-source-builders/flutter_vodozemac/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/flutter_vodozemac/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  rustPlatform,
+  writeText,
+  stdenv,
+}:
+
+{ version, src, ... }:
+
+let
+  rustDep = rustPlatform.buildRustPackage {
+    pname = "flutter_vodozemac-rs";
+    inherit version src;
+
+    sourceRoot = "${src.name}/rust";
+
+    useFetchCargoVendor = true;
+
+    cargoHash =
+      {
+        _0_2_2 = "sha256-Iw0AkHVjR1YmPe+C0YYBTDu5FsRk/ZpaRyBilcvqm6M=";
+      }
+      .${"_" + (lib.replaceStrings [ "." ] [ "_" ] version)} or (throw ''
+        Unsupported version of pub 'flutter_vodozemac': '${version}'
+        Please add cargoHash here. If the cargoHash
+        is the same with existing versions, add an alias here.
+      '');
+
+    passthru.libraryPath = "lib/libvodozemac_bindings_dart.so";
+  };
+
+  fakeCargokitCmake = writeText "FakeCargokit.cmake" ''
+    function(apply_cargokit target manifest_dir lib_name any_symbol_name)
+      set("''${target}_cargokit_lib" ${rustDep}/${rustDep.passthru.libraryPath} PARENT_SCOPE)
+    endfunction()
+  '';
+
+  getLibraryPath = ''
+    String _getLibraryPath() {
+      if (kIsWeb) {
+        return './';
+      }
+      try {
+        return Platform.resolvedExecutable + '/../lib/libvodozemac_bindings_dart.so';
+      } catch (_) {
+        return './';
+      }
+    }
+  '';
+in
+stdenv.mkDerivation {
+  pname = "flutter_vodozemac";
+  inherit version src;
+  passthru = src.passthru // {
+    # vodozemac-wasm in fluffychat will make use of it
+    inherit (rustDep) cargoDeps;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r "$src" "$out"
+    pushd $out
+      chmod +rwx cargokit/cmake/cargokit.cmake
+      cp ${fakeCargokitCmake} cargokit/cmake/cargokit.cmake
+      chmod +rw lib/flutter_vodozemac.dart
+      substituteInPlace lib/flutter_vodozemac.dart \
+        --replace-warn "libraryPath: './'" "libraryPath: _getLibraryPath()"
+      echo "${getLibraryPath}" >> lib/flutter_vodozemac.dart
+    popd
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -51,6 +51,12 @@
         inherit runCommand rustc;
       };
 
+      # Useful when rebuilding std
+      # e.g. when building wasm with wasm-pack
+      rustVendorSrc = callPackage ./rust-vendor-src.nix {
+        inherit runCommand rustc;
+      };
+
       # Hooks
       inherit
         (callPackages ../../../build-support/rust/hooks {

--- a/pkgs/development/compilers/rust/rust-vendor-src.nix
+++ b/pkgs/development/compilers/rust/rust-vendor-src.nix
@@ -1,0 +1,6 @@
+{ runCommand, rustc }:
+
+runCommand "rust-vendor-src" { } ''
+  tar --strip-components=1 -xzf ${rustc.src}
+  mv vendor $out
+''


### PR DESCRIPTION
The most difficult update, took two full days. Enjoy.

Haven't tested fluffychat-web.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
