### PR TITLE
epson_202101w: init at 1.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4006,6 +4006,12 @@
       { fingerprint = "8916 F727 734E 77AB 437F  A33A 19AB 76F5 CEE1 1392"; }
     ];
   };
+  caguiclajmg = {
+    email = "jmg.caguicla@guarandoo.me";
+    github = "caguiclajmg";
+    githubId = 32662060;
+    name = "John Mark Gabriel Caguicla";
+  };
   CaiqueFigueiredo = {
     email = "public@caiquefigueiredo.me";
     github = "caiquefigueiredo";

--- a/pkgs/by-name/ep/epson-202101w/package.nix
+++ b/pkgs/by-name/ep/epson-202101w/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  rpmextract,
+  autoreconfHook,
+  autoPatchelfHook,
+  file,
+  libjpeg,
+  cups,
+}:
+
+let
+  version = "1.0.2";
+in
+stdenv.mkDerivation {
+  pname = "epson-202101w";
+  inherit version;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    # NOTE: Don't forget to update the webarchive link too!
+    urls = [
+      "https://download3.ebz.epson.net/dsc/f/03/00/15/15/02/f5cba2761f2f501363cdbf7e1b9b9879b0715aa5/epson-inkjet-printer-202101w-1.0.2-1.src.rpm"
+      "https://web.archive.org/web/20250609030209if_/https://download3.ebz.epson.net/dsc/f/03/00/15/15/02/f5cba2761f2f501363cdbf7e1b9b9879b0715aa5/epson-inkjet-printer-202101w-1.0.2-1.src.rpm"
+    ];
+    sha256 = "17lz5cccknabp8cbkplhv1sn92m5w5md01rhhycbngp10zdmyhcz";
+  };
+
+  nativeBuildInputs = [
+    rpmextract
+    autoreconfHook
+    autoPatchelfHook
+    file
+  ];
+
+  buildInputs = [
+    libjpeg
+    cups
+    (lib.getLib stdenv.cc.cc)
+  ];
+
+  unpackPhase = ''
+    rpmextract $src
+    tar -zxf epson-inkjet-printer-202101w-${version}.tar.gz
+    tar -zxf epson-inkjet-printer-filter-${version}.tar.gz
+    for ppd in epson-inkjet-printer-202101w-${version}/ppds/*; do
+      substituteInPlace $ppd --replace "/opt/epson-inkjet-printer-202101w" "$out"
+      substituteInPlace $ppd --replace "/cups/lib" "/lib/cups"
+    done
+    cd epson-inkjet-printer-filter-${version}
+  '';
+
+  preConfigure = ''
+    chmod +x configure
+  '';
+
+  postInstall = ''
+    cd ../epson-inkjet-printer-202101w-${version}
+    cp -a lib64 resource watermark $out
+    mkdir -p $out/share/cups/model/epson-inkjet-printer-202101w
+    cp -a ppds $out/share/cups/model/epson-inkjet-printer-202101w/
+    cp -a Manual.txt $out/doc/
+    cp -a README $out/doc/README.driver
+  '';
+
+  meta = {
+    homepage = "https://www.openprinting.org/driver/epson-202101w";
+    description = "Epson printer driver (L1210, L1250, L3200, L3210)";
+    longDescription = ''
+      This software is a filter program used with the Common UNIX Printing
+      System (CUPS) under Linux. It supplies high quality printing with
+      Seiko Epson Color Ink Jet Printers.
+
+      To use the driver adjust your configuration.nix file:
+        services.printing = {
+          enable = true;
+          drivers = [ pkgs.epson-202101w ];
+        };
+    '';
+    license = with lib.licenses; [
+      lgpl21
+      epson
+    ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      caguiclajmg
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Package epson_202101w and add caguiclajmg as maintainer. Solves #305763

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
