### PR TITLE
SDL2_sound: 2.0.1 -> 2.0.4; modernize

### DIFF
--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -23,11 +23,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL2 ];
 
-  meta = with lib; {
+  meta = {
     description = "SDL2 sound library";
     mainProgram = "playsound";
-    platforms = platforms.unix;
-    license = licenses.zlib;
+    platforms = lib.platforms.unix;
+    license = lib.licenses.zlib;
     teams = [ lib.teams.sdl ];
     homepage = "https://www.icculus.org/SDL_sound/";
   };

--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-5t2ELm8d8IX+cIJqGl/8sffwXGj5Cm0kZI6+bmjvvPg=";
   };
 
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [

--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   SDL2,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,6 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [ SDL2 ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "SDL2 sound library";

--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "SDL2 sound library";
     mainProgram = "playsound";
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.all;
     license = with lib.licenses; [
       zlib
 

--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -4,10 +4,6 @@
   fetchFromGitHub,
   cmake,
   SDL2,
-  flac,
-  libmikmod,
-  libvorbis,
-  timidity,
 }:
 
 stdenv.mkDerivation rec {
@@ -25,13 +21,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DSDLSOUND_DECODER_MIDI=1" ];
 
-  buildInputs = [
-    SDL2
-    flac
-    libmikmod
-    libvorbis
-    timidity
-  ];
+  buildInputs = [ SDL2 ];
 
   meta = with lib; {
     description = "SDL2 sound library";

--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   SDL2,
   flac,
@@ -13,23 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "SDL2_sound";
-  version = "2.0.1";
+  version = "2.0.4";
 
   src = fetchFromGitHub {
     owner = "icculus";
     repo = "SDL_sound";
     rev = "v${version}";
-    hash = "sha256-N2znqy58tMHgYa07vEsSedWLRhoJzDoINcsUu0UYLnA=";
+    hash = "sha256-5t2ELm8d8IX+cIJqGl/8sffwXGj5Cm0kZI6+bmjvvPg=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/icculus/SDL_sound/pull/32 - fix build on darwin
-      # can be dropped on the next update
-      url = "https://github.com/icculus/SDL_sound/commit/c15d75b7720113b28639baad284f45f943846294.patch";
-      hash = "sha256-4GL8unsZ7eNkzjLXq9QdaxFQMzX2tdP0cBR1jTaRLc0=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DSDLSOUND_DECODER_MIDI=1" ];
+  cmakeFlags = [ (lib.cmakeBool "SDLSOUND_DECODER_MIDI" true) ];
 
   buildInputs = [ SDL2 ];
 
@@ -27,7 +27,16 @@ stdenv.mkDerivation (finalAttrs: {
     description = "SDL2 sound library";
     mainProgram = "playsound";
     platforms = lib.platforms.unix;
-    license = lib.licenses.zlib;
+    license = with lib.licenses; [
+      zlib
+
+      # various vendored decoders
+      publicDomain
+
+      # timidity
+      artistic1
+      lgpl21Only
+    ];
     teams = [ lib.teams.sdl ];
     homepage = "https://www.icculus.org/SDL_sound/";
   };

--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -19,7 +19,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ (lib.cmakeBool "SDLSOUND_DECODER_MIDI" true) ];
+  cmakeFlags = [
+    (lib.cmakeBool "SDLSOUND_DECODER_MIDI" true)
+    (lib.cmakeBool "SDLSOUND_BUILD_SHARED" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "SDLSOUND_BUILD_STATIC" stdenv.hostPlatform.isStatic)
+  ];
 
   buildInputs = [ SDL2 ];
 

--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -6,14 +6,14 @@
   SDL2,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "SDL2_sound";
   version = "2.0.4";
 
   src = fetchFromGitHub {
     owner = "icculus";
     repo = "SDL_sound";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-5t2ELm8d8IX+cIJqGl/8sffwXGj5Cm0kZI6+bmjvvPg=";
   };
 
@@ -31,4 +31,4 @@ stdenv.mkDerivation rec {
     teams = [ lib.teams.sdl ];
     homepage = "https://www.icculus.org/SDL_sound/";
   };
-}
+})

--- a/pkgs/by-name/sd/SDL2_sound/package.nix
+++ b/pkgs/by-name/sd/SDL2_sound/package.nix
@@ -7,6 +7,8 @@
   nix-update-script,
 }:
 
+# As of 2025-06-27 this library has no dependents in nixpkgs (https://github.com/NixOS/nixpkgs/pull/420339) and is
+# considered for deletion.
 stdenv.mkDerivation (finalAttrs: {
   pname = "SDL2_sound";
   version = "2.0.4";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
