### PR TITLE
[Backport release-25.05] opencv: remove CUDA toolkit

### DIFF
--- a/pkgs/applications/graphics/qimgv/default.nix
+++ b/pkgs/applications/graphics/qimgv/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     exiv2
     mpv
-    opencv4
+    opencv4.cxxdev
     libsForQt5.qtbase
     libsForQt5.qtimageformats
     libsForQt5.qtsvg

--- a/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     obs-studio
     onnxruntime
-    opencv
+    opencv.cxxdev
     qt6.qtbase
     curl
   ];

--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
       webkitgtk_4_0
       wxGTK'
       xorg.libX11
-      opencv
+      opencv.cxxdev
     ]
     ++ lib.optionals withSystemd [ systemd ]
     ++ checkInputs;

--- a/pkgs/by-name/ba/basalt-monado/package.nix
+++ b/pkgs/by-name/ba/basalt-monado/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
     libGL
     lz4
     magic-enum
-    opencv
+    opencv.cxxdev
     tbb
     xorg.libX11
   ];

--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
       webkitgtk_4_0
       wxGTK'
       xorg.libX11
-      opencv
+      opencv.cxxdev
       libnoise
     ]
     ++ lib.optionals withSystemd [ systemd ]

--- a/pkgs/by-name/rp/rpcs3/package.nix
+++ b/pkgs/by-name/rp/rpcs3/package.nix
@@ -129,7 +129,7 @@ stdenv.mkDerivation {
       flatbuffers
       llvm_18
       libSM
-      opencv
+      opencv.cxxdev
     ]
     ++ cubeb.passthru.backendLibs
     ++ lib.optional faudioSupport faudio

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -585,13 +585,9 @@ effectiveStdenv.mkDerivation {
       mkdir -p "$cxxdev/nix-support"
       echo "''${!outputDev}" >> "$cxxdev/nix-support/propagated-build-inputs"
     ''
-    # hard-wire CUDA_TOOLKIT_ROOT_DIR so FindCUDA sees the toolkit
     # remove the requirement that the exact same version of CUDA is used in packages
-    #   consuming OpenCV's CMakes files
+    # consuming OpenCV's CMakes files
     + optionalString enableCuda ''
-      sed -i '1s;^;set(CUDA_TOOLKIT_ROOT_DIR ${cudaPackages.cudatoolkit})\n;' \
-        "$out/lib/cmake/opencv4/OpenCVConfig.cmake"
-
       substituteInPlace "$out/lib/cmake/opencv4/OpenCVConfig.cmake" \
         --replace-fail \
           'find_host_package(CUDA ''${OpenCV_CUDA_VERSION} EXACT REQUIRED)' \

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -591,7 +591,7 @@ effectiveStdenv.mkDerivation {
       substituteInPlace "$out/lib/cmake/opencv4/OpenCVConfig.cmake" \
         --replace-fail \
           'find_host_package(CUDA ''${OpenCV_CUDA_VERSION} EXACT REQUIRED)' \
-          'find_host_package(CUDA REQUIRED)' \
+          'find_host_package(CUDAToolkit REQUIRED)' \
         --replace-fail \
           'message(FATAL_ERROR "OpenCV static library was compiled with CUDA' \
           'message("OpenCV static library was compiled with CUDA'


### PR DESCRIPTION
Manual backport of #419716 due to a merge conflict.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
