### PR TITLE
fido2-manage: 0-unstable-2024-11-22 → 0-unstable-2025-06-06

### DIFF
--- a/pkgs/by-name/fi/fido2-manage/package.nix
+++ b/pkgs/by-name/fi/fido2-manage/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  unstableGitUpdater,
   fetchurl,
   pkg-config,
   cmake,
@@ -37,6 +38,8 @@ stdenv.mkDerivation rec {
     rev = "4fc6a4e0d905dcc2a7bfee70232a0398e9e4b45d";
     hash = "sha256-olkEUHJ350FIMUlWG37wqSfO2wyYni4CYspwa4lAO5w=";
   };
+
+  passthru.updateScript = unstableGitUpdater { };
 
   icon = fetchurl {
     url = "https://token2.net/img/icon/logo-white.png";

--- a/pkgs/by-name/fi/fido2-manage/package.nix
+++ b/pkgs/by-name/fi/fido2-manage/package.nix
@@ -29,13 +29,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "fido2-manage";
-  version = "0-unstable-2024-11-22";
+  version = "0-unstable-2025-06-06";
 
   src = fetchFromGitHub {
     owner = "token2";
     repo = "fido2-manage";
-    rev = "2c14b222a432e34750bb3929c620bbdffd1c75be";
-    hash = "sha256-xdElYXx+F2XCP5zsbRTmTRyHKGnEt97jNRrQM0Oab5E=";
+    rev = "4fc6a4e0d905dcc2a7bfee70232a0398e9e4b45d";
+    hash = "sha256-olkEUHJ350FIMUlWG37wqSfO2wyYni4CYspwa4lAO5w=";
   };
 
   icon = fetchurl {


### PR DESCRIPTION
fido2-manage: 0-unstable-2024-11-22 → 0-unstable-2025-06-06

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
