### PR TITLE
workflows/labels: fix stale label date sorting

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -246,8 +246,8 @@ jobs:
                     'unmarked_as_duplicate',
                   ].includes(event))
                   .map(({ created_at, updated_at, committer, submitted_at }) => new Date(updated_at ?? created_at ?? submitted_at ?? committer.date))
-                  .sort()
-                  .reverse()
+                  // Reverse sort by date value. The default sort() sorts by string representation, which is bad for dates.
+                  .sort((a,b) => b-a)
                   .at(0) ?? item.created_at
                 )
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/419654#discussion_r2166026721

With the help of:
https://stackabuse.com/how-to-sort-an-array-by-date-in-javascript/

## Things done

- [x] Tested locally in node
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
