### PR TITLE
gigalixir: 1.13.1 -> 1.14.0; switch to fetching from github; modernize

### DIFF
--- a/pkgs/by-name/gi/gigalixir/package.nix
+++ b/pkgs/by-name/gi/gigalixir/package.nix
@@ -1,15 +1,15 @@
 {
   stdenv,
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
   git,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "gigalixir";
   version = "1.13.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -18,11 +18,15 @@ python3.pkgs.buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," "" \
-      --replace "cryptography==" "cryptography>="
+      --replace-fail "'pytest-runner'," "" \
+      --replace-fail "cryptography==" "cryptography>="
   '';
 
-  propagatedBuildInputs = with python3.pkgs; [
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
     click
     pygments
     pyopenssl
@@ -32,15 +36,13 @@ python3.pkgs.buildPythonApplication rec {
     stripe
   ];
 
-  nativeCheckInputs =
-    [
-      git
-    ]
-    ++ (with python3.pkgs; [
-      httpretty
-      pytestCheckHook
-      sure
-    ]);
+  nativeCheckInputs = with python3Packages; [
+    git
+
+    httpretty
+    pytestCheckHook
+    sure
+  ];
 
   disabledTests = [
     # Test requires network access
@@ -57,11 +59,11 @@ python3.pkgs.buildPythonApplication rec {
     "gigalixir"
   ];
 
-  meta = with lib; {
+  meta = {
     broken = stdenv.hostPlatform.isDarwin;
     description = "Gigalixir Command-Line Interface";
     homepage = "https://github.com/gigalixir/gigalixir-cli";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "gigalixir";
   };

--- a/pkgs/by-name/gi/gigalixir/package.nix
+++ b/pkgs/by-name/gi/gigalixir/package.nix
@@ -2,24 +2,25 @@
   stdenv,
   lib,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
   git,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "gigalixir";
-  version = "1.13.1";
+  version = "1.14.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-hYIuSLK2HeeXPL28qKvkKwPVpOwObNGrVWbDq6B0/IA=";
+  src = fetchFromGitHub {
+    owner = "gigalixir";
+    repo = "gigalixir-cli";
+    tag = "v${version}";
+    hash = "sha256-D7HbNQ0heQ0aXAA+z0JIwqWlerChPvzXrIGtXz+UiwQ=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace-fail "'pytest-runner'," "" \
-      --replace-fail "cryptography==" "cryptography>="
+      --replace-fail "'pytest-runner'," ""
   '';
 
   build-system = with python3Packages; [
@@ -27,6 +28,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   dependencies = with python3Packages; [
+    importlib-metadata
     click
     pygments
     pyopenssl
@@ -47,6 +49,8 @@ python3Packages.buildPythonApplication rec {
   disabledTests = [
     # Test requires network access
     "test_rollback_without_version"
+    "test_rollback"
+    "test_create_user"
     # These following test's are now depraced and removed, check out these commits:
     # https://github.com/gigalixir/gigalixir-cli/commit/00b758ed462ad8eff6ff0b16cd37fa71f75b2d7d
     # https://github.com/gigalixir/gigalixir-cli/commit/76fa25f96e71fd75cc22e5439b4a8f9e9ec4e3e5
@@ -60,7 +64,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Gigalixir Command-Line Interface";
     homepage = "https://github.com/gigalixir/gigalixir-cli";
     license = lib.licenses.mit;


### PR DESCRIPTION
- **gigalixir: modernize**
- **gigalixir: 1.13.1 -> 1.14.0; switch to fetching from github**

Noticed this package while working on issue #419698, so I bumped it to 1.14.0 as well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
