### PR TITLE
python3Packages.sqlite-vec: init at 0.1.6

### DIFF
--- a/pkgs/development/python-modules/sqlite-vec/default.nix
+++ b/pkgs/development/python-modules/sqlite-vec/default.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchpatch,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  sqlite-vec-c, # alias for pkgs.sqlite-vec
+
+  # optional dependencies
+  numpy,
+
+  # check inputs
+  openai,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  inherit (sqlite-vec-c) pname version src;
+  pyproject = true;
+
+  # The actual source root is bindings/python but the patches
+  # apply to the bindings directory.
+  # This is a known issue, see https://discourse.nixos.org/t/how-to-apply-patches-with-sourceroot/59727
+  sourceRoot = "${src.name}/bindings";
+
+  patches = [
+    (fetchpatch {
+      # https://github.com/asg017/sqlite-vec/pull/233
+      name = "add-python-build-files.patch";
+      url = "https://github.com/asg017/sqlite-vec/commit/c1917deb11aa79dcac32440679345b93e13b1b86.patch";
+      hash = "sha256-4/9QLKuM/1AbD8AQHwJ14rhWVYVc+MILvK6+tWwWQlw=";
+      stripLen = 1;
+    })
+    (fetchpatch {
+      # https://github.com/asg017/sqlite-vec/pull/233
+      name = "add-python-test.patch";
+      url = "https://github.com/asg017/sqlite-vec/commit/608972c9dcbfc7f4583e99fd8de6e5e16da11081.patch";
+      hash = "sha256-8dfw7zs7z2FYh8DoAxurMYCDMOheg8Zl1XGcPw1A1BM=";
+      stripLen = 1;
+    })
+  ];
+
+  # Change into the proper directory for building, move `extra_init.py` into its proper location,
+  # and supply the path to the library.
+  postPatch = ''
+    cd python
+    mv extra_init.py sqlite_vec/
+    substituteInPlace sqlite_vec/__init__.py \
+      --replace-fail "@libpath@" "${lib.getLib sqlite-vec-c}/lib/"
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    sqlite-vec-c
+  ];
+
+  optional-dependencies = {
+    numpy = [
+      numpy
+    ];
+  };
+
+  nativeCheckInputs = [
+    numpy
+    openai
+    pytestCheckHook
+    sqlite-vec-c
+  ];
+
+  pythonImportsCheck = [ "sqlite_vec" ];
+
+  meta = sqlite-vec-c.meta // {
+    description = "Python bindings for sqlite-vec";
+    maintainers = [ lib.maintainers.sarahec ];
+    badPlatforms = [ "x86_64-darwin" ];
+  };
+}

--- a/pkgs/development/python-modules/sqlite-vec/default.nix
+++ b/pkgs/development/python-modules/sqlite-vec/default.nix
@@ -80,6 +80,9 @@ buildPythonPackage rec {
   meta = sqlite-vec-c.meta // {
     description = "Python bindings for sqlite-vec";
     maintainers = [ lib.maintainers.sarahec ];
-    badPlatforms = [ "x86_64-darwin" ];
+    badPlatforms = [
+      # segfaults during test
+      "x86_64-darwin"
+    ];
   };
 }

--- a/pkgs/development/python-modules/txtai/default.nix
+++ b/pkgs/development/python-modules/txtai/default.nix
@@ -24,7 +24,7 @@
   hnswlib,
   pgvector,
   sqlalchemy,
-  sqlite-vec,
+  sqlite-vec-c,
   # api
   aiohttp,
   fastapi,
@@ -103,7 +103,7 @@ let
     hnswlib
     pgvector
     sqlalchemy
-    sqlite-vec
+    sqlite-vec-c
   ];
   api = [
     aiohttp

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17009,6 +17009,10 @@ self: super: with self; {
 
   sqlite-utils = callPackage ../development/python-modules/sqlite-utils { };
 
+  sqlite-vec = callPackage ../development/python-modules/sqlite-vec {
+    sqlite-vec-c = pkgs.sqlite-vec;
+  };
+
   sqlitedict = callPackage ../development/python-modules/sqlitedict { };
 
   sqliteschema = callPackage ../development/python-modules/sqliteschema { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18312,7 +18312,7 @@ self: super: with self; {
 
   txrequests = callPackage ../development/python-modules/txrequests { };
 
-  txtai = callPackage ../development/python-modules/txtai { };
+  txtai = callPackage ../development/python-modules/txtai { sqlite-vec-c = pkgs.sqlite-vec; };
 
   txtorcon = callPackage ../development/python-modules/txtorcon { };
 


### PR DESCRIPTION
`sqlite-vec` exists as a C library, this provides the Python interfaces.

~~Building from PyPi wheels as the Github sources don't provide any mechanism for building. No tests in package.~~

Added missing files needed for a source build plus a test.

P.S. This is a requirement for bringing `python3Packages.langgraph-checkpoint-sqlite` up to date

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
