### PR TITLE
_1password-gui{,beta} 8.10.82, 8.11.0-25.BETA

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -42,15 +42,15 @@
       }
     },
     "darwin": {
-      "version": "8.10.82-27.BETA",
+      "version": "8.11.0-25.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.82-27.BETA-x86_64.zip",
-          "hash": "sha256-jCxzPxRvb7gjhDeZVcTcuED4N436aJsivpfgae9dVc0="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.0-25.BETA-x86_64.zip",
+          "hash": "sha256-9cE31VdYoxFnxsO0jOLQsXA2SEBUdy7ABvUIfsGEE04="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.82-27.BETA-aarch64.zip",
-          "hash": "sha256-PibtIpKpyp0+jkzZ9odNow6Gew/fjWy9EvdIgeewpA4="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.0-25.BETA-aarch64.zip",
+          "hash": "sha256-bxBoJZSt7znOhiIu20Nuq5MzNyS1HzLkNyt/cgY1dBg="
         }
       }
     }

--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.10.80",
+      "version": "8.10.82",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.80.x64.tar.gz",
-          "hash": "sha256-fxhLeeJzzbIhRZcrLnkBvrwAA+jzGeOhnmiH3ErlDTE="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.82.x64.tar.gz",
+          "hash": "sha256-/mpp+HRQO7Xu+faYUzq00LxFrDRTod7Wvro3IoVGFAg="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.80.arm64.tar.gz",
-          "hash": "sha256-Ffr7Xow6ZMGE4Spf3QfDoSydR3OXasMpM3ttiiPup+Q="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.82.arm64.tar.gz",
+          "hash": "sha256-DiZVlq0xVGeCh6x5Bt8KP7B0iC15prvQrd9dnAmjWCI="
         }
       }
     },
     "darwin": {
-      "version": "8.10.80",
+      "version": "8.10.82",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.80-x86_64.zip",
-          "hash": "sha256-4b7mocNt/H9xiai9E9pqT5LWNsRi6Skr+F1vctfmU3k="
+          "url": "https://downloads.1password.com/mac/1Password-8.10.82-x86_64.zip",
+          "hash": "sha256-LATm0OcX+i02X3byaKQA32PpOXDyQFzyJVOgNzgtfYM="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.80-aarch64.zip",
-          "hash": "sha256-8PJq6VVTAMQWLP9rLwOhtK02KZckn7ps4evDPL6EvYs="
+          "url": "https://downloads.1password.com/mac/1Password-8.10.82-aarch64.zip",
+          "hash": "sha256-uXtXDfCE+CFaOXqpSEKh2x7lzeYOhrHoH017NzNS2p8="
         }
       }
     }


### PR DESCRIPTION
- **_1password-gui: 8.10.80 -> 8.10.82**
- **_1password-gui-beta: 8.10.82-27.BETA -> 8.11.0-25.BETA**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
