### PR TITLE
jqjq: init at 0-unstable-2025-06-02

### DIFF
--- a/pkgs/by-name/jq/jqjq/package.nix
+++ b/pkgs/by-name/jq/jqjq/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nix-update-script,
+  bashNonInteractive,
+  jaq,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jqjq";
+  version = "0-unstable-2025-06-02";
+
+  src = fetchFromGitHub {
+    owner = "wader";
+    repo = "jqjq";
+    rev = "46aabe64866de73bdc0b68cbaf6659266fe03254";
+    hash = "sha256-ypfT8L9ujBGbi1P2R1WmEN6lw3K2NI8d4GRZEcRhjx4=";
+  };
+
+  # So checkPhase can run
+  postPatch = "patchShebangs --build jqjq.jq";
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeBinaryWrapper ];
+  buildInputs = [
+    bashNonInteractive
+  ];
+  dontBuild = true;
+
+  doCheck = true;
+  nativeCheckInputs = [
+    jaq
+    bashNonInteractive
+  ];
+
+  # For some reason it doesn't detect the Makefile
+  checkPhase = ''
+    runHook preCheck
+
+    make JQ=jaq test-jqjq
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share"
+    cp jqjq.jq "$out/share/jqjq.jq"
+
+    makeWrapper "$out/share/jqjq.jq" "$out/bin/jqjq" \
+      --set JQ ${lib.getExe jaq}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    "$out/bin/jqjq" --run-tests < ${finalAttrs.src}/jqjq.test
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "jq implementation in jq";
+    homepage = "https://github.com/wader/jqjq";
+    maintainers = with lib.maintainers; [ RossSmyth ];
+    mainProgram = "jqjq";
+    license = lib.licenses.mit;
+    platforms = jaq.meta.platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes #420075 
## Things done

1. Patch shebangs so that the checkPhase can run
2. For some reason the makefile is not detected. So I manually run the checkPhase
3. Put `jqjq.jq` file in $out/share
This is a jq library. While it has a shebang, making it run is difficult with the `makeWrapper` utilities.
5. Add a wrapper around it
So the way that `jqjq` is intended to work is that bash asks jq to build another bash command with the "proper" arguments. This skips the first stage, and directly execute the second stage as it does not work otherwise.
6. Run the wrapped jqjq with the test suite again
This uses jaq instead of jq because I was unable to make jq work either either jqjq or the checkPhase.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
