### PR TITLE
mdns-scanner: 0.13.0 -> 0.15.0

### DIFF
--- a/pkgs/by-name/md/mdns-scanner/package.nix
+++ b/pkgs/by-name/md/mdns-scanner/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdns-scanner";
-  version = "0.13.0";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "CramBL";
     repo = "mdns-scanner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-86GpBjgfBMkqzoWPEbjQM6PvSEb67A8nL7sEtplXoic=";
+    hash = "sha256-15yVQfqzAYBrCzMZJE3IiQG+ZfGMQYltxDGf+pmD8ss=";
   };
 
-  cargoHash = "sha256-z0IHONtU1pgViQZu0Q2fZVjdJ6sSlgnIw83hqWLKfVM=";
+  cargoHash = "sha256-htYBCcK8aVCTmdxMW0QmX+2aS9ZuC7PsuebrWMpUl38=";
 
   meta = {
     homepage = "https://github.com/CramBL/mdns-scanner";


### PR DESCRIPTION
This PR updates mdns-scanner to v0.15.0 ([https://github.com/CramBL/mdns-scanner/releases/tag/v0.15.0](https://github.com/CramBL/mdns-scanner/releases/tag/v0.15.0)).

There were a few updates from v0.13.0 to v0.15.0, so here is a complete changelog:

## Added

- the `ui.log_limit` setting controls the maximum number of logs to store before the oldest logs are dropped (v0.14.0)
- The `scan.tcp_ports` setting now determines which TCP ports are scanned to ascertain host reachability. (v0.15.0)

## Changed

- Corrected label `Compact Output` to `Compact UI` to better reflect what it does (v0.13.1)
- Don't accept missing values from persisted config (v0.13.1)
- Tweak config layout for better readability and extensibility (v0.13.1)
- Flip table/log panes, the log now appears on the bottom which seems better (v0.14.0)
- Adjust search box to take up less space, and scale with the input if it's enough to fill the box (v0.14.0)
- If an IP address was previously found to be reachable, the status is now re-verified using the exact method (exact TCP port connection or ICMP ping) that initially confirmed its reachability. (v0.15.0)
## Fixed

- Erroneous definition of the `interfaces.ignore_patterns` config option (v0.13.2)

[https://github.com/CramBL/mdns-scanner/compare/v0.13.0...v0.15.0](https://github.com/CramBL/mdns-scanner/compare/v0.13.0...v0.15.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
