### PR TITLE
[Backport release-25.05] vscode-extensions.reditorsupport.r: install languageserver correctly

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
@@ -3,8 +3,10 @@
   vscode-utils,
   jq,
   moreutils,
+  languageserver ? rPackages.languageserver,
   python311Packages,
   R,
+
   rPackages,
 }:
 
@@ -19,17 +21,13 @@ vscode-utils.buildVscodeMarketplaceExtension {
     jq
     moreutils
   ];
-  buildInputs = [
-    python311Packages.radian
-    R
-    rPackages.languageserver
-  ];
   postInstall = ''
     cd "$out/$installPrefix"
     jq '.contributes.configuration.properties."r.rpath.mac".default = "${lib.getExe' R "R"}"' package.json | sponge package.json
     jq '.contributes.configuration.properties."r.rpath.linux".default = "${lib.getExe' R "R"}"' package.json | sponge package.json
     jq '.contributes.configuration.properties."r.rterm.mac".default = "${lib.getExe python311Packages.radian}"' package.json | sponge package.json
     jq '.contributes.configuration.properties."r.rterm.linux".default = "${lib.getExe python311Packages.radian}"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."r.libPaths".default = [ "${languageserver}/library" ]' package.json | sponge package.json
   '';
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/REditorSupport.r/changelog";


### PR DESCRIPTION
Manual backport of #419610 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.