### PR TITLE
rescript-language-server: Fix updateScript, slight refactor

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
+++ b/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  nix-update-script,
   ocamlPackages,
 }:
 
@@ -13,8 +14,8 @@ ocamlPackages.buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "rescript-lang";
     repo = "rescript-vscode";
-    rev = version;
-    hash = "sha256-v+qCVge57wvA97mtzbxAX9Fvi7ruo6ZyIC14O8uWl9Y=";
+    tag = version;
+    hash = "sha256-Tox5Qq0Kpqikac90sQww2cGr9RHlXnVy7GMnRA18CoA=";
   };
 
   strictDeps = true;
@@ -22,12 +23,21 @@ ocamlPackages.buildDunePackage rec {
     ocamlPackages.cppo
   ];
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "([0-9]+\.[0-9]+\.[0-9]+)"
+    ];
+  };
+
   meta = {
     description = "Analysis binary for the ReScript VSCode plugin";
     homepage = "https://github.com/rescript-lang/rescript-vscode";
-    maintainers = [
-      lib.maintainers.dlip
-      lib.maintainers.jayesh-bhoot
+    changelog = "https://github.com/rescript-lang/rescript-vscode/releases/tag/${version}";
+    maintainers = with lib.maintainers; [
+      dlip
+      jayesh-bhoot
+      RossSmyth
     ];
     license = lib.licenses.mit;
     mainProgram = "rescript-editor-analysis";

--- a/pkgs/by-name/re/rescript-language-server/package.nix
+++ b/pkgs/by-name/re/rescript-language-server/package.nix
@@ -9,23 +9,25 @@
   rescript-editor-analysis,
 }:
 let
-  version = "1.62.0";
-
   platformDir =
     if stdenv.hostPlatform.isLinux then
       "linux"
     else if stdenv.hostPlatform.isDarwin then
       "darwin"
+    else if stdenv.hostPlatform.isFreeBSD then
+      "freebsd"
+    else if stdenv.hostPlatform.isWindows then
+      "win32"
     else
       throw "Unsupported system: ${stdenv.system}";
 in
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   # These have the same source, and must be the same version.
-  inherit (rescript-editor-analysis) src;
+  inherit (rescript-editor-analysis) src version;
   pname = "rescript-language-server";
-  inherit version;
 
-  sourceRoot = "${src.name}/server";
+  sourceRoot = "${finalAttrs.src.name}/server";
+
   npmDepsHash = "sha256-Qi41qDJ0WR0QWw7guhuz1imT51SqI7mORGjNbmZWnio";
 
   strictDeps = true;
@@ -36,14 +38,17 @@ buildNpmPackage rec {
   buildPhase = ''
     runHook preBuild
 
-    # https://github.com/rescript-lang/rescript-vscode/blob/1.62.0/.github/workflows/ci.yml#L182-L183
-    mkdir analysis_binaries/${platformDir}
-    cp ${lib.getExe rescript-editor-analysis} analysis_binaries/${platformDir}/
-
     # https://github.com/rescript-lang/rescript-vscode/blob/1.62.0/package.json#L252
     esbuild src/cli.ts --bundle --sourcemap --outfile=out/cli.js --format=cjs --platform=node --loader:.node=file --minify
 
     runHook postBuild
+  '';
+
+  postInstall = ''
+    DIR="$out/lib/node_modules/@rescript/language-server/analysis_binaries/${platformDir}"
+
+    mkdir -p "$DIR"
+    ln -s ${lib.getExe rescript-editor-analysis} "$DIR"/rescript-editor-analysis
   '';
 
   nativeInstallCheckInputs = [
@@ -52,15 +57,21 @@ buildNpmPackage rec {
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex" "([0-9]\.[0-9][0-9]\.[0-9])"]; };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "([0-9]+\.[0-9]+\.[0-9]+)"
+    ];
+  };
 
   meta = {
     description = "ReScript Language Server";
-    homepage = "https://github.com/rescript-lang/rescript-vscode/tree/${version}/server";
-    changelog = "https://github.com/rescript-lang/rescript-vscode/releases/tag/${version}";
+    homepage = "https://github.com/rescript-lang/rescript-vscode/tree/${finalAttrs.version}/server";
+    changelog = "https://github.com/rescript-lang/rescript-vscode/releases/tag/${finalAttrs.version}";
     mainProgram = "rescript-language-server";
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = [ lib.maintainers.RossSmyth ];
+    # https://github.com/rescript-lang/rescript-vscode/blob/1.62.0/CONTRIBUTING.md?plain=1#L186
+    platforms = with lib.platforms; linux ++ darwin ++ windows ++ freebsd;
+    maintainers = with lib.maintainers; [ RossSmyth ];
   };
-}
+})

--- a/pkgs/by-name/re/rescript-language-server/package.nix
+++ b/pkgs/by-name/re/rescript-language-server/package.nix
@@ -20,18 +20,13 @@ let
       throw "Unsupported system: ${stdenv.system}";
 in
 buildNpmPackage rec {
+  # These have the same source, and must be the same version.
+  inherit (rescript-editor-analysis) src;
   pname = "rescript-language-server";
   inherit version;
 
-  src = fetchFromGitHub {
-    owner = "rescript-lang";
-    repo = "rescript-vscode";
-    tag = version;
-    hash = "sha256-Tox5Qq0Kpqikac90sQww2cGr9RHlXnVy7GMnRA18CoA=";
-  };
-
   sourceRoot = "${src.name}/server";
-  npmDepsHash = "sha256-Qi41qDJ0WR0QWw7guhuz1imT51SqI7mORGjNbmZWnio=";
+  npmDepsHash = "sha256-Qi41qDJ0WR0QWw7guhuz1imT51SqI7mORGjNbmZWnio";
 
   strictDeps = true;
   nativeBuildInputs = [ esbuild ];
@@ -57,7 +52,7 @@ buildNpmPackage rec {
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex" "([0-9]\.[0-9][0-9]\.[0-9])"]; };
 
   meta = {
     description = "ReScript Language Server";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. The update script would pull the nightly tag. This fixes it so it will only grab releases
2. Refactored so that all of the supported platforms could be built (they don't due to other packages being broken)
3. rec -> finalAttrs
4. Use the same source as rescript-editor-analysis to ensure they stay in sync
5. Use a symlink rather than copying the analysis binary

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
