### PR TITLE
[24.11] guix: 1.4.0 -> 1.4.0-unstable-2025-06.24

### DIFF
--- a/pkgs/by-name/gu/guix/missing-cstdint-include.patch
+++ b/pkgs/by-name/gu/guix/missing-cstdint-include.patch
@@ -1,0 +1,24 @@
+From bdf4159dd5c1cf925512c0eb8490846c084e3c8c Mon Sep 17 00:00:00 2001
+From: Reepca Russelstein
+Date: Tue, 24 Jun 2025 22:35:04 -0500
+Subject: [PATCH] nix: libutil: add <cstdint> include to seccomp.hh.
+
+* nix/libutil/seccomp.hh (<cstdint>): add include of header.
+
+Change-Id: I0a0b2892d81dbab662eda1ba80f4736178d70c65
+---
+ nix/libutil/seccomp.hh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/nix/libutil/seccomp.hh b/nix/libutil/seccomp.hh
+index 634dfad5f8..a4b449fc66 100644
+--- a/nix/libutil/seccomp.hh
++++ b/nix/libutil/seccomp.hh
+@@ -4,6 +4,7 @@
+ #include <linux/audit.h> /* For AUDIT_ARCH_* */
+ #include <linux/seccomp.h>
+ #include <linux/filter.h>
++#include <cstdint>
+ 
+ 
+ /* This file provides two preprocessor macros (among other things):

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -1,9 +1,9 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
-  fetchDebianPatch,
+  fetchgit,
+  graphviz,
+  gettext,
   autoreconfHook,
   disarchive,
   git,
@@ -27,6 +27,7 @@
   pkg-config,
   po4a,
   scheme-bytestructures,
+  slirp4netns,
   texinfo,
   bzip2,
   libgcrypt,
@@ -37,45 +38,21 @@
   storeDir ? "/gnu/store",
   confDir ? "/etc",
 }:
-
+let
+  rev = "30a5d140aa5a789a362749d057754783fea83dde";
+in
 stdenv.mkDerivation rec {
   pname = "guix";
-  version = "1.4.0";
+  version = "1.4.0-unstable-2025-06-24";
 
-  src = fetchurl {
-    url = "mirror://gnu/guix/guix-${version}.tar.gz";
-    hash = "sha256-Q8dpy/Yy7wVEmsH6SMG6FSwzSUxqvH5HE3u6eyFJ+KQ=";
+  src = fetchgit {
+    url = "https://codeberg.org/guix/guix.git";
+    inherit rev;
+    hash = "sha256-QsOYApnwA2hb1keSv6p3EpMT09xCs9uyoSeIdXzftF0=";
   };
 
   patches = [
-    (fetchpatch {
-      name = "CVE-2024-27297_1.patch";
-      url = "https://git.savannah.gnu.org/cgit/guix.git/patch/?id=8f4ffb3fae133bb21d7991e97c2f19a7108b1143";
-      hash = "sha256-xKo1h2uckC2pYHt+memekagfL6dWcF8gOnTOOW/wJUU=";
-    })
-    (fetchpatch {
-      name = "CVE-2024-27297_2.patch";
-      url = "https://git.savannah.gnu.org/cgit/guix.git/patch/?id=ff1251de0bc327ec478fc66a562430fbf35aef42";
-      hash = "sha256-f4KWDVrvO/oI+4SCUHU5GandkGtHrlaM1BWygM/Qlao=";
-    })
-    # see https://guix.gnu.org/en/blog/2024/build-user-takeover-vulnerability
-    (fetchDebianPatch {
-      inherit pname version;
-      debianRevision = "8";
-      patch = "security/0101-daemon-Sanitize-failed-build-outputs-prior-to-exposi.patch";
-      hash = "sha256-cbra/+K8+xHUJrCKRgzJCuhMBpzCSjgjosKAkJx7QIo=";
-    })
-    (fetchDebianPatch {
-      inherit pname version;
-      debianRevision = "8";
-      patch = "security/0102-daemon-Sanitize-successful-build-outputs-prior-to-ex.patch";
-      hash = "sha256-mOnlYtpIuYL+kDvSNuXuoDLJP03AA9aI2ALhap+0NOM=";
-    })
-    (fetchpatch {
-      name = "fix-guile-ssh-detection.patch";
-      url = "https://git.savannah.gnu.org/cgit/guix.git/patch/?id=b8a45bd0473ab2ba9b96b7ef429a557ece9bf06c";
-      hash = "sha256-oYkgM694qPK8kqgxatkr4fj/GL73ozTNQADNyDeU6WY=";
-    })
+    ./missing-cstdint-include.patch
   ];
 
   postPatch = ''
@@ -90,6 +67,8 @@ stdenv.mkDerivation rec {
     autoreconfHook
     disarchive
     git
+    graphviz
+    gettext
     glibcLocales
     guile
     guile-avahi
@@ -110,6 +89,7 @@ stdenv.mkDerivation rec {
     pkg-config
     po4a
     scheme-bytestructures
+    slirp4netns
     texinfo
   ];
 
@@ -136,6 +116,7 @@ stdenv.mkDerivation rec {
     guile-zlib
     guile-zstd
     scheme-bytestructures
+    slirp4netns
   ];
 
   configureFlags = [
@@ -144,6 +125,11 @@ stdenv.mkDerivation rec {
     "--sysconfdir=${confDir}"
     "--with-bash-completion-dir=$(out)/etc/bash_completion.d"
   ];
+
+  preAutoreconf = ''
+    echo ${version} > .tarball-version
+    ./bootstrap
+  '';
 
   enableParallelBuilding = true;
 
@@ -174,8 +160,8 @@ stdenv.mkDerivation rec {
       Guix.
       Guix is based on the Nix package manager.
     '';
-    homepage = "http://www.gnu.org/software/guix";
-    changelog = "https://git.savannah.gnu.org/cgit/guix.git/plain/NEWS?h=v${version}";
+    homepage = "https://guix.gnu.org/";
+    changelog = "https://codeberg.org/guix/guix/raw/commit/${rev}/NEWS";
     license = lib.licenses.gpl3Plus;
     mainProgram = "guix";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -154,7 +154,7 @@ stdenv.mkDerivation rec {
     inherit (nixosTests) guix;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Functional package manager with a Scheme interface";
     longDescription = ''
       GNU Guix is a purely functional package manager for the GNU system, and a distribution thereof.
@@ -170,12 +170,12 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.gnu.org/software/guix";
     changelog = "https://git.savannah.gnu.org/cgit/guix.git/plain/NEWS?h=v${version}";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
     mainProgram = "guix";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       cafkafk
       foo-dogsquared
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -71,6 +71,11 @@ stdenv.mkDerivation rec {
       patch = "security/0102-daemon-Sanitize-successful-build-outputs-prior-to-ex.patch";
       hash = "sha256-mOnlYtpIuYL+kDvSNuXuoDLJP03AA9aI2ALhap+0NOM=";
     })
+    (fetchpatch {
+      name = "fix-guile-ssh-detection.patch";
+      url = "https://git.savannah.gnu.org/cgit/guix.git/patch/?id=b8a45bd0473ab2ba9b96b7ef429a557ece9bf06c";
+      hash = "sha256-oYkgM694qPK8kqgxatkr4fj/GL73ozTNQADNyDeU6WY=";
+    })
   ];
 
   postPatch = ''
@@ -147,7 +152,7 @@ stdenv.mkDerivation rec {
       wrapProgram $f \
         --prefix GUILE_LOAD_PATH : "$out/${guile.siteDir}:$GUILE_LOAD_PATH" \
         --prefix GUILE_LOAD_COMPILED_PATH : "$out/${guile.siteCcacheDir}:$GUILE_LOAD_COMPILED_PATH" \
-        --prefix GUILE_EXTENSIONS_PATH : "${guile-ssh}/lib/guile/3.0/extensions:$GUILE_EXTENSIONS_PATH"
+        --prefix GUILE_EXTENSIONS_PATH : "${guile-ssh}/lib/guile/3.0/extensions"
     done
   '';
 

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -146,7 +146,8 @@ stdenv.mkDerivation rec {
     for f in $out/bin/*; do
       wrapProgram $f \
         --prefix GUILE_LOAD_PATH : "$out/${guile.siteDir}:$GUILE_LOAD_PATH" \
-        --prefix GUILE_LOAD_COMPILED_PATH : "$out/${guile.siteCcacheDir}:$GUILE_LOAD_COMPILED_PATH"
+        --prefix GUILE_LOAD_COMPILED_PATH : "$out/${guile.siteCcacheDir}:$GUILE_LOAD_COMPILED_PATH" \
+        --prefix GUILE_EXTENSIONS_PATH : "${guile-ssh}/lib/guile/3.0/extensions:$GUILE_EXTENSIONS_PATH"
     done
   '';
 


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/419555 with conflict resolution of a treewide change.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
