### PR TITLE
maintainers/README.md: expand section on maintainer tooling

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -58,10 +58,34 @@ person as a reviewer, and then waiting a week for a reaction.
 
 The maintainer is welcome to come back at any time.
 
-### Tools for maintainers
+## Tools for maintainers
 
-When a pull request is made against a package, OfBorg will notify the
-appropriate maintainer(s).
+When a pull request is made against a package, nixpkgs CI will notify the appropriate
+maintainer(s) by trying to correlate the files the PR touches with the packages that need rebuilding.
+
+Maintainers can also invoke the [nixpkgs-merge-bot](https://github.com/nixos/nixpkgs-merge-bot)
+to merge pull requests targeting packages they are the maintainer of, which satisfy the current
+security [constraints](https://github.com/NixOS/nixpkgs-merge-bot/blob/main/README.md#constraints).
+Examples: [#397273](https://github.com/NixOS/nixpkgs/pull/397273#issuecomment-2789382120) and [#377027](https://github.com/NixOS/nixpkgs/pull/377027#issuecomment-2614510869)
+
+New maintainers will automatically get invited to join the [NixOS/nixpkgs-maintainers](https://github.com/orgs/NixOS/teams/nixpkgs-maintainers) GitHub team.
+By joining, you will get some triaging rights in the nixpkgs repository, like the ability to close and reopen issues made by others, and managing labels.
+However, the GitHub team invite is usually only sent by email, and is only valid for one week!
+Should it expire, please ask for a re-invite in the [GitHub org owners help desk Matrix channel](https://matrix.to/#/#org_owners:nixos.org).
+
+### Unofficial maintainer tooling
+
+[zh.fail](https://zh.fail/failed/overview.html) tracks all package build failures on `master` grouped by maintainer.
+
+[asymmetric/nixpkgs-update-notifier](https://github.com/asymmetric/nixpkgs-update-notifier) is a matrix
+bot that scrapes the [nixpkgs-update logs](https://nixpkgs-update-logs.nix-community.org/) and notifies
+you if nixpkgs-update/@r-ryantm fails to update any of the packages you've subscribed to.
+
+[repology.org](https://repology.org) tracks and compares the versions of packages between various package repositories, letting you know what packages may be out of date or insecure.
+You can view which packages a specific maintainer maintains and subscribe to updates with atom/rss. Example: [repology.org/maintainer/pbsds](https://repology.org/maintainer/pbsds%40hotmail.com).
+
+[nixpk.gs/pr-tracker](https://nixpk.gs/pr-tracker.html) and [nixpkgs-tracker.ocfox.me](https://nixpkgs-tracker.ocfox.me/)
+can visualize the release status of any nixpkgs pull request.
 
 ## Reviewing contributions
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -42,7 +42,7 @@ package's `meta.maintainers` list, and send a PR with the changes.
 
 If you're adding yourself as a maintainer as part of another PR (in which
 you become a maintainer of a package, for example), make your change to
-`maintainer-list.nix` in a separate commit.
+`maintainer-list.nix` in a separate commit titled `maintainers: add <name>`.
 
 ### How to lose maintainer status
 


### PR DESCRIPTION
Addresses https://github.com/NixOS/nixpkgs/issues/234293#issuecomment-3000177145 and more

We should address/tick these before merging:

* [x] Does joining the `nixpkgs-maintainers` team grant any additional triaging rights we can mention? Can they close issues/PRs?
* [ ] Do we have any other venues than `#org_owners:nixos.org` for those who do not use matrix?
* [x] @mweinelt / @vcunat: I fear my hydra dashboard could be quite taxing on the database, should we drop the dashboard example or is anubis sufficient?
* [x] @asymmetric is it okay with you that we link to your tool?
* [x] @alyssais is it okay with you that we link to your tool?
* [x] @ocfox is it okay with you that we link to your tool?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
