### PR TITLE
lib/systems: move kernel configuration out of the platform structure

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -20,6 +20,13 @@
 - `space-orbit` package has been removed due to lack of upstream maintenance. Debian upstream stopped tracking it in 2011.
 - `command-not-found` package is now disabled by default; it works only for nix-channels based systems, and requires setup for it to work.
 
+- Linux kernel configuration has been moved out of the `linux-kernel` field of the platform structure into the kernel builders:
+  - `linux-kernel.name` has been removed.
+  - `linux-kernel.target` is available as the `target` parameter and passthru attribute on the kernel builders.
+  - `linux-kernel.installTarget` has been removed, as it should not be necessary to customize.
+  - `linux-kernel.DTB` is available as the `buildDTBs` parameter and passthru attribute on the kernel builders.
+  - `linux-kernel.{autoModules,preferBuiltin,extraConfig}` were already available as kernel builder parameters.
+
 - The ARMv5 Linux kernel build now uses a standard configuration and generates a standard compressed image instead of the deprecated legacy U‐Boot image format.
   `lib.systems.{examples,platforms}.{sheevaplug,pogoplug4}` have been unified into `lib.systems.examples.armv5tel-multiplatform`.
   Note that there is no official support for ARMv5 and it is not possible to build even a simple NixOS configuration out of the box.

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -24,6 +24,8 @@
   `lib.systems.{examples,platforms}.{sheevaplug,pogoplug4}` have been unified into `lib.systems.examples.armv5tel-multiplatform`.
   Note that there is no official support for ARMv5 and it is not possible to build even a simple NixOS configuration out of the box.
 
+- Support for the legacy U‐Boot image format has been removed from the Linux kernel builders, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
+
 - `victoriametrics` no longer contains VictoriaLogs components. These have been separated into the new package `victorialogs`.
 
 - `gnome-keyring` no longer ships with an SSH agent anymore because it has been deprecated upstream. You should use `gcr_4` instead, which provides the same features. More information on why this was done can be found on [the relevant GCR upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67).

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -20,6 +20,10 @@
 - `space-orbit` package has been removed due to lack of upstream maintenance. Debian upstream stopped tracking it in 2011.
 - `command-not-found` package is now disabled by default; it works only for nix-channels based systems, and requires setup for it to work.
 
+- The ARMv5 Linux kernel build now uses a standard configuration and generates a standard compressed image instead of the deprecated legacy U‐Boot image format.
+  `lib.systems.{examples,platforms}.{sheevaplug,pogoplug4}` have been unified into `lib.systems.examples.armv5tel-multiplatform`.
+  Note that there is no official support for ARMv5 and it is not possible to build even a simple NixOS configuration out of the box.
+
 - `victoriametrics` no longer contains VictoriaLogs components. These have been separated into the new package `victorialogs`.
 
 - `gnome-keyring` no longer ships with an SSH agent anymore because it has been deprecated upstream. You should use `gcr_4` instead, which provides the same features. More information on why this was done can be found on [the relevant GCR upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67).

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -266,12 +266,10 @@ let
           inherit
             (
               {
-                linux-kernel = args.linux-kernel or { };
                 gcc = args.gcc or { };
               }
               // platforms.select final
             )
-            linux-kernel
             gcc
             ;
 
@@ -564,6 +562,11 @@ let
           };
         };
     in
+    # TODO: Remove in 26.05.
+    assert
+      args ? linux-kernel
+      -> throw "lib.systems.elaborate: linux-kernel has been removed; see the 25.11 release notes";
+
     assert final.useAndroidPrebuilt -> final.isAndroid;
     assert foldl (pass: { assertion, message }: if assertion final then pass else throw message) true (
       final.parsed.abi.assertions or [ ]

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -35,9 +35,9 @@ rec {
     };
   };
 
