### PR TITLE
octotail: init at 1.0.17

### DIFF
--- a/pkgs/by-name/oc/octotail/package.nix
+++ b/pkgs/by-name/oc/octotail/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "octotail";
+  version = "1.0.17";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "getbettr";
+    repo = "octotail";
+    tag = "v${version}";
+    hash = "sha256-UC+3XLls8WL4yquCYc8QsPTrKrO5gO8v2NUTM3dMy18=";
+  };
+
+  build-system = [
+    python3.pkgs.hatchling
+  ];
+
+  dependencies = with python3.pkgs; [
+    fake-useragent
+    mitmproxy
+    pygithub
+    pykka
+    pyppeteer
+    pyppeteer-stealth
+    pyxdg
+    returns
+    rich
+    shellingham
+    termcolor
+    typer
+    websockets
+  ];
+
+  pythonImportsCheck = [
+    "octotail"
+  ];
+
+  meta = {
+    description = "Live tail GitHub Action runs on 'git push'. It's cursed";
+    homepage = "https://github.com/getbettr/octotail";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    mainProgram = "octotail";
+  };
+}

--- a/pkgs/development/python-modules/pyppeteer-stealth/default.nix
+++ b/pkgs/development/python-modules/pyppeteer-stealth/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  python,
+  fetchFromGitHub,
+  buildPythonPackage,
+}:
+buildPythonPackage {
+  pname = "pyppeteer-stealth";
+  # https://pypi.org/project/pyppeteer-stealth/#history
+  version = "2.7.4";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "MeiK2333";
+    repo = "pyppeteer_stealth";
+    rev = "0f04fcfbf596052bbbe102d5e68f82956af57338";
+    hash = "sha256-/Ja51TicRytMrL3z/kultuQjhlq3m7IHU/CLY3EqdN8=";
+  };
+
+  pythonImportsCheck = [ "pyppeteer_stealth" ];
+
+  propagatedBuildInputs = [ python.pkgs.pyppeteer ];
+
+  meta = {
+    description = "Pyppeteer stealth";
+    homepage = "https://github.com/MeiK2333/pyppeteer_stealth";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phanirithvij ];
+  };
+}

--- a/pkgs/development/python-modules/pyppeteer/default.nix
+++ b/pkgs/development/python-modules/pyppeteer/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pyppeteer";
-  version = "1.0.2";
+  version = "2.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -27,14 +27,14 @@ buildPythonPackage rec {
     owner = "pyppeteer";
     repo = "pyppeteer";
     tag = version;
-    hash = "sha256-izMaWtJdkLHMQbyq7o7n46xB8dOHXZ5uO0UXt+twjL4=";
+    hash = "sha256-LYyV4Wzz4faewSsGjNe0i/9BLbCHzzEns2ZL2MYkGWw=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'pyee = "^8.1.0"' 'pyee = "*"' \
-      --replace 'urllib3 = "^1.25.8"' 'urllib3 = "*"' \
-      --replace 'websockets = "^10.0"' 'websockets = "*"'
+      --replace-fail 'pyee = "^11.0.0"' 'pyee = "*"' \
+      --replace-fail 'urllib3 = "^1.25.8"' 'urllib3 = "*"' \
+      --replace-fail 'websockets = "^10.0"' 'websockets = "*"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14139,6 +14139,8 @@ self: super: with self; {
 
   pyppeteer-ng = callPackage ../development/python-modules/pyppeteer-ng { };
 
+  pyppeteer-stealth = callPackage ../development/python-modules/pyppeteer-stealth { };
+
   pyppmd = callPackage ../development/python-modules/pyppmd { };
 
   pyprecice = callPackage ../development/python-modules/pyprecice {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
