### PR TITLE
git-sync: 0-unstable-2024-11-30 -> 0-unstable-2025-06-26

### DIFF
--- a/pkgs/by-name/gi/git-sync/package.nix
+++ b/pkgs/by-name/gi/git-sync/package.nix
@@ -12,7 +12,7 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "git-sync";
   version = "0-unstable-2025-06-26";
 

--- a/pkgs/by-name/gi/git-sync/package.nix
+++ b/pkgs/by-name/gi/git-sync/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   coreutils,
+  fswatch,
   git,
   gnugrep,
   gnused,
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
   wrapperPath = lib.makeBinPath (
     [
       coreutils
+      fswatch
       git
       gnugrep
       gnused

--- a/pkgs/by-name/gi/git-sync/package.nix
+++ b/pkgs/by-name/gi/git-sync/package.nix
@@ -6,7 +6,7 @@
   git,
   gnugrep,
   gnused,
-  makeWrapper,
+  makeBinaryWrapper,
   inotify-tools,
   nix-update-script,
 }:
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-7sCncPxVMiDGi1PSoFhA9emSY2Jit35/FaBbinCdS/A=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
 
   dontBuild = true;
 

--- a/pkgs/by-name/gi/git-sync/package.nix
+++ b/pkgs/by-name/gi/git-sync/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "git-sync";
-  version = "0-unstable-2024-11-30";
+  version = "0-unstable-2025-06-26";
 
   src = fetchFromGitHub {
     owner = "simonthum";
     repo = "git-sync";
-    rev = "7242291edf543ecc1bb9de8f47086bb69a5cb9f7";
-    hash = "sha256-t1NVgp+ELmTMK0N1fFFJCoKQd8mSYSMAIDG9+kNs3Ok=";
+    rev = "15af8a43cb4d8354f0b7e7c8d27e09587a9a3994";
+    hash = "sha256-7sCncPxVMiDGi1PSoFhA9emSY2Jit35/FaBbinCdS/A=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/gi/git-sync/package.nix
+++ b/pkgs/by-name/gi/git-sync/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   coreutils,
   fswatch,
-  git,
+  gitMinimal,
   gnugrep,
   gnused,
   makeBinaryWrapper,
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
         [
           coreutils
           fswatch
-          git
+          gitMinimal
           gnugrep
           gnused
         ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
