### PR TITLE
[Backport release-25.05] treewide: remove astsmtl as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2310,12 +2310,6 @@
     githubId = 119769817;
     name = "goatastronaut0212";
   };
-  astsmtl = {
-    email = "astsmtl@yandex.ru";
-    github = "astsmtl";
-    githubId = 2093941;
-    name = "Alexander Tsamutali";
-  };
   asymmetric = {
     email = "lorenzo@mailbox.org";
     github = "asymmetric";

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -133,7 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/brummer10/guitarix";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
-      astsmtl
       lord-valen
     ];
     platforms = platforms.linux;

--- a/pkgs/applications/misc/goldendict/default.nix
+++ b/pkgs/applications/misc/goldendict/default.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation rec {
     platforms = with platforms; linux ++ darwin;
     mainProgram = "goldendict";
     maintainers = with maintainers; [
-      astsmtl
       sikmir
     ];
     license = licenses.gpl3Plus;

--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -228,7 +228,6 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2Plus
       mit
     ];
-    maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/al/alienarena/package.nix
+++ b/pkgs/by-name/al/alienarena/package.nix
@@ -60,7 +60,6 @@ stdenv.mkDerivation rec {
     homepage = "https://alienarena.org";
     # Engine is under GPLv2, everything else is under
     license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.linux;
     hydraPlatforms = [ ];
   };

--- a/pkgs/by-name/ap/apg/package.nix
+++ b/pkgs/by-name/ap/apg/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation {
     '';
     homepage = "https://github.com/wilx/apg";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ astsmtl ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ca/caps/package.nix
+++ b/pkgs/by-name/ca/caps/package.nix
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.quitte.de/dsp/caps.html";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.astsmtl ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/li/libcue/package.nix
+++ b/pkgs/by-name/li/libcue/package.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/lipnitsk/libcue";
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ astsmtl ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/li/libmikmod/package.nix
+++ b/pkgs/by-name/li/libmikmod/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
     homepage = "https://mikmod.shlomifish.org/";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [
-      astsmtl
       lovek323
     ];
     platforms = platforms.unix;

--- a/pkgs/by-name/m1/m17n_db/package.nix
+++ b/pkgs/by-name/m1/m17n_db/package.nix
@@ -36,6 +36,5 @@ stdenv.mkDerivation rec {
     }";
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ astsmtl ];
   };
 }

--- a/pkgs/by-name/ma/mars/package.nix
+++ b/pkgs/by-name/ma/mars/package.nix
@@ -52,7 +52,6 @@ stdenv.mkDerivation {
     homepage = "https://mars-game.sourceforge.net/";
     description = "Game about fighting with ships in a 2D space setting";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.astsmtl ];
     platforms = lib.platforms.linux;
     mainProgram = "mars";
   };

--- a/pkgs/by-name/qu/quesoglc/package.nix
+++ b/pkgs/by-name/qu/quesoglc/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://quesoglc.sourceforge.net/";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ astsmtl ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ry/rymcast/package.nix
+++ b/pkgs/by-name/ry/rymcast/package.nix
@@ -48,6 +48,5 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ astsmtl ];
   };
 }

--- a/pkgs/by-name/sa/sakura/package.nix
+++ b/pkgs/by-name/sa/sakura/package.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
-      astsmtl
       codyopel
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/sf/sfml_2/package.nix
+++ b/pkgs/by-name/sf/sfml_2/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
       It is written in C++, and has bindings for various languages such as C, .Net, Ruby, Python.
     '';
     license = lib.licenses.zlib;
-    maintainers = [ lib.maintainers.astsmtl ];
     platforms = lib.platforms.unix;
     badPlatforms = [
       # error: implicit instantiation of undefined template 'std::char_traits<unsigned int>'

--- a/pkgs/by-name/te/teeworlds/package.nix
+++ b/pkgs/by-name/te/teeworlds/package.nix
@@ -142,7 +142,6 @@ stdenv.mkDerivation rec {
       # zlib src/engine/external/zlib/
     ];
     maintainers = with lib.maintainers; [
-      astsmtl
       Luflosi
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/te/terminus_font/package.nix
+++ b/pkgs/by-name/te/terminus_font/package.nix
@@ -56,6 +56,5 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://terminus-font.sourceforge.net/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ astsmtl ];
   };
 }

--- a/pkgs/by-name/tr/transmission_3/package.nix
+++ b/pkgs/by-name/tr/transmission_3/package.nix
@@ -170,7 +170,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "http://www.transmissionbt.com/";
     license = lib.licenses.gpl2Plus; # parts are under MIT
-    maintainers = with lib.maintainers; [ astsmtl ];
     platforms = lib.platforms.unix;
   };
 

--- a/pkgs/by-name/ur/urbanterror/package.nix
+++ b/pkgs/by-name/ur/urbanterror/package.nix
@@ -116,7 +116,6 @@ stdenv.mkDerivation {
     '';
     mainProgram = "urbanterror";
     maintainers = with lib.maintainers; [
-      astsmtl
       drupol
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -164,7 +164,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [
-      astsmtl
       antono
     ];
     teams = [ teams.gnome ];

--- a/pkgs/by-name/wa/warzone2100/package.nix
+++ b/pkgs/by-name/wa/warzone2100/package.nix
@@ -141,7 +141,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://wz2100.net";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [
-      astsmtl
       fgaz
     ];
     platforms = platforms.all;

--- a/pkgs/games/oilrush/default.nix
+++ b/pkgs/games/oilrush/default.nix
@@ -130,7 +130,6 @@ stdenv.mkDerivation {
     '';
     homepage = "http://oilrush-game.com/";
     license = lib.licenses.unfree;
-    #maintainers = with lib.maintainers; [ astsmtl ];
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];

--- a/pkgs/games/warsow/default.nix
+++ b/pkgs/games/warsow/default.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation rec {
     homepage = "http://www.warsow.net";
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [
-      astsmtl
       abbradar
     ];
     platforms = warsow-engine.meta.platforms;

--- a/pkgs/games/warsow/engine.nix
+++ b/pkgs/games/warsow/engine.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation {
     homepage = "http://www.warsow.net";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [
-      astsmtl
       abbradar
     ];
     platforms = platforms.linux;

--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -64,7 +64,6 @@ let
     homepage = "https://www.xonotic.org/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      astsmtl
       zalakain
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [
-      astsmtl
       qusic
     ];
     platforms = platforms.linux;

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -270,7 +270,6 @@ let
         homepage = "https://www.musicpd.org/";
         license = licenses.gpl2Only;
         maintainers = with maintainers; [
-          astsmtl
           tobim
         ];
         platforms = platforms.unix;

--- a/pkgs/tools/inputmethods/m17n-lib/default.nix
+++ b/pkgs/tools/inputmethods/m17n-lib/default.nix
@@ -32,6 +32,5 @@ stdenv.mkDerivation rec {
     description = "Multilingual text processing library (runtime)";
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ astsmtl ];
   };
 }

--- a/pkgs/tools/misc/qjoypad/default.nix
+++ b/pkgs/tools/misc/qjoypad/default.nix
@@ -53,7 +53,6 @@ mkDerivation rec {
     '';
     homepage = "https://github.com/panzi/qjoypad/";
     license = lib.licenses.gpl2Only;
-    maintainers = with maintainers; [ astsmtl ];
     platforms = with platforms; linux;
     mainProgram = "qjoypad";
   };


### PR DESCRIPTION
Manual backport of #417063 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.