### PR TITLE
python3Packages.{everett,comet-ml,cometx}: init at {3.4.0,3.49.11,2.3.1}

### DIFF
--- a/pkgs/development/python-modules/comet-ml/default.nix
+++ b/pkgs/development/python-modules/comet-ml/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  dulwich,
+  everett,
+  importlib-metadata,
+  jsonschema,
+  numpy,
+  psutil,
+  python-box,
+  requests,
+  requests-toolbelt,
+  rich,
+  semantic-version,
+  sentry-sdk,
+  setuptools,
+  simplejson,
+  urllib3,
+  wrapt,
+  wurlitzer,
+}:
+
+buildPythonPackage rec {
+  pname = "comet-ml";
+  version = "3.53.0";
+
+  src = fetchPypi {
+    pname = "comet_ml";
+    inherit version;
+    hash = "sha256-KYMe6lDNj5nyXaB0hsk2STwGATkAuRwr8SSzlz3W4tA=";
+  };
+
+  pyproject = true;
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    dulwich
+    everett
+    importlib-metadata
+    jsonschema
+    numpy
+    psutil
+    python-box
+    requests
+    requests-toolbelt
+    rich
+    semantic-version
+    sentry-sdk
+    simplejson
+    urllib3
+    wrapt
+    wurlitzer
+  ];
+
+  pythonRelaxDeps = [
+    "everett"
+    "python-box"
+  ];
+
+  pythonImportsCheck = [ "comet_ml" ];
+
+  meta = {
+    description = "Platform designed to help machine learning teams track, compare, explain, and optimize their models";
+    homepage = "https://www.comet.com/site/";
+    changelog = "https://www.comet.com/docs/v2/api-and-sdk/python-sdk/releases/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jherland ];
+    mainProgram = "comet";
+  };
+}

--- a/pkgs/development/python-modules/cometx/default.nix
+++ b/pkgs/development/python-modules/cometx/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  comet-ml,
+  ipython,
+  matplotlib,
+  numpy,
+  requests,
+  scipy,
+  selenium,
+  urllib3,
+  zipfile2,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "cometx";
+  version = "2.6.0";
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  src = fetchFromGitHub {
+    owner = "comet-ml";
+    repo = "cometx";
+    tag = version;
+    hash = "sha256-zlSk3DlrkvPOPCe6gtiXvn65NCw/y5BxCiVmC0GzvFg=";
+  };
+
+  dependencies = [
+    comet-ml
+    ipython
+    matplotlib
+    numpy
+    requests
+    scipy
+    selenium
+    urllib3
+    zipfile2
+    tqdm
+  ];
+
+  # WARNING: Running the tests will create experiments, models, assets, etc.
+  # on your Comet account.
+  doCheck = false;
+
+  pythonImportsCheck = [ "cometx" ];
+
+  meta = {
+    description = "Open source extensions for the Comet SDK";
+    homepage = "https://github.com/comet-ml/comet-sdk-extensions/";
+    changelog = "https://github.com/comet-ml/cometx/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jherland ];
+    mainProgram = "cometx";
+  };
+}

--- a/pkgs/development/python-modules/everett/default.nix
+++ b/pkgs/development/python-modules/everett/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  configobj,
+  pytestCheckHook,
+  pyyaml,
+  setuptools,
+  sphinx,
+}:
+
+buildPythonPackage rec {
+  pname = "everett";
+  version = "3.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "willkg";
+    repo = "everett";
+    tag = "v${version}";
+    hash = "sha256-olYxUbsKaL7C5UTAPwW+EufjbWbbHZdZcQ/lfogNJrg=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    configobj
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    sphinx
+  ];
+
+  pythonImportsCheck = [ "everett" ];
+
+  meta = {
+    description = "Python configuration library for your app";
+    homepage = "https://github.com/willkg/everett";
+    changelog = "https://github.com/willkg/everett/releases/tag/${version}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2871,6 +2871,8 @@ self: super: with self; {
 
   colout = callPackage ../development/python-modules/colout { };
 
+  comet-ml = callPackage ../development/python-modules/comet-ml { };
+
   cometblue-lite = callPackage ../development/python-modules/cometblue-lite { };
 
   comicapi = callPackage ../development/python-modules/comicapi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2875,6 +2875,8 @@ self: super: with self; {
 
   cometblue-lite = callPackage ../development/python-modules/cometblue-lite { };
 
+  cometx = callPackage ../development/python-modules/cometx { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4851,6 +4851,8 @@ self: super: with self; {
 
   events = callPackage ../development/python-modules/events { };
 
+  everett = callPackage ../development/python-modules/everett { };
+
   evohome-async = callPackage ../development/python-modules/evohome-async { };
 
   evolutionhttp = callPackage ../development/python-modules/evolutionhttp { };


### PR DESCRIPTION
These packages depend on each other (cometx -> comet-ml -> everett), so I bundle them in one PR. Happy to split into separate PRs if that is preferable (but I'm not sure how to properly encode PR dependencies between PRs started from a fork).

Commits:
- **python3Packages.everett: init at 3.4.0**
- **python3Packages.comet-ml: init at 3.49.11**
- **python3Packages.cometx: init at 2.3.1**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
