### PR TITLE
icbm3d, xgalagapp: fix darwin and cross-compiled builds

### DIFF
--- a/pkgs/by-name/ic/icbm3d/package.nix
+++ b/pkgs/by-name/ic/icbm3d/package.nix
@@ -16,11 +16,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ libX11 ];
 
+  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ]; # fix darwin and cross-compiled builds
+
   # Function are declared after they are used in the file, this is error since gcc-14.
   #   randnum.c:25:3: warning: implicit declaration of function 'srand' [-Wimplicit-function-declaration]
   #   randnum.c:33:7: warning: implicit declaration of function 'rand'; did you mean 'randnum'? [-Wimplicit-function-declaration]
   #   text.c:34:50: warning: implicit declaration of function 'strlen' [-Wimplicit-function-declaration]
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  postPatch = ''
+    substituteInPlace randnum.c --replace-fail 'stdio.h' 'stdlib.h'
+    sed -i '1i\
+    #include <string.h>' text.c
+  '';
 
   installPhase = ''
     runHook preInstall
@@ -35,6 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "3D vector-based clone of the atari game Missile Command";
     mainProgram = "icbm3d";
     license = lib.licenses.gpl2Plus;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ic/icbm3d/package.nix
+++ b/pkgs/by-name/ic/icbm3d/package.nix
@@ -26,6 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace randnum.c --replace-fail 'stdio.h' 'stdlib.h'
     sed -i '1i\
     #include <string.h>' text.c
+
+    # The Makefile tries to install icbm3d immediately after building it, and
+    # ends up trying to copy it to /icbm3d. Normally this just gets an error
+    # and moves on, but it's probably better to not try it in the first place.
+    sed -i '/INSTALLROOT/d' makefile
   '';
 
   installPhase = ''

--- a/pkgs/by-name/xg/xgalagapp/package.nix
+++ b/pkgs/by-name/xg/xgalagapp/package.nix
@@ -19,14 +19,20 @@ stdenv.mkDerivation rec {
     libXpm
   ];
 
-  buildPhase = ''
-    make all HIGH_SCORES_FILE=.xgalaga++.scores
-  '';
+  buildFlags = [
+    "all"
+    "HIGH_SCORES_FILE=.xgalaga++.scores"
+    "CXX=${stdenv.cc.targetPrefix}c++" # fix darwin and cross-compiled builds
+  ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/share/man
     mv xgalaga++ $out/bin
     mv xgalaga++.6x $out/share/man
+
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -34,6 +40,6 @@ stdenv.mkDerivation rec {
     description = "XGalaga++ is a classic single screen vertical shoot ’em up. It is inspired by XGalaga and reuses most of its sprites";
     mainProgram = "xgalaga++";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Let me know if you would prefer these split into separate PRs.

## `icbm3d`
- Forces `$CC` back to the correct value so it doesn't just assume `gcc`.
- Patches `randnum.c` and `text.c` to use the correct `#include`s instead of just ignoring the implicit declaration warnings.
- Keeps the Makefile from running its own install command that tries to write outside the store.

## `xgalagapp`
- Forces `$CXX` back to the correct value so it doesn't just assume `g++`.
- Also rewrites the derivation to use the standard `buildPhase`, and properly call the `preInstall` and `postInstall` hooks.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
