### PR TITLE
cargo: Add cargo-wrapper for adding cargo subcommands to Cargo's environment

### DIFF
--- a/pkgs/by-name/op/open-scq30/package.nix
+++ b/pkgs/by-name/op/open-scq30/package.nix
@@ -12,59 +12,61 @@
   gtk4,
   libadwaita,
   pango,
-  cargo-make,
 }:
 
-rustPlatform.buildRustPackage rec {
-  pname = "open-scq30";
-  version = "1.12.0";
+rustPlatform.buildRustPackage.override
+  (old: {
+    cargo = old.cargo.withCommands (c: [ c.cargo-make ]);
+  })
+  (finalAttrs: {
+    pname = "open-scq30";
+    version = "1.12.0";
 
-  src = fetchFromGitHub {
-    owner = "Oppzippy";
-    repo = "OpenSCQ30";
-    rev = "v${version}";
-    hash = "sha256-DL2hYm1j27K0nnBvE3iGnguqm0m1k56bkuG+6+u4u4c=";
-  };
+    src = fetchFromGitHub {
+      owner = "Oppzippy";
+      repo = "OpenSCQ30";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-DL2hYm1j27K0nnBvE3iGnguqm0m1k56bkuG+6+u4u4c=";
+    };
 
-  nativeBuildInputs = [
-    pkg-config
-    protobuf
-    wrapGAppsHook4
-    cargo-make
-  ];
+    nativeBuildInputs = [
+      pkg-config
+      protobuf
+      wrapGAppsHook4
+    ];
 
-  buildInputs = [
-    cairo
-    dbus
-    gdk-pixbuf
-    glib
-    gtk4
-    libadwaita
-    pango
-  ];
+    buildInputs = [
+      cairo
+      dbus
+      gdk-pixbuf
+      glib
+      gtk4
+      libadwaita
+      pango
+    ];
 
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-3K+/CpTGWSjCRa2vOEcDvLIiZMdntugIqnzkXF4wkng=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-3K+/CpTGWSjCRa2vOEcDvLIiZMdntugIqnzkXF4wkng=";
 
-  INSTALL_PREFIX = placeholder "out";
+    INSTALL_PREFIX = placeholder "out";
 
-  # Requires headphones
-  doCheck = false;
+    # Requires headphones
+    doCheck = false;
 
-  buildPhase = ''
-    cargo make --profile release build
-  '';
+    buildPhase = ''
+      cargo make --profile release build
+    '';
 
-  installPhase = ''
-    cargo make --profile release install
-  '';
+    installPhase = ''
+      cargo make --profile release install
+    '';
 
-  meta = with lib; {
-    description = "Cross platform application for controlling settings of Soundcore headphones";
-    homepage = "https://github.com/Oppzippy/OpenSCQ30";
-    changelog = "https://github.com/Oppzippy/OpenSCQ30/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ mkg20001 ];
-    mainProgram = "open-scq30";
-  };
-}
+    meta = {
+      description = "Cross platform application for controlling settings of Soundcore headphones";
+      homepage = "https://github.com/Oppzippy/OpenSCQ30";
+      changelog = "https://github.com/Oppzippy/OpenSCQ30/blob/v${finalAttrs.version}/CHANGELOG.md";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [ mkg20001 ];
+      mainProgram = "open-scq30";
+    };
+  })

--- a/pkgs/by-name/tr/tracexec/package.nix
+++ b/pkgs/by-name/tr/tracexec/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   rustPlatform,
-  cargo-about,
   nix-update-script,
   pkg-config,
   libbpf,
@@ -13,84 +12,85 @@
   clang,
 }:
 
