### PR TITLE
nixos/filebrowser-quantum: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1548,8 +1548,8 @@
   ./services/web-apps/ethercalc.nix
   ./services/web-apps/fediwall.nix
   ./services/web-apps/fider.nix
-  ./services/web-apps/filebrowser.nix
   ./services/web-apps/filebrowser-quantum.nix
+  ./services/web-apps/filebrowser.nix
   ./services/web-apps/filesender.nix
   ./services/web-apps/firefly-iii-data-importer.nix
   ./services/web-apps/firefly-iii.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1549,6 +1549,7 @@
   ./services/web-apps/fediwall.nix
   ./services/web-apps/fider.nix
   ./services/web-apps/filebrowser.nix
+  ./services/web-apps/filebrowser-quantum.nix
   ./services/web-apps/filesender.nix
   ./services/web-apps/firefly-iii-data-importer.nix
   ./services/web-apps/firefly-iii.nix

--- a/nixos/modules/services/web-apps/filebrowser-quantum.nix
+++ b/nixos/modules/services/web-apps/filebrowser-quantum.nix
@@ -1,0 +1,363 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.filebrowser-quantum;
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  options.services.filebrowser-quantum = with lib; {
+    enable = mkEnableOption "Filebrowser-quantum web file manager";
+
+    address = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "Address to bind to.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 80;
+      description = "Port to bind to.";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.filebrowser-quantum;
+      description = "The filebrowser-quantum package to use.";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "filebrowser-quantum";
+      description = "User account under which filebrowser-quantum runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "filebrowser-quantum";
+      description = "Group under which filebrowser-quantum runs.";
+    };
+
+    home = mkOption {
+      type = types.str;
+      default = "/var/lib/filebrowser-quantum";
+      description = "The home of the filebrowser-quantum user";
+    };
+
+    files = mkOption {
+      type = types.str;
+      default = "${cfg.home}/files";
+      description = "Root directory for file browsing.";
+    };
+
+    database = mkOption {
+      type = types.str;
+      default = "${cfg.home}/database.db";
+      description = "Path to the database file.";
+    };
+
+    environmentVariables = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = "Environment variables to set for the service. All availble variables can be found [here](https://github.com/gtsteffaniak/filebrowser/wiki/Environment-Variables)";
+    };
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Environment file to set for the service. All availble variables can be found [here](https://github.com/gtsteffaniak/filebrowser/wiki/Environment-Variables)";
+    };
+
+    settings = mkOption {
+      type = jsonFormat.type;
+      default = {
+        server = {
+          port = cfg.port;
+          database = cfg.database;
+          sources = [
+            {
+              path = cfg.files;
+            }
+          ];
+          logging = [
+            {
+              levels = "info|warning|error";
+              apiLevels = "info|warning|error";
+              output = "stdout";
+              noColors = false;
+              utc = false;
+            }
+          ];
+        };
+        frontend.name = "Filebrowser Quantum";
+        auth = {
+          adminUsername = "admin";
+          adminPassword = "admin";
+        };
+        userDefaults.permissions = {
+          api = false;
+          admin = false;
+          modify = false;
+          share = false;
+          realtime = false;
+        };
+      };
+      description = # markdown
+        ''
+          Configuration settings for filebrowser. The defaults are the default settings generated using `Filebrowser setup` All configuration settings with explaination can be found [here](https://github.com/gtsteffaniak/filebrowser/wiki/Full-Config-Example)
+        '';
+      example = # nix
+        ''
+          {
+            server = {
+              numImageProcessors = 14;
+              socket = "";
+              tlsKey = "";
+              tlsCert = "";
+              disablePreviews = false;
+              disablePreviewResize = false;
+              disableTypeDetectionByHeader = false;
+              port = 80;
+              baseURL = "/";
+              logging = [
+                {
+                  levels = "";
+                  apiLevels = "";
+                  output = "stdout";
+                  noColors = false;
+                  json = false;
+                  utc = false;
+                }
+              ];
+              debugMedia = false;
+              database = "database.db";
+              sources = [
+                {
+                  path = "/relative/or/absolute/path";
+                  name = "backend";
+                  config = {
+                    indexingIntervalMinutes = 0;
+                    disableIndexing = false;
+                    maxWatchers = 0;
+                    neverWatchPaths = [
+
+                    ];
+                    ignoreHidden = false;
+                    ignoreZeroSizeFolders = false;
+                    exclude = {
+                      files = [
+
+                      ];
+                      folders = [
+
+                      ];
+                      fileEndsWith = [
+
+                      ];
+                    };
+                    include = {
+                      files = [
+
+                      ];
+                      folders = [
+
+                      ];
+                      fileEndsWith = [
+
+                      ];
+                    };
+                    defaultUserScope = "/";
+                    defaultEnabled = true;
+                    createUserDir = false;
+                  };
+                }
+              ];
+              externalUrl = "";
+              internalUrl = "";
+              cacheDir = "tmp";
+              maxArchiveSize = 50;
+            };
+            auth = {
+              tokenExpirationHours = 2;
+              methods = {
+                proxy = {
+                  enabled = false;
+                  createUser = false;
+                  header = "";
+                  logoutRedirectUrl = "";
+                };
+                noauth = false;
+                password = {
+                  enabled = true;
+                  minLength = 5;
+                  signup = false;
+                  recaptcha = {
+                    host = "";
+                    key = "";
+                    secret = "";
+                  };
+                  enforcedOtp = false;
+                };
+                oidc = {
+                  enabled = false;
+                  clientId = "";
+                  clientSecret = "";
+                  issuerUrl = "";
+                  scopes = "";
+                  userIdentifier = "";
+                  disableVerifyTLS = false;
+                  logoutRedirectUrl = "";
+                  createUser = false;
+                  adminGroup = "";
+                };
+              };
+              key = "";
+              adminUsername = "admin";
+              adminPassword = "admin";
+              resetAdminOnStart = false;
+              totpSecret = "";
+            };
+            frontend = {
+              name = "FileBrowser Quantum";
+              disableDefaultLinks = false;
+              disableUsedPercentage = false;
+              externalLinks = [
+                {
+                  text = "(untracked)";
+                  title = "untracked";
+                  url = "https://github.com/gtsteffaniak/filebrowser/releases/";
+                }
+                {
+                  text = "Help";
+                  title = "";
+                  url = "https://github.com/gtsteffaniak/filebrowser/wiki";
+                }
+              ];
+            };
+            userDefaults = {
+              stickySidebar = true;
+              darkMode = true;
+              locale = "en";
+              viewMode = "normal";
+              singleClick = false;
+              showHidden = false;
+              dateFormat = false;
+              gallerySize = 3;
+              themeColor = "var(--blue)";
+              quickDownload = false;
+              disableOnlyOfficeExt = ".txt .csv .html .pdf";
+              disableOfficePreviewExt = "";
+              lockPassword = false;
+              disableSettings = false;
+              preview = {
+                highQuality = false;
+                image = false;
+                video = false;
+                motionVideoPreview = false;
+                office = false;
+                popup = false;
+              };
+              permissions = {
+                api = false;
+                admin = false;
+                modify = false;
+                share = false;
+                realtime = false;
+              };
+              loginMethod = "password";
+              disableUpdateNotifications = false;
+            };
+            integrations = {
+              office = {
+                url = "";
+                internalUrl = "";
+                secret = "";
+              };
+              media = {
+                ffmpegPath = "";
+              };
+            };
+          }
+        '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to open the firewall for the specified port.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      description = "Filebrowser-quantum service user";
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.home;
+      createHome = true;
+    };
+
+    users.groups.${cfg.group} = { };
+
+    systemd.services.filebrowser-quantum = {
+      description = "Filebrowser-quantum web file manager";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment = cfg.environmentVariables;
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.home;
+
+        EnvironmentFile = cfg.environmentFile;
+
+        ExecStart =
+          let
+            config =
+              if (cfg.settings == { }) then
+                "./config.yaml"
+              else
+                pkgs.writers.writeJSON "config.yaml" cfg.settings;
+          in
+          "${lib.getExe cfg.package} -c ${config}";
+
+        Restart = "always";
+        RestartSec = "10s";
+
+        ProtectSystem = "full";
+        ProtectHome = true;
+        PrivateTmp = "disconnected";
+        PrivateDevices = true;
+        PrivateMounts = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        ProtectClock = true;
+        MemoryDenyWriteExecute = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.files} 0755 ${cfg.user} ${cfg.group} -"
+      "d ${dirOf cfg.database} 0755 ${cfg.user} ${cfg.group} -"
+    ];
+  };
+}

