### PR TITLE
go_1_25: init at 1.25rc2

### DIFF
--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -1,0 +1,173 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  apple-sdk_12,
+  tzdata,
+  replaceVars,
+  iana-etc,
+  mailcap,
+  buildPackages,
+  pkgsBuildTarget,
+  targetPackages,
+  testers,
+  skopeo,
+  buildGo125Module,
+}:
+
+let
+  goBootstrap = buildPackages.callPackage ./bootstrap122.nix { };
+
+  skopeoTest = skopeo.override { buildGoModule = buildGo125Module; };
+
+  # We need a target compiler which is still runnable at build time,
+  # to handle the cross-building case where build != host == target
+  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
+
+  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "go";
+  version = "1.25rc2";
+
+  src = fetchurl {
+    url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
+    hash = "sha256-5jFKMjTEwDuNAGvNHRRZTZKBcNGES23/3V+lojM0SeE=";
+  };
+
+  strictDeps = true;
+  buildInputs =
+    [ ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.libc.out ]
+    ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+  depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [
+    apple-sdk_12
+  ];
+
+  depsBuildTarget = lib.optional isCross targetCC;
+
+  depsTargetTarget = lib.optional stdenv.targetPlatform.isWindows targetPackages.threads.package;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  patches = [
+    (replaceVars ./iana-etc-1.25.patch {
+      iana = iana-etc;
+    })
+    # Patch the mimetype database location which is missing on NixOS.
+    # but also allow static binaries built with NixOS to run outside nix
+    (replaceVars ./mailcap-1.17.patch {
+      inherit mailcap;
+    })
+    # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
+    # that run outside a nix server
+    (replaceVars ./tzdata-1.19.patch {
+      inherit tzdata;
+    })
+    ./remove-tools-1.11.patch
+    ./go_no_vendor_checks-1.23.patch
+  ];
+
+  inherit (stdenv.targetPlatform.go) GOOS GOARCH GOARM;
+  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+  # Go will nevertheless build a for host system that we will copy over in
+  # the install phase.
+  GOHOSTOS = stdenv.buildPlatform.go.GOOS;
+  GOHOSTARCH = stdenv.buildPlatform.go.GOARCH;
+
+  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+  # to be different from CC/CXX
+  CC_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}cc" else null;
+  CXX_FOR_TARGET = if isCross then "${targetCC}/bin/${targetCC.targetPrefix}c++" else null;
+
+  GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
+  # Wasi does not support CGO
+  CGO_ENABLED = if stdenv.targetPlatform.isWasi then 0 else 1;
+
+  GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
+
+  buildPhase = ''
+    runHook preBuild
+    export GOCACHE=$TMPDIR/go-cache
+
+    export PATH=$(pwd)/bin:$PATH
+
+    ${lib.optionalString isCross ''
+      # Independent from host/target, CC should produce code for the building system.
+      # We only set it when cross-compiling.
+      export CC=${buildPackages.stdenv.cc}/bin/cc
+    ''}
+    ulimit -a
+
+    pushd src
+    ./make.bash
+    popd
+    runHook postBuild
+  '';
+
+  preInstall =
+    ''
+      # Contains the wrong perl shebang when cross compiling,
+      # since it is not used for anything we can deleted as well.
+      rm src/regexp/syntax/make_perl_groups.pl
+    ''
+    + (
+      if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then
+        ''
+          mv bin/*_*/* bin
+          rmdir bin/*_*
+          ${lib.optionalString
+            (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS))
+            ''
+              rm -rf pkg/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH} pkg/tool/${finalAttrs.GOHOSTOS}_${finalAttrs.GOHOSTARCH}
+            ''
+          }
+        ''
+      else
+        lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
+          rm -rf bin/*_*
+          ${lib.optionalString
+            (!(finalAttrs.GOHOSTARCH == finalAttrs.GOARCH && finalAttrs.GOOS == finalAttrs.GOHOSTOS))
+            ''
+              rm -rf pkg/${finalAttrs.GOOS}_${finalAttrs.GOARCH} pkg/tool/${finalAttrs.GOOS}_${finalAttrs.GOARCH}
+            ''
+          }
+        ''
+    );
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/go
+    cp -a bin pkg src lib misc api doc go.env VERSION $out/share/go
+    mkdir -p $out/bin
+    ln -s $out/share/go/bin/* $out/bin
+    runHook postInstall
+  '';
+
+  disallowedReferences = [ goBootstrap ];
+
+  passthru = {
+    inherit goBootstrap skopeoTest;
+    tests = {
+      skopeo = testers.testVersion { package = skopeoTest; };
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "go version";
+        version = "go${finalAttrs.version}";
+      };
+    };
+  };
+
+  meta = with lib; {
+    changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor finalAttrs.version}";
+    description = "Go Programming language";
+    homepage = "https://go.dev/";
+    license = licenses.bsd3;
+    teams = [ teams.golang ];
+    platforms = platforms.darwin ++ platforms.linux ++ platforms.wasi ++ platforms.freebsd;
+    mainProgram = "go";
+  };
+})

--- a/pkgs/development/compilers/go/iana-etc-1.25.patch
+++ b/pkgs/development/compilers/go/iana-etc-1.25.patch
@@ -1,0 +1,26 @@
+diff --git a/src/net/lookup_unix.go b/src/net/lookup_unix.go
+index 7416cb01f8..62722cab14 100644
+--- a/src/net/lookup_unix.go
++++ b/src/net/lookup_unix.go
+@@ -15,7 +15,7 @@ import (
+ // readProtocolsOnce loads contents of /etc/protocols into protocols map
+ // for quick access.
+ var readProtocolsOnce = sync.OnceFunc(func() {
+-	file, err := open("/etc/protocols")
++	file, err := open("@iana@/etc/protocols")
+ 	if err != nil {
+ 		return
+ 	}
+diff --git a/src/net/port_unix.go b/src/net/port_unix.go
+index df73dbabb3..a5dcf2ca1c 100644
+--- a/src/net/port_unix.go
++++ b/src/net/port_unix.go
+@@ -16,7 +16,7 @@ import (
+ var onceReadServices sync.Once
+ 
+ func readServices() {
+-	file, err := open("/etc/services")
++	file, err := open("@iana@/etc/services")
+ 	if err != nil {
+ 		return
+ 	}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9865,6 +9865,11 @@ with pkgs;
     go = buildPackages.go_1_24;
   };
 
+  go_1_25 = callPackage ../development/compilers/go/1.25.nix { };
+  buildGo125Module = callPackage ../build-support/go/module.nix {
+    go = buildPackages.go_1_25;
+  };
+
   ### DEVELOPMENT / HARE
 
   hareHook = callPackage ../by-name/ha/hare/hook.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://go.dev/doc/go1.25

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
___
`depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin` this is how we used to handle newer versions of the apple sdk for go, still need to check if that is correct or not.

```diff
--- pkgs/development/compilers/go/1.24.nix	2025-06-27 10:37:37
+++ pkgs/development/compilers/go/1.25.nix	2025-06-27 11:21:38
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  apple-sdk_12,
   tzdata,
   replaceVars,
   iana-etc,
@@ -11,13 +12,13 @@
   targetPackages,
   testers,
   skopeo,
-  buildGo124Module,
+  buildGo125Module,
 }:
 
 let
   goBootstrap = buildPackages.callPackage ./bootstrap122.nix { };
 
-  skopeoTest = skopeo.override { buildGoModule = buildGo124Module; };
+  skopeoTest = skopeo.override { buildGoModule = buildGo125Module; };
 
   # We need a target compiler which is still runnable at build time,
   # to handle the cross-building case where build != host == target
@@ -27,11 +28,11 @@
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.24.4";
+  version = "1.25rc1";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-WoaoOjH5+oFJC4xUIKw4T9PZWj5x+6Zlx7P5XR3+8rQ=";
+    hash = "sha256-DNZ3L+Ezp4T7t6CdbaMImJf+9I0DohchQ0v4gYilhik=";
   };
 
   strictDeps = true;
@@ -40,6 +41,10 @@
     ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.libc.out ]
     ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
 
+  depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [
+    apple-sdk_12
+  ];
+
   depsBuildTarget = lib.optional isCross targetCC;
 
   depsTargetTarget = lib.optional stdenv.targetPlatform.isWindows targetPackages.threads.package;
@@ -49,7 +54,7 @@
   '';
 
   patches = [
-    (replaceVars ./iana-etc-1.17.patch {
+    (replaceVars ./iana-etc-1.25.patch {
       iana = iana-etc;
     })
     # Patch the mimetype database location which is missing on NixOS.

```