### PR TITLE
[Backport release-24.11] git-lfs: 3.5.1 -> 3.6.1; assorted other commits

### DIFF
--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -12,13 +12,13 @@
 
 buildGoModule rec {
   pname = "git-lfs";
-  version = "3.6.0";
+  version = "3.6.1";
 
   src = fetchFromGitHub {
     owner = "git-lfs";
     repo = "git-lfs";
     tag = "v${version}";
-    hash = "sha256-PpNdbvtDAZDT43yyEkUvnhfUTAMM+mYImb3dVbAVPic=";
+    hash = "sha256-zZ9VYWVV+8G3gojj1m74syvsYM1mX0YT4hKnpkdMAQk=";
   };
 
   vendorHash = "sha256-JT0r/hs7ZRtsYh4aXy+v8BjwiLvRJ10e4yRirqmWVW0=";

--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -95,7 +95,7 @@ buildGoModule rec {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = [ "--version" ];
+  versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
   passthru = {

--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "git-lfs";
     repo = "git-lfs";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-PpNdbvtDAZDT43yyEkUvnhfUTAMM+mYImb3dVbAVPic=";
   };
 

--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -12,16 +12,16 @@
 
 buildGoModule rec {
   pname = "git-lfs";
-  version = "3.5.1";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "git-lfs";
     repo = "git-lfs";
     rev = "v${version}";
-    hash = "sha256-xSLXbAvIoY3c341qi89pTrjBZdXh/bPrweJD2O2gkjY=";
+    hash = "sha256-PpNdbvtDAZDT43yyEkUvnhfUTAMM+mYImb3dVbAVPic=";
   };
 
-  vendorHash = "sha256-N8HB2qwBxjzfNucftHxmX2W9srCx62pjmkCWzwiCj/I=";
+  vendorHash = "sha256-JT0r/hs7ZRtsYh4aXy+v8BjwiLvRJ10e4yRirqmWVW0=";
 
   nativeBuildInputs = [
     asciidoctor

--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -50,6 +50,37 @@ buildGoModule rec {
     unset subPackages
   '';
 
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin (
+    let
+      # Fail in the sandbox with network-related errors.
+      # Enabling __darwinAllowLocalNetworking is not enough.
+      skippedTests = [
+        "TestAPIBatch"
+        "TestAPIBatchOnlyBasic"
+        "TestAuthErrWithBody"
+        "TestAuthErrWithoutBody"
+        "TestCertFromSSLCAInfoConfig"
+        "TestCertFromSSLCAInfoEnv"
+        "TestCertFromSSLCAInfoEnvWithSchannelBackend"
+        "TestCertFromSSLCAPathConfig"
+        "TestCertFromSSLCAPathEnv"
+        "TestClientRedirect"
+        "TestClientRedirectReauthenticate"
+        "TestDoAPIRequestWithAuth"
+        "TestDoWithAuthApprove"
+        "TestDoWithAuthNoRetry"
+        "TestDoWithAuthReject"
+        "TestFatalWithBody"
+        "TestFatalWithoutBody"
+        "TestHttp2"
+        "TestHttpVersion"
+        "TestWithNonFatal500WithBody"
+        "TestWithNonFatal500WithoutBody"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ]
+  );
+
   postInstall =
     ''
       installManPage man/man*/*
@@ -70,6 +101,8 @@ buildGoModule rec {
   passthru = {
     updateScript = nix-update-script { };
   };
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Git extension for versioning large files";

--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -1,13 +1,13 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   asciidoctor,
   installShellFiles,
   git,
-  testers,
-  git-lfs,
-  stdenv,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 buildGoModule rec {
@@ -17,7 +17,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "git-lfs";
     repo = "git-lfs";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-PpNdbvtDAZDT43yyEkUvnhfUTAMM+mYImb3dVbAVPic=";
   };
 
@@ -61,16 +61,22 @@ buildGoModule rec {
         --zsh <($out/bin/git-lfs completion zsh)
     '';
 
-  passthru.tests.version = testers.testVersion {
-    package = git-lfs;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Git extension for versioning large files";
     homepage = "https://git-lfs.github.com/";
     changelog = "https://github.com/git-lfs/git-lfs/raw/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ twey ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ twey ];
     mainProgram = "git-lfs";
   };
 }


### PR DESCRIPTION
Manual backport to `release-24.11` of:
* #357914
* #361797 (excluding the move to by-name)
* #373823 (which has a fix for CVE-2024-53263)
* 2 treewides, as applied to pkgs/applications/version-management/git-lfs/default.nix. **The cherry-pick check will fail due to these.**

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.