### PR TITLE
sgx-psw: 2.25 -> 2.26

### DIFF
--- a/pkgs/os-specific/linux/sgx/psw/add-missing-header-pr-1063.patch
+++ b/pkgs/os-specific/linux/sgx/psw/add-missing-header-pr-1063.patch
@@ -1,0 +1,12 @@
+diff --git a/psw/enclave_common/sgx_enclave_common.cpp b/psw/enclave_common/sgx_enclave_common.cpp
+index 9867ecc86..46fcf8733 100644
+--- a/psw/enclave_common/sgx_enclave_common.cpp
++++ b/psw/enclave_common/sgx_enclave_common.cpp
+@@ -35,6 +35,7 @@
+ #include <dlfcn.h>
+ #include <map>
+ #include <functional>
++#include <algorithm>
+ #include "sgx_enclave_common.h"
+ #include "sgx_urts.h"
+ #include "arch.h"

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -20,15 +20,15 @@
 stdenv.mkDerivation rec {
   pname = "sgx-psw";
   # Version as given in se_version.h
-  version = "2.25.100.3";
+  version = "2.26.100.0";
   # Version as used in the Git tag
-  versionTag = "2.25";
+  versionTag = "2.26";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-sgx";
     rev = "sgx_${versionTag}";
-    hash = "sha256-RR+vFTd9ZM6XUn3KgQeUM+xoj1Ava4zQzFYA/nfXyaw=";
+    hash = "sha256-g7t51Js4JoF7QeEngzmJJcRP2bQDbEMeKimVzqNDkFI=";
     fetchSubmodules = true;
   };
 
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
       # Fetch the Data Center Attestation Primitives (DCAP) platform enclaves
       # and pre-built sgxssl.
       dcap = rec {
-        version = "1.22";
+        version = "1.23";
         filename = "prebuilt_dcap_${version}.tar.gz";
         prebuilt = fetchurl {
           url = "https://download.01.org/intel-sgx/sgx-dcap/${version}/linux/${filename}";
@@ -90,6 +90,10 @@ stdenv.mkDerivation rec {
     # binary. Without changes, the `aesm_service` will be different after every
     # build because the embedded zip file contents have different modified times.
     ./cppmicroservices-no-mtime.patch
+
+    # Add missing `#include <algorithm>` to fix build with GCC 14
+    # PR: <https://github.com/intel/linux-sgx/pull/1063>
+    ./add-missing-header-pr-1063.patch
   ];
 
   postPatch =


### PR DESCRIPTION
## Changes

Update the `sgx-psw` package to the [latest 2.26 release](https://github.com/intel/linux-sgx/releases/tag/sgx_2.26).

+ Diff: <https://github.com/intel/linux-sgx/compare/sgx_2.25..sgx_2.26>
+ Changelog: <https://github.com/intel/linux-sgx/releases/tag/sgx_2.26>

Fix the `aesmd` service, which broke with the update to `systemd-v257` (https://github.com/NixOS/nixpkgs/pull/356818).

If possible, it would be nice to backport this to release-25.05, as `sgx-psw`/`aesmd` are currently broken on that release.

Prior update attempt (2.25 -> 2.26): https://github.com/NixOS/nixpkgs/pull/403984
Previous update PR (2.24 -> 2.25): https://github.com/NixOS/nixpkgs/pull/353041


**Quick Glossary:**

- **Intel SGX** is a Confidential Computing technology for running hardware-isolated enclaves and confidential VMs (Intel TDX) on Intel server CPUs alongside an untrusted hypervisor/Linux/userspace software stack.
- `sgx-psw` (Platform SoftWare) provides the `aesmd` service (Architecture Enclave Service Manager Daemon), which simplifies running enclaves and getting remote attestation quotes.


**Testing:**

These changes were tested on an SGX-enabled Azure gen2 VM (DCSv3) running NixOS.


## Run against real SGX hardware

Make sure you're running on a recent x86-64 Intel CPU, against a somewhat recent kernel with the in-tree kernel SGX driver (any NixOS config in the last few years should cover this).

Check the hardware and kernel setup:

```bash
$ journalctl --boot --dmesg --grep=sgx
kernel: sgx: EPC section 0x2c0000000-0x3bfffffff
```

In your NixOS `configuration.nix`, add something like:

```nix
  services.aesmd = {
    enable = true;
    # Include this if you're running on Azure
    quoteProviderLibrary = pkgs.sgx-azure-dcap-client;
  };
```

After a `nixos-rebuild switch`, check that the devices are configured and the `aesmd` service is running:

```bash
$ find /dev -name "*sgx*" -ls
 83      0 crw-rw----   1 root     sgx_prv   10, 126 May  8 17:21 /dev/sgx_provision
 84      0 crw-rw----   1 root     sgx       10, 125 May  8 17:21 /dev/sgx_enclave
400      0 drwxr-xr-x   2 root     root           80 May  8 17:21 /dev/sgx

$ systemctl status aesmd.service
● aesmd.service - Intel Architectural Enclave Service Manager
     Loaded: loaded (/etc/systemd/system/aesmd.service; enabled; preset: ignored)
     Active: active (running) since Thu 2025-06-26 00:19:15 UTC; 22min ago
 Invocation: d358b870341e4fb88622346358d5fb64
    Process: 861 ExecStartPre=/nix/store/ig3jvcxc2qb1qzmar2l3hrg3mf6rm55m-copy-aesmd-data-files.sh (code=exited, status=0/SUCCESS)
   Main PID: 866 (aesm_service)
         IP: 17.1K in, 3.2K out
         IO: 16.8M read, 16K written
      Tasks: 4 (limit: 9495)
     Memory: 20M (peak: 20.2M)
        CPU: 363ms
     CGroup: /system.slice/aesmd.service
             └─866 /nix/store/rkwsxksksxlwcnjxsfpakd02vrslnj2m-sgx-psw-2.26.100.0/aesm/aesm_service --no-daemon

Jun 26 00:19:15 lexe-dev-sgx aesm_service[866]: epid_quote_service_bundle_name:2.0.0
Jun 26 00:19:15 lexe-dev-sgx aesm_service[866]: le_launch_service_bundle_name:2.0.0
Jun 26 00:19:15 lexe-dev-sgx aesm_service[866]: linux_network_service_bundle_name:2.0.0
Jun 26 00:19:15 lexe-dev-sgx aesm_service[866]: pce_service_bundle_name:2.0.0
Jun 26 00:19:15 lexe-dev-sgx aesm_service[866]: quote_ex_service_bundle_name:2.0.0
Jun 26 00:19:15 lexe-dev-sgx aesm_service[866]: system_bundle:4.0.0
Jun 26 00:19:16 lexe-dev-sgx aesm_service[866]: Failed to set logging callback for the quote provider library.
Jun 26 00:19:16 lexe-dev-sgx aesm_service[866]: The server sock is 0x1edfb790
Jun 26 00:21:17 lexe-dev-sgx aesm_service[866]: InKernel LE loaded
Jun 26 00:21:17 lexe-dev-sgx aesm_service[866]: Azure Quote Provider: libdcap_quoteprov.so [INFO]: Debug Logging Enabled

$ ls -l /var/run/aesmd/aesm.socket
srwxrwxrwx 1 aesmd sgx 0 Jun 26 00:19 /var/run/aesmd/aesm.socket
```

Run a test enclave that exercises remote attestation:

```bash
$ nix run -L github:lexe-app/lexe-public#run-sgx-test
Ensure SGX platform primitives work (sealing, attestation, etc)
machine_id: e6f7d35736746f205a71551771263b86
measurement: eac7ec70f2de593d368f4e56622a0cd9121299ea8d423a55d687c5fbaccb7444

SEALING
seal('label', 'my data') := 4c00000004000100000000000e0e100fffff010000000000000000000700000000000000e70000000000000056fb656bd71b051ba6a95a9a9e6f35a65954215f4cdbda2fae2ad4edff95ceff000000001700000018330baa813a2b8cb80a351935551f1ffb4f1da134714a

REMOTE ATTESTATION
fake pubkey we're attesting to: 4545454545454545454545454545454545454545454545454545454545454545
SGX DER-serialized evidence:
quote: 03000200000000000b00..4452d2d2d2d2d0a00

SGX enclave Report:
measurement: eac7ec70f2de593d368f4e56622a0cd9121299ea8d423a55d687c5fbaccb7444
mrsigner: 9affcfae47b848ec2caf1c49b4b283531e1cc425f93582b36806e52a43d78d1a
reportdata: 45454545454545454545454545454545454545454545454545454545454545450000000000000000000000000000000000000000000000000000000000000000
attributes: Attributes { flags: INIT | MODE64BIT, xfrm: 231 }
miscselect: (empty)
cpusvn: 10101110ffff01000000000000000000
isvsvn: 0
isvsvn: 0
```