### PR TITLE
python3Packages.lxml-html-clean: skip failing tests; python3Packages.trafilatura: skip failing tests, cleanup; python3Packages.html-sanitizer: skip failing test

### DIFF
--- a/pkgs/development/python-modules/html-sanitizer/default.nix
+++ b/pkgs/development/python-modules/html-sanitizer/default.nix
@@ -2,20 +2,23 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   hatchling,
+
+  # dependencies
   lxml,
   lxml-html-clean,
   beautifulsoup4,
+
+  # tests
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "html-sanitizer";
   version = "2.4.4";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "matthiask";
@@ -24,9 +27,9 @@ buildPythonPackage rec {
     hash = "sha256-6OWFLsuefeDzQ1uHnLmboKDgrbY/xJCwqsSQlDaJlRs=";
   };
 
-  nativeBuildInputs = [ hatchling ];
+  build-system = [ hatchling ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     lxml
     lxml-html-clean
     beautifulsoup4
@@ -40,15 +43,19 @@ buildPythonPackage rec {
     # Tests are sensitive to output
     "test_billion_laughs"
     "test_10_broken_html"
+
+    # Mismatch snapshot (AssertionError)
+    # https://github.com/matthiask/html-sanitizer/issues/53
+    "test_keep_typographic_whitespace"
   ];
 
   pythonImportsCheck = [ "html_sanitizer" ];
 
-  meta = with lib; {
+  meta = {
     description = "Allowlist-based and very opinionated HTML sanitizer";
     homepage = "https://github.com/matthiask/html-sanitizer";
     changelog = "https://github.com/matthiask/html-sanitizer/blob/${version}/CHANGELOG.rst";
-    license = with licenses; [ bsd3 ];
-    maintainers = with maintainers; [ fab ];
+    license = with lib.licenses; [ bsd3 ];
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/lxml-html-clean/default.nix
+++ b/pkgs/development/python-modules/lxml-html-clean/default.nix
@@ -2,10 +2,9 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   lxml,
   unittestCheckHook,
-  pythonOlder,
-  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -13,14 +12,28 @@ buildPythonPackage rec {
   version = "0.4.2";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
   src = fetchFromGitHub {
     owner = "fedora-python";
     repo = "lxml_html_clean";
     tag = version;
     hash = "sha256-KGUFRbcaeDcX2jyoyyZMZsVTbN+h8uy+ugcritkZe38=";
   };
+
+  # Disable failing snapshot tests (AssertionError)
+  # https://github.com/fedora-python/lxml_html_clean/issues/24
+  # As this derivation must use unittestCheckHook, we cannot use disabledTests
+  postPatch = ''
+    substituteInPlace tests/test_clean.py \
+      --replace-fail \
+        "test_host_whitelist_valid" \
+        "DISABLED_test_host_whitelist_valid" \
+      --replace-fail \
+        "test_host_whitelist_invalid" \
+        "DISABLED_test_host_whitelist_invalid" \
+      --replace-fail \
+        "test_host_whitelist_sneaky_userinfo" \
+        "DISABLED_test_host_whitelist_sneaky_userinfo"
+  '';
 
   build-system = [ setuptools ];
 
@@ -30,11 +43,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "lxml_html_clean" ];
 
-  meta = with lib; {
+  meta = {
     description = "Separate project for HTML cleaning functionalities copied from lxml.html.clean";
     homepage = "https://github.com/fedora-python/lxml_html_clean/";
     changelog = "https://github.com/fedora-python/lxml_html_clean/blob/${version}/CHANGES.rst";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/trafilatura/default.nix
+++ b/pkgs/development/python-modules/trafilatura/default.nix
@@ -1,17 +1,22 @@
 {
   lib,
   buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   certifi,
   charset-normalizer,
   courlan,
-  fetchPypi,
   htmldate,
   justext,
   lxml,
-  pytestCheckHook,
-  pythonOlder,
-  setuptools,
   urllib3,
+
+  # tests
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -19,11 +24,11 @@ buildPythonPackage rec {
   version = "2.0.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.9";
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-zrcJSm7Ml+cv6nPH26NnFMXFtXe2Rw5FINyok3BtYkc=";
+  src = fetchFromGitHub {
+    owner = "adbar";
+    repo = "trafilatura";
+    tag = "v${version}";
+    hash = "sha256-Cf1W3JEGSMkVmRZVTXYsXzZK/Nt/aDG890Sf0/0OZAA=";
   };
 
   postPatch = ''
@@ -48,6 +53,15 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTests = [
+    # TypeError: argument of type 'NoneType' is not iterable
+    # https://github.com/adbar/trafilatura/issues/805
+    "test_external"
+    "test_extract"
+
+    # AttributeError: 'NoneType' object has no attribute 'find'
+    # https://github.com/adbar/trafilatura/issues/805
+    "test_table_processing"
+
     # Disable tests that require an internet connection
     "test_cli_pipeline"
     "test_crawl_page"


### PR DESCRIPTION
## Things done

~~Tests should be run with `unittest`, which `pytest` is not completely compatible with.
However, only `pytest` allows us to skip specific tests.~~

~~I skipped the three failing tests + three more that are Incompatible with `pytest`.~~

- **python3Packages.lxml-html-clean: skip failing tests**
- **python3Packages.trafilatura: skip failing tests, cleanup**
- **python3Packages.html-sanitizer: skip failing test**

cc @fab

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
