### PR TITLE
dsda-doom: 0.29.0 -> 0.29.2, use finalAttrs

### DIFF
--- a/pkgs/by-name/ds/dsda-doom/package.nix
+++ b/pkgs/by-name/ds/dsda-doom/package.nix
@@ -17,18 +17,18 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dsda-doom";
   version = "0.29.2";
 
   src = fetchFromGitHub {
     owner = "kraflab";
     repo = "dsda-doom";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-KNF91ikLFJPjSSsoz01kwAG5aCoABFyIQ5ZzbshFlkI=";
   };
 
-  sourceRoot = "${src.name}/prboom2";
+  sourceRoot = "${finalAttrs.src.name}/prboom2";
 
   nativeBuildInputs = [ cmake ];
 
@@ -50,11 +50,11 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://github.com/kraflab/dsda-doom";
-    changelog = "https://github.com/kraflab/dsda-doom/releases/tag/v${version}";
+    changelog = "https://github.com/kraflab/dsda-doom/releases/tag/v${finalAttrs.version}";
     description = "Advanced Doom source port with a focus on speedrunning, successor of PrBoom+";
     mainProgram = "dsda-doom";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ Gliczy ];
   };
-}
+})

--- a/pkgs/by-name/ds/dsda-doom/package.nix
+++ b/pkgs/by-name/ds/dsda-doom/package.nix
@@ -8,7 +8,7 @@
   SDL2_image,
   fluidsynth,
   portmidi,
-  dumb,
+  libopenmpt,
   libvorbis,
   libmad,
   libGLU,
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation rec {
   pname = "dsda-doom";
-  version = "0.29.0";
+  version = "0.29.2";
 
   src = fetchFromGitHub {
     owner = "kraflab";
     repo = "dsda-doom";
-    rev = "v${version}";
-    hash = "sha256-mcg3GAQ90Qg7d1+/ci/XlTTF2q0tB6j+pp+Fb1Mpcao=";
+    tag = "v${version}";
+    hash = "sha256-KNF91ikLFJPjSSsoz01kwAG5aCoABFyIQ5ZzbshFlkI=";
   };
 
   sourceRoot = "${src.name}/prboom2";
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     alsa-lib
-    dumb
+    libopenmpt
     fluidsynth
     libGLU
     libmad


### PR DESCRIPTION
Changelog: https://github.com/kraflab/dsda-doom/releases/tag/v0.29.1
Diff: https://github.com/kraflab/dsda-doom/compare/v0.29.0...v0.29.1

- Replace `dumb` with `libopenmpt`
- Use `finalAttrs` instead of `rec` 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
