### PR TITLE
.github/labeler: label changes to nixpkgs release notes as "has changelog"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -586,6 +586,7 @@
   - any:
       - changed-files:
           - any-glob-to-any-file:
+              - doc/release-notes/**/*
               - nixos/doc/manual/release-notes/**/*
 
 "8.has: maintainer-list (update)":


### PR DESCRIPTION
Previously only the NixOS release notes were taken into account.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
