### PR TITLE
Revert "electron-cash: remove" (partially)

### DIFF
--- a/pkgs/by-name/el/electron-cash/package.nix
+++ b/pkgs/by-name/el/electron-cash/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3Packages,
+  qt5,
+  secp256k1,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "electron-cash";
+  version = "4.4.2";
+
+  src = fetchFromGitHub {
+    owner = "Electron-Cash";
+    repo = "Electron-Cash";
+    tag = version;
+    sha256 = "sha256-hqaPxetS6JONvlRMjNonXUGFpdmnuadD00gcPzY07x0=";
+  };
+
+  build-system = with python3Packages; [
+    cython
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    # requirements
+    pyaes
+    ecdsa
+    requests
+    qrcode
+    protobuf
+    jsonrpclib-pelix
+    pysocks
+    qdarkstyle
+    python-dateutil
+    stem
+    certifi
+    pathvalidate
+    dnspython
+    bitcoinrpc
+
+    # requirements-binaries
+    pyqt5
+    psutil
+    pycryptodomex
+    cryptography
+    zxing-cpp
+
+    # requirements-hw
+    trezor
+    keepkey
+    btchip-python
+    hidapi
+    pyopenssl
+    pyscard
+    pysatochip
+  ];
+
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+
+  buildInputs = [ ] ++ lib.optional stdenv.hostPlatform.isLinux qt5.qtwayland;
+
+  # If secp256k1 wasn't added to the library path, the following warning is given:
+  #
+  #   Electron Cash was unable to find the secp256k1 library on this system.
+  #   Elliptic curve cryptography operations will be performed in slow
+  #   Python-only mode.
+  #
+  # Upstream hardcoded `libsecp256k1.so.0` where we provides
+  # `libsecp256k1.so.5`. The only breaking change is the removal of two
+  # functions which seem not used by electron-cash.
+  # See: <https://github.com/Electron-Cash/Electron-Cash/issues/3009>
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "(share_dir" '("share"'
+    substituteInPlace electroncash/secp256k1.py \
+      --replace-fail "libsecp256k1.so.0" "${secp256k1}/lib/libsecp256k1.so.5"
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    output="$($out/bin/electron-cash help 2>&1)"
+    if [[ "$output" == *"failed to load"* ]]; then
+      echo "$output"
+      echo "Forbidden text detected: failed to load"
+      exit 1
+    fi
+  '';
+
+  meta = {
+    description = "Bitcoin Cash SPV Wallet";
+    mainProgram = "electron-cash";
+    longDescription = ''
+      An easy-to-use Bitcoin Cash client featuring wallets generated from
+      mnemonic seeds (in addition to other, more advanced, wallet options)
+      and the ability to perform transactions without downloading a copy
+      of the blockchain.
+    '';
+    homepage = "https://www.electroncash.org/";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      nyanloutre
+      oxalica
+    ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/by-name/el/electron-cash/package.nix
+++ b/pkgs/by-name/el/electron-cash/package.nix
@@ -10,6 +10,7 @@
 python3Packages.buildPythonApplication rec {
   pname = "electron-cash";
   version = "4.4.2";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Electron-Cash";
@@ -20,9 +21,10 @@ python3Packages.buildPythonApplication rec {
 
   build-system = with python3Packages; [
     cython
+    setuptools
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     # requirements
     pyaes
     ecdsa
@@ -60,7 +62,7 @@ python3Packages.buildPythonApplication rec {
 
   buildInputs = [ ] ++ lib.optional stdenv.hostPlatform.isLinux qt5.qtwayland;
 
-  # If secp256k1 wasn't added to the library path, the following warning is given:
+  # 1. If secp256k1 wasn't added to the library path, the following warning is given:
   #
   #   Electron Cash was unable to find the secp256k1 library on this system.
   #   Elliptic curve cryptography operations will be performed in slow
@@ -70,11 +72,17 @@ python3Packages.buildPythonApplication rec {
   # `libsecp256k1.so.5`. The only breaking change is the removal of two
   # functions which seem not used by electron-cash.
   # See: <https://github.com/Electron-Cash/Electron-Cash/issues/3009>
+  #
+  # 2. The code should be compatible with python-dateutil 2.10 which is the
+  # version we have in nixpkgs. Changelog:
+  # <https://dateutil.readthedocs.io/en/latest/changelog.html#version-2-9-0-post0-2024-03-01>
   postPatch = ''
     substituteInPlace setup.py \
       --replace-fail "(share_dir" '("share"'
     substituteInPlace electroncash/secp256k1.py \
       --replace-fail "libsecp256k1.so.0" "${secp256k1}/lib/libsecp256k1.so.5"
+    substituteInPlace contrib/requirements/requirements.txt \
+      --replace-fail "python-dateutil<2.9" "python-dateutil<2.10"
   '';
 
   preFixup = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -595,7 +595,6 @@ mapAliases {
   eidolon = throw "eidolon was removed as it is unmaintained upstream."; # Added 2025-05-28
   eintopf = lauti; # Project was renamed, added 2025-05-01
   elasticsearch7Plugins = elasticsearchPlugins;
-  electron-cash = throw "'electron-cash' has been removed due to lack of maintenance."; # Added 2025-06-17
   electronplayer = throw "'electronplayer' has been removed as it had been discontinued upstream since October 2024"; # Added 2024-12-17
 
   element-desktop-wayland = throw "element-desktop-wayland has been removed. Consider setting NIXOS_OZONE_WL=1 via 'environment.sessionVariables' instead"; # Added 2024-12-17


### PR DESCRIPTION
This reverts commit cf5d8bd81d871d8a6daf2da62bd11cced11c1520 of #357086 (cc @Lassulus  @nyanloutre).

I am using it and has always been the maintainer of it. I don't know why it's removed because of "lack of maintenance" without even tried to notify me.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
