### PR TITLE
python313Packages.certifi: 2025.4.26 -> 2025.6.15

### DIFF
--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "certifi";
-  version = "2025.04.26";
+  version = "2025.06.15";
   pyproject = true;
 
   disabled = pythonOlder "3.6";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = "python-certifi";
     rev = version;
-    hash = "sha256-OJ/XzywazpG0QpGTjTcLv1tDSqVdVP7xvp/tnyPPZzQ=";
+    hash = "sha256-ah2a+Qspll3jZ8M7CRL7zhTIt2kuRIiWeI6vTgwb3vs=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   version = "2025.06.15";
   pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = pname;

--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = pname;
+    owner = "certifi";
     repo = "python-certifi";
     rev = version;
     hash = "sha256-ah2a+Qspll3jZ8M7CRL7zhTIt2kuRIiWeI6vTgwb3vs=";

--- a/pkgs/development/python-modules/certifi/env.patch
+++ b/pkgs/development/python-modules/certifi/env.patch
@@ -1,5 +1,5 @@
 diff --git a/certifi/core.py b/certifi/core.py
-index 91f538b..1110ce0 100644
+index 1c9661c..7039be3 100644
 --- a/certifi/core.py
 +++ b/certifi/core.py
 @@ -4,6 +4,7 @@ certifi.py
@@ -41,8 +41,8 @@ index 91f538b..1110ce0 100644
 +            return open(_CACERT_PATH, encoding="utf-8").read()
          return files("certifi").joinpath("cacert.pem").read_text(encoding="ascii")
  
- elif sys.version_info >= (3, 7):
-@@ -51,7 +63,7 @@ elif sys.version_info >= (3, 7):
+ else:
+@@ -51,7 +63,7 @@ else:
      from importlib.resources import path as get_path, read_text
  
      _CACERT_CTX = None
@@ -51,37 +51,3 @@ index 91f538b..1110ce0 100644
  
      def where() -> str:
          # This is slightly terrible, but we want to delay extracting the
-@@ -80,7 +92,9 @@ elif sys.version_info >= (3, 7):
-         return _CACERT_PATH
- 
-     def contents() -> str:
--        return read_text("certifi", "cacert.pem", encoding="ascii")
-+        if _CACERT_PATH is not None:
-+            return open(_CACERT_PATH, encoding="utf-8").read()
-+        return read_text("certifi", "cacert.pem", encoding="utf-8")
- 
- else:
-     import os
-@@ -90,6 +104,8 @@ else:
-     Package = Union[types.ModuleType, str]
-     Resource = Union[str, "os.PathLike"]
- 
-+    _CACERT_PATH = get_cacert_path_from_environ()
-+
-     # This fallback will work for Python versions prior to 3.7 that lack the
-     # importlib.resources module but relies on the existing `where` function
-     # so won't address issues with environments like PyOxidizer that don't set
-@@ -108,7 +124,13 @@ else:
-     def where() -> str:
-         f = os.path.dirname(__file__)
- 
-+        if _CACERT_PATH is not None:
-+            return _CACERT_PATH
-+
-         return os.path.join(f, "cacert.pem")
- 
-     def contents() -> str:
-+        if _CACERT_PATH is not None:
-+            with open(_CACERT_PATH, encoding="utf-8") as data:
-+                return data.read()
-         return read_text("certifi", "cacert.pem", encoding="ascii")


### PR DESCRIPTION
update version
patch adjusted for upstream minimum: python 3.7

@koral
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
