### PR TITLE
nixos/corteza: init, nixosTests.corteza: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -36,6 +36,8 @@
 
 - Docker now defaults to 28.x, because version 27.x stopped receiving security updates and bug fixes after [May 2, 2025](https://github.com/moby/moby/pull/49910).
 
+- [Corteza](https://cortezaproject.org/), a low-code platform. Available as [services.corteza](#opt-services.corteza.enable).
+
 - [Draupnir](https://github.com/the-draupnir-project/draupnir), a Matrix moderation bot. Available as [services.draupnir](#opt-services.draupnir.enable).
 
 - [postfix-tlspol](https://github.com/Zuplu/postfix-tlspol), MTA-STS and DANE resolver and TLS policy server for Postfix. Available as [services.postfix-tlspol](#opt-services.postfix-tlspol.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -579,6 +579,7 @@
   ./services/development/athens.nix
   ./services/development/blackfire.nix
   ./services/development/bloop.nix
+  ./services/development/corteza.nix
   ./services/development/distccd.nix
   ./services/development/gemstash.nix
   ./services/development/hoogle.nix

--- a/nixos/modules/services/development/corteza.nix
+++ b/nixos/modules/services/development/corteza.nix
@@ -1,0 +1,113 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.corteza;
+in
+{
+  options.services.corteza = {
+    enable = lib.mkEnableOption "Corteza, a low-code platform";
+    package = lib.mkPackageOption pkgs "corteza" { };
+
+    address = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = ''
+        IP for the HTTP server.
+      '';
+    };
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 80;
+      description = ''
+        Port for the HTTP server.
+      '';
+    };
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = "Whether to open ports in the firewall.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "corteza";
+      description = "The user to run Corteza under.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "corteza";
+      description = "The group to run Corteza under.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf lib.types.str;
+        options = {
+          HTTP_WEBAPP_ENABLED = lib.mkEnableOption "webapps" // {
+            default = true;
+            apply = toString;
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Configuration for Corteza, will be passed as environment variables.
+        See <https://docs.cortezaproject.org/corteza-docs/2024.9/devops-guide/references/configuration/server.html>.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !cfg.settings ? HTTP_ADDR;
+        message = "Use `services.corteza.address` and `services.corteza.port` instead.";
+      }
+    ];
+
+    warnings = lib.optional (!cfg.settings ? DB_DSN) ''
+      A database connection string is not set.
+      Corteza will create a temporary SQLite database in memory, but it will not persist data.
+      For production use, set `services.corteza.settings.DB_DSN`.
+    '';
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+
+    systemd.services.corteza = {
+      description = "Corteza";
+      documentation = [ "https://docs.cortezaproject.org/" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = {
+        HTTP_WEBAPP_BASE_DIR = "./webapp";
+        HTTP_ADDR = "${cfg.address}:${toString cfg.port}";
+      } // cfg.settings;
+      path = [ pkgs.dart-sass ];
+      serviceConfig = {
+        WorkingDirectory = cfg.package;
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${lib.getExe cfg.package} serve-api";
+      };
+    };
+
+    users = {
+      groups.${cfg.group} = { };
+      users.${cfg.user} = {
+        inherit (cfg) group;
+        isSystemUser = true;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    prince213
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -347,6 +347,7 @@ in
   containers-unified-hierarchy = runTest ./containers-unified-hierarchy.nix;
   convos = runTest ./convos.nix;
   corerad = handleTest ./corerad.nix { };
+  corteza = runTest ./corteza.nix;
   cosmic = runTest {
     imports = [ ./cosmic.nix ];
     _module.args.testName = "cosmic";

--- a/nixos/tests/corteza.nix
+++ b/nixos/tests/corteza.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+let
+  port = 8080;
+in
+{
+  name = "corteza";
+  meta.maintainers = [ lib.teams.ngi.members ];
+
+  nodes.machine = {
+    services.corteza = {
+      enable = true;
+      inherit port;
+    };
+  };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("default.target")
+
+    machine.wait_until_succeeds("curl http://localhost:${toString port}/auth/login | grep button-login")
+  '';
+}

--- a/pkgs/by-name/co/corteza/package.nix
+++ b/pkgs/by-name/co/corteza/package.nix
@@ -5,6 +5,7 @@
   callPackage,
   fetchFromGitHub,
   lib,
+  nixosTests,
   stdenvNoCC,
 }:
 
@@ -161,6 +162,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru = {
     srcs = { inherit corteza-server corteza-webapp; };
+    tests = { inherit (nixosTests) corteza; };
   };
 
   inherit (corteza-server) meta;


### PR DESCRIPTION
Related to:
- https://github.com/ngi-nix/projects/issues/112
- https://github.com/NixOS/nixpkgs/pull/419513

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