--- a/nixos/modules/services/web-apps/filebrowser-quantum.nix
+++ b/nixos/modules/services/web-apps/filebrowser-quantum.nix
@@ -108,7 +108,9 @@ in
       };
       description = # markdown
         ''
-          Configuration settings for filebrowser. The defaults are the default settings generated using `Filebrowser setup` All configuration settings with explaination can be found [here](https://github.com/gtsteffaniak/filebrowser/wiki/Full-Config-Example)
+          Configuration settings for filebrowser.
+          The defaults are the default settings generated using `Filebrowser setup` All configuration settings with explaination can be found [here](https://github.com/gtsteffaniak/filebrowser/wiki/Full-Config-Example).
+          If settings = { } then the config.yaml in the home directory will be used.
         '';
       example = # nix
         ''
@@ -321,9 +323,9 @@ in
           let
             config =
               if (cfg.settings == { }) then
-                "./config.yaml"
+                "${cfg.home}/config.yaml"
               else
-                pkgs.writers.writeJSON "config.yaml" cfg.settings;
+                pkgs.writers.writeJSON "filebrowswer-quantum-config.yaml" cfg.settings;
           in
           "${lib.getExe cfg.package} -c ${config}";
 

--- a/nixos/modules/services/web-apps/filebrowser-quantum.nix
+++ b/nixos/modules/services/web-apps/filebrowser-quantum.nix
@@ -10,69 +10,69 @@ let
   jsonFormat = pkgs.formats.json { };
 in
 {
-  options.services.filebrowser-quantum = with lib; {
-    enable = mkEnableOption "Filebrowser-quantum web file manager";
+  options.services.filebrowser-quantum = {
+    enable = lib.mkEnableOption "Filebrowser-quantum web file manager";
 
-    address = mkOption {
-      type = types.str;
+    address = lib.mkOption {
+      type = lib.types.str;
       default = "127.0.0.1";
       description = "Address to bind to.";
     };
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 80;
       description = "Port to bind to.";
     };
 
-    package = mkOption {
-      type = types.package;
+    package = lib.mkOption {
+      type = lib.types.package;
       default = pkgs.filebrowser-quantum;
       description = "The filebrowser-quantum package to use.";
     };
 
-    user = mkOption {
-      type = types.str;
+    user = lib.mkOption {
+      type = lib.types.str;
       default = "filebrowser-quantum";
       description = "User account under which filebrowser-quantum runs.";
     };
 
-    group = mkOption {
-      type = types.str;
+    group = lib.mkOption {
+      type = lib.types.str;
       default = "filebrowser-quantum";
       description = "Group under which filebrowser-quantum runs.";
     };
 
-    home = mkOption {
-      type = types.str;
+    home = lib.mkOption {
+      type = lib.types.str;
       default = "/var/lib/filebrowser-quantum";
       description = "The home of the filebrowser-quantum user";
     };
 
-    files = mkOption {
-      type = types.str;
+    files = lib.mkOption {
+      type = lib.types.str;
       default = "${cfg.home}/files";
       description = "Root directory for file browsing.";
     };
 
-    database = mkOption {
-      type = types.str;
+    database = lib.mkOption {
+      type = lib.types.str;
       default = "${cfg.home}/database.db";
       description = "Path to the database file.";
     };
 
-    environmentVariables = mkOption {
-      type = types.attrsOf types.str;
+    environmentVariables = lib.mkOption {
+      type = with lib.types; attrsOf str;
       default = { };
       description = "Environment variables to set for the service. All availble variables can be found [here](https://github.com/gtsteffaniak/filebrowser/wiki/Environment-Variables)";
     };
-    environmentFile = mkOption {
-      type = types.nullOr types.path;
+    environmentFile = lib.mkOption {
+      type = with lib.types; nullOr path;
       default = null;
       description = "Environment file to set for the service. All availble variables can be found [here](https://github.com/gtsteffaniak/filebrowser/wiki/Environment-Variables)";
     };
 
-    settings = mkOption {
+    settings = lib.mkOption {
       type = jsonFormat.type;
       default = {
         server = {
@@ -285,8 +285,8 @@ in
         '';
     };
 
-    openFirewall = mkOption {
-      type = types.bool;
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = "Whether to open the firewall for the specified port.";
     };


### PR DESCRIPTION
Adds a module for [filebrowser-quantum](https://github.com/gtsteffaniak/filebrowser/). Is dependent on [PR 419206](https://github.com/NixOS/nixpkgs/pull/419206), which packages filebrowser-quantum
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
