### PR TITLE
[Backport release-25.05] nvchecker: 2.16 -> 2.18; adopt; set passthru.updateScript

### DIFF
--- a/pkgs/development/python-modules/nvchecker/default.nix
+++ b/pkgs/development/python-modules/nvchecker/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "nvchecker";
-  version = "2.16";
+  version = "2.17";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "lilydjwg";
     repo = "nvchecker";
     tag = "v${version}";
-    hash = "sha256-HdL3BnjQZzKXtjhQqDst6dJH82g3BONFsGUnwzDMRDA=";
+    hash = "sha256-jA41WoD0WXdb8CM9dUchIAhYd4GoUA9zLYbkaPIScLg=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/nvchecker/default.nix
+++ b/pkgs/development/python-modules/nvchecker/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "nvchecker";
-  version = "2.17";
+  version = "2.18";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "lilydjwg";
     repo = "nvchecker";
     tag = "v${version}";
-    hash = "sha256-jA41WoD0WXdb8CM9dUchIAhYd4GoUA9zLYbkaPIScLg=";
+    hash = "sha256-6uFox07mZeKwyhRXGuU8dMoPhLB5CkgdLaWCfG2dy4k=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/nvchecker/default.nix
+++ b/pkgs/development/python-modules/nvchecker/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   docutils,
   fetchFromGitHub,
+  nix-update-script,
   flaky,
   installShellFiles,
   pycurl,
@@ -77,11 +78,13 @@ buildPythonPackage rec {
     htmlparser = [ lxml ];
   };
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "New version checker for software";
     homepage = "https://github.com/lilydjwg/nvchecker";
     changelog = "https://github.com/lilydjwg/nvchecker/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.mdaniels5757 ];
   };
 }


### PR DESCRIPTION
Manual backport of #408274 and #420008 to `release-25.05`.

- [X] Built and tested on `x86_64-linux`.
- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.