### PR TITLE
[Backport release-25.05] nushell: 0.104.0 -> 0.105.1

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -20,7 +20,7 @@
 }:
 
 let
-  version = "0.104.0";
+  version = "0.104.1";
 in
 
 rustPlatform.buildRustPackage {
@@ -31,11 +31,11 @@ rustPlatform.buildRustPackage {
     owner = "nushell";
     repo = "nushell";
     tag = version;
-    hash = "sha256-F4nHCOpbcvmdXDX5KJc9MS3hIIrtMlZR8IjDU7Us/xs=";
+    hash = "sha256-ibQBwcoWzxl7t5q0KpiCiEmAasJJjBg2LMGf28y3sCk=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-zem4HgxO0DD22Bxvs9KN3Zb5E991svV5qcw7MfDUOq4=";
+  cargoHash = "sha256-8HxLX94i86F9vsnlZFgvVdTCkponlEA51WXCT3zlc2w=";
 
   nativeBuildInputs =
     [ pkg-config ]

--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -20,9 +20,8 @@
 }:
 
 let
-  version = "0.104.1";
+  version = "0.105.1";
 in
-
 rustPlatform.buildRustPackage {
   pname = "nushell";
   inherit version;
@@ -31,11 +30,11 @@ rustPlatform.buildRustPackage {
     owner = "nushell";
     repo = "nushell";
     tag = version;
-    hash = "sha256-ibQBwcoWzxl7t5q0KpiCiEmAasJJjBg2LMGf28y3sCk=";
+    hash = "sha256-UcIcCzfe2C7qFJKLo3WxwXyGI1rBBrhQHtrglKNp6ck=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-8HxLX94i86F9vsnlZFgvVdTCkponlEA51WXCT3zlc2w=";
+  cargoHash = "sha256-v3BtcEd1eMtHlDLsu0Y4i6CWA47G0CMOyVlMchj7EJo=";
 
   nativeBuildInputs =
     [ pkg-config ]
@@ -43,13 +42,8 @@ rustPlatform.buildRustPackage {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ rustPlatform.bindgenHook ];
 
   buildInputs =
-    [
-      openssl
-      zstd
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      zlib
-    ]
+    [ zstd ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ zlib ]
     ++ lib.optionals (withDefaultFeatures && stdenv.hostPlatform.isLinux) [ xorg.libX11 ]
     ++ lib.optionals (withDefaultFeatures && stdenv.hostPlatform.isDarwin) [
       nghttp2
@@ -75,9 +69,9 @@ rustPlatform.buildRustPackage {
     runHook postCheck
   '';
 
-  checkInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    curlMinimal
-  ];
+  checkInputs =
+    lib.optionals stdenv.hostPlatform.isDarwin [ curlMinimal ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ openssl ];
 
   passthru = {
     shellPath = "/bin/nu";


### PR DESCRIPTION
Manual backport of #410184 #415706 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
