### PR TITLE
nixos/sssd: use upstream unit directives

### DIFF
--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -165,6 +165,14 @@ in
         serviceConfig = {
           ExecStartPre = "-${pkgs.sssd}/bin/sssd --genconf-section=kcm";
           ExecStart = "${pkgs.sssd}/libexec/sssd/sssd_kcm --uid 0 --gid 0";
+          CapabilityBoundingSet = [
+            "CAP_IPC_LOCK"
+            "CAP_CHOWN"
+            "CAP_DAC_READ_SEARCH"
+            "CAP_FOWNER"
+            "CAP_SETGID"
+            "CAP_SETUID"
+          ];
         };
         restartTriggers = [
           settingsFileUnsubstituted

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -6,7 +6,6 @@
 }:
 let
   cfg = config.services.sssd;
-  nscd = config.services.nscd;
 
   dataDir = "/var/lib/sssd";
   settingsFile = "${dataDir}/sssd.conf";
@@ -106,17 +105,35 @@ in
           config.environment.etc."nscd.conf".source
           settingsFileUnsubstituted
         ];
-        script = ''
-          export LDB_MODULES_PATH+="''${LDB_MODULES_PATH+:}${pkgs.ldb}/modules/ldb:${pkgs.sssd}/modules/ldb"
-          mkdir -p /var/lib/sss/{pubconf,db,mc,pipes,gpo_cache,secrets} /var/lib/sss/pipes/private /var/lib/sss/pubconf/krb5.include.d
-          ${pkgs.sssd}/bin/sssd -D -c ${settingsFile}
-        '';
+        environment.LDB_MODULES_PATH = "${pkgs.ldb}/modules/ldb:${pkgs.sssd}/modules/ldb";
         serviceConfig = {
-          Type = "forking";
+          # systemd needs to start sssd directly for "NotifyAccess=main" to work
+          ExecStart = "${pkgs.sssd}/bin/sssd -i -c ${settingsFile}";
+          Type = "notify";
+          NotifyAccess = "main";
           PIDFile = "/run/sssd.pid";
+          CapabilityBoundingSet = [
+            "CAP_IPC_LOCK"
+            "CAP_CHOWN"
+            "CAP_DAC_READ_SEARCH"
+            "CAP_KILL"
+            "CAP_NET_ADMIN"
+            "CAP_SYS_NICE"
+            "CAP_FOWNER"
+            "CAP_SETGID"
+            "CAP_SETUID"
+            "CAP_SYS_ADMIN"
+            "CAP_SYS_RESOURCE"
+            "CAP_BLOCK_SUSPEND"
+          ];
+          Restart = "on-abnormal";
           StateDirectory = baseNameOf dataDir;
           # We cannot use LoadCredential here because it's not available in ExecStartPre
           EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        };
+        unitConfig = {
+          StartLimitIntervalSec = "50s";
+          StartLimitBurst = 5;
         };
         preStart = ''
           mkdir -p "${dataDir}/conf.d"
@@ -127,6 +144,7 @@ in
             -o ${settingsFile} \
             -i ${settingsFileUnsubstituted}
           umask $old_umask
+          mkdir -p /var/lib/sss/{pubconf,db,mc,pipes,gpo_cache,secrets} /var/lib/sss/pipes/private /var/lib/sss/pubconf/krb5.include.d
         '';
       };
 


### PR DESCRIPTION
Import upstream systemd unit directives for `sssd.service` and `sssd-kcm.service`.

For the most useful changes:

- Have `Restart=on-abnormal`: this is the primary reason I'm doing this. I had an issue where the `sssd` service didn't restart on high server load / I/O usage, and systemd didn't automatically restart it. This PR should fix this
- Have `Type=notify`: should give a better indication of when the service is ready
- Some hardening options

Using upstream systemd services should be possible, with `systemd.packages`, but would require more work (due to the service defaulting to file logs, hardcoded path to conf file, etc.)

Checked using available NixOS VM tests.
For the `sssd-kcm.service` I checked that it worked by manually adding `CapabilityBoundingSet=...` with `systemctl edit --runtime sssd-kcm` on a running, configured system.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
