### PR TITLE
correct the link to workflow file in pkgs/by-name/README.md

### DIFF
--- a/pkgs/by-name/README.md
+++ b/pkgs/by-name/README.md
@@ -140,8 +140,6 @@ You can locally emulate the CI check using
 $ ./ci/nixpkgs-vet.sh master
 ```
 
-See [here](../../.github/workflows/nixpkgs-vet.yml) for more info.
-
 ## Recommendation for new packages with multiple versions
 
 These checks of the `pkgs/by-name` structure can cause problems in combination:


### PR DESCRIPTION
## Things done

- Change the link to the workflow file in the pkgs/by-name/README.md file from `nixpkgs-vet.yml` to `lint.yml`. The workflow file was renamed in 7de034555644ba323a89633d69ebbd887ba4dc03.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
