### PR TITLE
fzf-preview: init at 0-unstable-2025-06-26

### DIFF
--- a/pkgs/by-name/fz/fzf-preview/package.nix
+++ b/pkgs/by-name/fz/fzf-preview/package.nix
@@ -1,0 +1,90 @@
+{
+  atool,
+  bat,
+  catdoc,
+  chafa,
+  exiftool,
+  eza,
+  fetchFromGitHub,
+  ffmpegthumbnailer,
+  file,
+  glow,
+  gnumeric,
+  jq,
+  lib,
+  libcdio,
+  makeWrapper,
+  mediainfo,
+  odt2txt,
+  openssl,
+  p7zip,
+  poppler-utils,
+  stdenv,
+  w3m,
+}:
+
+stdenv.mkDerivation {
+  pname = "fzf-preview";
+  version = "0-unstable-2025-06-26";
+
+  src = fetchFromGitHub {
+    owner = "niksingh710";
+    repo = "fzf-preview";
+    rev = "5f6e936d1c3943192f9bdade71cff8879bdab3a6";
+    hash = "sha256-vDgYv9PjQQYcMKG97ryncd30JPplnEqAKBp5hAE0E+o=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin/ ./fzf-preview
+
+    wrapProgram $out/bin/fzf-preview \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          atool
+          bat
+          catdoc
+          chafa
+          exiftool
+          eza
+          ffmpegthumbnailer
+          file
+          glow
+          gnumeric
+          jq
+          libcdio
+          mediainfo
+          odt2txt
+          openssl
+          p7zip
+          poppler-utils
+          w3m
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Simple fzf preview script for previewing any filetype in fzf's preview window";
+
+    longDescription = ''
+      fzf-preview is a lightweight Bash script designed to enhance the user experience
+      with fzf (fuzzy finder) by providing instant previews of files directly in the
+      fzf preview pane. It supports a wide variety of filetypes—including images and
+      text—and delivers relevant file information in the terminal. The script aims to
+      be simple, fast, and highly compatible, making it a useful tool for anyone
+      leveraging fzf for file navigation or search.
+    '';
+    homepage = "https://github.com/niksingh710/fzf-preview";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      niksingh710
+    ];
+    mainProgram = "fzf-preview";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
