### PR TITLE
comaps: init at 2025.08.13-8

### DIFF
--- a/pkgs/by-name/co/comaps/package.nix
+++ b/pkgs/by-name/co/comaps/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  organicmaps,
+  fetchurl,
+  fetchFromGitea,
+  boost,
+  gtest,
+  glm,
+  gflags,
+  imgui,
+  jansson,
+  python3,
+  optipng,
+  utf8cpp,
+  nix-update-script,
+}:
+let
+  mapRev = 250804;
+
+  worldMap = fetchurl {
+    url = "https://cdn-fi-1.comaps.app/maps/${toString mapRev}/World.mwm";
+    hash = "sha256-xYMH3y0Y6sSXYUTpy+A5YCyb+n5YChOXhyDvUFqXxZ0=";
+  };
+
+  worldCoasts = fetchurl {
+    url = "https://cdn-fi-1.comaps.app/maps/${toString mapRev}/WorldCoasts.mwm";
+    hash = "sha256-2vc4kkNX9bRTqXYlALfwVwOlvr122kvUk7pUyM91vjc=";
+  };
+in
+organicmaps.overrideAttrs (oldAttrs: rec {
+  pname = "comaps";
+  version = "2025.08.13-8";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "comaps";
+    repo = "comaps";
+    tag = "v${version}";
+    hash = "sha256-kvE3H+siV/8v4WgsG1Ifd4gMMwGLqz28oXf1hB9gQ2Q=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    ./remove-lto.patch
+    ./use-vendored-protobuf.patch
+  ];
+
+  postPatch = (oldAttrs.postPatch or "") + ''
+    rm -f 3party/boost/b2
+  '';
+
+  nativeBuildInputs = (builtins.filter (x: x != python3) oldAttrs.nativeBuildInputs or [ ]) ++ [
+    (python3.withPackages (
+      ps: with ps; [
+        protobuf
+      ]
+    ))
+    optipng
+  ];
+
+  buildInputs = (oldAttrs.buildInputs or [ ]) ++ [
+    boost
+    gtest
+    gflags
+    glm
+    imgui
+    jansson
+    utf8cpp
+  ];
+
+  preConfigure = ''
+    bash ./configure.sh --skip-map-download
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_SYSTEM_PROVIDED_3PARTY" true)
+  ];
+
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-I/build/source/3party/fast_double_parser/include"
+    ];
+    PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";
+  };
+
+  postInstall = ''
+    install -Dm644 ${worldMap} $out/share/comaps/data/World.mwm
+    install -Dm644 ${worldCoasts} $out/share/comaps/data/WorldCoasts.mwm
+    ln -s $out/bin/CoMaps $out/bin/comaps
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "-vr"
+      "v(.*)"
+    ];
+  };
+
+  meta = oldAttrs.meta // {
+    description = "Community-led fork of Organic Maps";
+    homepage = "https://comaps.app";
+    changelog = "https://codeberg.org/comaps/comaps/releases/tag/v${version}";
+    maintainers = [ lib.maintainers.ryand56 ];
+    mainProgram = "comaps";
+  };
+})

--- a/pkgs/by-name/co/comaps/remove-lto.patch
+++ b/pkgs/by-name/co/comaps/remove-lto.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c559bf5..42ed617 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -106,7 +106,7 @@ if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+ elseif (${CMAKE_BUILD_TYPE} MATCHES "Rel")
+   add_definitions(-DRELEASE)
+   if (NOT MSVC)
+-    add_compile_options(-O3 $<$<CXX_COMPILER_ID:GNU>:-flto=auto>)
++    add_compile_options(-O3)
+   endif()
+ else()
+   message(FATAL_ERROR "Unknown build type: " ${CMAKE_BUILD_TYPE})
+@@ -116,19 +116,6 @@ if (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")
+   add_compile_options(-fno-omit-frame-pointer)
+ endif()
+ 
+-# Linux GCC LTO plugin fix.
+-if (PLATFORM_LINUX AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_BUILD_TYPE MATCHES "^Rel"))
+-  # To force errors if LTO was not enabled.
+-  add_compile_options(-fno-fat-lto-objects)
+-  # To fix ar and ranlib "plugin needed to handle lto object".
+-  string(REGEX MATCH "[0-9]+" GCC_MAJOR_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+-  file(GLOB_RECURSE plugin /usr/lib/gcc/*/${GCC_MAJOR_VERSION}/liblto_plugin.so)
+-  set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> --plugin ${plugin} qcs <TARGET> <OBJECTS>")
+-  set(CMAKE_C_ARCHIVE_FINISH "<CMAKE_RANLIB> --plugin ${plugin} <TARGET>")
+-  set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> --plugin ${plugin} qcs <TARGET> <OBJECTS>")
+-  set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> --plugin ${plugin} <TARGET>")
+-endif()
+-
+ message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
+ 
+ if (PLATFORM_LINUX OR PLATFORM_ANDROID)

--- a/pkgs/by-name/co/comaps/use-vendored-protobuf.patch
+++ b/pkgs/by-name/co/comaps/use-vendored-protobuf.patch
@@ -1,0 +1,24 @@
+diff --git a/3party/CMakeLists.txt b/3party/CMakeLists.txt
+index 5178ae0..abe103f 100644
+--- a/3party/CMakeLists.txt
++++ b/3party/CMakeLists.txt
+@@ -41,9 +41,6 @@ if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
+   # Add pugixml library.
+   add_subdirectory(pugixml)
+
+-  # Add protobuf library.
+-  add_subdirectory(protobuf)
+-
+   if (NOT PLATFORM_LINUX)
+     add_subdirectory(freetype)
+     add_subdirectory(icu)
+@@ -55,6 +52,9 @@ if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
+   target_include_directories(utf8cpp INTERFACE "${OMIM_ROOT}/3party/utfcpp/source")
+ endif()
+
++# Add protobuf library.
++add_subdirectory(protobuf)
++
+ add_subdirectory(agg)
+ add_subdirectory(bsdiff-courgette)
+ add_subdirectory(minizip)


### PR DESCRIPTION
Adds [CoMaps](https://www.comaps.app), a community-led fork of Organic Maps.
https://codeberg.org/comaps/comaps

Closes #419794

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
