### PR TITLE
[Backport release-25.05] [python3Packages.]uv: remove `cmake`, reuse existing `uv` binary.

### DIFF
--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -8,9 +8,7 @@
   rust-jemalloc-sys,
 
   # nativeBuildInputs
-  cmake,
   installShellFiles,
-  pkg-config,
 
   buildPackages,
   versionCheckHook,
@@ -36,13 +34,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rust-jemalloc-sys
   ];
 
-  nativeBuildInputs = [
-    cmake
-    installShellFiles
-    pkg-config
-  ];
-
-  dontUseCmakeConfigure = true;
+  nativeBuildInputs = [ installShellFiles ];
 
   cargoBuildFlags = [
     "--package"
@@ -64,9 +56,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ''
   );
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 

--- a/pkgs/development/python-modules/uv/default.nix
+++ b/pkgs/development/python-modules/uv/default.nix
@@ -1,36 +1,45 @@
 {
   buildPythonPackage,
-  installShellFiles,
-  rustPlatform,
-  pkgs,
-  versionCheckHook,
+  hatchling,
+  lib,
+  uv,
 }:
 
 buildPythonPackage {
-  inherit (pkgs.uv)
+  inherit (uv)
     pname
     version
     src
-    cargoDeps
     meta
-    cargoBuildFlags
-    postInstall
-    versionCheckProgramArg
     ;
+  pyproject = true;
 
-  postPatch = ''
-    substituteInPlace python/uv/_find_uv.py \
-      --replace-fail '"""Return the uv binary path."""' "return '$out/bin/uv'"
+  build-system = [ hatchling ];
+
+  postPatch =
+    # Do not rely on path lookup at runtime to find the uv binary.
+    # Use the propagated binary instead.
+    ''
+      substituteInPlace python/uv/_find_uv.py \
+        --replace-fail '"""Return the uv binary path."""' "return '${lib.getExe uv}'"
+    ''
+    # Sidestep the maturin build system in favour of reusing the binary already built by nixpkgs,
+    # to avoid rebuilding the uv binary for every active python package set.
+    + ''
+      substituteInPlace pyproject.toml \
+        --replace-fail 'requires = ["maturin>=1.0,<2.0"]' 'requires = ["hatchling"]' \
+        --replace-fail 'build-backend = "maturin"' 'build-backend = "hatchling.build"'
+
+      cat >> pyproject.toml <<EOF
+      [tool.hatch.build]
+      packages = ['python/uv']
+
+      EOF
+    '';
+
+  postInstall = ''
+    mkdir -p $out/bin && ln -s ${lib.getExe uv} $out/bin/uv
   '';
 
-  nativeBuildInputs = [
-    installShellFiles
-    rustPlatform.cargoSetupHook
-    rustPlatform.maturinBuildHook
-  ];
-
-  nativeCheckInputs = [ versionCheckHook ];
-
-  pyproject = true;
   pythonImportsCheck = [ "uv" ];
 }

--- a/pkgs/development/python-modules/uv/default.nix
+++ b/pkgs/development/python-modules/uv/default.nix
@@ -3,6 +3,7 @@
   installShellFiles,
   rustPlatform,
   pkgs,
+  versionCheckHook,
 }:
 
 buildPythonPackage {
@@ -27,6 +28,8 @@ buildPythonPackage {
     rustPlatform.cargoSetupHook
     rustPlatform.maturinBuildHook
   ];
+
+  nativeCheckInputs = [ versionCheckHook ];
 
   pyproject = true;
   pythonImportsCheck = [ "uv" ];

--- a/pkgs/development/python-modules/uv/default.nix
+++ b/pkgs/development/python-modules/uv/default.nix
@@ -1,7 +1,6 @@
 {
   buildPythonPackage,
   installShellFiles,
-  pkg-config,
   rustPlatform,
   pkgs,
 }:
@@ -12,7 +11,6 @@ buildPythonPackage {
     version
     src
     cargoDeps
-    dontUseCmakeConfigure
     meta
     cargoBuildFlags
     postInstall
@@ -25,9 +23,7 @@ buildPythonPackage {
   '';
 
   nativeBuildInputs = [
-    pkgs.cmake
     installShellFiles
-    pkg-config
     rustPlatform.cargoSetupHook
     rustPlatform.maturinBuildHook
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18613,7 +18613,7 @@ self: super: with self; {
 
   uuid6 = callPackage ../development/python-modules/uuid6 { };
 
-  uv = callPackage ../development/python-modules/uv { };
+  uv = callPackage ../development/python-modules/uv { inherit (pkgs) uv; };
 
   uv-build = callPackage ../development/python-modules/uv-build { };
 


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/407665 (remove `cmake`, `pkg-config`) and https://github.com/NixOS/nixpkgs/pull/412206 (reuse existing `uv` binary).

As these changes only affect the way the package is built, and don't change anything about how `uv` functions, this should be acceptable for backport.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
