### PR TITLE
python3Packages: remove most --replace usages

### DIFF
--- a/pkgs/development/python-modules/adblock/default.nix
+++ b/pkgs/development/python-modules/adblock/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}"
+      --replace-fail "0.0.0" "${version}"
   '';
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/development/python-modules/aeidon/default.nix
+++ b/pkgs/development/python-modules/aeidon/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   postPatch = ''
     mv setup.py setup_gaupol.py
     substituteInPlace setup-aeidon.py \
-      --replace "from setup import" "from setup_gaupol import"
+      --replace-fail "from setup import" "from setup_gaupol import"
     mv setup-aeidon.py setup.py
   '';
 

--- a/pkgs/development/python-modules/aioemonitor/default.nix
+++ b/pkgs/development/python-modules/aioemonitor/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace setup.py --replace '"pytest-runner>=5.2",' ""
+    substituteInPlace setup.py --replace-fail '"pytest-runner>=5.2",' ""
   '';
 
   pythonImportsCheck = [ "aioemonitor" ];

--- a/pkgs/development/python-modules/aiokef/default.nix
+++ b/pkgs/development/python-modules/aiokef/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace tox.ini \
-      --replace "--mypy" ""
+      --replace-fail "--mypy" ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiomusiccast/default.nix
+++ b/pkgs/development/python-modules/aiomusiccast/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"0.0.0"' '"${version}"'
+      --replace-fail '"0.0.0"' '"${version}"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/aiooncue/default.nix
+++ b/pkgs/development/python-modules/aiooncue/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"setuptools>=75.8.0"' ""
+      --replace-fail '"setuptools>=75.8.0"' ""
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/aiopg/default.nix
+++ b/pkgs/development/python-modules/aiopg/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "psycopg2-binary" "psycopg2"
+      --replace-fail "psycopg2-binary" "psycopg2"
   '';
 
   # Tests requires a PostgreSQL Docker instance

--- a/pkgs/development/python-modules/aiopyarr/default.nix
+++ b/pkgs/development/python-modules/aiopyarr/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'version="master"' 'version="${version}"'
+      --replace-fail 'version="master"' 'version="${version}"'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiosignal/default.nix
+++ b/pkgs/development/python-modules/aiosignal/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "filterwarnings = error" ""
+      --replace-fail "filterwarnings = error" ""
   '';
 
   pythonImportsCheck = [ "aiosignal" ];

--- a/pkgs/development/python-modules/aioskybell/default.nix
+++ b/pkgs/development/python-modules/aioskybell/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'version="master",' 'version="${version}",'
+      --replace-fail 'version="master",' 'version="${version}",'
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/amazon-ion/default.nix
+++ b/pkgs/development/python-modules/amazon-ion/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/amqtt/default.nix
+++ b/pkgs/development/python-modules/amqtt/default.nix
@@ -33,8 +33,8 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'transitions = "^0.8.0"' 'transitions = "*"' \
-      --replace 'websockets = ">=9.0,<11.0"' 'websockets = "*"'
+      --replace-fail 'transitions = "^0.8.0"' 'transitions = "*"' \
+      --replace-fail 'websockets = ">=9.0,<11.0"' 'websockets = "*"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
@@ -18,11 +18,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  postPatch = ''
-    substituteInPlace tests/TestIntervalSet.py \
-      --replace "assertEquals" "assertEqual"
-  '';
-
   # We use an asterisk because this expression is used also for old antlr
   # versions, where there the tests directory is `test` and not `tests`.
   # See e.g in package `baserow`.

--- a/pkgs/development/python-modules/anywidget/default.nix
+++ b/pkgs/development/python-modules/anywidget/default.nix
@@ -28,14 +28,6 @@ buildPythonPackage rec {
     hash = "sha256-Jiz0WbUXp9BE1vvIS5U+nIPwJnkLLdPOkPIaf47e0A8=";
   };
 