-  sheevaplug = {
+  armv5tel-multiplatform = {
     config = "armv5tel-unknown-linux-gnueabi";
-  } // platforms.sheevaplug;
+  };
 
   raspberryPi = {
     config = "armv6l-unknown-linux-gnueabihf";
@@ -87,10 +87,6 @@ rec {
     useAndroidPrebuilt = false;
     useLLVM = true;
   };
-
-  pogoplug4 = {
-    config = "armv5tel-unknown-linux-gnueabi";
-  } // platforms.pogoplug4;
 
   ben-nanonote = {
     config = "mipsel-unknown-linux-uclibc";

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -135,7 +135,6 @@ rec {
   gnu64 = {
     config = "x86_64-unknown-linux-gnu";
   };
-  gnu64_simplekernel = gnu64 // platforms.pc_simplekernel; # see test/cross/default.nix
   gnu32 = {
     config = "i686-unknown-linux-gnu";
   };

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -40,139 +40,15 @@ rec {
   ## ARM
   ##
 
-  pogoplug4 = {
+  armv5tel-multiplatform = {
     linux-kernel = {
-      name = "pogoplug4";
+      name = "armv5tel-multiplatform";
 
       baseConfig = "multi_v5_defconfig";
-      autoModules = false;
-      extraConfig = ''
-        # Ubi for the mtd
-        MTD_UBI y
-        UBIFS_FS y
-        UBIFS_FS_XATTR y
-        UBIFS_FS_ADVANCED_COMPR y
-        UBIFS_FS_LZO y
-        UBIFS_FS_ZLIB y
-        UBIFS_FS_DEBUG n
-      '';
-      makeFlags = [ "LOADADDR=0x8000" ];
-      target = "uImage";
-      # TODO reenable once manual-config's config actually builds a .dtb and this is checked to be working
-      #DTB = true;
-    };
-    gcc = {
-      arch = "armv5te";
-    };
-  };
-
-  sheevaplug = {
-    linux-kernel = {
-      name = "sheevaplug";
-
-      baseConfig = "multi_v5_defconfig";
-      autoModules = false;
-      extraConfig = ''
-        BLK_DEV_RAM y
-        BLK_DEV_INITRD y
-        BLK_DEV_CRYPTOLOOP m
-        BLK_DEV_DM m
-        DM_CRYPT m
-        MD y
-        REISERFS_FS m
-        BTRFS_FS m
-        XFS_FS m
-        JFS_FS m
-        EXT4_FS m
-        USB_STORAGE_CYPRESS_ATACB m
-
-        # mv cesa requires this sw fallback, for mv-sha1
-        CRYPTO_SHA1 y
-        # Fast crypto
-        CRYPTO_TWOFISH y
-        CRYPTO_TWOFISH_COMMON y
-        CRYPTO_BLOWFISH y
-        CRYPTO_BLOWFISH_COMMON y
-
-        IP_PNP y
-        IP_PNP_DHCP y
-        NFS_FS y
-        ROOT_NFS y
-        TUN m
-        NFS_V4 y
-        NFS_V4_1 y
-        NFS_FSCACHE y
-        NFSD m
-        NFSD_V2_ACL y
-        NFSD_V3 y
-        NFSD_V3_ACL y
-        NFSD_V4 y
-        NETFILTER y
-        IP_NF_IPTABLES y
-        IP_NF_FILTER y
-        IP_NF_MATCH_ADDRTYPE y
-        IP_NF_TARGET_LOG y
-        IP_NF_MANGLE y
-        IPV6 m
-        VLAN_8021Q m
-
-        CIFS y
-        CIFS_XATTR y
-        CIFS_POSIX y
-        CIFS_FSCACHE y
-        CIFS_ACL y
-
-        WATCHDOG y
-        WATCHDOG_CORE y
-        ORION_WATCHDOG m
-
-        ZRAM m
-        NETCONSOLE m
-
-        # Disable OABI to have seccomp_filter (required for systemd)
-        # https://github.com/raspberrypi/firmware/issues/651
-        OABI_COMPAT n
-
-        # Fail to build
-        DRM n
-        SCSI_ADVANSYS n
-        USB_ISP1362_HCD n
-        SND_SOC n
-        SND_ALI5451 n
-        FB_SAVAGE n
-        SCSI_NSP32 n
-        ATA_SFF n
-        SUNGEM n
-        IRDA n
-        ATM_HE n
-        SCSI_ACARD n
-        BLK_DEV_CMD640_ENHANCED n
-
-        FUSE_FS m
-
-        # systemd uses cgroups
-        CGROUPS y
-
-        # Latencytop
-        LATENCYTOP y
-
-        # Ubi for the mtd
-        MTD_UBI y
-        UBIFS_FS y
-        UBIFS_FS_XATTR y
-        UBIFS_FS_ADVANCED_COMPR y
-        UBIFS_FS_LZO y
-        UBIFS_FS_ZLIB y
-        UBIFS_FS_DEBUG n
-
-        # Kdb, for kernel troubles
-        KGDB y
-        KGDB_SERIAL_CONSOLE y
-        KGDB_KDB y
-      '';
-      makeFlags = [ "LOADADDR=0x0200000" ];
-      target = "uImage";
-      DTB = true; # Beyond 3.10
+      DTB = true;
+      autoModules = true;
+      preferBuiltin = true;
+      target = "zImage";
     };
     gcc = {
       arch = "armv5te";
@@ -402,7 +278,7 @@ rec {
       if version == null then
         pc
       else if lib.versionOlder version "6" then
-        sheevaplug
+        armv5tel-multiplatform
       else if lib.versionOlder version "7" then
         raspberrypi
       else

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -9,8 +9,6 @@
 rec {
   pc = {
     linux-kernel = {
-      name = "pc";
-
       baseConfig = "defconfig";
       # Build whatever possible as a module, if not stated in the extra config.
       autoModules = true;
@@ -20,8 +18,6 @@ rec {
 
   powernv = {
     linux-kernel = {
-      name = "PowerNV";
-
       baseConfig = "powernv_defconfig";
       target = "vmlinux";
       autoModules = true;
@@ -42,8 +38,6 @@ rec {
 
   armv5tel-multiplatform = {
     linux-kernel = {
-      name = "armv5tel-multiplatform";
-
       baseConfig = "multi_v5_defconfig";
       DTB = true;
       autoModules = true;
@@ -57,8 +51,6 @@ rec {
 
   raspberrypi = {
     linux-kernel = {
-      name = "raspberrypi";
-
       baseConfig = "bcm2835_defconfig";
       DTB = true;
       autoModules = true;
@@ -99,7 +91,6 @@ rec {
 
   # https://developer.android.com/ndk/guides/abis#v7a
   armv7a-android = {
-    linux-kernel.name = "armeabi-v7a";
     gcc = {
       arch = "armv7-a";
       float-abi = "softfp";
@@ -109,7 +100,6 @@ rec {
 
   armv7l-hf-multiplatform = {
     linux-kernel = {
-      name = "armv7l-hf-multiplatform";
       baseConfig = "defconfig";
       DTB = true;
       autoModules = true;
@@ -141,7 +131,6 @@ rec {
 
   aarch64-multiplatform = {
     linux-kernel = {
-      name = "aarch64-multiplatform";
       baseConfig = "defconfig";
       DTB = true;
       autoModules = true;
@@ -170,9 +159,6 @@ rec {
   ##
 
   ben_nanonote = {
-    linux-kernel = {
-      name = "ben_nanonote";
-    };
     gcc = {
       arch = "mips32";
       float = "soft";
@@ -231,7 +217,6 @@ rec {
 
   riscv-multiplatform = {
     linux-kernel = {
-      name = "riscv-multiplatform";
       target = "Image";
       autoModules = true;
       preferBuiltin = true;
@@ -252,7 +237,6 @@ rec {
       cmodel = "medium";
     };
     linux-kernel = {
-      name = "loongarch-multiplatform";
       target = "vmlinuz.efi";
       autoModules = true;
       preferBuiltin = true;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -304,13 +304,6 @@ rec {
       autoModules = true;
       preferBuiltin = true;
       target = "zImage";
-      extraConfig = ''
-        # >=5.12 fails with:
-        # drivers/net/ethernet/micrel/ks8851_common.o: in function `ks8851_probe_common':
-        # ks8851_common.c:(.text+0x179c): undefined reference to `__this_module'
-        # See: https://lore.kernel.org/netdev/20210116164828.40545-1-marex@denx.de/T/
-        KS8851_MLL y
-      '';
     };
     gcc = {
       # Some table about fpu flags:

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -225,31 +225,6 @@ rec {
     };
   };
 
-  utilite = {
-    linux-kernel = {
-      name = "utilite";
-      maseConfig = "multi_v7_defconfig";
-      autoModules = false;
-      extraConfig = ''
-        # Ubi for the mtd
-        MTD_UBI y
-        UBIFS_FS y
-        UBIFS_FS_XATTR y
-        UBIFS_FS_ADVANCED_COMPR y
-        UBIFS_FS_LZO y
-        UBIFS_FS_ZLIB y
-        UBIFS_FS_DEBUG n
-      '';
-      makeFlags = [ "LOADADDR=0x10800000" ];
-      target = "uImage";
-      DTB = true;
-    };
-    gcc = {
-      cpu = "cortex-a9";
-      fpu = "neon";
-    };
-  };
-
   # https://developer.android.com/ndk/guides/abis#v7a
   armv7a-android = {
     linux-kernel.name = "armeabi-v7a";
@@ -375,35 +350,6 @@ rec {
     gcc = {
       arch = "mips64r6";
       abi = "64";
-    };
-  };
-
-  # based on:
-  #   https://www.mail-archive.com/qemu-discuss@nongnu.org/msg05179.html
-  #   https://gmplib.org/~tege/qemu.html#mips64-debian
-  mips64el-qemu-linux-gnuabi64 = {
-    linux-kernel = {
-      name = "mips64el";
-      baseConfig = "64r2el_defconfig";
-      target = "vmlinuz";
-      autoModules = false;
-      DTB = true;
-      # for qemu 9p passthrough filesystem
-      extraConfig = ''
-        MIPS_MALTA y
-        PAGE_SIZE_4KB y
-        CPU_LITTLE_ENDIAN y
-        CPU_MIPS64_R2 y
-        64BIT y
-        CPU_MIPS64_R2 y
-
-        NET_9P y
-        NET_9P_VIRTIO y
-        9P_FS y
-        9P_FS_POSIX_ACL y
-        PCI y
-        VIRTIO_PCI y
-      '';
     };
   };
 

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -18,10 +18,6 @@ rec {
     };
   };
 
-  pc_simplekernel = lib.recursiveUpdate pc {
-    linux-kernel.autoModules = false;
-  };
-
   powernv = {
     linux-kernel = {
       name = "PowerNV";

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -33,9 +33,7 @@ rec {
       extraConfig = ''
         PPC_64K_PAGES n
         PPC_4K_PAGES y
-        IPV6 y
 
-        ATA_BMDMA y
         ATA_SFF y
         VIRTIO_MENU y
       '';
@@ -193,11 +191,6 @@ rec {
       DTB = true;
       autoModules = true;
       preferBuiltin = true;
-      extraConfig = ''
-        # Disable OABI to have seccomp_filter (required for systemd)
-        # https://github.com/raspberrypi/firmware/issues/651
-        OABI_COMPAT n
-      '';
       target = "zImage";
     };
     gcc = {
@@ -312,19 +305,6 @@ rec {
       preferBuiltin = true;
       target = "zImage";
       extraConfig = ''
-        # Serial port for Raspberry Pi 3. Wasn't included in ARMv7 defconfig
-        # until 4.17.
-        SERIAL_8250_BCM2835AUX y
-        SERIAL_8250_EXTENDED y
-        SERIAL_8250_SHARE_IRQ y
-
-        # Hangs ODROID-XU4
-        ARM_BIG_LITTLE_CPUIDLE n
-
-        # Disable OABI to have seccomp_filter (required for systemd)
-        # https://github.com/raspberrypi/firmware/issues/651
-        OABI_COMPAT n
-
         # >=5.12 fails with:
         # drivers/net/ethernet/micrel/ks8851_common.o: in function `ks8851_probe_common':
         # ks8851_common.c:(.text+0x179c): undefined reference to `__this_module'
@@ -363,22 +343,6 @@ rec {
       autoModules = true;
       preferBuiltin = true;
       extraConfig = ''
-        # Raspberry Pi 3 stuff. Not needed for   s >= 4.10.
-        ARCH_BCM2835 y
-        BCM2835_MBOX y
-        BCM2835_WDT y
-        RASPBERRYPI_FIRMWARE y
-        RASPBERRYPI_POWER y
-        SERIAL_8250_BCM2835AUX y
-        SERIAL_8250_EXTENDED y
-        SERIAL_8250_SHARE_IRQ y
-
-        # Cavium ThunderX stuff.
-        PCI_HOST_THUNDER_ECAM y
-
-        # Nvidia Tegra stuff.
-        PCI_TEGRA y
-
         # The default (=y) forces us to have the XHCI firmware available in initrd,
         # which our initrd builder can't currently do easily.
         USB_XHCI_TEGRA m

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -307,7 +307,7 @@ rec {
     linux-kernel = {
       name = "armv7l-hf-multiplatform";
       Major = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.
-      baseConfig = "multi_v7_defconfig";
+      baseConfig = "defconfig";
       DTB = true;
       autoModules = true;
       preferBuiltin = true;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -631,8 +631,6 @@ rec {
     else if platform.parsed.cpu == lib.systems.parse.cpuTypes.powerpc64le then
       powernv
 
-    else if platform.isLoongArch64 then
-      loongarch64-multiplatform
     else
       { };
 }

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -306,7 +306,6 @@ rec {
   armv7l-hf-multiplatform = {
     linux-kernel = {
       name = "armv7l-hf-multiplatform";
-      Major = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.
       baseConfig = "defconfig";
       DTB = true;
       autoModules = true;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -211,15 +211,6 @@ rec {
   };
 
   zero-gravitas = {
-    linux-kernel = {
-      name = "zero-gravitas";
-
-      baseConfig = "zero-gravitas_defconfig";
-      # Target verified by checking /boot on reMarkable 1 device
-      target = "zImage";
-      autoModules = false;
-      DTB = true;
-    };
     gcc = {
       fpu = "neon";
       cpu = "cortex-a9";
@@ -227,15 +218,6 @@ rec {
   };
 
   zero-sugar = {
-    linux-kernel = {
-      name = "zero-sugar";
-
-      baseConfig = "zero-sugar_defconfig";
-      DTB = true;
-      autoModules = false;
-      preferBuiltin = true;
-      target = "zImage";
-    };
     gcc = {
       cpu = "cortex-a7";
       fpu = "neon-vfpv4";
@@ -265,24 +247,6 @@ rec {
     gcc = {
       cpu = "cortex-a9";
       fpu = "neon";
-    };
-  };
-
-  guruplug = lib.recursiveUpdate sheevaplug {
-    # Define `CONFIG_MACH_GURUPLUG' (see
-    # <http://kerneltrap.org/mailarchive/git-commits-head/2010/5/19/33618>)
-    # and other GuruPlug-specific things.  Requires the `guruplug-defconfig'
-    # patch.
-    linux-kernel.baseConfig = "guruplug_defconfig";
-  };
-
-  beaglebone = lib.recursiveUpdate armv7l-hf-multiplatform {
-    linux-kernel = {
-      name = "beaglebone";
-      baseConfig = "bb.org_defconfig";
-      autoModules = false;
-      extraConfig = ""; # TBD kernel config
-      target = "zImage";
     };
   };
 
@@ -369,76 +333,6 @@ rec {
   };
 
   fuloong2f_n32 = {
-    linux-kernel = {
-      name = "fuloong2f_n32";
-      baseConfig = "lemote2f_defconfig";
-      autoModules = false;
-      extraConfig = ''
-        MIGRATION n
-        COMPACTION n
-
-        # nixos mounts some cgroup
-        CGROUPS y
-
-        BLK_DEV_RAM y
-        BLK_DEV_INITRD y
-        BLK_DEV_CRYPTOLOOP m
-        BLK_DEV_DM m
-        DM_CRYPT m
-        MD y
-        REISERFS_FS m
-        EXT4_FS m
-        USB_STORAGE_CYPRESS_ATACB m
-
-        IP_PNP y
-        IP_PNP_DHCP y
-        IP_PNP_BOOTP y
-        NFS_FS y
-        ROOT_NFS y
-        TUN m
-        NFS_V4 y
-        NFS_V4_1 y
-        NFS_FSCACHE y
-        NFSD m
-        NFSD_V2_ACL y
-        NFSD_V3 y
-        NFSD_V3_ACL y
-        NFSD_V4 y
-
-        # Fail to build
-        DRM n
-        SCSI_ADVANSYS n
-        USB_ISP1362_HCD n
-        SND_SOC n
-        SND_ALI5451 n
-        FB_SAVAGE n
-        SCSI_NSP32 n
-        ATA_SFF n
-        SUNGEM n
-        IRDA n
-        ATM_HE n
-        SCSI_ACARD n
-        BLK_DEV_CMD640_ENHANCED n
-
-        FUSE_FS m
-
-        # Needed for udev >= 150
-        SYSFS_DEPRECATED_V2 n
-
-        VGA_CONSOLE n
-        VT_HW_CONSOLE_BINDING y
-        SERIAL_8250_CONSOLE y
-        FRAMEBUFFER_CONSOLE y
-        EXT2_FS y
-        EXT3_FS y
-        REISERFS_FS y
-        MAGIC_SYSRQ y
-
-        # The kernel doesn't boot at all, with FTRACE
-        FTRACE n
-      '';
-      target = "vmlinux";
-    };
     gcc = {
       arch = "loongson2f";
       float = "hard";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -71,6 +71,8 @@
 - `gitversion` was updated to 6.3.0, which includes a number of breaking changes, old configurations may need updating or they will cause the tool to fail to run.
   See the [6.0.0 release notes for GitVersion](https://github.com/GitTools/GitVersion/releases/tag/6.0.0) for details on the breaking changes, [the documentation on the configuration format](https://gitversion.net/docs/reference/configuration) for the new configuration specification, and [the documentation on version variables](https://gitversion.net/docs/reference/variables) for what is now supported.
 
+- Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
+
 - `renovate` was updated to v40. See the [upstream release notes](https://github.com/renovatebot/renovate/releases/tag/40.0.0) for breaking changes.
 
 - The `boot.readOnlyNixStore` has been removed. Control over bind mount options on `/nix/store` is now offered by the `boot.nixStoreMountOpts` option.

--- a/nixos/modules/hardware/device-tree.nix
+++ b/nixos/modules/hardware/device-tree.nix
@@ -122,7 +122,8 @@ in
   options = {
     hardware.deviceTree = {
       enable = lib.mkOption {
-        default = pkgs.stdenv.hostPlatform.linux-kernel.DTB or false;
+        default = config.boot.kernelPackages.kernel.buildDTBs;
+        defaultText = lib.literalExpression "config.boot.kernelPackages.kernel.buildDTBs";
         type = lib.types.bool;
         description = ''
           Build device tree files. These are used to describe the

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -110,7 +110,7 @@ with lib;
       #!ipxe
       # Use the cmdline variable to allow the user to specify custom kernel params
       # when chainloading this script from other iPXE scripts like netboot.xyz
-      kernel ${pkgs.stdenv.hostPlatform.linux-kernel.target} init=${config.system.build.toplevel}/init initrd=initrd ${toString config.boot.kernelParams} ''${cmdline}
+      kernel ${config.boot.kernelPackages.kernel.target} init=${config.system.build.toplevel}/init initrd=initrd ${toString config.boot.kernelParams} ''${cmdline}
       initrd initrd
       boot
     '';

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -142,8 +142,8 @@ in
 
     system.boot.loader.kernelFile = mkOption {
       internal = true;
-      default = pkgs.stdenv.hostPlatform.linux-kernel.target;
-      defaultText = literalExpression "pkgs.stdenv.hostPlatform.linux-kernel.target";
+      default = config.boot.kernelPackages.kernel.target;
+      defaultText = literalExpression "config.boot.kernelPackages.kernel.target";
       type = types.str;
       description = ''
         Name of the kernel file to be passed to the bootloader.

--- a/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
+++ b/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
@@ -66,7 +66,6 @@ in
 
     system.build.installBootLoader = generationsDirBuilder;
     system.boot.loader.id = "generationsDir";
-    system.boot.loader.kernelFile = pkgs.stdenv.hostPlatform.linux-kernel.target;
 
   };
 }

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -120,7 +120,7 @@ let
     tarball
     // {
       meta = {
-        description = "NixOS system tarball for ${system} - ${stdenv.hostPlatform.linux-kernel.name}";
+        description = "NixOS system tarball for ${system}";
         maintainers = map (x: lib.maintainers.${x}) maintainers;
       };
       inherit config;

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -155,7 +155,7 @@ let
         modules = makeModules module { };
       };
       build = configEvaled.config.system.build;
-      kernelTarget = configEvaled.pkgs.stdenv.hostPlatform.linux-kernel.target;
+      kernelTarget = build.kernel.target;
     in
     configEvaled.pkgs.symlinkJoin {
       name = "netboot";

--- a/pkgs/build-support/kernel/initrd-compressor-meta.nix
+++ b/pkgs/build-support/kernel/initrd-compressor-meta.nix
@@ -1,18 +1,15 @@
 rec {
   cat = {
     executable = pkgs: "cat";
-    ubootName = "none";
     extension = ".cpio";
   };
   gzip = {
     executable = pkgs: "${pkgs.gzip}/bin/gzip";
     defaultArgs = [ "-9n" ];
-    ubootName = "gzip";
     extension = ".gz";
   };
   bzip2 = {
     executable = pkgs: "${pkgs.bzip2}/bin/bzip2";
-    ubootName = "bzip2";
     extension = ".bz2";
   };
   xz = {
@@ -29,24 +26,20 @@ rec {
       "--check=crc32"
       "--lzma1=dict=512KiB"
     ];
-    ubootName = "lzma";
     extension = ".lzma";
   };
   lz4 = {
     executable = pkgs: "${pkgs.lz4}/bin/lz4";
     defaultArgs = [ "-l" ];
-    ubootName = "lz4";
     extension = ".lz4";
   };
   lzop = {
     executable = pkgs: "${pkgs.lzop}/bin/lzop";
-    ubootName = "lzo";
     extension = ".lzo";
   };
   zstd = {
     executable = pkgs: "${pkgs.zstd}/bin/zstd";
     defaultArgs = [ "-10" ];
-    ubootName = "zstd";
     extension = ".zst";
   };
   pigz = gzip // {

--- a/pkgs/build-support/kernel/make-initrd-ng.nix
+++ b/pkgs/build-support/kernel/make-initrd-ng.nix
@@ -4,14 +4,13 @@ let
   # from it.
   compressors = import ./initrd-compressor-meta.nix;
   # Get the basename of the actual compression program from the whole
-  # compression command, for the purpose of guessing the u-boot
-  # compression type and filename extension.
+  # compression command, for the purpose of guessing the compression
+  # type and filename extension.
   compressorName = fullCommand: builtins.elemAt (builtins.match "([^ ]*/)?([^ ]+).*" fullCommand) 1;
 in
 {
   stdenvNoCC,
   cpio,
-  ubootTools,
   lib,
   pkgsBuildHost,
   makeInitrdNGTool,
@@ -58,22 +57,13 @@ in
   # symlinks to store paths.
   prepend ? [ ],
 
-  # Whether to wrap the initramfs in a u-boot image.
-  makeUInitrd ? stdenvNoCC.hostPlatform.linux-kernel.target == "uImage",
-
-  # If generating a u-boot image, the architecture to use. The default
-  # guess may not align with u-boot's nomenclature correctly, so it can
-  # be overridden.
-  # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L81-106 for a list.
-  uInitrdArch ? stdenvNoCC.hostPlatform.ubootArch,
-
-  # The name of the compression, as recognised by u-boot.
-  # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L195-204 for a list.
-  # If this isn't guessed, you may want to complete the metadata above and send a PR :)
-  uInitrdCompression ?
-    _compressorMeta.ubootName
-      or (throw "Unrecognised compressor ${_compressorName}, please specify uInitrdCompression"),
+  # Deprecated; remove in 26.05.
+  makeUInitrd ? null,
+  uInitrdArch ? null,
+  uInitrdCompression ? null,
 }:
+assert lib.assertMsg (makeUInitrd == null && uInitrdArch == null && uInitrdCompression == null)
+  "makeInitrdNg: U‐Boot legacy image support has been removed as it is deprecated upstream and ARMv5 kernels no longer default to uImage";
 runCommand name
   ({
     compress = "${_compressorExecutable} ${lib.escapeShellArgs _compressorArgsReal}";
@@ -84,11 +74,8 @@ runCommand name
 
     inherit
       extension
-      makeUInitrd
-      uInitrdArch
       prepend
       ;
-    ${if makeUInitrd then "uInitrdCompression" else null} = uInitrdCompression;
 
     passAsFile = [ "contents" ];
     contents = builtins.toJSON contents;
@@ -96,7 +83,7 @@ runCommand name
     nativeBuildInputs = [
       makeInitrdNGTool
       cpio
-    ] ++ lib.optional makeUInitrd ubootTools;
+    ];
   })
   ''
     mkdir -p ./root/var/empty
@@ -107,12 +94,5 @@ runCommand name
       cat $PREP >> $out/initrd
     done
     (cd root && find . -print0 | sort -z | cpio --quiet -o -H newc -R +0:+0 --reproducible --null | eval -- $compress >> "$out/initrd")
-
-    if [ -n "$makeUInitrd" ]; then
-        mkimage -A "$uInitrdArch" -O linux -T ramdisk -C "$uInitrdCompression" -d "$out/initrd" $out/initrd.img
-        # Compatibility symlink
-        ln -sf "initrd.img" "$out/initrd"
-    else
-        ln -s "initrd" "$out/initrd$extension"
-    fi
+    ln -s "initrd" "$out/initrd$extension"
   ''

--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -40,10 +40,4 @@ done
 (cd root && find * .[^.*] -exec touch -h -d '@1' '{}' +)
 (cd root && find * .[^.*] -print0 | sort -z | cpio --quiet -o -H newc -R +0:+0 --reproducible --null | eval -- $compress >> "$out/initrd")
 
-if [ -n "$makeUInitrd" ]; then
-    mkimage -A "$uInitrdArch" -O linux -T ramdisk -C "$uInitrdCompression" -d "$out/initrd" $out/initrd.img
-    # Compatibility symlink
-    ln -sf "initrd.img" "$out/initrd"
-else
-    ln -s "initrd" "$out/initrd$extension"
-fi
+ln -s "initrd" "$out/initrd$extension"

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -3,7 +3,7 @@
   pkgs,
   customQemu ? null,
   kernel ? pkgs.linux,
-  img ? pkgs.stdenv.hostPlatform.linux-kernel.target,
+  img ? kernel.target,
   storeDir ? builtins.storeDir,
   rootModules ? [
     "virtio_pci"

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -646,6 +646,10 @@ let
       # default to dual role mode
       USB_DWC2_DUAL_ROLE = yes;
       USB_DWC3_DUAL_ROLE = yes;
+
+      # The default (=y) forces us to have the XHCI firmware available in initrd,
+      # which our initrd builder can't currently do easily.
+      USB_XHCI_TEGRA = lib.mkIf stdenv.hostPlatform.isAarch64 module;
     };
 
     usb-serial = {
@@ -742,6 +746,7 @@ let
 
       # Native Language Support modules, needed by some filesystems
       NLS = yes;
+
       NLS_DEFAULT = freeform "utf8";
       NLS_UTF8 = module;
       NLS_CODEPAGE_437 = module; # VFAT default for the codepage= mount option
@@ -969,6 +974,9 @@ let
 
       # Enable device detection on virtio-mmio hypervisors
       VIRTIO_MMIO_CMDLINE_DEVICES = yes;
+
+      # Disabled by default on PowerNV.
+      VIRTIO_MENU = yes;
     };
 
     media = {
@@ -1360,6 +1368,9 @@ let
         # Enable generic kernel watch queues
         # See https://docs.kernel.org/core-api/watch_queue.html
         WATCH_QUEUE = whenAtLeast "5.8" yes;
+
+        # Disabled by default on PowerNV.
+        ATA_SFF = yes;
       }
       //
         lib.optionalAttrs
@@ -1464,6 +1475,11 @@ let
 
         # Enable Intel Turbo Boost Max 3.0
         INTEL_TURBO_MAX_3 = yes;
+      }
+      // lib.optionalAttrs (stdenv.hostPlatform.parsed.cpu == lib.systems.parse.cpuTypes.powerpc64le) {
+        # avoid driver/FS trouble arising from unusual page size
+        PPC_64K_PAGES = no;
+        PPC_4K_PAGES = yes;
       };
 
     accel = {

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1060,7 +1060,7 @@ let
         useZstd = stdenv.buildPlatform.is64bit && lib.versionAtLeast version "5.9";
       in
       {
-        # stdenv.hostPlatform.linux-kernel.target assumes uncompressed on RISC-V.
+        # The default target assumes uncompressed on RISC-V.
         KERNEL_UNCOMPRESSED = lib.mkIf stdenv.hostPlatform.isRiscV yes;
         KERNEL_XZ = lib.mkIf (!stdenv.hostPlatform.isRiscV && !useZstd) yes;
         KERNEL_ZSTD = lib.mkIf (

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -64,11 +64,7 @@ let
       # symbolic name and `patch' is the actual patch.  The patch may
       # optionally be compressed with gzip or bzip2.
       kernelPatches ? [ ],
-      ignoreConfigErrors ?
-        !lib.elem stdenv.hostPlatform.linux-kernel.name [
-          "aarch64-multiplatform"
-          "pc"
-        ],
+      ignoreConfigErrors ? !(stdenv.hostPlatform.isx86 || stdenv.hostPlatform.isAarch64),
       extraMeta ? { },
       extraPassthru ? { },
 
@@ -199,7 +195,6 @@ let
 
         RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;
 
-        platformName = stdenv.hostPlatform.linux-kernel.name;
         # e.g. "defconfig"
         kernelBaseConfig =
           if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -143,26 +143,7 @@ let
       intermediateNixConfig =
         configfile.moduleStructuredConfig.intermediateNixConfig
         # extra config in legacy string format
-        + extraConfig
-        + (
-          if stdenv.hostPlatform.isAarch64 then
-            ''
-              # The default (=y) forces us to have the XHCI firmware available in initrd,
-              # which our initrd builder can't currently do easily.
-              USB_XHCI_TEGRA m
-            ''
-          else if stdenv.hostPlatform.parsed.cpu == lib.systems.parse.cpuTypes.powerpc64le then
-            # avoid driver/FS trouble arising from unusual page size
-            ''
-              PPC_64K_PAGES n
-              PPC_4K_PAGES y
-
-              ATA_SFF y
-              VIRTIO_MENU y
-            ''
-          else
-            ""
-        );
+        + extraConfig;
 
       structuredConfigFromPatches = map (
         {

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -25,7 +25,7 @@ lib.mapAttrs (n: make) (
     # on how to request an upload.
     # Sort following the sorting in `./default.nix` `bootstrapFiles` argument.
 
-    armv5tel-unknown-linux-gnueabi = sheevaplug;
+    armv5tel-unknown-linux-gnueabi = armv5tel-multiplatform;
     armv6l-unknown-linux-gnueabihf = raspberryPi;
     armv7l-unknown-linux-gnueabihf = armv7l-hf-multiplatform;
     aarch64-unknown-linux-gnu = aarch64-multiplatform;

--- a/pkgs/test/cross/default.nix
+++ b/pkgs/test/cross/default.nix
@@ -185,7 +185,7 @@ let
       pkgs.pkgsLLVM.stdenv
       pkgs.pkgsStatic.bash
       pkgs.pkgsCross.arm-embedded.stdenv
-      pkgs.pkgsCross.sheevaplug.stdenv # for armv5tel
+      pkgs.pkgsCross.armv5tel-multiplatform.stdenv
       pkgs.pkgsCross.raspberryPi.stdenv # for armv6l
       pkgs.pkgsCross.armv7l-hf-multiplatform.stdenv
       pkgs.pkgsCross.m68k.stdenv

--- a/pkgs/test/cross/default.nix
+++ b/pkgs/test/cross/default.nix
@@ -184,7 +184,6 @@ let
       pkgs.pkgsMusl.stdenv
       pkgs.pkgsLLVM.stdenv
       pkgs.pkgsStatic.bash
-      #pkgs.pkgsCross.gnu64_simplekernel.bash   # https://github.com/NixOS/nixpkgs/issues/264989
       pkgs.pkgsCross.arm-embedded.stdenv
       pkgs.pkgsCross.sheevaplug.stdenv # for armv5tel
       pkgs.pkgsCross.raspberryPi.stdenv # for armv6l

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -191,8 +191,8 @@ in
 
   crossIphone32 = mapTestOnCross systems.examples.iphone32 darwinCommon;
 
-  # Test some cross builds to the Sheevaplug
-  crossSheevaplugLinux = mapTestOnCross systems.examples.sheevaplug (
+  # Test some cross builds to ARMv5
+  armv5tel = mapTestOnCross systems.examples.armv5tel-multiplatform (
     linuxCommon
     // {
       ubootSheevaplug = nativePlatforms;
@@ -226,8 +226,6 @@ in
 
   # Linux on armv7l-hf
   armv7l-hf = mapTestOnCross systems.examples.armv7l-hf-multiplatform linuxCommon;
-
-  pogoplug4 = mapTestOnCross systems.examples.pogoplug4 linuxCommon;
 
   # Linux on aarch64
   aarch64 = mapTestOnCross systems.examples.aarch64-multiplatform linuxCommon;


### PR DESCRIPTION
I suggest reviewing this one commit‐by‐commit. See the commit messages for details, including “lib/systems: move kernel configuration out of the platform structure” for the main motivation.

It would be possible to split this up into several PRs (one of which would be zero rebuilds), and to do a more staged deprecation of some things here, but my GitHub searches suggested that few interfaces touched here are used outside of Nixpkgs, especially by things that actually work in 2025 already.

I have done some testing of this and cited my sources where applicable but have not systematically verified the results across every single platform and supported kernel version.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux *(various cross kernels)*
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
