### PR TITLE
pkg-config: Fix build with gcc-15

### DIFF
--- a/pkgs/by-name/pk/pkg-config-unwrapped/gcc-15.patch
+++ b/pkgs/by-name/pk/pkg-config-unwrapped/gcc-15.patch
@@ -1,0 +1,35 @@
+From 4444e3e5b7130c1664d7617e079e776ac0437661 Mon Sep 17 00:00:00 2001
+From: Dmitry Bogatov <serenity@kaction.cc>
+Date: Thu, 26 Jun 2025 00:26:31 +0000
+Subject: [PATCH] Avoid using "bool" as identifier (was made a keyword in
+ gcc-15)
+
+---
+ glib/glib/goption.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/glib/glib/goption.c b/glib/glib/goption.c
+index 0a22f6f..bdd8837 100644
+--- a/glib/glib/goption.c
++++ b/glib/glib/goption.c
+@@ -166,7 +166,7 @@ typedef struct
+   gpointer arg_data;
+   union
+   {
+-    gboolean bool;
++    gboolean bool_value;
+     gint integer;
+     gchar *str;
+     gchar **array;
+@@ -1600,7 +1600,7 @@ free_changes_list (GOptionContext *context,
+           switch (change->arg_type)
+             {
+             case G_OPTION_ARG_NONE:
+-              *(gboolean *)change->arg_data = change->prev.bool;
++              *(gboolean *)change->arg_data = change->prev.bool_value;
+               break;
+             case G_OPTION_ARG_INT:
+               *(gint *)change->arg_data = change->prev.integer;
+-- 
+2.47.2
+

--- a/pkgs/by-name/pk/pkg-config-unwrapped/package.nix
+++ b/pkgs/by-name/pk/pkg-config-unwrapped/package.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
   # http://bugs.freedesktop.org/show_bug.cgi?id=4738, migrated to
   # https://gitlab.freedesktop.org/pkg-config/pkg-config/issues/28
   patches =
-    lib.optional (!vanilla) ./requires-private.patch
+    lib.optional (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "15.0") ./gcc-15.patch
+    ++ lib.optional (!vanilla) ./requires-private.patch
     ++ lib.optional stdenv.hostPlatform.isCygwin ./2.36.3-not-win32.patch;
 
   # These three tests fail due to a (desired) behavior change from our ./requires-private.patch


### PR DESCRIPTION
Add patch to compile with gcc-15 which made "bool" a keyword, not identifier.

The upstream is inactive for several years already, and their hosting platform requires [manual approval](https://gitlab.freedesktop.org/freedesktop/freedesktop/-/wikis/home#warning-restrictions-due-to-spam-warning) to be able to submit a PR, so patch is vendored, not submitted upstream.

## Things done

- Built on platform(s)
  - [x] x86_64-linux

I only built the source with this patch in nix-shell, actually re-building `pkg-config` from nixpkgs rebuilds whole world, hence this PR targets staging.

@RossComputerGuy You might be interested, I noticed your [issue on the upstream tracker](https://gitlab.freedesktop.org/pkg-config/pkg-config/-/issues/85)