### PR TITLE
ao3downloader: init at 2025.6.1

### DIFF
--- a/pkgs/by-name/ao/ao3downloader/package.nix
+++ b/pkgs/by-name/ao/ao3downloader/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  python312Packages,
+  fetchFromGitHub,
+}:
+
+# ao3downloader explicitly does not support Python 3.13 yet
+# https://github.com/nianeyna/ao3downloader/blob/f8399bb8aca276ae7359157b90afd13925c90056/pyproject.toml#L8
+python312Packages.buildPythonApplication rec {
+  pname = "ao3downloader";
+  version = "2025.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nianeyna";
+    repo = "ao3downloader";
+    tag = "v${version}";
+    hash = "sha256-ukS3uku8OW5nhM2Nr0IxAiG03XfqUn/Xyd0lZDGGkWw=";
+  };
+
+  build-system = with python312Packages; [
+    hatchling
+  ];
+
+  dependencies = with python312Packages; [
+    beautifulsoup4
+    mobi
+    pdfquery
+    requests
+    six
+    tqdm
+  ];
+
+  pythonRelaxDeps = [
+    "requests"
+  ];
+
+  pythonImportsCheck = [
+    "ao3downloader"
+  ];
+
+  nativeCheckInputs = with python312Packages; [
+    pytestCheckHook
+    syrupy
+    pythonImportsCheckHook
+  ];
+
+  meta = {
+    description = "Utility for downloading fanfiction in bulk from the Archive of Our Own";
+    changelog = "https://github.com/nianeyna/ao3downloader/releases/tag/v${version}";
+    mainProgram = "ao3downloader";
+    homepage = "https://nianeyna.dev/ao3downloader";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.samasaur ];
+  };
+}

--- a/pkgs/development/python-modules/pdfquery/default.nix
+++ b/pkgs/development/python-modules/pdfquery/default.nix
@@ -1,0 +1,60 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  cssselect,
+  chardet,
+  lxml,
+  pdfminer-six,
+  pyquery,
+  roman,
+  six,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pdfquery";
+  version = "0.4.3";
+  pyproject = true;
+
+  # The latest version is on PyPI but not tagged on GitHub
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-oqKXTLMS/aT1aa3I1jN30l1cY2ckC0p7+xZTksc+Hc4=";
+  };
+
+  dependencies = [
+    cssselect
+    chardet
+    lxml
+    pdfminer-six
+    pyquery
+    roman
+
+    # Not explicitly listed in setup.py; found through trial and error
+    six
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  # Although this package has tests, they aren't runnable with
+  # `unittestCheckHook` or `pytestCheckHook` because you're meant
+  # to run the tests with `python setup.py test`, but that's deprecated
+  # and doesn't work anymore. So there are no runnable tests.
+  doCheck = false;
+
+  # This runs as a different phase than checkPhase, so still runs
+  # despite `doCheck = false`
+  pythonImportsCheck = [
+    "pdfquery"
+  ];
+
+  meta = {
+    description = "Concise, friendly PDF scraping using JQuery or XPath syntax";
+    homepage = "https://github.com/jcushman/pdfquery";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.samasaur ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11185,6 +11185,8 @@ self: super: with self; {
 
   pdfplumber = callPackage ../development/python-modules/pdfplumber { };
 
+  pdfquery = callPackage ../development/python-modules/pdfquery { };
+
   pdfrw = callPackage ../development/python-modules/pdfrw { };
 
   pdfrw2 = callPackage ../development/python-modules/pdfrw2 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [ao3downloader](https://github.com/nianeyna/ao3downloader). Also adds [pdfquery](https://github.com/jcushman/pdfquery), since it is a dependency that was not yet packaged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
