### PR TITLE
[Backport release-24.11] gcsfuse: 2.5.1 -> 2.12.2

### DIFF
--- a/pkgs/by-name/gc/gcsfuse/package.nix
+++ b/pkgs/by-name/gc/gcsfuse/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "gcsfuse";
-  version = "2.9.0";
+  version = "2.10.0";
 
   src = fetchFromGitHub {
     owner = "googlecloudplatform";
     repo = "gcsfuse";
     rev = "v${version}";
-    hash = "sha256-/Jy8vaCblHqHq0m5bEfYoZhYJOHm+FjMAbbOh6uks+E=";
+    hash = "sha256-gKKsUihV/YiIYbdTPjOXl/SEmi7dTAncNEAnAS/42VY=";
   };
 
   vendorHash = "sha256-/9LhIZ/KThuTI1OYfdZHfV9Ad70gw4Yii3MsE5ZVLSI=";

--- a/pkgs/by-name/gc/gcsfuse/package.nix
+++ b/pkgs/by-name/gc/gcsfuse/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "gcsfuse";
-  version = "2.6.0";
+  version = "2.9.0";
 
   src = fetchFromGitHub {
     owner = "googlecloudplatform";
     repo = "gcsfuse";
     rev = "v${version}";
-    hash = "sha256-+dzArLWP6mZ0m/pS64AYPckpf4SDu0Rt84x00Q4QC7I=";
+    hash = "sha256-/Jy8vaCblHqHq0m5bEfYoZhYJOHm+FjMAbbOh6uks+E=";
   };
 
-  vendorHash = "sha256-FIPIEIa14oOIgHonXXYwQS9XkuCJjABgq6I8B7V1jQI=";
+  vendorHash = "sha256-/9LhIZ/KThuTI1OYfdZHfV9Ad70gw4Yii3MsE5ZVLSI=";
 
   subPackages = [
     "."

--- a/pkgs/by-name/gc/gcsfuse/package.nix
+++ b/pkgs/by-name/gc/gcsfuse/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "gcsfuse";
-  version = "2.5.1";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     owner = "googlecloudplatform";
     repo = "gcsfuse";
     rev = "v${version}";
-    hash = "sha256-4UzRg6fNKBrTSoimJ9jURW9oPRhUOAUDMG3JaM7f100=";
+    hash = "sha256-+dzArLWP6mZ0m/pS64AYPckpf4SDu0Rt84x00Q4QC7I=";
   };
 
-  vendorHash = "sha256-QrpILFzgUQwmrvjCdtrlgq1zSW7f82qMHsifI39WaB0=";
+  vendorHash = "sha256-FIPIEIa14oOIgHonXXYwQS9XkuCJjABgq6I8B7V1jQI=";
 
   subPackages = [
     "."

--- a/pkgs/by-name/gc/gcsfuse/package.nix
+++ b/pkgs/by-name/gc/gcsfuse/package.nix
@@ -1,22 +1,22 @@
 {
   lib,
-  buildGoModule,
+  buildGo124Module,
   fetchFromGitHub,
   stdenv,
 }:
 
-buildGoModule rec {
+buildGo124Module rec {
   pname = "gcsfuse";
-  version = "2.10.0";
+  version = "2.11.0";
 
   src = fetchFromGitHub {
     owner = "googlecloudplatform";
     repo = "gcsfuse";
     rev = "v${version}";
-    hash = "sha256-gKKsUihV/YiIYbdTPjOXl/SEmi7dTAncNEAnAS/42VY=";
+    hash = "sha256-TOilPoyibR6tuBeSuu+kSUE5xamurD31QJ1486rZHG0=";
   };
 
-  vendorHash = "sha256-/9LhIZ/KThuTI1OYfdZHfV9Ad70gw4Yii3MsE5ZVLSI=";
+  vendorHash = "sha256-Xw2XsDhQpJJq7peh015ckIvV7yG87dE+HZ2b+XwuXMY=";
 
   subPackages = [
     "."

--- a/pkgs/by-name/gc/gcsfuse/package.nix
+++ b/pkgs/by-name/gc/gcsfuse/package.nix
@@ -7,13 +7,13 @@
 
 buildGo124Module rec {
   pname = "gcsfuse";
-  version = "2.11.0";
+  version = "2.11.1";
 
   src = fetchFromGitHub {
     owner = "googlecloudplatform";
     repo = "gcsfuse";
     rev = "v${version}";
-    hash = "sha256-TOilPoyibR6tuBeSuu+kSUE5xamurD31QJ1486rZHG0=";
+    hash = "sha256-SWbIfAE/pmokhJO0rimfHqxqOH23HrJRTJHDikNC7TI=";
   };
 
   vendorHash = "sha256-Xw2XsDhQpJJq7peh015ckIvV7yG87dE+HZ2b+XwuXMY=";

--- a/pkgs/by-name/gc/gcsfuse/package.nix
+++ b/pkgs/by-name/gc/gcsfuse/package.nix
@@ -7,16 +7,16 @@
 
 buildGo124Module rec {
   pname = "gcsfuse";
-  version = "2.12.1";
+  version = "2.12.2";
 
   src = fetchFromGitHub {
     owner = "googlecloudplatform";
     repo = "gcsfuse";
     rev = "v${version}";
-    hash = "sha256-5sQU1yVt4oOSpanteeH2eBHNphbPoGPhS8m2ZkPr1sE=";
+    hash = "sha256-WuCrwL7iM9U4qXtLNntLeOxELe+tR7dsbsJyvdLHVaI=";
   };
 
-  vendorHash = "sha256-aXhgl7CQavI6iSQ6AVt9x536bQxlbRIqkUf99MudoYI=";
+  vendorHash = "sha256-aj3NvgKuaBiAfPNLYK9g7kzBcdeMkC4I6jjtvFHxsU8=";
 
   subPackages = [
     "."

--- a/pkgs/by-name/gc/gcsfuse/package.nix
+++ b/pkgs/by-name/gc/gcsfuse/package.nix
@@ -7,16 +7,16 @@
 
 buildGo124Module rec {
   pname = "gcsfuse";
-  version = "2.11.1";
+  version = "2.12.1";
 
   src = fetchFromGitHub {
     owner = "googlecloudplatform";
     repo = "gcsfuse";
     rev = "v${version}";
-    hash = "sha256-SWbIfAE/pmokhJO0rimfHqxqOH23HrJRTJHDikNC7TI=";
+    hash = "sha256-5sQU1yVt4oOSpanteeH2eBHNphbPoGPhS8m2ZkPr1sE=";
   };
 
-  vendorHash = "sha256-Xw2XsDhQpJJq7peh015ckIvV7yG87dE+HZ2b+XwuXMY=";
+  vendorHash = "sha256-aXhgl7CQavI6iSQ6AVt9x536bQxlbRIqkUf99MudoYI=";
 
   subPackages = [
     "."


### PR DESCRIPTION
Contains security fix for CVE-2025-27144.

Manual backport of #364915 #373715 #384363 #390822 #394194 #404936 #415050 to `release-24.11`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
