### PR TITLE
terraform-mcp-server init at 0.1.0

### DIFF
--- a/pkgs/by-name/te/terraform-mcp-server/package.nix
+++ b/pkgs/by-name/te/terraform-mcp-server/package.nix
@@ -1,0 +1,42 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule (finalAttrs: {
+  pname = "terraform-mcp-server";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "hashicorp";
+    repo = "terraform-mcp-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HYiA0Mfp87czQShiXbS+y20yQzxTn0+hfM0M1kLFZFM=";
+  };
+
+  vendorHash = "sha256-m4J2WGcL0KB1InyciQEmLOSBw779/kagUOIkTwc4CE4=";
+
+  ldflags = [
+    "-X main.version=${finalAttrs.version}"
+    "-X main.commit=${finalAttrs.src.rev}"
+  ];
+
+  subPackages = [ "cmd/terraform-mcp-server" ];
+
+  meta = {
+    description = "Terraform Model Context Protocol (MCP) Server";
+    longDescription = ''
+      The Terraform MCP Server is a Go implementation of the Model Context
+      Protocol (MCP) server that provides seamless integration with Terraform
+      Registry APIs, enabling advanced automation and interaction capabilities
+      for developers and tools.
+
+      This server allows LLMs to interact with Terraform modules, providers,
+      and other Terraform Registry features through structured API interactions.
+    '';
+    homepage = "https://github.com/hashicorp/terraform-mcp-server";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ connerohnesorge ];
+    mainProgram = "terraform-mcp-server";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

Tested first few stdio calls to the terraform mcp server.
