### PR TITLE
balsa: 2.6.4 -> 2.6.5, modernize

### DIFF
--- a/pkgs/by-name/ba/balsa/package.nix
+++ b/pkgs/by-name/ba/balsa/package.nix
@@ -1,41 +1,44 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   glib,
   gmime3,
   gnutls,
-  gobject-introspection,
   gpgme,
   gtk3,
   gtksourceview4,
   gtkspell3,
-  intltool,
   libcanberra-gtk3,
   libesmtp,
   libical,
   libnotify,
   libsecret,
   openssl,
+  meson,
+  ninja,
   pkg-config,
   sqlite,
   webkitgtk_4_0,
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "balsa";
-  version = "2.6.4";
+  version = "2.6.5";
 
-  src = fetchurl {
-    url = "https://pawsa.fedorapeople.org/balsa/${pname}-${version}.tar.xz";
-    sha256 = "1hcgmjka2x2igdrmvzlfs12mv892kv4vzv5iy90kvcqxa625kymy";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "balsa";
+    tag = finalAttrs.version;
+    hash = "sha256-KvgDIFbXmVkTqOibKF+8UhupEDgdhje600aSbmeKZqo=";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     pkg-config
-    intltool
-    gobject-introspection
     wrapGAppsHook3
   ];
 
@@ -57,6 +60,10 @@ stdenv.mkDerivation rec {
     webkitgtk_4_0
   ];
 
+  mesonFlags = [
+    (lib.mesonOption "sysconfdir" "etc")
+  ];
+
   configureFlags = [
     "--with-canberra"
     "--with-gtksourceview"
@@ -70,11 +77,13 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
-    homepage = "http://pawsa.fedorapeople.org/balsa/";
+  meta = {
     description = "E-mail client for GNOME";
-    license = licenses.gpl2Plus;
-    platforms = platforms.unix;
-    maintainers = [ maintainers.romildo ];
+    homepage = "https://gitlab.gnome.org/GNOME/balsa";
+    changelog = "https://gitlab.gnome.org/GNOME/balsa/-/blob/master/ChangeLog";
+    mainProgram = "balsa";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ romildo ];
   };
-}
+})

--- a/pkgs/by-name/ba/balsa/package.nix
+++ b/pkgs/by-name/ba/balsa/package.nix
@@ -84,6 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "balsa";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ romildo ];
+    maintainers = with lib.maintainers; [ timon ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Latest version not available via fedora (after 2 month).
I therefore switch src and links to official repo (gnome gitlab). 
https://gitlab.gnome.org/GNOME/balsa/-/releases/2.6.5
I also included some other modernization
- use meson for build
- use `finalAttrs` instead of rec
- removed `meta = with lib;`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
