### PR TITLE
keymap-drawer: init at 0.22.0

### DIFF
--- a/pkgs/by-name/ke/keymap-drawer/package.nix
+++ b/pkgs/by-name/ke/keymap-drawer/package.nix
@@ -1,0 +1,4 @@
+{
+  python3Packages,
+}:
+python3Packages.toPythonApplication python3Packages.keymap-drawer

--- a/pkgs/development/python-modules/keymap-drawer/default.nix
+++ b/pkgs/development/python-modules/keymap-drawer/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  nix-update-script,
+  pcpp,
+  platformdirs,
+  poetry-core,
+  pydantic,
+  pydantic-settings,
+  pyparsing,
+  pyyaml,
+  tree-sitter,
+  tree-sitter-grammars,
+  versionCheckHook,
+}:
+let
+  version = "0.22.0";
+in
+buildPythonPackage {
+  inherit version;
+  pname = "keymap-drawer";
+  pyproject = true;
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "caksoylar";
+    repo = "keymap-drawer";
+    tag = "v${version}";
+    hash = "sha256-SPnIfrUA0M9xznjEe60T+0VHh9lCmY4cni9hyqFlZqM=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pcpp
+    platformdirs
+    pydantic
+    pydantic-settings
+    pyparsing
+    pyyaml
+    tree-sitter
+    tree-sitter-grammars.tree-sitter-devicetree
+  ];
+
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+
+  pythonImportsCheck = [ "keymap_drawer" ];
+
+  versionCheckProgram = "${placeholder "out"}/bin/keymap";
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Module and CLI tool to help parse and draw keyboard layouts";
+    homepage = "https://github.com/caksoylar/keymap-drawer";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      MattSturgeon
+    ];
+    mainProgram = "keymap";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7584,6 +7584,8 @@ self: super: with self; {
 
   keyboard = callPackage ../development/python-modules/keyboard { };
 
+  keymap-drawer = callPackage ../development/python-modules/keymap-drawer { };
+
   keyring = callPackage ../development/python-modules/keyring { };
 
   keyring-pass = callPackage ../development/python-modules/keyring-pass { };


### PR DESCRIPTION
<h1 align="center"><img alt="keymap-drawer logo" src="https://caksoylar.github.io/keymap-drawer/logo.svg" max-width="100%"/></h1>

Add the [keymap-drawer](https://github.com/caksoylar/keymap-drawer) python package, which I've been using to draw [my glove80 keymap](https://github.com/MattSturgeon/Glove80-Config) via an [out-of-tree package](https://github.com/MattSturgeon/glove80-config/blob/d55267dd26593037256b35a5d6ebba0f75541da5/packages/keymap-drawer.nix). This PR upstreams that package to nixpkgs.

keymap-drawer is able to render [ZMK](https://zmk.dev) and [QMK](https://qmk.fm) keymaps to SVG images.

The upstream repo currently has _nearly_ 1000 GitHub Stars. It can be used as a python module, although it is primarily intended to be used as a CLI tool.

As an alternative to using the package directly, upstream also provides a GitHub Actions "reusable workflow" and a web-app.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Used this branch as a flake input to my glove80 keymap, and used this package instead of the out-of-tree package. Everything seems to work as expected.
- [ ] [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
