### PR TITLE
input-leap: build on Darwin at 3.0.3

### DIFF
--- a/pkgs/applications/misc/input-leap/default.nix
+++ b/pkgs/applications/misc/input-leap/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
 
-  withLibei ? true,
+  withLibei ? !stdenv.hostPlatform.isDarwin,
 
   avahi,
   curl,
@@ -19,6 +19,7 @@
   libei,
   libportal,
   openssl,
+  pkgsStatic,
   pkg-config,
   qtbase,
   qttools,
@@ -38,6 +39,8 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [ ./macos-no-dmg.patch ];
+
   nativeBuildInputs = [
     pkg-config
     cmake
@@ -45,6 +48,7 @@ stdenv.mkDerivation rec {
     wrapQtAppsHook
     qttools
   ];
+
   buildInputs =
     [
       curl
@@ -62,6 +66,9 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withLibei [
       libei
       libportal
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      pkgsStatic.openssl
     ];
 
   cmakeFlags = [
@@ -94,6 +101,6 @@ stdenv.mkDerivation rec {
       twey
       shymega
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }

--- a/pkgs/applications/misc/input-leap/macos-no-dmg.patch
+++ b/pkgs/applications/misc/input-leap/macos-no-dmg.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ab4e56f2..d01d946d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -289,17 +289,6 @@ endmacro (configure_files)
+ # Make a bundle for mac os
+ if (APPLE)
+     set (CMAKE_INSTALL_RPATH "@loader_path/../Libraries;@loader_path/../Frameworks")
+-    set(INPUTLEAP_BUNDLE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/dist/macos/bundle)
+-    set(INPUTLEAP_BUNDLE_DIR ${CMAKE_BINARY_DIR}/bundle)
+-    set(INPUTLEAP_BUNDLE_APP_DIR ${INPUTLEAP_BUNDLE_DIR}/InputLeap.app)
+-    set(INPUTLEAP_BUNDLE_BINARY_DIR ${INPUTLEAP_BUNDLE_APP_DIR}/Contents/MacOS)
+-
+-    configure_files(${INPUTLEAP_BUNDLE_SOURCE_DIR} ${INPUTLEAP_BUNDLE_DIR})
+-
+-    add_custom_target(InputLeap_MacOS ALL
+-                      bash build_dist.sh
+-                      DEPENDS input-leap input-leaps input-leapc
+-                      WORKING_DIRECTORY ${INPUTLEAP_BUNDLE_DIR})
+ elseif (UNIX AND NOT APPLE)
+     install(FILES doc/input-leapc.1 doc/input-leaps.1 DESTINATION share/man/man1)
+ 


### PR DESCRIPTION
This builds `input-leap` on Darwin. Closes #419996. I'll rebase on #419991 once that lands.

CC @shymega 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