-rustPlatform.buildRustPackage rec {
-  pname = "tracexec";
-  version = "0.12.0";
+rustPlatform.buildRustPackage.override
+  (old: { cargo = old.cargo.withCommands (c: [ c.cargo-about ]); })
+  (finalAttrs: {
+    pname = "tracexec";
+    version = "0.12.0";
 
-  src = fetchFromGitHub {
-    owner = "kxxt";
-    repo = "tracexec";
-    tag = "v${version}";
-    hash = "sha256-j1zgHDO5bmJAXi9KvkHqenm/QfM9DmD9yNqF6TxJ9sY=";
-  };
+    src = fetchFromGitHub {
+      owner = "kxxt";
+      repo = "tracexec";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-j1zgHDO5bmJAXi9KvkHqenm/QfM9DmD9yNqF6TxJ9sY=";
+    };
 
-  # remove if updating to rust 1.85
-  postPatch = ''
-    substituteInPlace Cargo.toml \
-      --replace-fail "[package]" ''$'cargo-features = ["edition2024"]\n[package]' \
-      --replace-fail 'rust-version = "1.85"' ""
-  '';
+    # remove if updating to rust 1.85
+    postPatch = ''
+      substituteInPlace Cargo.toml \
+        --replace-fail "[package]" ''$'cargo-features = ["edition2024"]\n[package]' \
+        --replace-fail 'rust-version = "1.85"' ""
+    '';
 
-  # remove if updating to rust 1.85
-  env.RUSTC_BOOTSTRAP = 1;
+    # remove if updating to rust 1.85
+    env.RUSTC_BOOTSTRAP = 1;
 
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-XuuLuIeD/S60by/hg1fR+ML3PtIyX9JNrEvgGzI3UiM=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-XuuLuIeD/S60by/hg1fR+ML3PtIyX9JNrEvgGzI3UiM=";
 
-  hardeningDisable = [ "zerocallusedregs" ];
+    hardeningDisable = [ "zerocallusedregs" ];
 
-  nativeBuildInputs = [
-    cargo-about
-    pkg-config
-    clang
-  ];
-
-  buildInputs = [
-    libbpf
-    elfutils
-    libseccomp
-    zlib
-  ];
-
-  cargoBuildFlags =
-    [
-      "--no-default-features"
-      "--features=recommended"
-    ]
-    # Remove RiscV64 specialisation when this is fixed:
-    # * https://github.com/NixOS/nixpkgs/pull/310158#pullrequestreview-2046944158
-    # * https://github.com/rust-vmm/seccompiler/pull/72
-    ++ lib.optional stdenv.hostPlatform.isRiscV64 "--no-default-features";
-
-  preBuild = ''
-    sed -i '1ino-clearly-defined = true' about.toml  # disable network requests
-    cargo about generate --config about.toml -o THIRD_PARTY_LICENSES.HTML about.hbs
-  '';
-
-  checkFlags = [
-    "--skip=cli::test::log_mode_without_args_works" # `Permission denied` (needs `CAP_SYS_PTRACE`)
-  ];
-
-  postInstall = ''
-    # Remove test binaries (e.g. `empty-argv`, `corrupted-envp`) and only retain `tracexec`
-    find "$out/bin" -type f \! -name tracexec -print0 | xargs -0 rm -v
-
-    install -Dm644 LICENSE -t "$out/share/licenses/tracexec/"
-    install -Dm644 THIRD_PARTY_LICENSES.HTML -t "$out/share/licenses/tracexec/"
-  '';
-
-  passthru.updateScript = nix-update-script { };
-
-  meta = {
-    changelog = "https://github.com/kxxt/tracexec/blob/v${version}/CHANGELOG.md";
-    description = "Small utility for tracing execve{,at} and pre-exec behavior";
-    homepage = "https://github.com/kxxt/tracexec";
-    license = lib.licenses.gpl2Plus;
-    mainProgram = "tracexec";
-    maintainers = with lib.maintainers; [
-      fpletz
-      nh2
+    nativeBuildInputs = [
+      pkg-config
+      clang
     ];
-    platforms = lib.platforms.linux;
-  };
-}
+
+    buildInputs = [
+      libbpf
+      elfutils
+      libseccomp
+      zlib
+    ];
+
+    cargoBuildFlags =
+      [
+        "--no-default-features"
+        "--features=recommended"
+      ]
+      # Remove RiscV64 specialisation when this is fixed:
+      # * https://github.com/NixOS/nixpkgs/pull/310158#pullrequestreview-2046944158
+      # * https://github.com/rust-vmm/seccompiler/pull/72
+      ++ lib.optional stdenv.hostPlatform.isRiscV64 "--no-default-features";
+
+    preBuild = ''
+      sed -i '1ino-clearly-defined = true' about.toml  # disable network requests
+      cargo about generate --config about.toml -o THIRD_PARTY_LICENSES.HTML about.hbs
+    '';
+
+    checkFlags = [
+      "--skip=cli::test::log_mode_without_args_works" # `Permission denied` (needs `CAP_SYS_PTRACE`)
+    ];
+
+    postInstall = ''
+      # Remove test binaries (e.g. `empty-argv`, `corrupted-envp`) and only retain `tracexec`
+      find "$out/bin" -type f \! -name tracexec -print0 | xargs -0 rm -v
+
+      install -Dm644 LICENSE -t "$out/share/licenses/tracexec/"
+      install -Dm644 THIRD_PARTY_LICENSES.HTML -t "$out/share/licenses/tracexec/"
+    '';
+
+    passthru.updateScript = nix-update-script { };
+
+    meta = {
+      changelog = "https://github.com/kxxt/tracexec/blob/v${finalAttrs.version}/CHANGELOG.md";
+      description = "Small utility for tracing execve{,at} and pre-exec behavior";
+      homepage = "https://github.com/kxxt/tracexec";
+      license = lib.licenses.gpl2Plus;
+      mainProgram = "tracexec";
+      maintainers = with lib.maintainers; [
+        fpletz
+        nh2
+      ];
+      platforms = lib.platforms.linux;
+    };
+  })

--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -25,10 +25,8 @@
   vulkan-loader,
   envsubst,
   nix-update-script,
-  cargo-about,
   versionCheckHook,
   buildFHSEnv,
-  cargo-bundle,
   git,
   apple-sdk_15,
   darwinMinVersionHook,
@@ -97,51 +95,56 @@ let
 
   gpu-lib = if withGLES then libglvnd else vulkan-loader;
 in
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "zed-editor";
-  version = "0.191.7";
+rustPlatform.buildRustPackage.override
+  (old: {
+    cargo = old.cargo.withCommands (
+      c: [ c.cargo-about ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ c.cargo-bundle ]
+    );
+  })
+  (finalAttrs: {
+    pname = "zed-editor";
+    version = "0.191.7";
 
-  outputs =
-    [ "out" ]
-    ++ lib.optionals buildRemoteServer [
-      "remote_server"
+    outputs =
+      [ "out" ]
+      ++ lib.optionals buildRemoteServer [
+        "remote_server"
+      ];
+
+    src = fetchFromGitHub {
+      owner = "zed-industries";
+      repo = "zed";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-Kx9VolPqKR0ML7F7ITnp5GPT4ULJvmTsRHKgkKZPGwQ=";
+    };
+
+    patches = [
+      # Upstream delegates linking on Linux to clang to make use of mold,
+      # but builds fine with our standard linker.
+      # This patch removes their linker override from the cargo config.
+      ./0001-linux-linker.patch
     ];
 
-  src = fetchFromGitHub {
-    owner = "zed-industries";
-    repo = "zed";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-Kx9VolPqKR0ML7F7ITnp5GPT4ULJvmTsRHKgkKZPGwQ=";
-  };
+    cargoPatches = [
+      ./0002-fix-duplicate-reqwest.patch
+    ];
 
-  patches = [
-    # Upstream delegates linking on Linux to clang to make use of mold,
-    # but builds fine with our standard linker.
-    # This patch removes their linker override from the cargo config.
-    ./0001-linux-linker.patch
-  ];
+    postPatch =
+      # Dynamically link WebRTC instead of static
+      ''
+        substituteInPlace $cargoDepsCopy/webrtc-sys-*/build.rs \
+          --replace-fail "cargo:rustc-link-lib=static=webrtc" "cargo:rustc-link-lib=dylib=webrtc"
 
-  cargoPatches = [
-    ./0002-fix-duplicate-reqwest.patch
-  ];
+        # Zed team renamed the function but forgot to update its usage in this file
+        # We rename it ourselves for now, until upstream fixes the issue
+        substituteInPlace $cargoDepsCopy/reqwest-0.12*/src/blocking/client.rs \
+          --replace-fail "inner.redirect(policy)" "inner.redirect_policy(policy)"
+      '';
 
-  postPatch =
-    # Dynamically link WebRTC instead of static
-    ''
-      substituteInPlace $cargoDepsCopy/webrtc-sys-*/build.rs \
-        --replace-fail "cargo:rustc-link-lib=static=webrtc" "cargo:rustc-link-lib=dylib=webrtc"
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-MMQYbhv/6s+9zxP9E5bcCDS9TUYSbapkX5sklVpNHnI=";
 
-      # Zed team renamed the function but forgot to update its usage in this file
-      # We rename it ourselves for now, until upstream fixes the issue
-      substituteInPlace $cargoDepsCopy/reqwest-0.12*/src/blocking/client.rs \
-        --replace-fail "inner.redirect(policy)" "inner.redirect_policy(policy)"
-    '';
-
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-MMQYbhv/6s+9zxP9E5bcCDS9TUYSbapkX5sklVpNHnI=";
-
-  nativeBuildInputs =
-    [
+    nativeBuildInputs = [
       cmake
       copyDesktopItems
       curl
@@ -149,200 +152,197 @@ rustPlatform.buildRustPackage (finalAttrs: {
       pkg-config
       protobuf
       rustPlatform.bindgenHook
-      cargo-about
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ makeBinaryWrapper ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ cargo-bundle ];
+    ] ++ lib.optionals stdenv.hostPlatform.isLinux [ makeBinaryWrapper ];
 
-  dontUseCmakeConfigure = true;
+    dontUseCmakeConfigure = true;
 
-  buildInputs =
-    [
-      curl
-      fontconfig
-      freetype
-      libgit2
-      openssl
-      sqlite
-      zlib
-      zstd
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      alsa-lib
-      libxkbcommon
-      wayland
-      xorg.libxcb
-      # required by livekit:
-      libGL
-      libX11
-      libXext
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      apple-sdk_15
-      # ScreenCaptureKit, required by livekit, is only available on 12.3 and up:
-      # https://developer.apple.com/documentation/screencapturekit
-      (darwinMinVersionHook "12.3")
-    ];
-
-  cargoBuildFlags = [
-    "--package=zed"
-    "--package=cli"
-  ] ++ lib.optionals buildRemoteServer [ "--package=remote_server" ];
-
-  # Required on darwin because we don't have access to the
-  # proprietary Metal shader compiler.
-  buildFeatures = lib.optionals stdenv.hostPlatform.isDarwin [ "gpui/runtime_shaders" ];
-
-  env = {
-    ALLOW_MISSING_LICENSES = true;
-    ZSTD_SYS_USE_PKG_CONFIG = true;
-    FONTCONFIG_FILE = makeFontsConf {
-      fontDirectories = [
-        "${finalAttrs.src}/assets/fonts/plex-mono"
-        "${finalAttrs.src}/assets/fonts/plex-sans"
+    buildInputs =
+      [
+        curl
+        fontconfig
+        freetype
+        libgit2
+        openssl
+        sqlite
+        zlib
+        zstd
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        alsa-lib
+        libxkbcommon
+        wayland
+        xorg.libxcb
+        # required by livekit:
+        libGL
+        libX11
+        libXext
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        apple-sdk_15
+        # ScreenCaptureKit, required by livekit, is only available on 12.3 and up:
+        # https://developer.apple.com/documentation/screencapturekit
+        (darwinMinVersionHook "12.3")
       ];
+
+    cargoBuildFlags = [
+      "--package=zed"
+      "--package=cli"
+    ] ++ lib.optionals buildRemoteServer [ "--package=remote_server" ];
+
+    # Required on darwin because we don't have access to the
+    # proprietary Metal shader compiler.
+    buildFeatures = lib.optionals stdenv.hostPlatform.isDarwin [ "gpui/runtime_shaders" ];
+
+    env = {
+      ALLOW_MISSING_LICENSES = true;
+      ZSTD_SYS_USE_PKG_CONFIG = true;
+      FONTCONFIG_FILE = makeFontsConf {
+        fontDirectories = [
+          "${finalAttrs.src}/assets/fonts/plex-mono"
+          "${finalAttrs.src}/assets/fonts/plex-sans"
+        ];
+      };
+      # Setting this environment variable allows to disable auto-updates
+      # https://zed.dev/docs/development/linux#notes-for-packaging-zed
+      ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
+      # Used by `zed --version`
+      RELEASE_VERSION = finalAttrs.version;
+      LK_CUSTOM_WEBRTC = livekit-libwebrtc;
     };
-    # Setting this environment variable allows to disable auto-updates
-    # https://zed.dev/docs/development/linux#notes-for-packaging-zed
-    ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
-    # Used by `zed --version`
-    RELEASE_VERSION = finalAttrs.version;
-    LK_CUSTOM_WEBRTC = livekit-libwebrtc;
-  };
 
-  RUSTFLAGS = lib.optionalString withGLES "--cfg gles";
+    RUSTFLAGS = lib.optionalString withGLES "--cfg gles";
 
-  preBuild = ''
-    bash script/generate-licenses
-  '';
-
-  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-    patchelf --add-rpath ${gpu-lib}/lib $out/libexec/*
-    patchelf --add-rpath ${wayland}/lib $out/libexec/*
-    wrapProgram $out/libexec/zed-editor --suffix PATH : ${lib.makeBinPath [ nodejs ]}
-  '';
-
-  nativeCheckInputs = [
-    writableTmpDirAsHomeHook
-  ];
-
-  checkFlags =
-    [
-      # Flaky: unreliably fails on certain hosts (including Hydra)
-      "--skip=zed::tests::test_window_edit_state_restoring_enabled"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      # Fails on certain hosts (including Hydra) for unclear reason
-      "--skip=test_open_paths_action"
-    ];
-
-  installPhase =
-    ''
-      runHook preInstall
-
-      release_target="target/${stdenv.hostPlatform.rust.cargoShortTarget}/release"
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # cargo-bundle expects the binary in target/release
-      mv $release_target/zed target/release/zed
-
-      pushd crates/zed
-
-      # Note that this is GNU sed, while Zed's bundle-mac uses BSD sed
-      sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
-      export CARGO_BUNDLE_SKIP_BUILD=true
-      app_path=$(cargo bundle --release | xargs)
-
-      # We're not using Zed's fork of cargo-bundle, so we must manually append their plist extensions
-      # Remove closing tags from Info.plist (last two lines)
-      head -n -2 $app_path/Contents/Info.plist > Info.plist
-      # Append extensions
-      cat resources/info/*.plist >> Info.plist
-      # Add closing tags
-      printf "</dict>\n</plist>\n" >> Info.plist
-      mv Info.plist $app_path/Contents/Info.plist
-
-      popd
-
-      mkdir -p $out/Applications $out/bin
-      # Zed expects git next to its own binary
-      ln -s ${lib.getExe git} $app_path/Contents/MacOS/git
-      mv $release_target/cli $app_path/Contents/MacOS/cli
-      mv $app_path $out/Applications/
-
-      # Physical location of the CLI must be inside the app bundle as this is used
-      # to determine which app to start
-      ln -s $out/Applications/Zed.app/Contents/MacOS/cli $out/bin/zeditor
-    ''
-    + lib.optionalString stdenv.hostPlatform.isLinux ''
-      install -Dm755 $release_target/zed $out/libexec/zed-editor
-      install -Dm755 $release_target/cli $out/bin/zeditor
-
-      install -Dm644 $src/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/1024x1024@2x/apps/zed.png
-      install -Dm644 $src/crates/zed/resources/app-icon.png $out/share/icons/hicolor/512x512/apps/zed.png
-
-      # extracted from https://github.com/zed-industries/zed/blob/v0.141.2/script/bundle-linux (envsubst)
-      # and https://github.com/zed-industries/zed/blob/v0.141.2/script/install.sh (final desktop file name)
-      (
-        export DO_STARTUP_NOTIFY="true"
-        export APP_CLI="zeditor"
-        export APP_ICON="zed"
-        export APP_NAME="Zed"
-        export APP_ARGS="%U"
-        mkdir -p "$out/share/applications"
-        ${lib.getExe envsubst} < "crates/zed/resources/zed.desktop.in" > "$out/share/applications/dev.zed.Zed.desktop"
-      )
-    ''
-    + lib.optionalString buildRemoteServer ''
-      install -Dm755 $release_target/remote_server $remote_server/bin/zed-remote-server-stable-$version
-    ''
-    + ''
-      runHook postInstall
+    preBuild = ''
+      bash script/generate-licenses
     '';
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
-  versionCheckProgram = "${placeholder "out"}/bin/zeditor";
-  versionCheckProgramArg = "--version";
-  doInstallCheck = true;
+    postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf --add-rpath ${gpu-lib}/lib $out/libexec/*
+      patchelf --add-rpath ${wayland}/lib $out/libexec/*
+      wrapProgram $out/libexec/zed-editor --suffix PATH : ${lib.makeBinPath [ nodejs ]}
+    '';
 
-  passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--version-regex"
-        "^v(?!.*(?:-pre|0\.999999\.0|0\.9999-temporary)$)(.+)$"
-      ];
-    };
-    fhs = fhs { zed-editor = finalAttrs.finalPackage; };
-    fhsWithPackages =
-      f:
-      fhs {
-        zed-editor = finalAttrs.finalPackage;
-        additionalPkgs = f;
-      };
-    tests =
-      {
-        remoteServerVersion = testers.testVersion {
-          package = finalAttrs.finalPackage.remote_server;
-          command = "zed-remote-server-stable-${finalAttrs.version} version";
-        };
-      }
-      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
-        withGles = zed-editor.override { withGLES = true; };
-      };
-  };
-
-  meta = {
-    description = "High-performance, multiplayer code editor from the creators of Atom and Tree-sitter";
-    homepage = "https://zed.dev";
-    changelog = "https://github.com/zed-industries/zed/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [
-      GaetanLepage
-      niklaskorz
+    nativeCheckInputs = [
+      writableTmpDirAsHomeHook
     ];
-    mainProgram = "zeditor";
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-  };
-})
+
+    checkFlags =
+      [
+        # Flaky: unreliably fails on certain hosts (including Hydra)
+        "--skip=zed::tests::test_window_edit_state_restoring_enabled"
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        # Fails on certain hosts (including Hydra) for unclear reason
+        "--skip=test_open_paths_action"
+      ];
+
+    installPhase =
+      ''
+        runHook preInstall
+
+        release_target="target/${stdenv.hostPlatform.rust.cargoShortTarget}/release"
+      ''
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        # cargo-bundle expects the binary in target/release
+        mv $release_target/zed target/release/zed
+
+        pushd crates/zed
+
+        # Note that this is GNU sed, while Zed's bundle-mac uses BSD sed
+        sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
+        export CARGO_BUNDLE_SKIP_BUILD=true
+        app_path=$(cargo bundle --release | xargs)
+
+        # We're not using Zed's fork of cargo-bundle, so we must manually append their plist extensions
+        # Remove closing tags from Info.plist (last two lines)
+        head -n -2 $app_path/Contents/Info.plist > Info.plist
+        # Append extensions
+        cat resources/info/*.plist >> Info.plist
+        # Add closing tags
+        printf "</dict>\n</plist>\n" >> Info.plist
+        mv Info.plist $app_path/Contents/Info.plist
+
+        popd
+
+        mkdir -p $out/Applications $out/bin
+        # Zed expects git next to its own binary
+        ln -s ${lib.getExe git} $app_path/Contents/MacOS/git
+        mv $release_target/cli $app_path/Contents/MacOS/cli
+        mv $app_path $out/Applications/
+
+        # Physical location of the CLI must be inside the app bundle as this is used
+        # to determine which app to start
+        ln -s $out/Applications/Zed.app/Contents/MacOS/cli $out/bin/zeditor
+      ''
+      + lib.optionalString stdenv.hostPlatform.isLinux ''
+        install -Dm755 $release_target/zed $out/libexec/zed-editor
+        install -Dm755 $release_target/cli $out/bin/zeditor
+
+        install -Dm644 $src/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/1024x1024@2x/apps/zed.png
+        install -Dm644 $src/crates/zed/resources/app-icon.png $out/share/icons/hicolor/512x512/apps/zed.png
+
+        # extracted from https://github.com/zed-industries/zed/blob/v0.141.2/script/bundle-linux (envsubst)
+        # and https://github.com/zed-industries/zed/blob/v0.141.2/script/install.sh (final desktop file name)
+        (
+          export DO_STARTUP_NOTIFY="true"
+          export APP_CLI="zeditor"
+          export APP_ICON="zed"
+          export APP_NAME="Zed"
+          export APP_ARGS="%U"
+          mkdir -p "$out/share/applications"
+          ${lib.getExe envsubst} < "crates/zed/resources/zed.desktop.in" > "$out/share/applications/dev.zed.Zed.desktop"
+        )
+      ''
+      + lib.optionalString buildRemoteServer ''
+        install -Dm755 $release_target/remote_server $remote_server/bin/zed-remote-server-stable-$version
+      ''
+      + ''
+        runHook postInstall
+      '';
+
+    nativeInstallCheckInputs = [
+      versionCheckHook
+    ];
+    versionCheckProgram = "${placeholder "out"}/bin/zeditor";
+    versionCheckProgramArg = "--version";
+    doInstallCheck = true;
+
+    passthru = {
+      updateScript = nix-update-script {
+        extraArgs = [
+          "--version-regex"
+          "^v(?!.*(?:-pre|0\.999999\.0|0\.9999-temporary)$)(.+)$"
+        ];
+      };
+      fhs = fhs { zed-editor = finalAttrs.finalPackage; };
+      fhsWithPackages =
+        f:
+        fhs {
+          zed-editor = finalAttrs.finalPackage;
+          additionalPkgs = f;
+        };
+      tests =
+        {
+          remoteServerVersion = testers.testVersion {
+            package = finalAttrs.finalPackage.remote_server;
+            command = "zed-remote-server-stable-${finalAttrs.version} version";
+          };
+        }
+        // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+          withGles = zed-editor.override { withGLES = true; };
+        };
+    };
+
+    meta = {
+      description = "High-performance, multiplayer code editor from the creators of Atom and Tree-sitter";
+      homepage = "https://zed.dev";
+      changelog = "https://github.com/zed-industries/zed/releases/tag/v${finalAttrs.version}";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [
+        GaetanLepage
+        niklaskorz
+      ];
+      mainProgram = "zeditor";
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    };
+  })

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   pkgsHostHost,
+  callPackage,
   file,
   curl,
   pkg-config,
@@ -36,6 +37,11 @@ rustPlatform.buildRustPackage.override
       passthru = {
         rustc = rustc;
         inherit (rustc.unwrapped) tests;
+
+        # cargo.withCommands (c: [ c.cargo-fuzz c.cargo-vet c.cargo-pgo ]);
+        withCommands = callPackage ./make-cargo-wrapper.nix {
+          cargoSubcommands = lib.filterAttrs (name: _: lib.hasPrefix "cargo-" name) pkgsHostHost;
+        };
       };
 
       # changes hash of vendor directory otherwise

--- a/pkgs/development/compilers/rust/make-cargo-wrapper.nix
+++ b/pkgs/development/compilers/rust/make-cargo-wrapper.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  runCommand,
+  cargo,
+  makeBinaryWrapper,
+  cargoSubcommands,
+}:
+
+lib.makeOverridable (
+  subcommands: f:
+  runCommand "cargo-wrapper"
+    {
+      inherit (cargo) version meta;
+      buildInputs = [
+        makeBinaryWrapper
+      ];
+    }
+    ''
+      mkdir -p "$out/bin"
+      makeWrapper "${lib.getExe cargo}" "$out/bin/cargo" \
+        --prefix PATH : ${lib.makeBinPath (f subcommands)}
+    ''
+) cargoSubcommands


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Add cargo-wrapper
Example: `cargo.withCommands(c: [ c.cargo-fuzz ])`
2. Change several of the packages in nixpkgs to use the wrapper as examples

**Question:**
Would it be less confusing to modify the attrset keys so they do not have the `cargo-` prefix? For example with the above example, it would be `cargo.withCommands(c: [ c.fuzz ])`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
