### PR TITLE
dia-browser: init at 0.38.0-65530

### DIFF
--- a/pkgs/by-name/di/dia-browser/package.nix
+++ b/pkgs/by-name/di/dia-browser/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+  writeShellApplication,
+  cacert,
+  curl,
+  common-updater-scripts,
+  xmlstarlet,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "dia-browser";
+  version = "0.38.0-65530";
+
+  src = fetchurl {
+    url = "https://releases.diabrowser.com/release/Dia-${finalAttrs.version}.zip";
+    hash = "sha256-+WthIiVUYpsEueE25zDc6BwHRcftSl8LkxzyAkx0TLM=";
+  };
+
+  # Preserve Notarization
+  dontFixup = true;
+
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = "Dia.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications/Dia.app"
+    cp -R . "$out/Applications/Dia.app"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "dia-browser-update-script";
+    runtimeInputs = [
+      cacert
+      curl
+      common-updater-scripts
+      xmlstarlet
+    ];
+    text = ''
+      xml_content=$(curl -s "https://releases.diabrowser.com/BoostBrowser-updates.xml")
+      latest_build=$(echo "$xml_content" | xmlstarlet sel -N sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" -t -v "//item[1]/sparkle:version" 2>/dev/null || echo "")
+      short_version=$(echo "$xml_content" | xmlstarlet sel -N sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" -t -v "//item[1]/sparkle:shortVersionString" 2>/dev/null || echo "")
+      # Parse version from shortVersionString (format: "0.35.2 (64884)")
+      version_info=$(echo "$short_version" | sed -n 's/^\([0-9]*\.[0-9]*\.[0-9]*\) .*/\1/p' || echo "")
+
+      if [[ -z "$latest_build" || -z "$version_info" ]]; then
+        echo "Failed to extract version information from XML feed"
+        echo "Build: '$latest_build', Version: '$version_info'"
+        echo "Short version string: '$short_version'"
+        exit 1
+      fi
+      new_version="$version_info-$latest_build"
+
+      update-source-version dia-browser "$new_version"
+    '';
+  });
+
+  meta = {
+    description = "Dia the AI browser from The Browser Company";
+    homepage = "https://www.diabrowser.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ donteatoreo ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc