### PR TITLE
winterreise: init at 2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1453,6 +1453,12 @@
     githubId = 5149377;
     name = "Amine Chikhaoui";
   };
+  amkhlv = {
+    email = "amkhlv@gmail.com";
+    github = "amkhlv";
+    githubId = 4640720;
+    name = "Andrei Mikhailov";
+  };
   amorsillo = {
     email = "andrew.morsillo@gmail.com";
     github = "evelant";

--- a/pkgs/by-name/wi/winterreise/package.nix
+++ b/pkgs/by-name/wi/winterreise/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  glib,
+  gdk-pixbuf,
+  cairo,
+  pango,
+  atk,
+  gtk3,
+  zlib,
+  libxcb,
+  pkg-config,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "winterreise";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "amkhlv";
+    repo = "winterreise";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fYrcA5sNNiyMroZJ5WQjhx0eyXVn1LUiyLocL6xnzhQ=";
+  };
+
+  buildInputs = [
+    glib
+    gdk-pixbuf
+    cairo
+    pango
+    atk
+    gtk3
+    zlib
+    libxcb
+  ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-hu/5YYnD+gEI2fmm1x5FMMv1+INHA02+tkt1YxAhtJ8=";
+
+  meta = {
+    description = "Keyboard navigation and window tiling for X11 Linux desktop";
+    homepage = "https://github.com/amkhlv/winterreise";
+    maintainers = with lib.maintainers; [
+      amkhlv
+    ];
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [
+      gpl3Only
+    ];
+  };
+})


### PR DESCRIPTION
Please include the new package `winterreise`. 
I am the author of the package.
This is a program for keyboard navigation and window tiling for Linux desktop.
It provides mouseless navigation for an X11 desktop, using `EWMH`. 
[Package homepage](https://github.com/amkhlv/winterreise)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
