### PR TITLE
actions/get-merge-commit: checkout trusted/untrusted as worktrees

### DIFF
--- a/.github/actions/get-merge-commit/action.yml
+++ b/.github/actions/get-merge-commit/action.yml
@@ -80,16 +80,13 @@ runs:
           throw new Error("Not retrying anymore. It's likely that GitHub is having internal issues: check https://www.githubstatus.com.")
 
     - if: inputs.merged-as-untrusted && (inputs.mergedSha || steps.commits.outputs.mergedSha)
-      # Would be great to do the checkouts in git worktrees of the existing spare checkout instead,
-      # but Nix is broken with them:
-      # https://github.com/NixOS/nix/issues/6073
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        ref: ${{ inputs.mergedSha || steps.commits.outputs.mergedSha }}
-        path: untrusted
+      shell: bash
+      run: |
+        git fetch --depth 1 origin ${{ inputs.mergedSha || steps.commits.outputs.mergedSha }}
+        git worktree add untrusted ${{ inputs.mergedSha || steps.commits.outputs.mergedSha }}
 
     - if: inputs.target-as-trusted && (inputs.targetSha || steps.commits.outputs.targetSha)
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        ref: ${{ inputs.targetSha || steps.commits.outputs.targetSha }}
-        path: trusted
+      shell: bash
+      run: |
+        git fetch --depth 1 origin ${{ inputs.targetSha || steps.commits.outputs.targetSha }}
+        git worktree add trusted ${{ inputs.targetSha || steps.commits.outputs.targetSha }}

--- a/.github/actions/get-merge-commit/action.yml
+++ b/.github/actions/get-merge-commit/action.yml
@@ -84,9 +84,11 @@ runs:
       run: |
         git fetch --depth 1 origin ${{ inputs.mergedSha || steps.commits.outputs.mergedSha }}
         git worktree add untrusted ${{ inputs.mergedSha || steps.commits.outputs.mergedSha }}
+        git -C untrusted sparse-checkout disable
 
     - if: inputs.target-as-trusted && (inputs.targetSha || steps.commits.outputs.targetSha)
       shell: bash
       run: |
         git fetch --depth 1 origin ${{ inputs.targetSha || steps.commits.outputs.targetSha }}
         git worktree add trusted ${{ inputs.targetSha || steps.commits.outputs.targetSha }}
+        git -C trusted sparse-checkout disable

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ name: PR
 on:
   pull_request:
     paths:
+      - .github/actions/get-merge-commit/action.yml
       - .github/workflows/build.yml
       - .github/workflows/check.yml
       - .github/workflows/eval.yml


### PR DESCRIPTION
This should be minimally more efficient, but ultimately it's just the "right" thing to do - why keep multiple .git repos around?

Possible after Nix was updated and include a fix around worktrees in shallow clones.

Needs:
- [ ] https://github.com/NixOS/nix/issues/6073
- [ ] https://github.com/NixOS/nix/pull/13260

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