-  # We do not need the jupyterlab build dependency, because we do not need to
-  # build any JS components; these are present already in the PyPI artifact.
-  #
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace '"jupyterlab==3.*"' ""
-  '';
-
   build-system = [
     hatch-jupyter-builder
     hatchling

--- a/pkgs/development/python-modules/apcaccess/default.nix
+++ b/pkgs/development/python-modules/apcaccess/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "setup_requires='pytest-runner'," ""
+      --replace-fail "setup_requires='pytest-runner'," ""
   '';
 
   pythonImportsCheck = [ "apcaccess" ];

--- a/pkgs/development/python-modules/aqipy-atmotech/default.nix
+++ b/pkgs/development/python-modules/aqipy-atmotech/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'" ""
+      --replace-fail "'pytest-runner'" ""
   '';
 
   pythonImportsCheck = [ "aqipy" ];

--- a/pkgs/development/python-modules/async-modbus/default.nix
+++ b/pkgs/development/python-modules/async-modbus/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"--durations=2", "--verbose"' ""
+      --replace-fail '"--durations=2", "--verbose"' ""
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/avion/default.nix
+++ b/pkgs/development/python-modules/avion/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   postPatch = ''
     # https://github.com/mjg59/python-avion/pull/16
     substituteInPlace setup.py \
-      --replace "bluepy>==1.1.4" "bluepy>=1.1.4"
+      --replace-fail "bluepy>==1.1.4" "bluepy>=1.1.4"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/awesome-slugify/default.nix
+++ b/pkgs/development/python-modules/awesome-slugify/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   prePatch = ''
     substituteInPlace setup.py \
-        --replace 'Unidecode>=0.04.14,<0.05' 'Unidecode>=0.04.14'
+        --replace-fail 'Unidecode>=0.04.14,<0.05' 'Unidecode>=0.04.14'
   '';
 
   patches = [

--- a/pkgs/development/python-modules/bacpypes/default.nix
+++ b/pkgs/development/python-modules/bacpypes/default.nix
@@ -25,8 +25,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," "" \
-      --replace "(3, 8): 'py34'," "(3, 8): 'py34', (3, 9): 'py34', (3, 10): 'py34', (3, 11): 'py34', (3, 12): 'py34',"
+      --replace-fail "'pytest-runner'," "" \
+      --replace-fail "(3, 8): 'py34'," "(3, 8): 'py34', (3, 9): 'py34', (3, 10): 'py34', (3, 11): 'py34', (3, 12): 'py34',"
   '';
 
   propagatedBuildInputs = [ wheel ];

--- a/pkgs/development/python-modules/base36/default.nix
+++ b/pkgs/development/python-modules/base36/default.nix
@@ -19,8 +19,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "[pytest]" "[tool:pytest]" \
-      --replace "--pep8 --cov" ""
+      --replace-fail "[pytest]" "[tool:pytest]" \
+      --replace-fail "--pep8 --cov" ""
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/beautysh/default.nix
+++ b/pkgs/development/python-modules/beautysh/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'types-setuptools = "^57.4.0"' 'types-setuptools = "*"'
+      --replace-fail 'types-setuptools = "^57.4.0"' 'types-setuptools = "*"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/binaryornot/default.nix
+++ b/pkgs/development/python-modules/binaryornot/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   prePatch = ''
     # TypeError: binary() got an unexpected keyword argument 'average_size'
     substituteInPlace tests/test_check.py \
-      --replace "average_size=512" ""
+      --replace-fail "average_size=512" ""
   '';
 
   propagatedBuildInputs = [ chardet ];

--- a/pkgs/development/python-modules/bitcoin-utils-fork-minimal/default.nix
+++ b/pkgs/development/python-modules/bitcoin-utils-fork-minimal/default.nix
@@ -23,13 +23,6 @@ buildPythonPackage rec {
     sympy
   ];
 
-  preConfigure = ''
-    substituteInPlace setup.py \
-      --replace "sympy==1.3" "sympy>=1.3" \
-      --replace "base58==2.1.0" "base58>=2.1.0" \
-      --replace "ecdsa==0.17.0" "ecdsa>=0.17.0"
-  '';
-
   # Project doesn't ship tests
   doCheck = false;
 

--- a/pkgs/development/python-modules/bleak/default.nix
+++ b/pkgs/development/python-modules/bleak/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   postPatch = ''
     # bleak checks BlueZ's version with a call to `bluetoothctl --version`
     substituteInPlace bleak/backends/bluezdbus/version.py \
-      --replace \"bluetoothctl\" \"${bluez}/bin/bluetoothctl\"
+      --replace-fail \"bluetoothctl\" \"${bluez}/bin/bluetoothctl\"
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/blinkpy/default.nix
+++ b/pkgs/development/python-modules/blinkpy/default.nix
@@ -39,8 +39,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace ', "wheel~=0.40.0"' "" \
-      --replace "setuptools~=68.0" "setuptools"
+      --replace-fail ', "wheel~=0.40.0"' "" \
+      --replace-fail "setuptools~=68.0" "setuptools"
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/blivet/default.nix
+++ b/pkgs/development/python-modules/blivet/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   postPatch = ''
     find blivet -name '*.py' | while IFS= read -r i ; do
       substituteInPlace "$i" \
-        --replace \
+        --replace-quiet \
           'gi.require_version("BlockDev",' \
           'import gi.repository
     gi.require_version("GIRepository", "2.0")

--- a/pkgs/development/python-modules/blockchain/default.nix
+++ b/pkgs/development/python-modules/blockchain/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace "enum-compat" ""
+    substituteInPlace setup.py --replace-fail "enum-compat" ""
   '';
 
   propagatedBuildInputs = [ future ];

--- a/pkgs/development/python-modules/boilerpy3/default.nix
+++ b/pkgs/development/python-modules/boilerpy3/default.nix
@@ -22,12 +22,6 @@ buildPythonPackage {
     hash = "sha256-dhAB0VbBGsSrgYGUlZEYaKA6sQB/f9Bb3alsRuQ8opo=";
   };
 
-  postPatch = ''
-    # the version mangling in mautrix_signal/get_version.py interacts badly with pythonRelaxDepsHook
-    substituteInPlace setup.py \
-      --replace '>=3.6.*' '>=3.6'
-  '';
-
   pythonImportsCheck = [ "boilerpy3" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/bpython/default.nix
+++ b/pkgs/development/python-modules/bpython/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
 
   postInstall = ''
     substituteInPlace "$out/share/applications/org.bpython-interpreter.bpython.desktop" \
-      --replace "Exec=/usr/bin/bpython" "Exec=bpython"
+      --replace-fail "Exec=/usr/bin/bpython" "Exec=bpython"
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/bqplot/default.nix
+++ b/pkgs/development/python-modules/bqplot/default.nix
@@ -27,8 +27,8 @@ buildPythonPackage rec {
   # jupyter_packaging to hatch, so let's patch instead of fixing upstream
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "jupyter_packaging~=" "jupyter_packaging>=" \
-      --replace "jupyterlab~=" "jupyterlab>="
+      --replace-fail "jupyter_packaging~=" "jupyter_packaging>=" \
+      --replace-fail "jupyterlab~=" "jupyterlab>="
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/btchip-python/default.nix
+++ b/pkgs/development/python-modules/btchip-python/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   postPatch = ''
     # fix extra_requires validation
     substituteInPlace setup.py \
-      --replace "python-pyscard>=1.6.12-4build1" "python-pyscard>=1.6.12"
+      --replace-fail "python-pyscard>=1.6.12-4build1" "python-pyscard>=1.6.12"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/bunch/default.nix
+++ b/pkgs/development/python-modules/bunch/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "rU" "r"
+      --replace-fail "rU" "r"
   '';
 
   # No real tests available

--- a/pkgs/development/python-modules/busypie/default.nix
+++ b/pkgs/development/python-modules/busypie/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pytest-runner" ""
+      --replace-fail "pytest-runner" ""
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/bwapy/default.nix
+++ b/pkgs/development/python-modules/bwapy/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     cp ${bwa}/lib/*.a ${bwa}/include/*.h bwa/
 
     substituteInPlace setup.py \
-      --replace 'setuptools>=49.2.0' 'setuptools'
+      --replace-fail 'setuptools>=49.2.0' 'setuptools'
   '';
 
   buildInputs = [

--- a/pkgs/development/python-modules/calver/default.nix
+++ b/pkgs/development/python-modules/calver/default.nix
@@ -22,7 +22,7 @@ let
 
     postPatch = ''
       substituteInPlace setup.py \
-        --replace "version=calver_version(True)" 'version="${version}"'
+        --replace-fail "version=calver_version(True)" 'version="${version}"'
     '';
 
     build-system = [ setuptools ];

--- a/pkgs/development/python-modules/capstone/4.nix
+++ b/pkgs/development/python-modules/capstone/4.nix
@@ -26,7 +26,7 @@ buildPythonPackage {
   postPatch = ''
     ln -s ${capstone_4}/lib/libcapstone${stdenv.targetPlatform.extensions.sharedLibrary} prebuilt/
     ln -s ${capstone_4}/lib/libcapstone${stdenv.targetPlatform.extensions.staticLibrary} prebuilt/
-    substituteInPlace setup.py --replace manylinux1 manylinux2014
+    substituteInPlace setup.py --replace-fail manylinux1 manylinux2014
   '';
 
   # aarch64 only available from MacOS SDK 11 onwards, so fix the version tag.

--- a/pkgs/development/python-modules/capstone/default.nix
+++ b/pkgs/development/python-modules/capstone/default.nix
@@ -19,7 +19,6 @@ buildPythonPackage rec {
   postPatch = ''
     ln -s ${capstone}/lib/libcapstone${stdenv.targetPlatform.extensions.sharedLibrary} prebuilt/
     touch prebuilt/libcapstone${stdenv.targetPlatform.extensions.staticLibrary}
-    substituteInPlace setup.py --replace manylinux1 manylinux2014
   '';
 
   # aarch64 only available from MacOS SDK 11 onwards, so fix the version tag.

--- a/pkgs/development/python-modules/chai/default.nix
+++ b/pkgs/development/python-modules/chai/default.nix
@@ -14,14 +14,6 @@ buildPythonPackage rec {
     sha256 = "ff8d2b6855f660cd23cd5ec79bd10264d39f24f6235773331b48e7fcd637d6cc";
   };
 
-  postPatch = ''
-    # python 3.12 compatibility
-    substituteInPlace tests/*.py \
-      --replace "assertEquals" "assertEqual" \
-      --replace "assertNotEquals" "assertNotEqual" \
-      --replace "assert_equals" "assert_equal"
-  '';
-
   meta = with lib; {
     description = "Mocking, stubbing and spying framework for python";
   };

--- a/pkgs/development/python-modules/chalice/default.nix
+++ b/pkgs/development/python-modules/chalice/default.nix
@@ -39,8 +39,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "inquirer>=2.7.0,<3.0.0" "inquirer" \
-      --replace "pip>=9,<23.1" "pip" \
+      --replace-fail "inquirer>=2.7.0,<3.0.0" "inquirer" \
+      --replace-fail "pip>=9,<23.1" "pip" \
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/characteristic/default.nix
+++ b/pkgs/development/python-modules/characteristic/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytest ];
 
   postPatch = ''
-    substituteInPlace setup.cfg --replace "[pytest]" "[tool:pytest]"
+    substituteInPlace setup.cfg --replace-fail "[pytest]" "[tool:pytest]"
   '';
 
   meta = {

--- a/pkgs/development/python-modules/cheroot/default.nix
+++ b/pkgs/development/python-modules/cheroot/default.nix
@@ -30,17 +30,6 @@ buildPythonPackage rec {
     hash = "sha256-4LgveXZY0muGE+yOtWPDsI5r1qeSHp1Qib0Rda0bF0A=";
   };
 
-  # remove setuptools-scm-git-archive dependency
-  # https://github.com/cherrypy/cheroot/commit/f0c51af263e20f332c6f675aa90ec6705ae4f5d1
-  # there is a difference between the github source and the pypi tarball source,
-  # and it is not easy to apply patches.
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace '"setuptools_scm_git_archive>=1.1",' ""
-    substituteInPlace setup.cfg \
-      --replace "setuptools_scm_git_archive>=1.0" ""
-  '';
-
   nativeBuildInputs = [ setuptools-scm ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/ci-py/default.nix
+++ b/pkgs/development/python-modules/ci-py/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner', " ""
+      --replace-fail "'pytest-runner', " ""
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/cliche/default.nix
+++ b/pkgs/development/python-modules/cliche/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "ipdb == 0.13.9" "ipdb"
+      --replace-fail "ipdb == 0.13.9" "ipdb"
   '';
 
   propagatedBuildInputs = [ ipdb ];

--- a/pkgs/development/python-modules/click-configfile/default.nix
+++ b/pkgs/development/python-modules/click-configfile/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "install_requires=install_requires," 'install_requires=["click >= 6.6", "six >= 1.10"],'
+      --replace-fail "install_requires=install_requires," 'install_requires=["click >= 6.6", "six >= 1.10"],'
   '';
 
   pythonImportsCheck = [ "click_configfile" ];

--- a/pkgs/development/python-modules/clickhouse-driver/default.nix
+++ b/pkgs/development/python-modules/clickhouse-driver/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "lz4<=3.0.1" "lz4<=4"
+      --replace-fail "lz4<=3.0.1" "lz4<=4"
   '';
 
   # remove source to prevent pytest testing source instead of the build artifacts

--- a/pkgs/development/python-modules/cocotb-bus/default.nix
+++ b/pkgs/development/python-modules/cocotb-bus/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     # remove circular dependency cocotb from setup.py
-    substituteInPlace setup.py --replace '"cocotb>=1.5.0.dev,<2.0"' ""
+    substituteInPlace setup.py --replace-fail '"cocotb>=1.5.0.dev,<2.0"' ""
   '';
 
   # tests require cocotb, disable for now to avoid circular dependency

--- a/pkgs/development/python-modules/commentjson/default.nix
+++ b/pkgs/development/python-modules/commentjson/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "lark-parser>=0.7.1,<0.8.0" "lark"
+      --replace-fail "lark-parser>=0.7.1,<0.8.0" "lark"
 
     # NixOS is missing test.test_json module
     rm -r commentjson/tests/test_json

--- a/pkgs/development/python-modules/corsair-scan/default.nix
+++ b/pkgs/development/python-modules/corsair-scan/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/cot/default.nix
+++ b/pkgs/development/python-modules/cot/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   prePatch = ''
     # argparse is part of the standardlib
     substituteInPlace setup.py \
-      --replace "'argparse'," ""
+      --replace-fail "'argparse'," ""
     rm versioneer.py
   '';
 

--- a/pkgs/development/python-modules/cppe/default.nix
+++ b/pkgs/development/python-modules/cppe/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage {
   # Using the nixpkgs version instead.
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "external/eigen3" "${eigen}/include/eigen3"
+      --replace-fail "external/eigen3" "${eigen}/include/eigen3"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/craft-application/default.nix
+++ b/pkgs/development/python-modules/craft-application/default.nix
@@ -97,7 +97,7 @@ buildPythonPackage rec {
     # Not using `--replace-fail` here only because it simplifies overriding this package in the charmcraft
     # derivation. Once charmcraft has moved to craft-application >= 5, `--replace-fail` can be added.
     substituteInPlace tests/conftest.py \
-      --replace "include_lsb=False, include_uname=False, include_oslevel=False" "include_lsb=False, include_uname=False, include_oslevel=False, os_release_file='$HOME/os-release'"
+      --replace-fail "include_lsb=False, include_uname=False, include_oslevel=False" "include_lsb=False, include_uname=False, include_oslevel=False, os_release_file='$HOME/os-release'"
 
     # The project attempts to write into the user's runtime directory, usually
     # '/run/user/<uid>', which fails in the build environment. By setting this

--- a/pkgs/development/python-modules/cram/default.nix
+++ b/pkgs/development/python-modules/cram/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   postPatch = ''
     patchShebangs scripts/cram
     substituteInPlace tests/test.t \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace-fail "/bin/bash" "${bash}/bin/bash"
   '';
 
   checkPhase = ''

--- a/pkgs/development/python-modules/crysp/default.nix
+++ b/pkgs/development/python-modules/crysp/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   pythonImportsCheck = [ "crysp" ];

--- a/pkgs/development/python-modules/ctap-keyring-device/default.nix
+++ b/pkgs/development/python-modules/ctap-keyring-device/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   # removing optional dependency needing pyobjc
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace "--flake8 --black --cov" ""
+      --replace-fail "--flake8 --black --cov" ""
   '';
 
   pythonRemoveDeps = [

--- a/pkgs/development/python-modules/cwl-upgrader/default.nix
+++ b/pkgs/development/python-modules/cwl-upgrader/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Version detection doesn't work for schema_salad
     substituteInPlace pyproject.toml \
-      --replace '"schema_salad",' ""
+      --replace-fail '"schema_salad",' ""
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/cxxfilt/default.nix
+++ b/pkgs/development/python-modules/cxxfilt/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     in
     ''
       substituteInPlace cxxfilt/__init__.py \
-        --replace "find_any_library('stdc++', 'c++')" '"${libstdcpp}"'
+        --replace-fail "find_any_library('stdc++', 'c++')" '"${libstdcpp}"'
     '';
 
   # no tests

--- a/pkgs/development/python-modules/dacite/default.nix
+++ b/pkgs/development/python-modules/dacite/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "--benchmark-autosave --benchmark-json=benchmark.json" ""
+      --replace-fail "--benchmark-autosave --benchmark-json=benchmark.json" ""
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/darkdetect/default.nix
+++ b/pkgs/development/python-modules/darkdetect/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = lib.optionalString (stdenv.hostPlatform.isLinux) ''
     substituteInPlace darkdetect/_linux_detect.py \
-      --replace "'gsettings'" "'${glib.bin}/bin/gsettings'"
+      --replace-fail "'gsettings'" "'${glib.bin}/bin/gsettings'"
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/dataclasses-serialization/default.nix
+++ b/pkgs/development/python-modules/dataclasses-serialization/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   postPatch = ''
     mv pypi_upload/setup.py .
     substituteInPlace setup.py \
-      --replace "project_root = Path(__file__).parents[1]" "project_root = Path(__file__).parents[0]"
+      --replace-fail "project_root = Path(__file__).parents[1]" "project_root = Path(__file__).parents[0]"
 
     # https://github.com/madman-bob/python-dataclasses-serialization/issues/16
     sed -i '/(\(Dict\|List\)/d' tests/test_json.py tests/test_bson.py

--- a/pkgs/development/python-modules/datasette/default.nix
+++ b/pkgs/development/python-modules/datasette/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner"' ""
+      --replace-fail '"pytest-runner"' ""
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/datrie/default.nix
+++ b/pkgs/development/python-modules/datrie/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner", ' ""
+      --replace-fail '"pytest-runner", ' ""
   '';
 
   dependencies = [

--- a/pkgs/development/python-modules/decopatch/default.nix
+++ b/pkgs/development/python-modules/decopatch/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "pytest-runner" ""
+      --replace-fail "pytest-runner" ""
   '';
 
   pythonImportsCheck = [ "decopatch" ];

--- a/pkgs/development/python-modules/deepwave/default.nix
+++ b/pkgs/development/python-modules/deepwave/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   # unable to find ninja although it is available, most likely because it looks for its pip version
   postPatch = ''
-    substituteInPlace setup.cfg --replace "ninja" ""
+    substituteInPlace setup.cfg --replace-fail "ninja" ""
 
     # Adding ninja to the path forcibly
     mv src/deepwave/__init__.py tmp

--- a/pkgs/development/python-modules/dendropy/default.nix
+++ b/pkgs/development/python-modules/dendropy/default.nix
@@ -30,10 +30,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '["pytest-runner"],' '[],'
+      --replace-fail '["pytest-runner"],' '[],'
 
     substituteInPlace src/dendropy/interop/paup.py \
-      --replace 'PAUP_PATH = os.environ.get(metavar.DENDROPY_PAUP_PATH_ENVAR, "paup")' 'PAUP_PATH = os.environ.get(metavar.DENDROPY_PAUP_PATH_ENVAR, "${paupPath}")'
+      --replace-fail 'PAUP_PATH = os.environ.get(metavar.DENDROPY_PAUP_PATH_ENVAR, "paup")' 'PAUP_PATH = os.environ.get(metavar.DENDROPY_PAUP_PATH_ENVAR, "${paupPath}")'
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/dictdiffer/default.nix
+++ b/pkgs/development/python-modules/dictdiffer/default.nix
@@ -27,9 +27,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner>=2.7'," ""
+      --replace-fail "'pytest-runner>=2.7'," ""
     substituteInPlace pytest.ini \
-      --replace ' --isort --pydocstyle --pycodestyle --doctest-glob="*.rst" --doctest-modules --cov=dictdiffer --cov-report=term-missing' ""
+      --replace-fail ' --isort --pydocstyle --pycodestyle --doctest-glob="*.rst" --doctest-modules --cov=dictdiffer --cov-report=term-missing' ""
   '';
 
   pythonImportsCheck = [ "dictdiffer" ];

--- a/pkgs/development/python-modules/discid/default.nix
+++ b/pkgs/development/python-modules/discid/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     in
     ''
       substituteInPlace discid/libdiscid.py \
-        --replace "_open_library(_LIB_NAME)" \
+        --replace-fail "_open_library(_LIB_NAME)" \
                   "_open_library('${libdiscid}/lib/libdiscid${extension}')"
     '';
 

--- a/pkgs/development/python-modules/django-rest-auth/default.nix
+++ b/pkgs/development/python-modules/django-rest-auth/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "djangorestframework-jwt" "drf-jwt"
+      --replace-fail "djangorestframework-jwt" "drf-jwt"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -90,7 +90,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace tests/utils_tests/test_autoreload.py \
-      --replace "/usr/bin/python" "${python.interpreter}"
+      --replace-fail "/usr/bin/python" "${python.interpreter}"
   ''
   + lib.optionalString (pythonAtLeast "3.12" && stdenv.hostPlatform.system == "aarch64-linux") ''
     # Test regression after xz was reverted from 5.6.0 to 5.4.6

--- a/pkgs/development/python-modules/dkimpy/default.nix
+++ b/pkgs/development/python-modules/dkimpy/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   ];
 
   patchPhase = ''
-    substituteInPlace dkim/dknewkey.py --replace \
+    substituteInPlace dkim/dknewkey.py --replace-fail \
       /usr/bin/openssl ${openssl}/bin/openssl
   '';
 

--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -27,12 +27,6 @@ buildPythonPackage {
     more-itertools
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "more-itertools<6.0.0" "more-itertools" \
-      --replace "pytest==3.8" "pytest"
-  '';
-
   # Pass CMake flags through to the build script
   preConfigure = ''
     for flag in $cmakeFlags; do

--- a/pkgs/development/python-modules/dnf4/default.nix
+++ b/pkgs/development/python-modules/dnf4/default.nix
@@ -38,16 +38,16 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace "@PYTHON_INSTALL_DIR@" "$out/${python.sitePackages}" \
-      --replace "SYSCONFDIR /etc" "SYSCONFDIR $out/etc" \
-      --replace "SYSTEMD_DIR /usr/lib/systemd/system" "SYSTEMD_DIR $out/lib/systemd/system"
+      --replace-fail "@PYTHON_INSTALL_DIR@" "$out/${python.sitePackages}" \
+      --replace-fail "SYSCONFDIR /etc" "SYSCONFDIR $out/etc" \
+      --replace-fail "SYSTEMD_DIR /usr/lib/systemd/system" "SYSTEMD_DIR $out/lib/systemd/system"
     substituteInPlace etc/tmpfiles.d/CMakeLists.txt \
-      --replace "DESTINATION /usr/lib/tmpfiles.d" "DESTINATION $out/usr/lib/tmpfiles.d"
+      --replace-fail "DESTINATION /usr/lib/tmpfiles.d" "DESTINATION $out/usr/lib/tmpfiles.d"
     substituteInPlace dnf/const.py.in \
-      --replace "/etc" "$out/etc" \
-      --replace "/var/tmp" "/tmp"
+      --replace-fail "/etc" "$out/etc" \
+      --replace-fail "/var/tmp" "/tmp"
     substituteInPlace doc/CMakeLists.txt \
-      --replace 'SPHINX_BUILD_NAME "sphinx-build-3"' 'SPHINX_BUILD_NAME "${sphinx}/bin/sphinx-build"'
+      --replace-fail 'SPHINX_BUILD_NAME "sphinx-build-3"' 'SPHINX_BUILD_NAME "${sphinx}/bin/sphinx-build"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/docformatter/default.nix
+++ b/pkgs/development/python-modules/docformatter/default.nix
@@ -29,8 +29,6 @@ buildPythonPackage rec {
   patches = [ ./test-path.patch ];
 
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'charset_normalizer = "^2.0.0"' 'charset_normalizer = ">=2.0.0"'
     substituteInPlace tests/conftest.py \
       --subst-var-by docformatter $out/bin/docformatter
   '';

--- a/pkgs/development/python-modules/dvc-objects/default.nix
+++ b/pkgs/development/python-modules/dvc-objects/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace " --benchmark-skip" ""
+      --replace-fail " --benchmark-skip" ""
   '';
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/python-modules/dvc-ssh/default.nix
+++ b/pkgs/development/python-modules/dvc-ssh/default.nix
@@ -39,11 +39,6 @@ buildPythonPackage rec {
     gssapi = [ sshfs ];
   };
 
-  # bcrypt is enabled for sshfs in nixpkgs
-  postPatch = ''
-    substituteInPlace setup.cfg --replace "sshfs[bcrypt]" "sshfs"
-  '';
-
   # Network access is needed for tests
   doCheck = false;
 

--- a/pkgs/development/python-modules/dynalite-panel/default.nix
+++ b/pkgs/development/python-modules/dynalite-panel/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "~=" ">="
+      --replace-fail "~=" ">="
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/easyenergy/default.nix
+++ b/pkgs/development/python-modules/easyenergy/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"0.0.0"' '"${version}"'
+      --replace-fail '"0.0.0"' '"${version}"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   setuptools,
   setuptools-scm,
-  coreutils,
   jinja2,
   pandas,
   pyparsing,
@@ -29,8 +28,6 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace tests/test_edam.py \
-      --replace /usr/bin/touch ${coreutils}/bin/touch
     patchShebangs tests/mock_commands/vsim
   '';
 

--- a/pkgs/development/python-modules/effect/default.nix
+++ b/pkgs/development/python-modules/effect/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace effect/test_do.py \
-      --replace "py.test" "pytest"
+      --replace-fail "py.test" "pytest"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/elgato/default.nix
+++ b/pkgs/development/python-modules/elgato/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}" \
+      --replace-fail "0.0.0" "${version}" \
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/etebase/default.nix
+++ b/pkgs/development/python-modules/etebase/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Use system OpenSSL, which gets security updates.
     substituteInPlace Cargo.toml \
-      --replace ', features = ["vendored"]' ""
+      --replace-fail ', features = ["vendored"]' ""
   '';
 
   pythonImportsCheck = [ "etebase" ];

--- a/pkgs/development/python-modules/exrex/default.nix
+++ b/pkgs/development/python-modules/exrex/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "version=about['__version__']," "version='${version}',"
+      --replace-fail "version=about['__version__']," "version='${version}',"
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/fairscale/default.nix
+++ b/pkgs/development/python-modules/fairscale/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage {
   # setup.py depends on ninja python dependency, but we have the binary in nixpkgs
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'setup_requires=["ninja"]' 'setup_requires=[]'
+      --replace-fail 'setup_requires=["ninja"]' 'setup_requires=[]'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/finalfusion/default.nix
+++ b/pkgs/development/python-modules/finalfusion/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
     # `np.float` was a deprecated alias of the builtin `float`
     substituteInPlace tests/test_storage.py \
-      --replace 'dtype=np.float)' 'dtype=float)'
+      --replace-fail 'dtype=np.float)' 'dtype=float)'
   '';
 
   checkPhase = ''

--- a/pkgs/development/python-modules/flask-caching/default.nix
+++ b/pkgs/development/python-modules/flask-caching/default.nix
@@ -24,11 +24,6 @@ buildPythonPackage rec {
     hash = "sha256-Zdf9G07r+BD4RN595iWCVLMkgpbuQpvcs/dBvL97mMk=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "cachelib >= 0.9.0, < 0.10.0" "cachelib"
-  '';
-
   propagatedBuildInputs = [
     cachelib
     flask

--- a/pkgs/development/python-modules/flask-dramatiq/default.nix
+++ b/pkgs/development/python-modules/flask-dramatiq/default.nix
@@ -32,8 +32,8 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'poetry>=0.12' 'poetry-core' \
-      --replace 'poetry.masonry.api' 'poetry.core.masonry.api'
+      --replace-fail 'poetry>=0.12' 'poetry-core' \
+      --replace-fail 'poetry.masonry.api' 'poetry.core.masonry.api'
 
     patchShebangs --build ./example.py
   '';
@@ -57,7 +57,7 @@ buildPythonPackage {
 
   postgresqlTestSetupPost = ''
     substituteInPlace config.py \
-      --replace 'SQLALCHEMY_DATABASE_URI = f"postgresql://{PGUSER}:{PGPASSWORD}@{PGHOST}/{PGDATABASE}"' \
+      --replace-fail 'SQLALCHEMY_DATABASE_URI = f"postgresql://{PGUSER}:{PGPASSWORD}@{PGHOST}/{PGDATABASE}"' \
         "SQLALCHEMY_DATABASE_URI = \"postgresql://$PGUSER/$PGDATABASE?host=$PGHOST\""
     python3 ./example.py db upgrade
   '';

--- a/pkgs/development/python-modules/flask-paranoid/default.nix
+++ b/pkgs/development/python-modules/flask-paranoid/default.nix
@@ -18,11 +18,6 @@ buildPythonPackage rec {
     hash = "sha256-tikD8efc3Q3xIQnaC3SSBaCRQxMI1HzXxeupvYeNnE4=";
   };
 
-  postPatch = ''
-    # tests have a typo in one of the assertions
-    substituteInPlace tests/test_paranoid.py --replace "01-Jan-1970" "01 Jan 1970"
-  '';
-
   propagatedBuildInputs = [ flask ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/foundationdb/default.nix
+++ b/pkgs/development/python-modules/foundationdb/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage {
 
   patchPhase = ''
     substituteInPlace ./fdb/impl.py \
-      --replace libfdb_c.so "${foundationdb.lib}/lib/libfdb_c.so"
+      --replace-fail libfdb_c.so "${foundationdb.lib}/lib/libfdb_c.so"
   '';
 
   doCheck = false;

--- a/pkgs/development/python-modules/fs/default.nix
+++ b/pkgs/development/python-modules/fs/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   postPatch = ''
     # https://github.com/PyFilesystem/pyfilesystem2/pull/591
     substituteInPlace tests/test_ftpfs.py \
-      --replace ThreadedTestFTPd FtpdThreadWrapper
+      --replace-fail ThreadedTestFTPd FtpdThreadWrapper
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/fusepy/default.nix
+++ b/pkgs/development/python-modules/fusepy/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   # On macOS, users are expected to install macFUSE. This means fusepy should
   # be able to find libfuse in /usr/local/lib.
   patchPhase = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    substituteInPlace fuse.py --replace \
+    substituteInPlace fuse.py --replace-fail \
       "find_library('fuse')" "'${lib.getLib pkgs.fuse}/lib/libfuse.so'"
   '';
 

--- a/pkgs/development/python-modules/genanki/default.nix
+++ b/pkgs/development/python-modules/genanki/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   # relies on upstream anki

--- a/pkgs/development/python-modules/geniushub-client/default.nix
+++ b/pkgs/development/python-modules/geniushub-client/default.nix
@@ -23,8 +23,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'VERSION = os.environ["GITHUB_REF_NAME"]' "" \
-      --replace "version=VERSION," 'version="${version}",'
+      --replace-fail 'VERSION = os.environ["GITHUB_REF_NAME"]' "" \
+      --replace-fail "version=VERSION," 'version="${version}",'
   '';
 
   propagatedBuildInputs = [ aiohttp ];

--- a/pkgs/development/python-modules/gerbonara/default.nix
+++ b/pkgs/development/python-modules/gerbonara/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   preConfigure = ''
     # setup.py tries to execute a call to git in a subprocess, this avoids it.
     substituteInPlace setup.py \
-      --replace "version=version()," \
+      --replace-fail "version=version()," \
                 "version='${version}',"
   '';
 

--- a/pkgs/development/python-modules/get-video-properties/default.nix
+++ b/pkgs/development/python-modules/get-video-properties/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace videoprops/__init__.py \
-      --replace "which('ffprobe')" "'${ffmpeg-headless}/bin/ffprobe'"
+      --replace-fail "which('ffprobe')" "'${ffmpeg-headless}/bin/ffprobe'"
 
     # unused and vulnerable to various CVEs
     rm -r videoprops/binary_dependencies

--- a/pkgs/development/python-modules/ghrepo-stats/default.nix
+++ b/pkgs/development/python-modules/ghrepo-stats/default.nix
@@ -22,12 +22,6 @@ buildPythonPackage rec {
     hash = "sha256-zdBIX/uetkOAalg4uJPWXRL9WUgNN+hmqUwQDTdzrzA=";
   };
 
-  postPatch = ''
-    # https://github.com/mrbean-bremen/ghrepo-stats/pull/1
-    substituteInPlace setup.py \
-      --replace "bs4" "beautifulsoup4"
-  '';
-
   propagatedBuildInputs = [
     beautifulsoup4
     matplotlib

--- a/pkgs/development/python-modules/gitpython/default.nix
+++ b/pkgs/development/python-modules/gitpython/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace git/cmd.py \
-      --replace 'git_exec_name = "git"' 'git_exec_name = "${pkgs.gitMinimal}/bin/git"'
+      --replace-fail 'git_exec_name = "git"' 'git_exec_name = "${pkgs.gitMinimal}/bin/git"'
   '';
 
   # Tests require a git repo

--- a/pkgs/development/python-modules/glfw/default.nix
+++ b/pkgs/development/python-modules/glfw/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   # Patch path to GLFW shared object
   postPatch = ''
-    substituteInPlace glfw/library.py --replace "_get_library_search_paths()," "[ '${glfw3}/lib' ],"
+    substituteInPlace glfw/library.py --replace-fail "_get_library_search_paths()," "[ '${glfw3}/lib' ],"
   '';
 
   propagatedBuildInputs = [ glfw3 ];

--- a/pkgs/development/python-modules/gnureadline/default.nix
+++ b/pkgs/development/python-modules/gnureadline/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   buildInputs = [ pkgs.ncurses ];
   patchPhase = ''
-    substituteInPlace setup.py --replace "/bin/bash" "${pkgs.bash}/bin/bash"
+    substituteInPlace setup.py --replace-fail "/bin/bash" "${pkgs.bash}/bin/bash"
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/gpib-ctypes/default.nix
+++ b/pkgs/development/python-modules/gpib-ctypes/default.nix
@@ -24,9 +24,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace gpib_ctypes/gpib/gpib.py \
-      --replace "libgpib.so.0" "${linux-gpib}/lib/libgpib.so.0"
+      --replace-fail "libgpib.so.0" "${linux-gpib}/lib/libgpib.so.0"
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   pythonImportsCheck = [ "gpib_ctypes.gpib" ];

--- a/pkgs/development/python-modules/gpuctypes/default.nix
+++ b/pkgs/development/python-modules/gpuctypes/default.nix
@@ -47,18 +47,18 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace gpuctypes/opencl.py \
-      --replace "ctypes.util.find_library('OpenCL')" "'${ocl-icd}/lib/libOpenCL.so'"
+      --replace-fail "ctypes.util.find_library('OpenCL')" "'${ocl-icd}/lib/libOpenCL.so'"
   ''
   # hipGetDevicePropertiesR0600 is a symbol from rocm-6. We are currently at rocm-5.
   # We are not sure that this works. Remove when rocm gets updated to version 6.
   + lib.optionalString rocmSupport ''
     substituteInPlace gpuctypes/hip.py \
-      --replace "/opt/rocm/lib/libamdhip64.so" "${rocmPackages.clr}/lib/libamdhip64.so" \
-      --replace "/opt/rocm/lib/libhiprtc.so" "${rocmPackages.clr}/lib/libhiprtc.so" \
-      --replace "hipGetDevicePropertiesR0600" "hipGetDeviceProperties"
+      --replace-fail "/opt/rocm/lib/libamdhip64.so" "${rocmPackages.clr}/lib/libamdhip64.so" \
+      --replace-fail "/opt/rocm/lib/libhiprtc.so" "${rocmPackages.clr}/lib/libhiprtc.so" \
+      --replace-fail "hipGetDevicePropertiesR0600" "hipGetDeviceProperties"
 
     substituteInPlace gpuctypes/comgr.py \
-      --replace "/opt/rocm/lib/libamd_comgr.so" "${rocmPackages.rocm-comgr}/lib/libamd_comgr.so"
+      --replace-fail "/opt/rocm/lib/libamd_comgr.so" "${rocmPackages.rocm-comgr}/lib/libamd_comgr.so"
   '';
 
   pythonImportsCheck = [ "gpuctypes" ];

--- a/pkgs/development/python-modules/gradient-utils/default.nix
+++ b/pkgs/development/python-modules/gradient-utils/default.nix
@@ -44,9 +44,9 @@ buildPythonPackage rec {
     # https://github.com/Paperspace/gradient-utils/issues/68
     # https://github.com/Paperspace/gradient-utils/issues/72
     substituteInPlace pyproject.toml \
-      --replace 'wheel = "^0.35.1"' 'wheel = "*"' \
-      --replace 'prometheus-client = ">=0.8,<0.10"' 'prometheus-client = "*"' \
-      --replace 'pymongo = "^3.11.0"' 'pymongo = ">=3.11.0"'
+      --replace-fail 'wheel = "^0.35.1"' 'wheel = "*"' \
+      --replace-fail 'prometheus-client = ">=0.8,<0.10"' 'prometheus-client = "*"' \
+      --replace-fail 'pymongo = "^3.11.0"' 'pymongo = ">=3.11.0"'
   '';
 
   preCheck = ''

--- a/pkgs/development/python-modules/gradient/default.nix
+++ b/pkgs/development/python-modules/gradient/default.nix
@@ -34,12 +34,12 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'attrs<=' 'attrs>=' \
-      --replace 'colorama==' 'colorama>=' \
-      --replace 'gql[requests]==3.0.0a6' 'gql' \
-      --replace 'PyYAML==5.*' 'PyYAML' \
-      --replace 'marshmallow<' 'marshmallow>=' \
-      --replace 'websocket-client==0.57.*' 'websocket-client'
+      --replace-fail 'attrs<=' 'attrs>=' \
+      --replace-fail 'colorama==' 'colorama>=' \
+      --replace-fail 'gql[requests]==3.0.0a6' 'gql' \
+      --replace-fail 'PyYAML==5.*' 'PyYAML' \
+      --replace-fail 'marshmallow<' 'marshmallow>=' \
+      --replace-fail 'websocket-client==0.57.*' 'websocket-client'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/grammalecte/default.nix
+++ b/pkgs/development/python-modules/grammalecte/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   patchPhase = ''
     runHook prePatch
-    substituteInPlace grammalecte-server.py --replace sys.version_info.major sys.version_info
+    substituteInPlace grammalecte-server.py --replace-fail sys.version_info.major sys.version_info
     runHook postPatch
   '';
 

--- a/pkgs/development/python-modules/graphene-django/default.nix
+++ b/pkgs/development/python-modules/graphene-django/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner"' ""
+      --replace-fail '"pytest-runner"' ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/graphlib-backport/default.nix
+++ b/pkgs/development/python-modules/graphlib-backport/default.nix
@@ -21,8 +21,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml        \
-      --replace 'poetry>=1.0' 'poetry-core' \
-      --replace 'poetry.masonry.api' 'poetry.core.masonry.api'
+      --replace-fail 'poetry>=1.0' 'poetry-core' \
+      --replace-fail 'poetry.masonry.api' 'poetry.core.masonry.api'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/graphql-relay/default.nix
+++ b/pkgs/development/python-modules/graphql-relay/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "poetry_core>=1,<2" "poetry-core" \
-      --replace ', "setuptools>=59,<70"' ""
+      --replace-fail ', "setuptools>=59,<70"' ""
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/gremlinpython/default.nix
+++ b/pkgs/development/python-modules/gremlinpython/default.nix
@@ -35,8 +35,8 @@ buildPythonPackage rec {
     sed -i '/pytest-runner/d' setup.py
 
     substituteInPlace setup.py \
-      --replace 'importlib-metadata<5.0.0' 'importlib-metadata' \
-      --replace "os.getenv('VERSION', '?').replace('-SNAPSHOT', '.dev-%d' % timestamp)" '"${version}"'
+      --replace-fail 'importlib-metadata<5.0.0' 'importlib-metadata' \
+      --replace-fail "os.getenv('VERSION', '?').replace('-SNAPSHOT', '.dev-%d' % timestamp)" '"${version}"'
   '';
 
   # setup-requires requirements
@@ -59,7 +59,7 @@ buildPythonPackage rec {
 
   # disable custom pytest report generation
   preCheck = ''
-    substituteInPlace setup.cfg --replace 'addopts' '#addopts'
+    substituteInPlace setup.cfg --replace-fail 'addopts' '#addopts'
     export TEST_TRANSACTIONS='false'
   '';
 

--- a/pkgs/development/python-modules/gridnet/default.nix
+++ b/pkgs/development/python-modules/gridnet/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}"
+      --replace-fail "0.0.0" "${version}"
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/grpcio-status/default.nix
+++ b/pkgs/development/python-modules/grpcio-status/default.nix
@@ -24,11 +24,6 @@ buildPythonPackage rec {
     hash = "sha256-ko9JzPlojbXyDNnkXEV4odAczKKa6qvwZvKsdqqIZmg=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace 'protobuf>=4.21.6' 'protobuf'
-  '';
-
   propagatedBuildInputs = [
     googleapis-common-protos
     grpcio

--- a/pkgs/development/python-modules/gruut-ipa/default.nix
+++ b/pkgs/development/python-modules/gruut-ipa/default.nix
@@ -23,8 +23,8 @@ buildPythonPackage rec {
   postPatch = ''
     patchShebangs bin/*
     substituteInPlace bin/speak-ipa \
-      --replace '${"\${src_dir}:"}' "$out/${python.sitePackages}:" \
-      --replace "do espeak" "do ${espeak}/bin/espeak"
+      --replace-fail '${"\${src_dir}:"}' "$out/${python.sitePackages}:" \
+      --replace-fail "do espeak" "do ${espeak}/bin/espeak"
   '';
 
   propagatedBuildInputs = [ numpy ];

--- a/pkgs/development/python-modules/gssapi/default.nix
+++ b/pkgs/development/python-modules/gssapi/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'get_output(f"{kc} gssapi --prefix")' '"${lib.getDev krb5-c}"'
+      --replace-fail 'get_output(f"{kc} gssapi --prefix")' '"${lib.getDev krb5-c}"'
   '';
 
   env = lib.optionalAttrs (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) {

--- a/pkgs/development/python-modules/gudhi/default.nix
+++ b/pkgs/development/python-modules/gudhi/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
 
   prePatch = ''
     substituteInPlace src/python/CMakeLists.txt \
-      --replace '"''${GUDHI_PYTHON_PATH_ENV}"' ""
+      --replace-fail '"''${GUDHI_PYTHON_PATH_ENV}"' ""
   '';
 
   preBuild = ''

--- a/pkgs/development/python-modules/gumath/default.nix
+++ b/pkgs/development/python-modules/gumath/default.nix
@@ -42,11 +42,11 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'add_include_dirs = [".", "libgumath", "ndtypes/python/ndtypes", "xnd/python/xnd"] + INCLUDES' \
+      --replace-fail 'add_include_dirs = [".", "libgumath", "ndtypes/python/ndtypes", "xnd/python/xnd"] + INCLUDES' \
                 'add_include_dirs = [".", "${libndtypes.dev}/include", "${libxnd}/include", "${libgumath}/include"]' \
-      --replace 'add_library_dirs = ["libgumath", "ndtypes/libndtypes", "xnd/libxnd"] + LIBS' \
+      --replace-fail 'add_library_dirs = ["libgumath", "ndtypes/libndtypes", "xnd/libxnd"] + LIBS' \
                 'add_library_dirs = ["${libndtypes}/lib", "${libxnd}/lib", "${libgumath}/lib"]' \
-      --replace 'add_runtime_library_dirs = ["$ORIGIN"]' \
+      --replace-fail 'add_runtime_library_dirs = ["$ORIGIN"]' \
                 'add_runtime_library_dirs = ["${libndtypes}/lib", "${libxnd}/lib", "${libgumath}/lib"]'
   '';
 
@@ -58,7 +58,7 @@ buildPythonPackage {
     pushd python
     mv gumath _gumath
     # minor precision issues
-    substituteInPlace test_gumath.py --replace 'test_sin' 'dont_test_sin'
+    substituteInPlace test_gumath.py --replace-fail 'test_sin' 'dont_test_sin'
     python test_gumath.py
     python test_xndarray.py
     popd

--- a/pkgs/development/python-modules/hwdata/default.nix
+++ b/pkgs/development/python-modules/hwdata/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ setuptools ];
 
   patchPhase = ''
-    substituteInPlace hwdata.py --replace "/usr/share/hwdata" "${pkgs.hwdata}/share/hwdata"
+    substituteInPlace hwdata.py --replace-fail "/usr/share/hwdata" "${pkgs.hwdata}/share/hwdata"
   '';
 
   pythonImportsCheck = [ "hwdata" ];

--- a/pkgs/development/python-modules/i3ipc/default.nix
+++ b/pkgs/development/python-modules/i3ipc/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace test/i3.config \
-      --replace /bin/true ${coreutils}/bin/true
+      --replace-fail /bin/true ${coreutils}/bin/true
   '';
 
   checkPhase = ''

--- a/pkgs/development/python-modules/icalendar-compatibility/default.nix
+++ b/pkgs/development/python-modules/icalendar-compatibility/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   # hatch-vcs tries to read the current git commit hash
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'dynamic = ["urls", "version"]' 'version = "${version}"'
+      --replace-fail 'dynamic = ["urls", "version"]' 'version = "${version}"'
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/icecream/default.nix
+++ b/pkgs/development/python-modules/icecream/default.nix
@@ -26,11 +26,6 @@ buildPythonPackage rec {
     hash = "sha256-WHVeWDl9U1CnbyWXbe57YH9f67PG4c3f5rGVGJbpFXM=";
   };
 
-  postPatch = ''
-    substituteInPlace tests/test_icecream.py \
-      --replace assertRegexpMatches assertRegex
-  '';
-
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/intensity-normalization/default.nix
+++ b/pkgs/development/python-modules/intensity-normalization/default.nix
@@ -30,11 +30,6 @@ buildPythonPackage rec {
     hash = "sha256-s/trDIRoqLFj3NO+iv3E+AEB4grBAHDlEL6+TCdsgmg=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg --replace "!=3.10.*," "" --replace "!=3.11.*" ""
-    substituteInPlace setup.cfg --replace "pytest-runner" ""
-  '';
-
   pythonRelaxDeps = [ "nibabel" ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/invisible-watermark/default.nix
+++ b/pkgs/development/python-modules/invisible-watermark/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace imwatermark/rivaGan.py --replace \
+    substituteInPlace imwatermark/rivaGan.py --replace-fail \
       'You can install it with pip: `pip install onnxruntime`.' \
       'You can install it with an override: `python3Packages.invisible-watermark.override { withOnnx = true; };`.'
   '';

--- a/pkgs/development/python-modules/invocations/default.nix
+++ b/pkgs/development/python-modules/invocations/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "semantic_version>=2.4,<2.7" "semantic_version"
+      --replace-fail "semantic_version>=2.4,<2.7" "semantic_version"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/ipfshttpclient/default.nix
+++ b/pkgs/development/python-modules/ipfshttpclient/default.nix
@@ -58,19 +58,19 @@ buildPythonPackage rec {
     # This can be removed for the 0.8.0 release
     # Use pytest-order instead of pytest-ordering since the latter is unmaintained and broken
     substituteInPlace test/run-tests.py \
-      --replace 'pytest_ordering' 'pytest_order'
+      --replace-fail 'pytest_ordering' 'pytest_order'
     substituteInPlace test/functional/test_miscellaneous.py \
-      --replace '@pytest.mark.last' '@pytest.mark.order("last")'
+      --replace-fail '@pytest.mark.last' '@pytest.mark.order("last")'
 
     # Until a proper fix is created, just skip these tests
     # and ignore any breakage that may result from the API change in IPFS
     # See https://github.com/ipfs-shipyard/py-ipfs-http-client/issues/308
     substituteInPlace test/functional/test_pubsub.py \
-      --replace '# the message that will be published' 'pytest.skip("This test fails because of an incompatibility with the experimental PubSub feature in IPFS>=0.11.0")' \
-      --replace '# subscribe to the topic testing'     'pytest.skip("This test fails because of an incompatibility with the experimental PubSub feature in IPFS>=0.11.0")'
+      --replace-fail '# the message that will be published' 'pytest.skip("This test fails because of an incompatibility with the experimental PubSub feature in IPFS>=0.11.0")' \
+      --replace-fail '# subscribe to the topic testing'     'pytest.skip("This test fails because of an incompatibility with the experimental PubSub feature in IPFS>=0.11.0")'
     substituteInPlace test/functional/test_other.py \
-      --replace 'import ipfshttpclient' 'import ipfshttpclient; import pytest' \
-      --replace 'assert ipfs_is_available' 'pytest.skip("Unknown test failure with IPFS >=0.11.0"); assert ipfs_is_available'
+      --replace-fail 'import ipfshttpclient' 'import ipfshttpclient; import pytest' \
+      --replace-fail 'assert ipfs_is_available' 'pytest.skip("Unknown test failure with IPFS >=0.11.0"); assert ipfs_is_available'
   '';
 
   checkPhase = ''

--- a/pkgs/development/python-modules/ipyparallel/default.nix
+++ b/pkgs/development/python-modules/ipyparallel/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   #
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"jupyterlab==4.*",' ""
+      --replace-fail '"jupyterlab==4.*",' ""
   '';
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/ipytablewidgets/default.nix
+++ b/pkgs/development/python-modules/ipytablewidgets/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   #
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'jupyterlab>=3.0.0,<3.7' 'jupyterlab>=3.0.0'
+      --replace-fail 'jupyterlab>=3.0.0,<3.7' 'jupyterlab>=3.0.0'
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/ismartgate/default.nix
+++ b/pkgs/development/python-modules/ismartgate/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner>=5.2",' ""
+      --replace-fail '"pytest-runner>=5.2",' ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/jproperties/default.nix
+++ b/pkgs/development/python-modules/jproperties/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "setuptools_scm ~= 3.3" "setuptools_scm"
+      --replace-fail "setuptools_scm ~= 3.3" "setuptools_scm"
   '';
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/jsonschema-spec/default.nix
+++ b/pkgs/development/python-modules/jsonschema-spec/default.nix
@@ -33,11 +33,6 @@ buildPythonPackage rec {
     hash = "sha256-rCepDnVAOEsokKjWCuqDYbGIq6/wn4rsQRx5dXTUsYo=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'referencing = ">=0.28.0,<0.30.0"' 'referencing = ">=0.28.0"'
-  '';
-
   nativeBuildInputs = [
     poetry-core
   ];

--- a/pkgs/development/python-modules/jupyterlab-pygments/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-pygments/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   # jupyterlab is not necessary since we get the source from pypi
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"jupyterlab>=4.0.0,<5",' ""
+      --replace-fail '"jupyterlab>=4.0.0,<5",' ""
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyterlab-widgets/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-widgets/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   # jupyterlab is required to build from source but we use the pre-build package
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"jupyterlab~=4.0"' ""
+      --replace-fail '"jupyterlab~=4.0"' ""
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/justbackoff/default.nix
+++ b/pkgs/development/python-modules/justbackoff/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pytest-runner>=5.2" ""
+      --replace-fail "pytest-runner>=5.2" ""
   '';
 
   pythonImportsCheck = [ "justbackoff" ];

--- a/pkgs/development/python-modules/jwt/default.nix
+++ b/pkgs/development/python-modules/jwt/default.nix
@@ -24,11 +24,6 @@ buildPythonPackage rec {
     hash = "sha256-Cv64SmhkETm8mx1Kj5u0WZpCPjPNvC+KS6/XaMzxCho=";
   };
 
-  postPatch = ''
-    # pytest-flake8 is incompatible flake8 6.0.0 and currently unmaintained
-    substituteInPlace setup.cfg --replace "--flake8" ""
-  '';
-
   build-system = [ setuptools ];
 
   dependencies = [ cryptography ];

--- a/pkgs/development/python-modules/kaptan/default.nix
+++ b/pkgs/development/python-modules/kaptan/default.nix
@@ -17,12 +17,6 @@ buildPythonPackage rec {
     hash = "sha256-EBMwpE/e3oiFhvMBC9FFwOxIpIBrxWQp+lSHpndAIfg=";
   };
 
-  postPatch = ''
-    sed -i "s/==.*//g" requirements/test.txt
-
-    substituteInPlace requirements/base.txt --replace 'PyYAML>=3.13,<6' 'PyYAML>=3.13'
-  '';
-
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [ pyyaml ];

--- a/pkgs/development/python-modules/keystone-engine/default.nix
+++ b/pkgs/development/python-modules/keystone-engine/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   ];
 
   preConfigure = ''
-    substituteInPlace setup.py --replace \
+    substituteInPlace setup.py --replace-fail \
       "libkeystone" "${keystone}/lib/libkeystone"
   '';
 

--- a/pkgs/development/python-modules/keyutils/default.nix
+++ b/pkgs/development/python-modules/keyutils/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace '"pytest-runner"' ""
+    substituteInPlace setup.py --replace-fail '"pytest-runner"' ""
   '';
 
   preBuild = ''

--- a/pkgs/development/python-modules/klaus/default.nix
+++ b/pkgs/development/python-modules/klaus/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   prePatch = ''
     substituteInPlace runtests.sh \
-      --replace "mkdir -p \$builddir" "mkdir -p \$builddir && pwd"
+      --replace-fail "mkdir -p \$builddir" "mkdir -p \$builddir && pwd"
   '';
 
   # TODO: remove in next version

--- a/pkgs/development/python-modules/lazy-object-proxy/default.nix
+++ b/pkgs/development/python-modules/lazy-object-proxy/default.nix
@@ -18,11 +18,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  postPatch = ''
-    substituteInPlace pyproject.toml --replace ",<6.0" ""
-    substituteInPlace setup.cfg --replace ",<6.0" ""
-  '';
-
   nativeCheckInputs = [ pytestCheckHook ];
 
   # Broken tests. Seem to be fixed upstream according to Travis.

--- a/pkgs/development/python-modules/lexid/default.nix
+++ b/pkgs/development/python-modules/lexid/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   prePatch = ''
     # Disable lib3to6, since we're only building this on 3.6+ anyway.
     substituteInPlace setup.py \
-      --replace 'if any(arg.startswith("bdist") for arg in sys.argv):' 'if False:'
+      --replace-fail 'if any(arg.startswith("bdist") for arg in sys.argv):' 'if False:'
   '';
 
   propagatedBuildInputs = [ click ];

--- a/pkgs/development/python-modules/libagent/default.nix
+++ b/pkgs/development/python-modules/libagent/default.nix
@@ -37,8 +37,8 @@ buildPythonPackage rec {
   # hardcode the path to gpgconf in the libagent library
   postPatch = ''
     substituteInPlace libagent/gpg/keyring.py \
-      --replace "util.which('gpgconf')" "'${gnupg}/bin/gpgconf'" \
-      --replace "'gpg-connect-agent'" "'${gnupg}/bin/gpg-connect-agent'"
+      --replace-fail "util.which('gpgconf')" "'${gnupg}/bin/gpgconf'" \
+      --replace-fail "'gpg-connect-agent'" "'${gnupg}/bin/gpg-connect-agent'"
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/libarchive-c/default.nix
+++ b/pkgs/development/python-modules/libarchive-c/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   LC_ALL = "en_US.UTF-8";
 
   postPatch = ''
-    substituteInPlace libarchive/ffi.py --replace \
+    substituteInPlace libarchive/ffi.py --replace-fail \
       "find_library('archive')" "'${libarchive.lib}/lib/libarchive${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 

--- a/pkgs/development/python-modules/libasyncns/default.nix
+++ b/pkgs/development/python-modules/libasyncns/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace resquery.c \
-      --replace '<arpa/nameser.h>' '<arpa/nameser_compat.h>'
+      --replace-fail '<arpa/nameser.h>' '<arpa/nameser_compat.h>'
   '';
 
   buildInputs = [ libasyncns ];

--- a/pkgs/development/python-modules/libcloud/default.nix
+++ b/pkgs/development/python-modules/libcloud/default.nix
@@ -28,11 +28,6 @@ buildPythonPackage rec {
     cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
   '';
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "setup_requires=pytest_runner," "setup_requires=[],"
-  '';
-
   # requires a certificates file
   doCheck = false;
 

--- a/pkgs/development/python-modules/libknot/default.nix
+++ b/pkgs/development/python-modules/libknot/default.nix
@@ -22,8 +22,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace libknot/__init__.py \
-      --replace "libknot%s.dylib" "${lib.getLib knot-dns}/lib/libknot%s.dylib" \
-      --replace "libknot.so%s" "${lib.getLib knot-dns}/lib/libknot.so%s"
+      --replace-fail "libknot%s.dylib" "${lib.getLib knot-dns}/lib/libknot%s.dylib" \
+      --replace-fail "libknot.so%s" "${lib.getLib knot-dns}/lib/libknot.so%s"
   '';
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/libnacl/default.nix
+++ b/pkgs/development/python-modules/libnacl/default.nix
@@ -30,10 +30,10 @@ buildPythonPackage rec {
     in
     ''
       substituteInPlace "./libnacl/__init__.py" \
-        --replace \
+        --replace-fail \
           "l_path = ctypes.util.find_library('sodium')" \
           "l_path = None" \
-        --replace \
+        --replace-fail \
           "ctypes.cdll.LoadLibrary('libsodium${soext}')" \
           "ctypes.cdll.LoadLibrary('${libsodium}/lib/libsodium${soext}')"
     '';

--- a/pkgs/development/python-modules/libsixel/default.nix
+++ b/pkgs/development/python-modules/libsixel/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   sourceRoot = "${src.name}/python";
 
   prePatch = ''
-    substituteInPlace libsixel/__init__.py --replace \
+    substituteInPlace libsixel/__init__.py --replace-fail \
       'from ctypes.util import find_library' \
       'find_library = lambda _x: "${lib.getLib libsixel}/lib/libsixel${stdenv.hostPlatform.extensions.sharedLibrary}"'
   '';

--- a/pkgs/development/python-modules/libusbsio/default.nix
+++ b/pkgs/development/python-modules/libusbsio/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   postPatch = ''
     rm -rf libusbsio/bin
     substituteInPlace libusbsio/libusbsio.py \
-        --replace "dllpath = LIBUSBSIO._lookup_dll_path(dfltdir, dllname)" 'dllpath = "${libusbsio}/lib/" + dllname'
+        --replace-fail "dllpath = LIBUSBSIO._lookup_dll_path(dfltdir, dllname)" 'dllpath = "${libusbsio}/lib/" + dllname'
   '';
 
   buildInputs = [ libusbsio ];

--- a/pkgs/development/python-modules/libversion/default.nix
+++ b/pkgs/development/python-modules/libversion/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pkg-config'" "'$(command -v $PKG_CONFIG)'"
+      --replace-fail "'pkg-config'" "'$(command -v $PKG_CONFIG)'"
   '';
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/python-modules/llfuse/default.nix
+++ b/pkgs/development/python-modules/llfuse/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
 
   preConfigure = ''
     substituteInPlace setup.py \
-        --replace "'pkg-config'" "'${stdenv.cc.targetPrefix}pkg-config'"
+        --replace-fail "'pkg-config'" "'${stdenv.cc.targetPrefix}pkg-config'"
   '';
 
   preBuild = ''

--- a/pkgs/development/python-modules/logfury/default.nix
+++ b/pkgs/development/python-modules/logfury/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'setuptools_scm<6.0'" "'setuptools_scm'"
+      --replace-fail "'setuptools_scm<6.0'" "'setuptools_scm'"
   '';
 
   pythonImportsCheck = [ "logfury" ];

--- a/pkgs/development/python-modules/lomond/default.nix
+++ b/pkgs/development/python-modules/lomond/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'" ""
+      --replace-fail "'pytest-runner'" ""
   '';
 
   propagatedBuildInputs = [ six ];

--- a/pkgs/development/python-modules/luddite/default.nix
+++ b/pkgs/development/python-modules/luddite/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace "--disable-socket" ""
+      --replace-fail "--disable-socket" ""
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/luqum/default.nix
+++ b/pkgs/development/python-modules/luqum/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '--doctest-modules --doctest-glob="test_*.rst"' ""
+      --replace-fail '--doctest-modules --doctest-glob="test_*.rst"' ""
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/lyricwikia/default.nix
+++ b/pkgs/development/python-modules/lyricwikia/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'" ""
+      --replace-fail "'pytest-runner'" ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/magic-filter/default.nix
+++ b/pkgs/development/python-modules/magic-filter/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace magic_filter/__init__.py \
-      --replace '"1"' '"${version}"'
+      --replace-fail '"1"' '"${version}"'
   '';
 
   nativeBuildInputs = [ hatchling ];

--- a/pkgs/development/python-modules/magic/default.nix
+++ b/pkgs/development/python-modules/magic/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage {
   inherit (pkgs.file) pname version src;
 
   patchPhase = ''
-    substituteInPlace python/magic.py --replace "find_library('magic')" "'${pkgs.file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
+    substituteInPlace python/magic.py --replace-fail "find_library('magic')" "'${pkgs.file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 
   buildInputs = [ pkgs.file ];

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -63,8 +63,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace dolphin/mat2.desktop \
-      --replace "@mat2@" "$out/bin/mat2" \
-      --replace "@mat2svg@" "$out/share/icons/hicolor/scalable/apps/mat2.svg"
+      --replace-fail "@mat2@" "$out/bin/mat2" \
+      --replace-fail "@mat2svg@" "$out/share/icons/hicolor/scalable/apps/mat2.svg"
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/matchpy/default.nix
+++ b/pkgs/development/python-modules/matchpy/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     sed -i '/pytest-runner/d' setup.cfg
 
     substituteInPlace setup.cfg \
-      --replace "multiset>=2.0,<3.0" "multiset"
+      --replace-fail "multiset>=2.0,<3.0" "multiset"
   '';
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/python-modules/matrix-client/default.nix
+++ b/pkgs/development/python-modules/matrix-client/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace setup.py --replace \
+    substituteInPlace setup.py --replace-fail \
       "pytest-runner~=5.1" ""
   '';
 

--- a/pkgs/development/python-modules/maxcube-api/default.nix
+++ b/pkgs/development/python-modules/maxcube-api/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace "license=license" "license='MIT'"
+    substituteInPlace setup.py --replace-fail "license=license" "license='MIT'"
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/merkletools/default.nix
+++ b/pkgs/development/python-modules/merkletools/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   postPatch = ''
     # pysha3 is deprecated and not needed for Python > 3.6
     substituteInPlace setup.py \
-      --replace "install_requires=install_requires" "install_requires=[],"
+      --replace-fail "install_requires=install_requires" "install_requires=[],"
   '';
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/mip/default.nix
+++ b/pkgs/development/python-modules/mip/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     # Allow newer cffi versions to be used
-    substituteInPlace pyproject.toml --replace "cffi==1.15.*" "cffi>=1.15"
+    substituteInPlace pyproject.toml --replace-fail "cffi==1.15.*" "cffi>=1.15"
   '';
 
   # Make MIP use the Gurobi solver, if configured to do so

--- a/pkgs/development/python-modules/mkdocs-autorefs/default.nix
+++ b/pkgs/development/python-modules/mkdocs-autorefs/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'dynamic = ["version"]' 'version = "${version}"'
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
   '';
 
   build-system = [ pdm-backend ];

--- a/pkgs/development/python-modules/mongoengine/default.nix
+++ b/pkgs/development/python-modules/mongoengine/default.nix
@@ -36,12 +36,6 @@ buildPythonPackage rec {
     blinker
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "coverage==4.2" "coverage" \
-      --replace "pymongo>=3.4,<=4.0" "pymongo"
-  '';
-
   # tests require mongodb running in background
   doCheck = false;
 

--- a/pkgs/development/python-modules/monotonic/default.nix
+++ b/pkgs/development/python-modules/monotonic/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   __propagatedImpureHostDeps = lib.optional stdenv.hostPlatform.isDarwin "/usr/lib/libc.dylib";
 
   patchPhase = lib.optionalString stdenv.hostPlatform.isLinux ''
-    substituteInPlace monotonic.py --replace \
+    substituteInPlace monotonic.py --replace-fail \
       "ctypes.util.find_library('c')" "'${stdenv.cc.libc}/lib/libc.so'"
   '';
 

--- a/pkgs/development/python-modules/moonraker-api/default.nix
+++ b/pkgs/development/python-modules/moonraker-api/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   postPatch = ''
     # see comment on https://github.com/cmroche/moonraker-api/commit/e5ca8ab60d2839e150a81182fbe65255d84b4e4e
     substituteInPlace setup.py \
-      --replace 'name="moonraker-api",' 'name="moonraker-api",version="${version}",'
+      --replace-fail 'name="moonraker-api",' 'name="moonraker-api",version="${version}",'
   '';
 
   propagatedBuildInputs = [ aiohttp ];

--- a/pkgs/development/python-modules/motioneye-client/default.nix
+++ b/pkgs/development/python-modules/motioneye-client/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'aiohttp = "^3.8.1,!=3.8.2,!=3.8.3"' 'aiohttp = "*"'
+      --replace-fail 'aiohttp = "^3.8.1,!=3.8.2,!=3.8.3"' 'aiohttp = "*"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/ms-cv/default.nix
+++ b/pkgs/development/python-modules/ms-cv/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pytest-runner" ""
+      --replace-fail "pytest-runner" ""
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/mujson/default.nix
+++ b/pkgs/development/python-modules/mujson/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   # https://github.com/mattgiles/mujson/issues/8
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "license_file = LICENSE" ""
+      --replace-fail "license_file = LICENSE" ""
   '';
 
   # No tests

--- a/pkgs/development/python-modules/murmurhash/default.nix
+++ b/pkgs/development/python-modules/murmurhash/default.nix
@@ -18,11 +18,6 @@ buildPythonPackage rec {
     hash = "sha256-c3JG1B7gD/dLB7C9HwiIvjBNIDzmaOZCyGqmTt4w+Lc=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "'wheel>=0.32.0,<0.33.0'" ""
-  '';
-
   buildInputs = [ cython ];
 
   # No test

--- a/pkgs/development/python-modules/mwparserfromhell/default.nix
+++ b/pkgs/development/python-modules/mwparserfromhell/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner"' ""
+      --replace-fail '"pytest-runner"' ""
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/name-that-hash/default.nix
+++ b/pkgs/development/python-modules/name-that-hash/default.nix
@@ -19,11 +19,6 @@ buildPythonPackage rec {
     hash = "sha256-zOb4BS3zG1x8GLXAooqqvMOw0fNbw35JuRWOdGP26/8=";
   };
 
-  # TODO remove on next update which bumps rich
-  postPatch = ''
-    substituteInPlace pyproject.toml --replace 'rich = ">=9.9,<11.0"' 'rich = ">=9.9"'
-  '';
-
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/namedlist/default.nix
+++ b/pkgs/development/python-modules/namedlist/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   # Test file has a `unittest.main()` at the bottom that fails the tests;
   # py.test can run the tests without it.
   postPatch = ''
-    substituteInPlace test/test_namedlist.py --replace "unittest.main()" ""
+    substituteInPlace test/test_namedlist.py --replace-fail "unittest.main()" ""
   '';
 
   pythonImportsCheck = [ "namedlist" ];

--- a/pkgs/development/python-modules/nampa/default.nix
+++ b/pkgs/development/python-modules/nampa/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   postPatch = ''
     # https://github.com/thebabush/nampa/pull/13
     substituteInPlace setup.py \
-      --replace "0.1.1" "${version}"
+      --replace-fail "0.1.1" "${version}"
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/nbtlib/default.nix
+++ b/pkgs/development/python-modules/nbtlib/default.nix
@@ -20,8 +20,8 @@ buildPythonPackage rec {
 
   prePatch = ''
     substituteInPlace pyproject.toml \
-    --replace "poetry>=0.12" "poetry-core" \
-    --replace "poetry.masonry" "poetry.core.masonry"
+    --replace-fail "poetry>=0.12" "poetry-core" \
+    --replace-fail "poetry.masonry" "poetry.core.masonry"
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/ndjson/default.nix
+++ b/pkgs/development/python-modules/ndjson/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner', " ""
+      --replace-fail "'pytest-runner', " ""
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/ndtypes/default.nix
+++ b/pkgs/development/python-modules/ndtypes/default.nix
@@ -23,11 +23,11 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'include_dirs = ["libndtypes"]' \
+      --replace-fail 'include_dirs = ["libndtypes"]' \
                 'include_dirs = ["${libndtypes.dev}/include"]' \
-      --replace 'library_dirs = ["libndtypes"]' \
+      --replace-fail 'library_dirs = ["libndtypes"]' \
                 'library_dirs = ["${libndtypes}/lib"]' \
-      --replace 'runtime_library_dirs = ["$ORIGIN"]' \
+      --replace-fail 'runtime_library_dirs = ["$ORIGIN"]' \
                 'runtime_library_dirs = ["${libndtypes}/lib"]'
   '';
 

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace nipype/interfaces/base/tests/test_core.py \
-      --replace "/usr/bin/env bash" "${bash}/bin/bash"
+      --replace-fail "/usr/bin/env bash" "${bash}/bin/bash"
   '';
 
   pythonRelaxDeps = [ "traits" ];

--- a/pkgs/development/python-modules/nodeenv/default.nix
+++ b/pkgs/development/python-modules/nodeenv/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   preFixup = ''
     substituteInPlace $out/${python.sitePackages}/nodeenv.py \
-      --replace '["which", candidate]' '["${lib.getBin which}/bin/which", candidate]'
+      --replace-fail '["which", candidate]' '["${lib.getBin which}/bin/which", candidate]'
   '';
 
   pythonImportsCheck = [ "nodeenv" ];

--- a/pkgs/development/python-modules/numdifftools/default.nix
+++ b/pkgs/development/python-modules/numdifftools/default.nix
@@ -31,11 +31,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner"' ""
-    # Remove optional dependencies
-    substituteInPlace requirements.txt \
-      --replace "algopy>=0.4" "" \
-      --replace "statsmodels>=0.6" ""
+      --replace-fail '"pytest-runner"' ""
   '';
 
   pythonImportsCheck = [ "numdifftools" ];

--- a/pkgs/development/python-modules/numpy/1.nix
+++ b/pkgs/development/python-modules/numpy/1.nix
@@ -91,7 +91,7 @@ buildPythonPackage rec {
 
     # remove needless reference to full Python path stored in built wheel
     substituteInPlace numpy/meson.build \
-      --replace 'py.full_path()' "'python'"
+      --replace-fail 'py.full_path()' "'python'"
 
     substituteInPlace pyproject.toml \
       --replace-fail "meson-python>=0.15.0,<0.16.0" "meson-python"

--- a/pkgs/development/python-modules/nunavut/default.nix
+++ b/pkgs/development/python-modules/nunavut/default.nix
@@ -20,11 +20,6 @@ buildPythonPackage rec {
     hash = "sha256-23C3biUUs10Po5qzn3EFaq4+HeWCXIC6WzxOKy59VgM=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "pydsdl ~= 1.16" "pydsdl"
-  '';
-
   propagatedBuildInputs = [
     importlib-resources
     pydsdl

--- a/pkgs/development/python-modules/ofxclient/default.nix
+++ b/pkgs/development/python-modules/ofxclient/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   };
 
   patchPhase = ''
-    substituteInPlace setup.py --replace '"argparse",' ""
+    substituteInPlace setup.py --replace-fail '"argparse",' ""
   '';
 
   # ImportError: No module named tests

--- a/pkgs/development/python-modules/oldest-supported-numpy/default.nix
+++ b/pkgs/development/python-modules/oldest-supported-numpy/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   #
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace 'numpy==' 'numpy>='
+      --replace-fail 'numpy==' 'numpy>='
   '';
 
   propagatedBuildInputs = [ numpy ];

--- a/pkgs/development/python-modules/oletools/default.nix
+++ b/pkgs/development/python-modules/oletools/default.nix
@@ -37,11 +37,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "pyparsing>=2.1.0,<3" "pyparsing>=2.1.0"
-  '';
-
   disabledTests = [
     # Test fails with AssertionError: Tuples differ: ('MS Word 2007+...
     "test_all"

--- a/pkgs/development/python-modules/omnikinverter/default.nix
+++ b/pkgs/development/python-modules/omnikinverter/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}"
+      --replace-fail "0.0.0" "${version}"
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/onlykey-solo-python/default.nix
+++ b/pkgs/development/python-modules/onlykey-solo-python/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "fido2 == 0.9.3" "fido2"
+      --replace-fail "fido2 == 0.9.3" "fido2"
   '';
 
   patches = [

--- a/pkgs/development/python-modules/openevsewifi/default.nix
+++ b/pkgs/development/python-modules/openevsewifi/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'pytest-cov = "^2.8.1"' ""
+      --replace-fail 'pytest-cov = "^2.8.1"' ""
   '';
 
   pythonImportsCheck = [ "openevsewifi" ];

--- a/pkgs/development/python-modules/orm/default.nix
+++ b/pkgs/development/python-modules/orm/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "typesystem==0.3.1" "typesystem"
+      --replace-fail "typesystem==0.3.1" "typesystem"
   '';
 
   # Tests require databases

--- a/pkgs/development/python-modules/osc-sdk-python/default.nix
+++ b/pkgs/development/python-modules/osc-sdk-python/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "ruamel.yaml==0.17.32" "ruamel.yaml"
+      --replace-fail "ruamel.yaml==0.17.32" "ruamel.yaml"
   '';
 
   # Only keep test not requiring access and secret keys

--- a/pkgs/development/python-modules/p1monitor/default.nix
+++ b/pkgs/development/python-modules/p1monitor/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"0.0.0"' '"${version}"'
+      --replace-fail '"0.0.0"' '"${version}"'
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/palace/default.nix
+++ b/pkgs/development/python-modules/palace/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   # Nix uses Release CMake configuration instead of what is assumed by palace.
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace IMPORTED_LOCATION_NOCONFIG IMPORTED_LOCATION_RELEASE
+      --replace-fail IMPORTED_LOCATION_NOCONFIG IMPORTED_LOCATION_RELEASE
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/pamela/default.nix
+++ b/pkgs/development/python-modules/pamela/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   };
 
   postUnpack = ''
-    substituteInPlace $sourceRoot/pamela.py --replace \
+    substituteInPlace $sourceRoot/pamela.py --replace-fail \
       'find_library("pam")' \
       '"${lib.getLib pkgs.pam}/lib/libpam.so"'
   '';

--- a/pkgs/development/python-modules/parameterized/default.nix
+++ b/pkgs/development/python-modules/parameterized/default.nix
@@ -34,8 +34,8 @@ buildPythonPackage rec {
     # https://github.com/wolever/parameterized/issues/167
     # https://github.com/wolever/parameterized/pull/162
     substituteInPlace parameterized/test.py \
-      --replace 'assert_equal(missing, [])' "" \
-      --replace "assertRaisesRegexp" "assertRaisesRegex"
+      --replace-fail 'assert_equal(missing, [])' "" \
+      --replace-fail "assertRaisesRegexp" "assertRaisesRegex"
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/parametrize-from-file/default.nix
+++ b/pkgs/development/python-modules/parametrize-from-file/default.nix
@@ -24,14 +24,6 @@ buildPythonPackage rec {
     hash = "sha256-t4WLNDkC/ErBnOGK6FoYIfjoL/zF9MxPThJtGM1nUL4=";
   };
 
-  # patch out coveralls since it doesn't provide us value
-  preBuild = ''
-    sed -i '/coveralls/d' ./pyproject.toml
-
-    substituteInPlace pyproject.toml \
-      --replace "more_itertools~=8.10" "more_itertools"
-  '';
-
   nativeBuildInputs = [ flit-core ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/parse-type/default.nix
+++ b/pkgs/development/python-modules/parse-type/default.nix
@@ -35,10 +35,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace "--metadata PACKAGE_UNDER_TEST parse_type" "" \
-      --replace "--metadata PACKAGE_VERSION ${version}" "" \
-      --replace "--html=build/testing/report.html --self-contained-html" "" \
-      --replace "--junit-xml=build/testing/report.xml" ""
+      --replace-fail "--metadata PACKAGE_UNDER_TEST parse_type" "" \
+      --replace-fail "--html=build/testing/report.html --self-contained-html" "" \
+      --replace-fail "--junit-xml=build/testing/report.xml" ""
   '';
 
   pythonImportsCheck = [ "parse_type" ];

--- a/pkgs/development/python-modules/parsimonious/default.nix
+++ b/pkgs/development/python-modules/parsimonious/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "regex>=2022.3.15" "regex"
+      --replace-fail "regex>=2022.3.15" "regex"
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/particle/default.nix
+++ b/pkgs/development/python-modules/particle/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     # Disable benchmark tests, so we won't need pytest-benchmark and pytest-cov
     # as dependencies
     substituteInPlace pyproject.toml \
-      --replace '"--benchmark-disable",' ""
+      --replace-fail '"--benchmark-disable",' ""
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/pasimple/default.nix
+++ b/pkgs/development/python-modules/pasimple/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace pasimple/pa_simple.py --replace \
+    substituteInPlace pasimple/pa_simple.py --replace-fail \
       "_libpulse_simple = ctypes.CDLL('libpulse-simple.so.0')" \
       "_libpulse_simple = ctypes.CDLL('${lib.getLib pulseaudio}/lib/libpulse-simple.so.0')"
   '';

--- a/pkgs/development/python-modules/pcodedmp/default.nix
+++ b/pkgs/development/python-modules/pcodedmp/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Circular dependency
     substituteInPlace setup.py \
-      --replace "'oletools>=0.54'," ""
+      --replace-fail "'oletools>=0.54'," ""
   '';
 
   # Module doesn't have tests

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -54,11 +54,6 @@ buildPythonPackage rec {
     '';
   };
 
-  postPatch = ''
-    substituteInPlace pelican/tests/test_pelican.py \
-      --replace "'git'" "'${git}/bin/git'"
-  '';
-
   build-system = [ pdm-backend ];
 
   pythonRelaxDeps = [ "pygments" ];

--- a/pkgs/development/python-modules/pescea/default.nix
+++ b/pkgs/development/python-modules/pescea/default.nix
@@ -32,12 +32,6 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
-  postPatch = ''
-    # https://github.com/lazdavila/pescea/pull/1
-    substituteInPlace setup.py \
-      --replace '"asyncio",' ""
-  '';
-
   disabledTests = [
     # AssertionError: assert <State.BUSY: 'BusyWaiting'>...
     "test_updates_while_busy"

--- a/pkgs/development/python-modules/phone-modem/default.nix
+++ b/pkgs/development/python-modules/phone-modem/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "aioserial==1.3.0" "aioserial"
+      --replace-fail "aioserial==1.3.0" "aioserial"
   '';
 
   propagatedBuildInputs = [ aioserial ];

--- a/pkgs/development/python-modules/piano-transcription-inference/default.nix
+++ b/pkgs/development/python-modules/piano-transcription-inference/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace piano_transcription_inference/inference.py --replace \
+    substituteInPlace piano_transcription_inference/inference.py --replace-fail \
       "checkpoint_path='{}/piano_transcription_inference_data/note_F1=0.9677_pedal_F1=0.9186.pth'.format(str(Path.home()))" \
       "checkpoint_path='$out/share/checkpoint.pth'"
   '';

--- a/pkgs/development/python-modules/pika/default.nix
+++ b/pkgs/development/python-modules/pika/default.nix
@@ -47,9 +47,9 @@ buildPythonPackage rec {
     # don't run acceptance tests because they access the network
     # don't report test coverage
     substituteInPlace nose2.cfg \
-      --replace "stop = 1" "stop = 0" \
-      --replace "tests=tests/unit,tests/acceptance" "tests=tests/unit" \
-      --replace "with-coverage = 1" "with-coverage = 0"
+      --replace-fail "stop = 1" "stop = 0" \
+      --replace-fail "tests=tests/unit,tests/acceptance" "tests=tests/unit" \
+      --replace-fail "with-coverage = 1" "with-coverage = 0"
   '';
 
   doCheck = false; # tests require rabbitmq instance, unsure how to skip

--- a/pkgs/development/python-modules/pilkit/default.nix
+++ b/pkgs/development/python-modules/pilkit/default.nix
@@ -34,11 +34,6 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
-  postPatch = ''
-    substituteInPlace pilkit/processors/resize.py \
-      --replace "Image.ANTIALIAS" "Image.Resampling.LANCZOS"
-  '';
-
   pythonImportsCheck = [ "pilkit" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pivy/default.nix
+++ b/pkgs/development/python-modules/pivy/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   postPatch = ''
-    substituteInPlace distutils_cmake/CMakeLists.txt --replace \$'{SoQt_INCLUDE_DIRS}' \
+    substituteInPlace distutils_cmake/CMakeLists.txt --replace-fail \$'{SoQt_INCLUDE_DIRS}' \
       \$'{Coin_INCLUDE_DIR}'\;\$'{SoQt_INCLUDE_DIRS}'
   '';
 

--- a/pkgs/development/python-modules/pkgconfig/default.nix
+++ b/pkgs/development/python-modules/pkgconfig/default.nix
@@ -30,11 +30,11 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pkgconfig/pkgconfig.py \
-      --replace "pkg_config_exe = os.environ.get('PKG_CONFIG', None) or 'pkg-config'" "pkg_config_exe = '${pkg-config}/bin/${pkg-config.targetPrefix}pkg-config'"
+      --replace-fail "pkg_config_exe = os.environ.get('PKG_CONFIG', None) or 'pkg-config'" "pkg_config_exe = '${pkg-config}/bin/${pkg-config.targetPrefix}pkg-config'"
 
     # those pc files are missing and pkg-config validates that they exist
     substituteInPlace data/fake-openssl.pc \
-      --replace "Requires: libssl libcrypto" ""
+      --replace-fail "Requires: libssl libcrypto" ""
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/podcastparser/default.nix
+++ b/pkgs/development/python-modules/podcastparser/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest.ini \
-      --replace "--cov=podcastparser --cov-report html --doctest-modules" ""
+      --replace-fail "--cov=podcastparser --cov-report html --doctest-modules" ""
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/polarizationsolver/default.nix
+++ b/pkgs/development/python-modules/polarizationsolver/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage {
   # setup.py states version="dev", which is not a valid version string for setuptools
   # There has never been a formal stable release, so let's say 0.0 here.
   postPatch = ''
-    substituteInPlace ./setup.py --replace 'version="dev",' 'version="0.0",'
+    substituteInPlace ./setup.py --replace-fail 'version="dev",' 'version="0.0",'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pot/default.nix
+++ b/pkgs/development/python-modules/pot/default.nix
@@ -87,8 +87,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace " --durations=20" "" \
-      --replace " --junit-xml=junit-results.xml" ""
+      --replace-fail " --durations=20" "" \
+      --replace-fail " --junit-xml=junit-results.xml" ""
 
     # we don't need setup.py to find the macos sdk for us
     sed -i '/sdk_path/d' setup.py

--- a/pkgs/development/python-modules/promise/default.nix
+++ b/pkgs/development/python-modules/promise/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace tests/test_extra.py \
-      --replace "assert_exc.traceback[-1].path.strpath" "str(assert_exc.traceback[-1].path)"
+      --replace-fail "assert_exc.traceback[-1].path.strpath" "str(assert_exc.traceback[-1].path)"
   '';
 
   propagatedBuildInputs = [ six ];

--- a/pkgs/development/python-modules/propcache/default.nix
+++ b/pkgs/development/python-modules/propcache/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace packaging/pep517_backend/_backend.py \
-      --replace "Cython ~= 3.0.12" Cython
+      --replace-fail "Cython ~= 3.0.12" Cython
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/proton-vpn-network-manager/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-network-manager/default.nix
@@ -52,9 +52,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace proton/vpn/backend/linux/networkmanager/killswitch/wireguard/killswitch_connection_handler.py \
-      --replace '/usr/sbin/ip' '${iproute2}/bin/ip'
+      --replace-fail '/usr/sbin/ip' '${iproute2}/bin/ip'
     substituteInPlace proton/vpn/backend/linux/networkmanager/killswitch/wireguard/wgkillswitch.py \
-      --replace '/usr/bin/apt' '${apt}/bin/apt'
+      --replace-fail '/usr/bin/apt' '${apt}/bin/apt'
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/protonup-ng/default.nix
+++ b/pkgs/development/python-modules/protonup-ng/default.nix
@@ -18,11 +18,6 @@ buildPythonPackage rec {
     hash = "sha256-rys9Noa3+w4phttfcI1OGEDfHMy8s80bm8kM8TzssQA=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "argparse" ""
-  '';
-
   propagatedBuildInputs = [
     requests
     configparser

--- a/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace protonvpn_nm_lib/core/dbus/dbus_reconnect.py \
-      --replace "exec_start = python_interpreter_path + \" \" + python_service_path" "exec_start = \"$out/bin/protonvpn_reconnector.py\""
+      --replace-fail "exec_start = python_interpreter_path + \" \" + python_service_path" "exec_start = \"$out/bin/protonvpn_reconnector.py\""
   '';
 
   postInstall = ''

--- a/pkgs/development/python-modules/proxy-py/default.nix
+++ b/pkgs/development/python-modules/proxy-py/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace Makefile \
-    --replace "SHELL := /bin/bash" "SHELL := ${bash}/bin/bash"
+    --replace-fail "SHELL := /bin/bash" "SHELL := ${bash}/bin/bash"
   '';
 
   build-system = [ setuptools-scm ];

--- a/pkgs/development/python-modules/publicsuffix2/default.nix
+++ b/pkgs/development/python-modules/publicsuffix2/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage {
   postPatch = ''
     # only used to update the interal publicsuffix list
     substituteInPlace setup.py \
-      --replace "'requests >= 2.7.0'," ""
+      --replace-fail "'requests >= 2.7.0'," ""
   '';
 
   pythonImportsCheck = [ "publicsuffix2" ];

--- a/pkgs/development/python-modules/purepng/default.nix
+++ b/pkgs/development/python-modules/purepng/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace code/test_png.py \
-      --replace numpy.bool bool
+      --replace-fail numpy.bool bool
   '';
 
   # checkPhase begins by deleting source dir to force test execution against installed version

--- a/pkgs/development/python-modules/pvo/default.nix
+++ b/pkgs/development/python-modules/pvo/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}"
+      --replace-fail "0.0.0" "${version}"
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/py-cid/default.nix
+++ b/pkgs/development/python-modules/py-cid/default.nix
@@ -27,9 +27,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "base58>=1.0.2,<2.0" "base58>=1.0.2" \
-      --replace "py-multihash>=0.2.0,<1.0.0" "py-multihash>=0.2.0" \
-      --replace "'pytest-runner'," ""
+      --replace-fail "base58>=1.0.2,<2.0" "base58>=1.0.2" \
+      --replace-fail "py-multihash>=0.2.0,<1.0.0" "py-multihash>=0.2.0" \
+      --replace-fail "'pytest-runner'," ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/py-cpuinfo/default.nix
+++ b/pkgs/development/python-modules/py-cpuinfo/default.nix
@@ -27,8 +27,8 @@ buildPythonPackage rec {
   # On Darwin sysctl is used to read CPU information.
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace cpuinfo/cpuinfo.py \
-      --replace "len(_program_paths('sysctl')) > 0" "True" \
-      --replace "_run_and_get_stdout(['sysctl'" "_run_and_get_stdout(['${sysctl}/bin/sysctl'"
+      --replace-fail "len(_program_paths('sysctl')) > 0" "True" \
+      --replace-fail "_run_and_get_stdout(['sysctl'" "_run_and_get_stdout(['${sysctl}/bin/sysctl'"
   '';
 
   pythonImportsCheck = [ "cpuinfo" ];

--- a/pkgs/development/python-modules/py-multiaddr/default.nix
+++ b/pkgs/development/python-modules/py-multiaddr/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace "'pytest-runner'," ""
+    substituteInPlace setup.py --replace-fail "'pytest-runner'," ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/py-multibase/default.nix
+++ b/pkgs/development/python-modules/py-multibase/default.nix
@@ -22,10 +22,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "[pytest]" "" \
-      --replace "python_classes = *TestCase" ""
+      --replace-fail "[pytest]" "" \
+      --replace-fail "python_classes = *TestCase" ""
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/py-multicodec/default.nix
+++ b/pkgs/development/python-modules/py-multicodec/default.nix
@@ -27,9 +27,9 @@ buildPythonPackage rec {
   # Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "[pytest]" "[tool:pytest]"
+      --replace-fail "[pytest]" "[tool:pytest]"
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/py-multihash/default.nix
+++ b/pkgs/development/python-modules/py-multihash/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner', " ""
+      --replace-fail "'pytest-runner', " ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/py-radix-sr/default.nix
+++ b/pkgs/development/python-modules/py-radix-sr/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "name='py-radix'" "name='py-radix-sr'"
+      --replace-fail "name='py-radix'" "name='py-radix-sr'"
 
     substituteInPlace tests/test_{compat,regression}.py \
       --replace-fail assertEquals assertEqual \

--- a/pkgs/development/python-modules/py3langid/default.nix
+++ b/pkgs/development/python-modules/py3langid/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   # nixify path to the courlan binary in the test suite
   postPatch = ''
-    substituteInPlace tests/test_langid.py --replace "'langid'" "'$out/bin/langid'"
+    substituteInPlace tests/test_langid.py --replace-fail "'langid'" "'$out/bin/langid'"
     substituteInPlace pyproject.toml --replace-fail \
       'numpy >= 2.0.0' numpy
   '';

--- a/pkgs/development/python-modules/pyaftership/default.nix
+++ b/pkgs/development/python-modules/pyaftership/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     # Upstream is releasing with the help of a CI to PyPI, GitHub releases
     # are not in their focus
     substituteInPlace setup.py \
-      --replace 'version="main",' 'version="${version}",'
+      --replace-fail 'version="main",' 'version="${version}",'
   '';
 
   pythonImportsCheck = [ "pyaftership" ];

--- a/pkgs/development/python-modules/pyarr/default.nix
+++ b/pkgs/development/python-modules/pyarr/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   postPatch = ''
     # https://github.com/totaldebug/pyarr/pull/167
     substituteInPlace pyproject.toml \
-      --replace "poetry.masonry.api" "poetry.core.masonry.api"
+      --replace-fail "poetry.masonry.api" "poetry.core.masonry.api"
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -145,7 +145,7 @@ buildPythonPackage rec {
     shopt -s extglob
     rm -r pyarrow/!(conftest.py|tests)
     mv pyarrow/conftest.py pyarrow/tests/parent_conftest.py
-    substituteInPlace pyarrow/tests/conftest.py --replace ..conftest .parent_conftest
+    substituteInPlace pyarrow/tests/conftest.py --replace-fail ..conftest .parent_conftest
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # OSError: [Errno 24] Too many open files

--- a/pkgs/development/python-modules/pyatspi/default.nix
+++ b/pkgs/development/python-modules/pyatspi/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   postPatch = ''
     # useless python existence check for us
     substituteInPlace configure \
-      --replace '&& ! which' '&& false'
+      --replace-fail '&& ! which' '&& false'
   '';
 
   disabled = !isPy3k;

--- a/pkgs/development/python-modules/pycarwings2/default.nix
+++ b/pkgs/development/python-modules/pycarwings2/default.nix
@@ -35,9 +35,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'" ""
+      --replace-fail "'pytest-runner'" ""
     substituteInPlace setup.cfg \
-      --replace " --flake8 --cov=pycarwings2 --cache-clear --ignore=venv --verbose" ""
+      --replace-fail " --flake8 --cov=pycarwings2 --cache-clear --ignore=venv --verbose" ""
   '';
 
   disabledTests = [

--- a/pkgs/development/python-modules/pycfdns/default.nix
+++ b/pkgs/development/python-modules/pycfdns/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'version="0",' 'version="${version}",'
+      --replace-fail 'version = "0"' 'version = "${version}"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pyclip/default.nix
+++ b/pkgs/development/python-modules/pyclip/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace docs/README.md README.md
+      --replace-fail docs/README.md README.md
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pycoin/default.nix
+++ b/pkgs/development/python-modules/pycoin/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ setuptools ];
 
   postPatch = ''
-    substituteInPlace ./pycoin/cmds/tx.py --replace '"gpg"' '"${gnupg}/bin/gpg"'
+    substituteInPlace ./pycoin/cmds/tx.py --replace-fail '"gpg"' '"${gnupg}/bin/gpg"'
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/pycritty/default.nix
+++ b/pkgs/development/python-modules/pycritty/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   postPatch = ''
     # remove custom install
     substituteInPlace setup.py \
-      --replace "'install': PostInstallHook," ""
+      --replace-fail "'install': PostInstallHook," ""
   '';
 
   propagatedBuildInputs = [ pyyaml ];

--- a/pkgs/development/python-modules/pydantic-scim/default.nix
+++ b/pkgs/development/python-modules/pydantic-scim/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'version=get_version(),' 'version="${version}",'
+      --replace-fail 'version=get_version(),' 'version="${version}",'
   '';
 
   propagatedBuildInputs = [ pydantic ] ++ pydantic.optional-dependencies.email;

--- a/pkgs/development/python-modules/pydbus/default.nix
+++ b/pkgs/development/python-modules/pydbus/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pydbus/_inspect3.py \
-      --replace "getargspec" "getfullargspec"
+      --replace-fail "getargspec" "getfullargspec"
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/pydelijn/default.nix
+++ b/pkgs/development/python-modules/pydelijn/default.nix
@@ -26,15 +26,6 @@ buildPythonPackage rec {
     pytz
   ];
 
-  postPatch = ''
-    # Remove with next release
-    substituteInPlace setup.py \
-      --replace "async_timeout>=3.0.1,<4.0" "async_timeout>=3.0.1"
-    # https://github.com/bollewolle/pydelijn/pull/11
-    substituteInPlace pydelijn/common.py \
-      --replace ", loop=self.loop" ""
-  '';
-
   # Project has no tests
   doCheck = false;
 

--- a/pkgs/development/python-modules/pydeps/default.nix
+++ b/pkgs/development/python-modules/pydeps/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Path is hard-coded
     substituteInPlace pydeps/dot.py \
-      --replace "dot -Gstart=1" "${lib.makeBinPath [ graphviz ]}/dot -Gstart=1"
+      --replace-fail "dot -Gstart=1" "${lib.makeBinPath [ graphviz ]}/dot -Gstart=1"
   '';
 
   disabledTests = [

--- a/pkgs/development/python-modules/pydocstyle/default.nix
+++ b/pkgs/development/python-modules/pydocstyle/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'version = "0.0.0-dev"' 'version = "${version}"'
+      --replace-fail 'version = "0.0.0-dev"' 'version = "${version}"'
   '';
 
   propagatedBuildInputs = [ snowballstemmer ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];

--- a/pkgs/development/python-modules/pydruid/default.nix
+++ b/pkgs/development/python-modules/pydruid/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   # patch out the CLI because it doesn't work with newer versions of pygments
   postPatch = ''
-    substituteInPlace setup.py --replace '"console_scripts": ["pydruid = pydruid.console:main"],' ""
+    substituteInPlace setup.py --replace-fail '"console_scripts": ["pydruid = pydruid.console:main"],' ""
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/pydyf/default.nix
+++ b/pkgs/development/python-modules/pydyf/default.nix
@@ -22,11 +22,6 @@ buildPythonPackage rec {
     hash = "sha256-OU3d9hnMqdDFVxXjxV6hIam/nLx4DNwSAaJCeRe4a2Q=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "--isort --flake8" ""
-  '';
-
   nativeBuildInputs = [ flit-core ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyenchant/default.nix
+++ b/pkgs/development/python-modules/pyenchant/default.nix
@@ -32,9 +32,8 @@ buildPythonPackage rec {
       # This code should never be hit, but in case it does, we don't want to have
       # it "accidentally" work by pulling something from /opt.
       substituteInPlace enchant/_enchant.py                  \
-        --replace 'os.environ.get("PYENCHANT_LIBRARY_PATH")' \
-                  "'${enchant2}/lib/libenchant-2${libext}'"  \
-        --replace '/opt/local/lib/' ""
+        --replace-fail 'os.environ.get("PYENCHANT_LIBRARY_PATH")' \
+                  "'${enchant2}/lib/libenchant-2${libext}'"
     '';
 
   # dictionaries needed for tests

--- a/pkgs/development/python-modules/pyexcel-xls/default.nix
+++ b/pkgs/development/python-modules/pyexcel-xls/default.nix
@@ -48,10 +48,6 @@ buildPythonPackage rec {
     pytest-cov-stub
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "xlrd<2" "xlrd<3"
-  '';
-
   meta = {
     description = "Wrapper library to read, manipulate and write data in xls using xlrd and xlwt";
     homepage = "http://docs.pyexcel.org/";

--- a/pkgs/development/python-modules/pyhamcrest/default.nix
+++ b/pkgs/development/python-modules/pyhamcrest/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'dynamic = ["version"]' 'version = "${version}"'
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyhocon/default.nix
+++ b/pkgs/development/python-modules/pyhocon/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pyparsing~=2.0" "pyparsing>=2.0"
+      --replace-fail "pyparsing~=2.0" "pyparsing>=2.0"
   '';
 
   pythonImportsCheck = [ "pyhocon" ];

--- a/pkgs/development/python-modules/pyisy/default.nix
+++ b/pkgs/development/python-modules/pyisy/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'version_format="{tag}"' 'version="${version}"'
+      --replace-fail 'version_format="{tag}"' 'version="${version}"'
   '';
 
   build-system = [ setuptools-scm ];

--- a/pkgs/development/python-modules/pykdl/default.nix
+++ b/pkgs/development/python-modules/pykdl/default.nix
@@ -29,7 +29,7 @@ toPythonModule (
     # Fix hardcoded installation path
     postPatch = ''
       substituteInPlace CMakeLists.txt \
-        --replace dist-packages site-packages
+        --replace-fail dist-packages site-packages
     '';
 
     nativeBuildInputs = [

--- a/pkgs/development/python-modules/pylacrosse/default.nix
+++ b/pkgs/development/python-modules/pylacrosse/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "version = version," "version = '${version}',"
+      --replace-fail "version = version," "version = '${version}',"
   '';
 
   propagatedBuildInputs = [ pyserial ];

--- a/pkgs/development/python-modules/pylsl/default.nix
+++ b/pkgs/development/python-modules/pylsl/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace src/pylsl/lib/__init__.py \
-      --replace "def find_liblsl_libraries(verbose=False):" "$(echo -e "def find_liblsl_libraries(verbose=False):\n    yield '${liblsl}/lib/liblsl.${
+      --replace-fail "def find_liblsl_libraries(verbose=False):" "$(echo -e "def find_liblsl_libraries(verbose=False):\n    yield '${liblsl}/lib/liblsl.${
         if stdenv.hostPlatform.isDarwin then "dylib" else "so"
       }'")"
   '';

--- a/pkgs/development/python-modules/pymediainfo/default.nix
+++ b/pkgs/development/python-modules/pymediainfo/default.nix
@@ -23,11 +23,11 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace src/pymediainfo/__init__.py \
-      --replace "libmediainfo.0.dylib" \
+      --replace-fail "libmediainfo.0.dylib" \
                 "${libmediainfo}/lib/libmediainfo.0${stdenv.hostPlatform.extensions.sharedLibrary}" \
-      --replace "libmediainfo.dylib" \
+      --replace-fail "libmediainfo.dylib" \
                 "${libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}" \
-      --replace "libmediainfo.so.0" \
+      --replace-fail "libmediainfo.so.0" \
                 "${libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}.0"
   '';
 

--- a/pkgs/development/python-modules/pyppeteer/default.nix
+++ b/pkgs/development/python-modules/pyppeteer/default.nix
@@ -32,9 +32,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'pyee = "^8.1.0"' 'pyee = "*"' \
-      --replace 'urllib3 = "^1.25.8"' 'urllib3 = "*"' \
-      --replace 'websockets = "^10.0"' 'websockets = "*"'
+      --replace-fail 'pyee = "^8.1.0"' 'pyee = "*"' \
+      --replace-fail 'urllib3 = "^1.25.8"' 'urllib3 = "*"' \
+      --replace-fail 'websockets = "^10.0"' 'websockets = "*"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pyqt3d/default.nix
+++ b/pkgs/development/python-modules/pyqt3d/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
+      --replace-fail "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
   '';
 
   outputs = [

--- a/pkgs/development/python-modules/pyqtchart/default.nix
+++ b/pkgs/development/python-modules/pyqtchart/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
+      --replace-fail "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
   '';
 
   outputs = [

--- a/pkgs/development/python-modules/pyqtdatavisualization/default.nix
+++ b/pkgs/development/python-modules/pyqtdatavisualization/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
+      --replace-fail "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
   '';
 
   outputs = [

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage (
 
     postPatch = ''
       substituteInPlace pyproject.toml \
-        --replace "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
+        --replace-fail "[tool.sip.project]" "[tool.sip.project]''\nsip-include-dirs = [\"${pyqt5}/${python.sitePackages}/PyQt5/bindings\"]"
     '';
 
     outputs = [

--- a/pkgs/development/python-modules/pyrevolve/default.nix
+++ b/pkgs/development/python-modules/pyrevolve/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace ', "flake8"' ""
+      --replace-fail ', "flake8"' ""
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyric/default.nix
+++ b/pkgs/development/python-modules/pyric/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "__version__ = '0.0.3'" "__version__ = '${version}'"
+      --replace-fail "__version__ = '0.0.3'" "__version__ = '${version}'"
   '';
 
   # Tests are outdated

--- a/pkgs/development/python-modules/pyscaffold/default.nix
+++ b/pkgs/development/python-modules/pyscaffold/default.nix
@@ -46,10 +46,6 @@ buildPythonPackage rec {
     wheel
   ];
 
-  postPatch = ''
-    substituteInPlace setup.cfg --replace "platformdirs>=2,<4" "platformdirs"
-  '';
-
   propagatedBuildInputs = [
     colorama
     configupdater

--- a/pkgs/development/python-modules/pysiaalarm/default.nix
+++ b/pkgs/development/python-modules/pysiaalarm/default.nix
@@ -25,11 +25,6 @@ buildPythonPackage rec {
     hash = "sha256-q42bsBeAwU9lt7wtYGFJv23UBND+aMXZJlSWyTfZDQE=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "==" ">="
-  '';
-
   build-system = [ setuptools-scm ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pysim/default.nix
+++ b/pkgs/development/python-modules/pysim/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage {
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace 'smpp.pdu @ git+https://github.com/hologram-io/smpp.pdu' 'smpp.pdu'
+    substituteInPlace setup.py --replace-fail 'smpp.pdu @ git+https://github.com/hologram-io/smpp.pdu' 'smpp.pdu'
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/pysmart/default.nix
+++ b/pkgs/development/python-modules/pysmart/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pySMART/utils.py \
-      --replace "which('smartctl')" '"${smartmontools}/bin/smartctl"'
+      --replace-fail "which('smartctl')" '"${smartmontools}/bin/smartctl"'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pysnooz/default.nix
+++ b/pkgs/development/python-modules/pysnooz/default.nix
@@ -33,8 +33,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'transitions = "^0.8.11"' 'transitions = ">=0.8.11"' \
-      --replace 'Events = "^0.4"' 'Events = ">=0.4"'
+      --replace-fail 'transitions = "^0.8.11"' 'transitions = ">=0.8.11"' \
+      --replace-fail 'Events = "^0.4"' 'Events = ">=0.4"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pysnow/default.nix
+++ b/pkgs/development/python-modules/pysnow/default.nix
@@ -55,9 +55,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'ijson = "^2.5.1"' 'ijson = "*"' \
-      --replace 'pytz = "^2019.3"' 'pytz = "*"' \
-      --replace 'oauthlib = "^3.1.0"' 'oauthlib = "*"'
+      --replace-fail 'ijson = "^2.5.1"' 'ijson = "*"' \
+      --replace-fail 'pytz = "^2019.3"' 'pytz = "*"' \
+      --replace-fail 'oauthlib = "^3.1.0"' 'oauthlib = "*"'
 
     # https://github.com/rbw/pysnow/pull/201 doesn't apply via fetchpatch, so we recreate it
     substituteInPlace tests/test_client.py tests/test_oauth_client.py tests/test_params_builder.py tests/test_resource.py \

--- a/pkgs/development/python-modules/pyspark/default.nix
+++ b/pkgs/development/python-modules/pyspark/default.nix
@@ -26,17 +26,17 @@ buildPythonPackage rec {
     sed -i "s/'pypandoc'//" setup.py
 
     substituteInPlace setup.py \
-      --replace py4j== 'py4j>='
+      --replace-fail py4j== 'py4j>='
   '';
 
   postFixup = ''
     # find_python_home.py has been wrapped as a shell script
     substituteInPlace $out/bin/find-spark-home \
-        --replace 'export SPARK_HOME=$($PYSPARK_DRIVER_PYTHON "$FIND_SPARK_HOME_PYTHON_SCRIPT")' \
+        --replace-fail 'export SPARK_HOME=$($PYSPARK_DRIVER_PYTHON "$FIND_SPARK_HOME_PYTHON_SCRIPT")' \
                   'export SPARK_HOME=$("$FIND_SPARK_HOME_PYTHON_SCRIPT")'
     # patch PYTHONPATH in pyspark so that it properly looks at SPARK_HOME
     substituteInPlace $out/bin/pyspark \
-        --replace 'export PYTHONPATH="''${SPARK_HOME}/python/:$PYTHONPATH"' \
+        --replace-fail 'export PYTHONPATH="''${SPARK_HOME}/python/:$PYTHONPATH"' \
                   'export PYTHONPATH="''${SPARK_HOME}/..:''${SPARK_HOME}/python/:$PYTHONPATH"'
   '';
 

--- a/pkgs/development/python-modules/pyspice/default.nix
+++ b/pkgs/development/python-modules/pyspice/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "PySpice" ];
 
   postPatch = ''
-    substituteInPlace PySpice/Spice/NgSpice/Shared.py --replace \
+    substituteInPlace PySpice/Spice/NgSpice/Shared.py --replace-fail \
         "ffi.dlopen(self.library_path)" \
         "ffi.dlopen('${libngspice}/lib/libngspice${stdenv.hostPlatform.extensions.sharedLibrary}')"
   '';

--- a/pkgs/development/python-modules/pytabix/default.nix
+++ b/pkgs/development/python-modules/pytabix/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   doCheck = !isPy3k;
   preCheck = ''
     substituteInPlace test/test.py \
-      --replace 'test_remote_file' 'dont_test_remote_file'
+      --replace-fail 'test_remote_file' 'dont_test_remote_file'
   '';
   pythonImportsCheck = [ "tabix" ];
 

--- a/pkgs/development/python-modules/pytest-annotate/default.nix
+++ b/pkgs/development/python-modules/pytest-annotate/default.nix
@@ -20,11 +20,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyannotate ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "pytest>=3.2.0,<7.0.0" "pytest>=3.2.0"
-  '';
-
   # Module has no tests
   doCheck = false;
 

--- a/pkgs/development/python-modules/pytest-celery/default.nix
+++ b/pkgs/development/python-modules/pytest-celery/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Avoid infinite recursion with celery
     substituteInPlace pyproject.toml \
-      --replace 'celery = { version = "*" }' ""
+      --replace-fail 'celery = { version = "*" }' ""
   '';
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/pytest-cid/default.nix
+++ b/pkgs/development/python-modules/pytest-cid/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "pytest >= 5.0, < 7.0" "pytest >= 5.0"
+      --replace-fail "pytest >= 5.0, < 7.0" "pytest >= 5.0"
   '';
 
   nativeBuildInputs = [ flit-core ];

--- a/pkgs/development/python-modules/pytest-console-scripts/default.nix
+++ b/pkgs/development/python-modules/pytest-console-scripts/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Patch the shebang of a script generated during test.
     substituteInPlace tests/test_run_scripts.py \
-      --replace "#!/usr/bin/env python" "#!${python.interpreter}"
+      --replace-fail "#!/usr/bin/env python" "#!${python.interpreter}"
   '';
 
   pythonImportsCheck = [ "pytest_console_scripts" ];

--- a/pkgs/development/python-modules/pytest-cram/default.nix
+++ b/pkgs/development/python-modules/pytest-cram/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pytest_cram/tests/test_options.py \
-      --replace "/bin/bash" "${bash}/bin/bash"
+      --replace-fail "/bin/bash" "${bash}/bin/bash"
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pytest-resource-path/default.nix
+++ b/pkgs/development/python-modules/pytest-resource-path/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "pytest-runner" ""
+      --replace-fail "pytest-runner" ""
   '';
 
   buildInputs = [ pytest ];

--- a/pkgs/development/python-modules/pytest-xprocess/default.nix
+++ b/pkgs/development/python-modules/pytest-xprocess/default.nix
@@ -18,12 +18,6 @@ buildPythonPackage rec {
     hash = "sha256-FeJwY3WG6rxWdV7l/MgcSL20a6fvfA1bG2QwLQgMxg8=";
   };
 
-  postPatch = ''
-    # Remove test QoL package from install_requires
-    substituteInPlace setup.py \
-      --replace "'pytest-cache', " ""
-  '';
-
   nativeBuildInputs = [ setuptools-scm ];
 
   buildInputs = [ pytest ];

--- a/pkgs/development/python-modules/python-bitcoinlib/default.nix
+++ b/pkgs/development/python-modules/python-bitcoinlib/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace bitcoin/core/key.py --replace \
+    substituteInPlace bitcoin/core/key.py --replace-fail \
       "ctypes.util.find_library('ssl.35') or ctypes.util.find_library('ssl') or ctypes.util.find_library('libeay32')" \
       "'${lib.getLib openssl}/lib/libssl${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';

--- a/pkgs/development/python-modules/python-creole/default.nix
+++ b/pkgs/development/python-modules/python-creole/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace "/bin/bash" "${runtimeShell}"
+      --replace-fail "/bin/bash" "${runtimeShell}"
 
     sed -i "/-cov/d" pytest.ini
   '';

--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -20,9 +20,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace gnupg.py \
-      --replace "gpgbinary='gpg'" "gpgbinary='${gnupg}/bin/gpg'"
+      --replace-fail "gpgbinary='gpg'" "gpgbinary='${gnupg}/bin/gpg'"
     substituteInPlace test_gnupg.py \
-      --replace "os.environ.get('GPGBINARY', 'gpg')" "os.environ.get('GPGBINARY', '${gnupg}/bin/gpg')"
+      --replace-fail "os.environ.get('GPGBINARY', 'gpg')" "os.environ.get('GPGBINARY', '${gnupg}/bin/gpg')"
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   # multiprocessing backend used on macos
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace tests/test_jenkins_sockets.py \
-      --replace test_jenkins_open_no_timeout dont_test_jenkins_open_no_timeout
+      --replace-fail test_jenkins_open_no_timeout dont_test_jenkins_open_no_timeout
   '';
 
   pythonRelaxDeps = [ "setuptools" ];

--- a/pkgs/development/python-modules/python-nmap/default.nix
+++ b/pkgs/development/python-modules/python-nmap/default.nix
@@ -17,11 +17,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ nmap ];
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "universal=3" "universal=1"
-  '';
-
   # Tests requires sudo and performs scans
   doCheck = false;
 

--- a/pkgs/development/python-modules/python-opensky/default.nix
+++ b/pkgs/development/python-modules/python-opensky/default.nix
@@ -30,9 +30,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'version = "0.0.0"' 'version = "${version}"'
+      --replace-fail 'version = "1.0.0"' 'version = "${version}"'
     substituteInPlace src/python_opensky/opensky.py \
-      --replace ".joinpath(uri)" "/ uri"
+      --replace-fail ".joinpath(uri)" "/ uri"
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/python-openzwave/default.nix
+++ b/pkgs/development/python-modules/python-openzwave/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   # /etc/openzwave if needed
   postPatch = ''
     substituteInPlace src-lib/libopenzwave/libopenzwave.pyx \
-      --replace /usr/local/etc/openzwave ${openzwave}/etc/openzwave
+      --replace-fail /usr/local/etc/openzwave ${openzwave}/etc/openzwave
   '';
 
   patches = [ ./cython.patch ];

--- a/pkgs/development/python-modules/python-pam/default.nix
+++ b/pkgs/development/python-modules/python-pam/default.nix
@@ -22,8 +22,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace src/pam/__internals.py \
-      --replace 'find_library("pam")' '"${pam}/lib/libpam.so"' \
-      --replace 'find_library("pam_misc")' '"${pam}/lib/libpam_misc.so"'
+      --replace-fail 'find_library("pam")' '"${pam}/lib/libpam.so"' \
+      --replace-fail 'find_library("pam_misc")' '"${pam}/lib/libpam_misc.so"'
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/python-xmp-toolkit/default.nix
+++ b/pkgs/development/python-modules/python-xmp-toolkit/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace libxmp/exempi.py \
-      --replace "ctypes.util.find_library('exempi')" "'${exempi}/lib/libexempi${stdenv.hostPlatform.extensions.sharedLibrary}'"
+      --replace-fail "ctypes.util.find_library('exempi')" "'${exempi}/lib/libexempi${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 
   # hangs on darwin + sandbox

--- a/pkgs/development/python-modules/pytidylib/default.nix
+++ b/pkgs/development/python-modules/pytidylib/default.nix
@@ -20,12 +20,12 @@ buildPythonPackage rec {
   postPatch = ''
     # Patch path to library
     substituteInPlace tidylib/tidy.py \
-      --replace "load_library(name)" \
+      --replace-fail "load_library(name)" \
         "load_library('${html-tidy}/lib/libtidy${stdenv.hostPlatform.extensions.sharedLibrary}')"
 
     # Test fails
     substituteInPlace tests/test_docs.py \
-      --replace "    def test_large_document(self):" \
+      --replace-fail "    def test_large_document(self):" \
         $'    @unittest.skip("")\n    def test_large_document(self):'
   '';
 

--- a/pkgs/development/python-modules/pytraccar/default.nix
+++ b/pkgs/development/python-modules/pytraccar/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set version in the repo
     substituteInPlace pyproject.toml \
-      --replace 'version = "0"' 'version = "${version}"'
+      --replace-fail 'version = "0"' 'version = "${version}"'
   '';
 
   pythonImportsCheck = [ "pytraccar" ];

--- a/pkgs/development/python-modules/pyu2f/default.nix
+++ b/pkgs/development/python-modules/pyu2f/default.nix
@@ -22,7 +22,6 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ six ];
-
   postPatch = ''
     for path in \
       customauthenticator_test.py \
@@ -36,9 +35,11 @@ buildPythonPackage rec {
     do
       # https://docs.python.org/3/whatsnew/3.12.html#id3
       substituteInPlace pyu2f/tests/$path \
-        --replace "assertEquals" "assertEqual" \
-        --replace "assertRaisesRegexp" "assertRaisesRegex"
+        --replace-fail "assertEquals" "assertEqual"
     done
+
+    substituteInPlace pyu2f/tests/hidtransport_test.py \
+      --replace-fail "assertRaisesRegexp" "assertRaisesRegex"
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyudev/default.nix
+++ b/pkgs/development/python-modules/pyudev/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
     substituteInPlace src/pyudev/_ctypeslib/utils.py \
-      --replace "find_library(name)" "'${lib.getLib udev}/lib/libudev.so'"
+      --replace-fail "find_library(name)" "'${lib.getLib udev}/lib/libudev.so'"
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pyunbound/default.nix
+++ b/pkgs/development/python-modules/pyunbound/default.nix
@@ -34,8 +34,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace Makefile.in \
-      --replace "\$(DESTDIR)\$(PYTHON_SITE_PKG)" "$out/${python.sitePackages}" \
-      --replace "\$(LIBTOOL) --mode=install cp _unbound.la" "cp _unbound.la"
+      --replace-fail "\$(DESTDIR)\$(PYTHON_SITE_PKG)" "$out/${python.sitePackages}" \
+      --replace-fail "\$(LIBTOOL) --mode=install cp _unbound.la" "cp _unbound.la"
   '';
 
   preConfigure = "export PYTHON_VERSION=${python.pythonVersion}";
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     mkdir -p $out/${python.sitePackages} $out/etc/${pname}
     cp .libs/_unbound.so .libs/libunbound.so* $out/${python.sitePackages}
     substituteInPlace _unbound.la \
-      --replace "-L.libs $PWD/libunbound.la" "-L$out/${python.sitePackages}"
+      --replace-fail "-L.libs $PWD/libunbound.la" "-L$out/${python.sitePackages}"
   '';
 
   installFlags = [

--- a/pkgs/development/python-modules/pyuptimerobot/default.nix
+++ b/pkgs/development/python-modules/pyuptimerobot/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set version in the repo
     substituteInPlace setup.py \
-      --replace 'version="main",' 'version="${version}",'
+      --replace-fail 'version="main",' 'version="${version}",'
   '';
 
   propagatedBuildInputs = [ aiohttp ];

--- a/pkgs/development/python-modules/pywal/default.nix
+++ b/pkgs/development/python-modules/pywal/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
 
     for f in tests/test_export.py tests/test_util.py ; do
       substituteInPlace "$f" \
-        --replace '/tmp/' "$TMPDIR/"
+        --replace-fail '/tmp/' "$TMPDIR/"
     done
   '';
 

--- a/pkgs/development/python-modules/pyxbe/default.nix
+++ b/pkgs/development/python-modules/pyxbe/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   # Update location for run with pytest
   preCheck = ''
     substituteInPlace tests/test_load.py \
-      --replace '"xbefiles"' '"tests/xbefiles"'
+      --replace-fail '"xbefiles"' '"tests/xbefiles"'
   '';
 
   pythonImportsCheck = [ "xbe" ];

--- a/pkgs/development/python-modules/r2pipe/default.nix
+++ b/pkgs/development/python-modules/r2pipe/default.nix
@@ -24,11 +24,11 @@ buildPythonPackage rec {
     ''
       # Fix find_library, can be removed after
       # https://github.com/NixOS/nixpkgs/issues/7307 is resolved.
-      substituteInPlace r2pipe/native.py --replace 'find_library("r_core")' "'${libr_core}'"
+      substituteInPlace r2pipe/native.py --replace-fail 'find_library("r_core")' "'${libr_core}'"
 
       # Fix the default r2 executable
-      substituteInPlace r2pipe/open_sync.py --replace 'r2e = "radare2"' "r2e = '${radare2}/bin/radare2'"
-      substituteInPlace r2pipe/open_base.py --replace 'which("radare2")' "'${radare2}/bin/radare2'"
+      substituteInPlace r2pipe/open_sync.py --replace-fail 'r2e = "radare2"' "r2e = '${radare2}/bin/radare2'"
+      substituteInPlace r2pipe/open_base.py --replace-fail 'which("radare2")' "'${radare2}/bin/radare2'"
     '';
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/rainbowstream/default.nix
+++ b/pkgs/development/python-modules/rainbowstream/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage {
   postPatch = ''
     clib=$out/${python.sitePackages}/rainbowstream/image.so
     substituteInPlace rainbowstream/c_image.py \
-      --replace @CLIB@ $clib
+      --replace-fail @CLIB@ $clib
     sed -i 's/requests.*"/requests"/' setup.py
   '';
 

--- a/pkgs/development/python-modules/rank-bm25/default.nix
+++ b/pkgs/development/python-modules/rank-bm25/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage {
 
   postPatch = ''
     # Upstream doesn't provide a PKG-INFO file
-    substituteInPlace setup.py --replace "get_version()" "'${version}'"
+    substituteInPlace setup.py --replace-fail "get_version()" "'${version}'"
   '';
 
   propagatedBuildInputs = [ numpy ];

--- a/pkgs/development/python-modules/rchitect/default.nix
+++ b/pkgs/development/python-modules/rchitect/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner"' ""
+      --replace-fail '"pytest-runner"' ""
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/reactivex/default.nix
+++ b/pkgs/development/python-modules/reactivex/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for their GitHub releases
     substituteInPlace pyproject.toml \
-      --replace 'version = "0.0.0"' 'version = "${version}"'
+      --replace-fail 'version = "0.0.0"' 'version = "${version}"'
   '';
 
   pythonImportsCheck = [ "reactivex" ];

--- a/pkgs/development/python-modules/readchar/default.nix
+++ b/pkgs/development/python-modules/readchar/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     # run Linux tests on Darwin as well
     # see https://github.com/magmax/python-readchar/pull/99 for why this is not upstreamed
     substituteInPlace tests/linux/conftest.py \
-      --replace 'sys.platform.startswith("linux")' 'sys.platform.startswith(("darwin", "linux"))'
+      --replace-fail 'sys.platform.startswith("linux")' 'sys.platform.startswith(("darwin", "linux"))'
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/recurring-ical-events/default.nix
+++ b/pkgs/development/python-modules/recurring-ical-events/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'dynamic = ["urls", "version"]' 'version = "${version}"'
+      --replace-fail 'dynamic = ["urls", "version"]' 'version = "${version}"'
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/redshift-connector/default.nix
+++ b/pkgs/development/python-modules/redshift-connector/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   # remove addops as they add test directory and coverage parameters to pytest
   postPatch = ''
-    substituteInPlace setup.cfg --replace 'addopts =' 'no-opts ='
+    substituteInPlace setup.cfg --replace-fail 'addopts =' 'no-opts ='
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/reflink/default.nix
+++ b/pkgs/development/python-modules/reflink/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pytest-runner" ""
+      --replace-fail "pytest-runner" ""
   '';
 
   # FIXME: These do not work, and I have been unable to figure out why.

--- a/pkgs/development/python-modules/releases/default.nix
+++ b/pkgs/development/python-modules/releases/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace "semantic_version<2.7" "semantic_version"
+    substituteInPlace setup.py --replace-fail "semantic_version<2.7" "semantic_version"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/reolink/default.nix
+++ b/pkgs/development/python-modules/reolink/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Packages in nixpkgs is different than the module name
     substituteInPlace setup.py \
-      --replace "ffmpeg" "ffmpeg-python"
+      --replace-fail "ffmpeg" "ffmpeg-python"
   '';
 
   # https://github.com/fwestenberg/reolink/issues/83

--- a/pkgs/development/python-modules/reproject/default.nix
+++ b/pkgs/development/python-modules/reproject/default.nix
@@ -30,11 +30,6 @@ buildPythonPackage rec {
     hash = "sha256-U8jqJ5uLVX8zoeQwr14FPNdHACRA4HK65q2TAtRr5Xk=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "cython==" "cython>="
-  '';
-
   nativeBuildInputs = [
     astropy-extension-helpers
     cython

--- a/pkgs/development/python-modules/rfc3986-validator/default.nix
+++ b/pkgs/development/python-modules/rfc3986-validator/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/rflink/default.nix
+++ b/pkgs/development/python-modules/rflink/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "version=version_from_git()" "version='${version}'"
+      --replace-fail "version=version_from_git()" "version='${version}'"
   '';
 
   pythonImportsCheck = [ "rflink.protocol" ];

--- a/pkgs/development/python-modules/riscof/default.nix
+++ b/pkgs/development/python-modules/riscof/default.nix
@@ -30,9 +30,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "import pip" ""
+      --replace-fail "import pip" ""
     substituteInPlace riscof/requirements.txt \
-      --replace "GitPython==3.1.17" "GitPython"
+      --replace-fail "GitPython==3.1.17" "GitPython"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/riscv-isac/default.nix
+++ b/pkgs/development/python-modules/riscv-isac/default.nix
@@ -30,8 +30,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace riscv_isac/requirements.txt \
-      --replace "pyelftools==0.26" "pyelftools" \
-      --replace "pytest" ""
+      --replace-fail "pyelftools==0.26" "pyelftools" \
+      --replace-fail "pytest" ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/rmcl/default.nix
+++ b/pkgs/development/python-modules/rmcl/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '= "^' '= ">='
+      --replace-fail '= "^' '= ">='
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/rpcq/default.nix
+++ b/pkgs/development/python-modules/rpcq/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "msgpack>=0.6,<1.0" "msgpack"
+      --replace-fail "msgpack>=0.6,<1.0" "msgpack"
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/rsa/default.nix
+++ b/pkgs/development/python-modules/rsa/default.nix
@@ -22,10 +22,6 @@ buildPythonPackage rec {
     hash = "sha256-PwaRe+ICy0UoguXSMSh3PFl5R+YAhJwNdNN9isadlJY=";
   };
 
-  preConfigure = lib.optionalString (pythonOlder "3.7") ''
-    substituteInPlace setup.py --replace "open('README.md')" "open('README.md',encoding='utf-8')"
-  '';
-
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [ pyasn1 ];

--- a/pkgs/development/python-modules/rtree/default.nix
+++ b/pkgs/development/python-modules/rtree/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace rtree/finder.py --replace \
+    substituteInPlace rtree/finder.py --replace-fail \
       'find_library("spatialindex_c")' '"${libspatialindex}/lib/libspatialindex_c${stdenv.hostPlatform.extensions.sharedLibrary}"'
   '';
 

--- a/pkgs/development/python-modules/ruyaml/default.nix
+++ b/pkgs/development/python-modules/ruyaml/default.nix
@@ -25,8 +25,8 @@ buildPythonPackage rec {
   postPatch = ''
     # https://github.com/pycontribs/ruyaml/pull/107
     substituteInPlace pyproject.toml \
-      --replace '"pip >= 19.3.1",' "" \
-      --replace '"setuptools_scm_git_archive >= 1.1",' ""
+      --replace-fail '"pip >= 19.3.1",' "" \
+      --replace-fail '"setuptools_scm_git_archive >= 1.1",' ""
   '';
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/python-modules/safety-schemas/default.nix
+++ b/pkgs/development/python-modules/safety-schemas/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace hatchling==1.26.3 hatchling
+      --replace-fail hatchling==1.26.3 hatchling
   '';
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/scapy/default.nix
+++ b/pkgs/development/python-modules/scapy/default.nix
@@ -55,10 +55,10 @@ buildPythonPackage rec {
         exit 1
     fi
     substituteInPlace "scapy/libs/winpcapy.py" \
-        --replace "@libpcap_file@" "$libpcap_file"
+        --replace-fail "@libpcap_file@" "$libpcap_file"
   ''
   + lib.optionalString withManufDb ''
-    substituteInPlace scapy/data.py --replace "/opt/wireshark" "${wireshark}"
+    substituteInPlace scapy/data.py --replace-fail "/opt/wireshark" "${wireshark}"
   '';
 
   buildInputs = lib.optional withVoipSupport sox;

--- a/pkgs/development/python-modules/schedule/default.nix
+++ b/pkgs/development/python-modules/schedule/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   preCheck = ''
     # https://github.com/dbader/schedule/issues/488
-    substituteInPlace test_schedule.py --replace \
+    substituteInPlace test_schedule.py --replace-fail \
       "self.assertRaises(ScheduleValueError, every().day.until, datetime.time(hour=5))" \
       "# self.assertRaises(ScheduleValueError, every().day.until, datetime.time(hour=5))"
   '';

--- a/pkgs/development/python-modules/scim2-filter-parser/default.nix
+++ b/pkgs/development/python-modules/scim2-filter-parser/default.nix
@@ -33,11 +33,6 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "poetry.masonry.api" "poetry.core.masonry.api"
-  '';
-
   dependencies = [ sly ];
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/screeninfo/default.nix
+++ b/pkgs/development/python-modules/screeninfo/default.nix
@@ -29,11 +29,11 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace screeninfo/enumerators/xinerama.py \
-      --replace 'load_library("X11")' 'ctypes.cdll.LoadLibrary("${libX11}/lib/libX11.so")' \
-      --replace 'load_library("Xinerama")' 'ctypes.cdll.LoadLibrary("${libXinerama}/lib/libXinerama.so")'
+      --replace-fail 'load_library("X11")' 'ctypes.cdll.LoadLibrary("${libX11}/lib/libX11.so")' \
+      --replace-fail 'load_library("Xinerama")' 'ctypes.cdll.LoadLibrary("${libXinerama}/lib/libXinerama.so")'
     substituteInPlace screeninfo/enumerators/xrandr.py \
-      --replace 'load_library("X11")' 'ctypes.cdll.LoadLibrary("${libX11}/lib/libX11.so")' \
-      --replace 'load_library("Xrandr")' 'ctypes.cdll.LoadLibrary("${libXrandr}/lib/libXrandr.so")'
+      --replace-fail 'load_library("X11")' 'ctypes.cdll.LoadLibrary("${libX11}/lib/libX11.so")' \
+      --replace-fail 'load_library("Xrandr")' 'ctypes.cdll.LoadLibrary("${libXrandr}/lib/libXrandr.so")'
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/seasonal/default.nix
+++ b/pkgs/development/python-modules/seasonal/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'setup_requires=["pytest-runner"],' ""
+      --replace-fail 'setup_requires=["pytest-runner"],' ""
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/seccomp/default.nix
+++ b/pkgs/development/python-modules/seccomp/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace ./setup.py \
-      --replace 'extra_objects=["../.libs/libseccomp.a"]' \
+      --replace-fail 'extra_objects=["../.libs/libseccomp.a"]' \
                 'libraries=["seccomp"]'
   '';
 

--- a/pkgs/development/python-modules/secp256k1/default.nix
+++ b/pkgs/development/python-modules/secp256k1/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   postPatch = ''
     # don't do hacky tarball download + setuptools check
     sed -i '38,54d' setup.py
-    substituteInPlace setup.py --replace ", 'pytest-runner==2.6.2'" ""
+    substituteInPlace setup.py --replace-fail ", 'pytest-runner==2.6.2'" ""
   '';
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/python-modules/segyio/default.nix
+++ b/pkgs/development/python-modules/segyio/default.nix
@@ -25,10 +25,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     # Removing unecessary build dependency
-    substituteInPlace python/setup.py --replace "'pytest-runner'," ""
+    substituteInPlace python/setup.py --replace-fail "'pytest-runner'," ""
 
     # Fixing bug making one test fail in the python 3.10 build
-    substituteInPlace python/segyio/open.py --replace \
+    substituteInPlace python/segyio/open.py --replace-fail \
     "cube_metrics = f.xfd.cube_metrics(iline, xline)" \
     "cube_metrics = f.xfd.cube_metrics(int(iline), int(xline))"
   '';

--- a/pkgs/development/python-modules/seqeval/default.nix
+++ b/pkgs/development/python-modules/seqeval/default.nix
@@ -21,8 +21,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "use_scm_version=True," "version='${version}'," \
-      --replace "setup_requires=['setuptools_scm']," "setup_requires=[],"
+      --replace-fail "use_scm_version=True," "version='${version}'," \
+      --replace-fail "setup_requires=['setuptools_scm']," "setup_requires=[],"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/serverlessrepo/default.nix
+++ b/pkgs/development/python-modules/serverlessrepo/default.nix
@@ -35,8 +35,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pyyaml~=5.1" "pyyaml" \
-      --replace "boto3~=1.9, >=1.9.56" "boto3"
+      --replace-fail "pyyaml~=5.1" "pyyaml" \
+      --replace-fail "boto3~=1.9, >=1.9.56" "boto3"
   '';
 
   enabledTestPaths = [ "tests/unit" ];

--- a/pkgs/development/python-modules/signalslot/default.nix
+++ b/pkgs/development/python-modules/signalslot/default.nix
@@ -22,8 +22,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "--pep8 --cov" "" \
-      --replace "--cov-report html" ""
+      --replace-fail "--pep8 --cov" "" \
+      --replace-fail "--cov-report html" ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/simple-rest-client/default.nix
+++ b/pkgs/development/python-modules/simple-rest-client/default.nix
@@ -41,9 +41,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "pytest-runner" ""
+      --replace-fail "pytest-runner" ""
     substituteInPlace requirements-dev.txt \
-      --replace "asyncmock" ""
+      --replace-fail "asyncmock" ""
   '';
 
   disabledTestPaths = [ "tests/test_decorators.py" ];

--- a/pkgs/development/python-modules/skein/default.nix
+++ b/pkgs/development/python-modules/skein/default.nix
@@ -44,8 +44,8 @@ buildPythonPackage rec {
   '';
 
   postPatch = ''
-    substituteInPlace skein/core.py --replace "'yarn'" "'${hadoop}/bin/yarn'" \
-      --replace "else 'java'" "else '${hadoop.jdk}/bin/java'"
+    substituteInPlace skein/core.py --replace-fail "'yarn'" "'${hadoop}/bin/yarn'" \
+      --replace-fail "else 'java'" "else '${hadoop.jdk}/bin/java'"
     # Remove vendorized versioneer
     rm versioneer.py
   ''

--- a/pkgs/development/python-modules/skia-pathops/default.nix
+++ b/pkgs/development/python-modules/skia-pathops/default.nix
@@ -28,16 +28,16 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "build_cmd = [sys.executable, build_skia_py, build_dir]" \
+      --replace-fail "build_cmd = [sys.executable, build_skia_py, build_dir]" \
         'build_cmd = [sys.executable, build_skia_py, "--no-fetch-gn", "--no-virtualenv", "--gn-path", "${gn}/bin/gn", build_dir]'
   ''
   + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
     substituteInPlace src/cpp/skia-builder/skia/gn/skia/BUILD.gn \
-      --replace "-march=armv7-a" "-march=armv8-a" \
-      --replace "-mfpu=neon" "" \
-      --replace "-mthumb" ""
+      --replace-fail "-march=armv7-a" "-march=armv8-a" \
+      --replace-fail "-mfpu=neon" "" \
+      --replace-fail "-mthumb" ""
     substituteInPlace src/cpp/skia-builder/skia/src/core/SkOpts.cpp \
-      --replace "defined(SK_CPU_ARM64)" "0"
+      --replace-fail "defined(SK_CPU_ARM64)" "0"
   ''
   +
     lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) # old compiler?

--- a/pkgs/development/python-modules/social-auth-core/default.nix
+++ b/pkgs/development/python-modules/social-auth-core/default.nix
@@ -62,11 +62,11 @@ buildPythonPackage rec {
   # Disable checking the code coverage
   prePatch = ''
     substituteInPlace social_core/tests/requirements.txt \
-      --replace "coverage>=3.6" "" \
-      --replace "pytest-cov>=2.7.1" ""
+      --replace-fail "coverage>=3.6" "" \
+      --replace-fail "pytest-cov>=2.7.1" ""
 
     substituteInPlace tox.ini \
-      --replace "{posargs:-v --cov=social_core}" "{posargs:-v}"
+      --replace-fail "{posargs:-v --cov=social_core}" "{posargs:-v}"
   '';
 
   pythonImportsCheck = [ "social_core" ];

--- a/pkgs/development/python-modules/sockio/default.nix
+++ b/pkgs/development/python-modules/sockio/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "--durations=2 --verbose" ""
+      --replace-fail "--durations=2 --verbose" ""
   '';
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/soundcard/default.nix
+++ b/pkgs/development/python-modules/soundcard/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage {
 
   patchPhase = ''
     substituteInPlace soundcard/pulseaudio.py \
-      --replace "'pulse'" "'${libpulseaudio}/lib/libpulse.so'"
+      --replace-fail "'pulse'" "'${libpulseaudio}/lib/libpulse.so'"
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace soundfile.py --replace "_find_library('sndfile')" "'${libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
+    substituteInPlace soundfile.py --replace-fail "_find_library('sndfile')" "'${libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/sphinx-automodapi/default.nix
+++ b/pkgs/development/python-modules/sphinx-automodapi/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace sphinx_automodapi/tests/{helpers,test_cases}.py \
-      --replace ", None)" ", (None, '${testInventory}'))"
+      --replace-fail ", None)" ", (None, '${testInventory}'))"
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/sphinxcontrib-tikz/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-tikz/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace sphinxcontrib/tikz.py \
-      --replace "config.latex_engine" "'${
+      --replace-fail "config.latex_engine" "'${
         texliveSmall.withPackages (
           ps: with ps; [
             standalone
@@ -27,7 +27,7 @@ buildPythonPackage rec {
           ]
         )
       }/bin/pdflatex'" \
-      --replace "system(['pdf2svg'" "system(['${pdf2svg}/bin/pdf2svg'"
+      --replace-fail "system(['pdf2svg'" "system(['${pdf2svg}/bin/pdf2svg'"
   '';
 
   propagatedBuildInputs = [ sphinx ];

--- a/pkgs/development/python-modules/sqlmap/default.nix
+++ b/pkgs/development/python-modules/sqlmap/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace sqlmap/thirdparty/magic/magic.py --replace "ctypes.util.find_library('magic')" \
+    substituteInPlace sqlmap/thirdparty/magic/magic.py --replace-fail "ctypes.util.find_library('magic')" \
       "'${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
 
     # the check for the last update date does not work in Nix,

--- a/pkgs/development/python-modules/ssdeep/default.nix
+++ b/pkgs/development/python-modules/ssdeep/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner"' ""
+      --replace-fail '"pytest-runner"' ""
   '';
 
   pythonImportsCheck = [ "ssdeep" ];

--- a/pkgs/development/python-modules/static3/default.nix
+++ b/pkgs/development/python-modules/static3/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace ", 'pytest-cov'" ""
+      --replace-fail ", 'pytest-cov'" ""
   '';
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/strenum/default.nix
+++ b/pkgs/development/python-modules/strenum/default.nix
@@ -33,9 +33,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace '"pytest-runner"' ""
+      --replace-fail '"pytest-runner"' ""
     substituteInPlace pytest.ini \
-      --replace " --cov=strenum --cov-report term-missing --black --pylint" ""
+      --replace-fail " --cov=strenum --cov-report term-missing --black --pylint" ""
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/strictyaml/default.nix
+++ b/pkgs/development/python-modules/strictyaml/default.nix
@@ -19,11 +19,6 @@ buildPythonPackage rec {
     hash = "sha256-IvhUpfyrQrXduoAwoOS+UcqJrwJnlhyNbPqGOVWGxAc=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "ruamel.yaml==0.17.4" "ruamel.yaml"
-  '';
-
   propagatedBuildInputs = [
     ruamel-yaml
     python-dateutil

--- a/pkgs/development/python-modules/subunit/default.nix
+++ b/pkgs/development/python-modules/subunit/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "version=VERSION" 'version="${subunit.version}"'
+      --replace-fail "version=VERSION" 'version="${subunit.version}"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/sudachidict/default.nix
+++ b/pkgs/development/python-modules/sudachidict/default.nix
@@ -23,12 +23,12 @@ buildPythonPackage rec {
   # setup script tries to get data from the network but we use the nixpkgs' one
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'ZIP_NAME = urlparse(ZIP_URL).path.split("/")[-1]' "" \
-      --replace "not os.path.exists(RESOURCE_DIR)" "False"
+      --replace-fail 'ZIP_NAME = urlparse(ZIP_URL).path.split("/")[-1]' "" \
+      --replace-fail "not os.path.exists(RESOURCE_DIR)" "False"
     substituteInPlace INFO.json \
-      --replace "%%VERSION%%" ${version} \
-      --replace "%%DICT_VERSION%%" ${version} \
-      --replace "%%DICT_TYPE%%" ${sudachidict.dict-type}
+      --replace-fail "%%VERSION%%" ${version} \
+      --replace-fail "%%DICT_VERSION%%" ${version} \
+      --replace-fail "%%DICT_TYPE%%" ${sudachidict.dict-type}
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/supervise-api/default.nix
+++ b/pkgs/development/python-modules/supervise-api/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace supervise_api/supervise.py \
-      --replace 'which("supervise")' '"${supervise}/bin/supervise"'
+      --replace-fail 'which("supervise")' '"${supervise}/bin/supervise"'
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/sure/default.nix
+++ b/pkgs/development/python-modules/sure/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "rednose = 1" ""
+      --replace-fail "rednose = 1" ""
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/tailscale/default.nix
+++ b/pkgs/development/python-modules/tailscale/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace 'version = "0.0.0"' 'version = "${version}"'
+      --replace-fail 'version = "0.0.0"' 'version = "${version}"'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/taskw/default.nix
+++ b/pkgs/development/python-modules/taskw/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   ];
   postPatch = ''
     substituteInPlace taskw/warrior.py \
-      --replace '@@taskwarrior@@' '${taskwarrior2}'
+      --replace-fail '@@taskwarrior@@' '${taskwarrior2}'
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/testscenarios/default.nix
+++ b/pkgs/development/python-modules/testscenarios/default.nix
@@ -26,8 +26,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "buffer = 1" "" \
-      --replace "catch = 1" ""
+      --replace-fail "buffer = 1" "" \
+      --replace-fail "catch = 1" ""
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/token-bucket/default.nix
+++ b/pkgs/development/python-modules/token-bucket/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'" ""
+      --replace-fail "'pytest-runner'" ""
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -352,7 +352,7 @@ buildPythonPackage rec {
 
     # Strangely, this is never set in cmake
     substituteInPlace cmake/public/LoadHIP.cmake \
-      --replace "set(ROCM_PATH \$ENV{ROCM_PATH})" \
+      --replace-fail "set(ROCM_PATH \$ENV{ROCM_PATH})" \
         "set(ROCM_PATH \$ENV{ROCM_PATH})''\nset(ROCM_VERSION ${lib.concatStrings (lib.intersperse "0" (lib.splitVersion rocmPackages.clr.version))})"
 
     # Use composable kernel as dependency, rather than built-in third-party

--- a/pkgs/development/python-modules/torchsde/default.nix
+++ b/pkgs/development/python-modules/torchsde/default.nix
@@ -29,12 +29,6 @@ buildPythonPackage rec {
     hash = "sha256-D0p2tL/VvkouXrXfRhMuCq8wMtzeoBTppWEG5vM1qCo=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "numpy==1.19.*" "numpy" \
-      --replace "scipy==1.5.*" "scipy"
-  '';
-
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/tox/default.nix
+++ b/pkgs/development/python-modules/tox/default.nix
@@ -34,11 +34,6 @@ buildPythonPackage rec {
     hash = "sha256-VySdeZDC71vi2mOtjdFJ4iCSpWbFEW3nzrVucPUz/oc=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "packaging>=22" "packaging"
-  '';
-
   nativeBuildInputs = [
     hatchling
     hatch-vcs

--- a/pkgs/development/python-modules/trezor-agent/default.nix
+++ b/pkgs/development/python-modules/trezor-agent/default.nix
@@ -38,12 +38,6 @@ buildPythonPackage rec {
     pinentry
   ];
 
-  # relax dependency constraint
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "trezor[hidapi]>=0.12.0,<0.13" "trezor[hidapi]>=0.12.0,<0.14"
-  '';
-
   doCheck = false;
   pythonImportsCheck = [ "libagent" ];
 

--- a/pkgs/development/python-modules/twentemilieu/default.nix
+++ b/pkgs/development/python-modules/twentemilieu/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream is creating GitHub releases without version
     substituteInPlace pyproject.toml \
-      --replace '"0.0.0"' '"${version}"'
+      --replace-fail '"0.0.0"' '"${version}"'
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/unidic/default.nix
+++ b/pkgs/development/python-modules/unidic/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "wasabi>=0.6.0,<1.0.0" "wasabi"
+      --replace-fail "wasabi>=0.6.0,<1.0.0" "wasabi"
   '';
 
   # no tests

--- a/pkgs/development/python-modules/update-dotdee/default.nix
+++ b/pkgs/development/python-modules/update-dotdee/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace tox.ini \
-      --replace " --cov --showlocals --verbose" ""
+      --replace-fail " --cov --showlocals --verbose" ""
   '';
 
   pythonImportsCheck = [ "update_dotdee" ];

--- a/pkgs/development/python-modules/vaa/default.nix
+++ b/pkgs/development/python-modules/vaa/default.nix
@@ -27,8 +27,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "requires = [\"flit\"]" "requires = [\"flit_core\"]" \
-      --replace "build-backend = \"flit.buildapi\"" "build-backend = \"flit_core.buildapi\""
+      --replace-fail "requires = [\"flit\"]" "requires = [\"flit_core\"]" \
+      --replace-fail "build-backend = \"flit.buildapi\"" "build-backend = \"flit_core.buildapi\""
   '';
 
   nativeBuildInputs = [ flit-core ];

--- a/pkgs/development/python-modules/vacuum-map-parser-base/default.nix
+++ b/pkgs/development/python-modules/vacuum-map-parser-base/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version in the pyproject.toml file
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}"
+      --replace-fail "0.0.0" "${version}"
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/vacuum-map-parser-roborock/default.nix
+++ b/pkgs/development/python-modules/vacuum-map-parser-roborock/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version in the pyproject.toml file
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}"
+      --replace-fail "0.0.0" "${version}"
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/vehicle/default.nix
+++ b/pkgs/development/python-modules/vehicle/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}" \
+      --replace-fail "0.0.0" "${version}" \
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/vg/default.nix
+++ b/pkgs/development/python-modules/vg/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'requires = ["setuptools", "poetry-core>=1.0.0"]' 'requires = ["poetry-core>=1.0.0"]'
+      --replace-fail 'requires = ["setuptools", "poetry-core>=1.0.0"]' 'requires = ["poetry-core>=1.0.0"]'
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/vilfo-api-client/default.nix
+++ b/pkgs/development/python-modules/vilfo-api-client/default.nix
@@ -22,11 +22,6 @@ buildPythonPackage rec {
     hash = "sha256-ZlmriBd+M+54ux/UNYa355mkz808/NxSz7IzmWouA0c=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "get-mac" "getmac"
-  '';
-
   nativeBuildInputs = [ setuptools-scm ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/vsts/default.nix
+++ b/pkgs/development/python-modules/vsts/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ msrest ];
 
   postPatch = ''
-    substituteInPlace setup.py --replace "msrest>=0.6.0,<0.7.0" "msrest"
+    substituteInPlace setup.py --replace-fail "msrest>=0.6.0,<0.7.0" "msrest"
   '';
 
   # Tests are highly impure

--- a/pkgs/development/python-modules/wand/default.nix
+++ b/pkgs/development/python-modules/wand/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace wand/api.py --replace \
+    substituteInPlace wand/api.py --replace-fail \
       "magick_home = os.environ.get('MAGICK_HOME')" \
       "magick_home = '${imagemagickBig}'"
   '';

--- a/pkgs/development/python-modules/warrant-lite/default.nix
+++ b/pkgs/development/python-modules/warrant-lite/default.nix
@@ -28,12 +28,6 @@ buildPythonPackage rec {
     requests
   ];
 
-  postPatch = ''
-    # requirements.txt is not part of the source
-    substituteInPlace setup.py \
-      --replace "parse_requirements('requirements.txt')," "[],"
-  '';
-
   # Tests require credentials
   doCheck = false;
 

--- a/pkgs/development/python-modules/warrant/default.nix
+++ b/pkgs/development/python-modules/warrant/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage {
   # this needs to go when 0.6.2 or later is released
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "python-jose-cryptodome>=1.3.2" "python-jose>=2.0.0"
+      --replace-fail "python-jose-cryptodome>=1.3.2" "python-jose>=2.0.0"
   '';
 
   nativeCheckInputs = [ mock ];

--- a/pkgs/development/python-modules/waterfurnace/default.nix
+++ b/pkgs/development/python-modules/waterfurnace/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "'pytest-runner'," ""
+      --replace-fail "'pytest-runner'," ""
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/wifi/default.nix
+++ b/pkgs/development/python-modules/wifi/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace wifi/scan.py \
-      --replace "/sbin/iwlist" "${wirelesstools}/bin/iwlist"
+      --replace-fail "/sbin/iwlist" "${wirelesstools}/bin/iwlist"
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/yasi/default.nix
+++ b/pkgs/development/python-modules/yasi/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "test.test_yasi" "tests.test_yasi"
+      --replace-fail "test.test_yasi" "tests.test_yasi"
   '';
 
   pythonImportsCheck = [ "yasi" ];

--- a/pkgs/development/python-modules/zigpy-xbee/default.nix
+++ b/pkgs/development/python-modules/zigpy-xbee/default.nix
@@ -27,8 +27,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace ', "setuptools-git-versioning<2"' "" \
-      --replace 'dynamic = ["version"]' 'version = "${version}"'
+      --replace-fail ', "setuptools-git-versioning<2"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/zigpy-zigate/default.nix
+++ b/pkgs/development/python-modules/zigpy-zigate/default.nix
@@ -30,8 +30,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace ', "setuptools-git-versioning<2"' "" \
-      --replace 'dynamic = ["version"]' 'version = "${version}"'
+      --replace-fail ', "setuptools-git-versioning<2"' "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
   '';
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/zstd/default.nix
+++ b/pkgs/development/python-modules/zstd/default.nix
@@ -18,11 +18,6 @@ buildPythonPackage rec {
     hash = "sha256-gixLZXXc0waR695lRUJbUcFOwbLlGfaE70sNBhaSEIg=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "/usr/bin/pkg-config" "${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config"
-  '';
-
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ zstd ];
 


### PR DESCRIPTION
Tracking: https://github.com/NixOS/nixpkgs/issues/356002

This was made semi-manually.

I tried building all packages I changed while I was working on the PR, and I am fairly certain they'll build fine.

The methodology was:
- Replace `--replace` with `--replace-fail` in around ~10 packages.
- Try building them
  - If the package is marked as broken or disabled on all currently supported python3 versions, I just skip it
    - I also skip if the package is not marked as broken, but still failed
  - If there is no rebuild triggered, it is probably behind an `isDarwin` conditional.
    - (In those cases I made sure it worked by forcing the conditional and checking manually)
- In case the substitution fails, check if it makes sense to remove it
  - In most cases, it makes sense. I check those manually to make sure it's fine to remove
  - In a the case of `blivet`, I opted to use `--replace-quiet` instead
  - For `pyu2f` I had to separate out a `substituteInPlace` into two parts
  - In some cases non-trivial changes are needed, I just skipped those
    - I put some of them in another PR: https://github.com/NixOS/nixpkgs/pull/422428
- After the 10 packages (or less if they were skipped), are deemed to build fine with the changes, git stash them, so that they don't cause rebuilds in the next iteration of 10 packages


---

Here's a script that  only checks out the changes
to the file that the package is defined in and then builds it.
It takes a few hours to run and will generate a `failed.txt` file (which will hopefully be empty).

Do note that some changes are behind optional flags, so this check is not 100% thorough.

```bash
#!/usr/bin/env bash

set -eou pipefail

# put the branch name here
# or just the git revision
branch="python-replace"

changed_files=$(git diff --name-only "$branch"~ "$branch")

git co "$branch"~
git reset "$branch"~ --hard

echo "The following packages failed to build:" > ./failed.txt

for file in $changed_files; do

  stripped=${file#pkgs/development/python-modules/}

  if [[ "$stripped" == "capstone/4.nix" ]]; then
    attrname="capstone_4"
  elif [[ "$stripped" == "numpy/1.nix" ]]; then
    attrname="numpy_1"
  elif [[ "$stripped" == "django/4.nix" ]]; then
    attrname="django_4"
  elif [[ "$stripped" == "torch/source/default.nix" ]]; then
    attrname="torch"
  elif [[ "$stripped" == "pytidylib/default.nix" ]]; then
    attrname="tidylib"
  elif [[ "$stripped" == "sudachidict/default.nix" ]]; then
    attrname="sudachidict-core"
  else
    attrname=$(dirname "$stripped")
  fi

  case "$attrname" in
    "deepwave"|"mip")
      # I didn't want to wait out the long tests...
      continue
      ;;
    "bacpypes"|"bwapy"|"pytest-cram")
      # disabled for higher versions
      python_pkgs="python311Packages"
      ;;
    "blockchain"|"certipy-ad"|"dataclasses-serialization"|"gradient-utils"|\
    "gradient"|"nampa"|"nipype"|"numpy_1"|"palace"|"pyrevolve"|"update-dotdee")
      # disabled for higher versions
      python_pkgs="python312Packages"
      ;;
    *)
      python_pkgs="python313Packages"
      ;;
  esac

  to_build="$python_pkgs"."$attrname"

  # Pull in the changes for one specific file
  git checkout "$branch" -- "$file"

  echo "Building python package: $attrname"
  if ! nix-build -A "$to_build"; then
    echo "Build failed for $attrname"
    echo "$attrname" >> ./failed.txt
  fi

  git reset "$branch"~ --hard
done
```

---

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
