### PR TITLE
python3Packages.robotframework-datadriver: init at 1.11.2

### DIFF
--- a/pkgs/development/python-modules/robotframework-datadriver/default.nix
+++ b/pkgs/development/python-modules/robotframework-datadriver/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  version = "1.11.2";
+  pname = "robotframework-datadriver";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "robotframework_datadriver"; # the package file has an underscore instead of a dash
+    sha256 = "sha256-x1o7iFbhQTMeZaIqa+0agmMiHuba2CHVJvkykYV2//0=";
+  };
+
+  meta = with lib; {
+    description = "Library to provide Data-Driven testing with CSV tables to Robot Framework";
+    homepage = "https://github.com/Snooz82/robotframework-datadriver/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tobiasBora ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15533,6 +15533,8 @@ self: super: with self; {
     callPackage ../development/python-modules/robotframework-databaselibrary
       { };
 
+  robotframework-datadriver = callPackage ../development/python-modules/robotframework-datadriver { };
+
   robotframework-excellib = callPackage ../development/python-modules/robotframework-excellib { };
 
   robotframework-pythonlibcore =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Robotframework-datadriver is a library (described in robotframework's documentation https://docs.robotframework.org/docs/testcase_styles/datadriven) that is used to run many tests/RPA tasks based on a simple CSV/excel/database/… file. This is particularly useful when doing RPA tasks involving many similar actions.

You can test this PR by creating a file `test.robot`:
```
*** Settings ***
Library        DataDriver    file=students.csv  encoding=utf_8
Test Template  Add instrument

*** Tasks ***

Add ${user} with instrument ${instrument}  Me  Piano

*** Keywords ***

Add instrument
    [Arguments]    ${user}    ${instrument}
    Log Many    ${user}    ${instrument}
```
and a file `students.csv` containing:
```
${user};${instrument}
Alice;Guitar
Bob;Piano
```
Then, after installing `python3.withPackages (ps: with ps; [robotframework robotframework-datadriver])`, you should be ale to run:
```
$ robot test.robot
```
that should print two passing tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
