### PR TITLE
libcap_ng: modernize, adopt

### DIFF
--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,10 +27,17 @@ stdenv.mkDerivation (finalAttrs: {
     "--without-python"
   ];
 
+  passthru = {
+    tests = {
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    };
+  };
+
   meta = {
     changelog = "https://people.redhat.com/sgrubb/libcap-ng/ChangeLog";
     description = "Library for working with POSIX capabilities";
     homepage = "https://people.redhat.com/sgrubb/libcap-ng/";
+    pkgConfigModules = [ "libcap-ng" ];
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl21;
   };

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
+  swig,
   testers,
 }:
 
@@ -9,13 +11,25 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libcap-ng";
   version = "0.8.5";
 
-  src = fetchurl {
-    url = "https://people.redhat.com/sgrubb/libcap-ng/libcap-ng-${finalAttrs.version}.tar.gz";
-    hash = "sha256-O6UpTRy9+pivqs+8ALavntK4PoohgXGF39hEzIx6xv8=";
+  src = fetchFromGitHub {
+    owner = "stevegrubb";
+    repo = "libcap-ng";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qcHIHG59PDPfPsXA1r4hG4QhK2qyE7AgXOwUDjIy7lE=";
   };
+
+  # NEWS needs to exist or else the build fails
+  postPatch = ''
+    touch NEWS
+  '';
 
   strictDeps = true;
   enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    swig
+  ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -4,14 +4,17 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libcap-ng";
   version = "0.8.5";
 
   src = fetchurl {
-    url = "https://people.redhat.com/sgrubb/libcap-ng/libcap-ng-${version}.tar.gz";
+    url = "https://people.redhat.com/sgrubb/libcap-ng/libcap-ng-${finalAttrs.version}.tar.gz";
     hash = "sha256-O6UpTRy9+pivqs+8ALavntK4PoohgXGF39hEzIx6xv8=";
   };
+
+  strictDeps = true;
+  enableParallelBuilding = true;
 
   outputs = [
     "out"
@@ -23,10 +26,11 @@ stdenv.mkDerivation rec {
     "--without-python"
   ];
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://people.redhat.com/sgrubb/libcap-ng/ChangeLog";
     description = "Library for working with POSIX capabilities";
     homepage = "https://people.redhat.com/sgrubb/libcap-ng/";
-    platforms = platforms.linux;
-    license = licenses.lgpl21;
+    platforms = lib.platforms.linux;
+    license = lib.licenses.lgpl21;
   };
-}
+})

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -47,6 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  # assumption: build machine runs linux kernel 5.0 or newer
+  # see https://github.com/stevegrubb/libcap-ng?tab=readme-ov-file#note-to-distributions
+  doCheck = true;
+
   meta = {
     changelog = "https://people.redhat.com/sgrubb/libcap-ng/ChangeLog";
     description = "Library for working with POSIX capabilities";

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -5,6 +5,7 @@
   autoreconfHook,
   swig,
   testers,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -42,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru = {
+    updateScript = nix-update-script { };
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     };

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -60,5 +60,6 @@ stdenv.mkDerivation (finalAttrs: {
     pkgConfigModules = [ "libcap-ng" ];
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ grimmauld ];
   };
 })


### PR DESCRIPTION
- add update script
- build from github sources (simplifies update script)
- `pkg-config` passthru tester
- add `changelog` to meta
- add pkg-config modules to meta
- add grimmauld to `meta.maintainers`
- use `finalAttrs` pattern
- `strictDeps = true`
- `parallelBuilding = true`
- `doCheck = true`

Checked using diffoscope: The output is basically unchanged apart from one libtool version string, and a couple nix store hashes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-linux (cross)
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
