### PR TITLE
workflows/labels: fix merge conflict label

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -136,12 +136,9 @@ jobs:
                 const pull_number = item.number
                 const issue_number = item.number
 
-                // The search result is of a format that works for both issues and pull requests and thus
-                // does not have all fields of a full pull_request response. Notably, it is missing `head.sha`,
-                // which we need to fetch the workflow run below. This field is already available non-search sources.
-                // This API request is also important for the merge-conflict label, because it triggers the
+                // This API request is important for the merge-conflict label, because it triggers the
                 // creation of a new test merge commit. This is needed to actually determine the state of a PR.
-                const pull_request = item.head ? item : (await github.rest.pulls.get({
+                const pull_request = (await github.rest.pulls.get({
                   ...context.repo,
                   pull_number
                 })).data


### PR DESCRIPTION
The previous implementation had two problems:
- When switching from /search to /pulls, we disabled the additional GET on each single pull request - which causes no test merge commit creation for all PRs. This means, merge conflicts will not actually be detected.
- By using `item` in the pull-request triggered case, this goes back to `context.payload.pull_request`, which is the state *at the beginning* of the workflow run. But this renders our "let's wait 3 minutes before checking merge_commit_sha" logic void. While we wait for 3 minutes, we still use the *old* value afterwards...

Just making the extra request every time simplifies the logic and solves both problems.

Fixes https://github.com/NixOS/nixpkgs/pull/419654#discussion_r2166057182

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
