### PR TITLE
(mostly) Pass nixpkgs release checks on RISC-V

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1115,7 +1115,7 @@ let
             publisher = "Continue";
             version = "1.1.49";
           }
-          // sources.${stdenv.system};
+          // sources.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
         nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
         buildInputs = [ (lib.getLib stdenv.cc.cc) ];
         meta = {
@@ -1387,7 +1387,7 @@ let
             publisher = "devsense";
             version = "1.41.14332";
           }
-          // sources.${stdenv.system};
+          // sources.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
 
         nativeBuildInputs = [ autoPatchelfHook ];
 
@@ -3334,7 +3334,7 @@ let
             publisher = "ms-dotnettools";
             version = "2.2.3";
           }
-          // sources.${stdenv.system};
+          // sources.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
         nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
         buildInputs = [
           (lib.getLib stdenv.cc.cc)

--- a/pkgs/by-name/bu/bulloak/package.nix
+++ b/pkgs/by-name/bu/bulloak/package.nix
@@ -47,7 +47,9 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   # provide the list of solc versions to the `svm-rs-builds` dependency
-  SVM_RELEASES_LIST_JSON = solc-versions.${stdenv.hostPlatform.system};
+  SVM_RELEASES_LIST_JSON =
+    solc-versions.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   meta = {
     description = "Solidity test generator based on the Branching Tree Technique";

--- a/pkgs/by-name/da/daytona-bin/package.nix
+++ b/pkgs/by-name/da/daytona-bin/package.nix
@@ -30,7 +30,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         };
       };
     in
-    fetchurl urls."${stdenvNoCC.hostPlatform.system}";
+    fetchurl (
+      urls."${stdenvNoCC.hostPlatform.system}"
+        or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}")
+    );
 
   dontUnpack = true;
 

--- a/pkgs/by-name/no/notion-app/package.nix
+++ b/pkgs/by-name/no/notion-app/package.nix
@@ -5,7 +5,9 @@
   unzip,
 }:
 let
-  info = (lib.importJSON ./info.json)."${stdenvNoCC.hostPlatform.parsed.cpu.name}-darwin";
+  info =
+    (lib.importJSON ./info.json)."${stdenvNoCC.hostPlatform.parsed.cpu.name}-darwin"
+      or (throw "Unsupported CPU architecture: ${stdenvNoCC.hostPlatform.parsed.cpu.name}");
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "notion-app";

--- a/pkgs/by-name/wk/wkhtmltopdf/package.nix
+++ b/pkgs/by-name/wk/wkhtmltopdf/package.nix
@@ -124,5 +124,7 @@ stdenv.mkDerivation (
     };
   }
   // lib.optionalAttrs (stdenv.hostPlatform.isDarwin) darwinAttrs
-  // lib.optionalAttrs (stdenv.hostPlatform.isLinux) linuxAttrs.${stdenv.system}
+  //
+    lib.optionalAttrs (stdenv.hostPlatform.isLinux)
+      linuxAttrs.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}")
 )

--- a/pkgs/by-name/ze/zenn-cli/package.nix
+++ b/pkgs/by-name/ze/zenn-cli/package.nix
@@ -24,7 +24,9 @@ let
   go-turbo = stdenv.mkDerivation {
     pname = "go-turbo";
     version = go-turbo-version;
-    src = go-turbo-srcs.${stdenv.hostPlatform.system};
+    src =
+      go-turbo-srcs.${stdenv.hostPlatform.system}
+        or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
     nativeBuildInputs = [ autoPatchelfHook ];
     dontBuild = true;
     installPhase = ''

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -484,6 +484,7 @@ stdenv.mkDerivation {
             "aarch64" = "AArch64";
           }
           .${targetPlatform.parsed.cpu.name}
+            or (throw "Unsupported CPU architecture: ${targetPlatform.parsed.cpu.name}")
         }
       "
       buildProject llvm llvm-project/llvm

--- a/pkgs/development/python-modules/tritonclient/default.nix
+++ b/pkgs/development/python-modules/tritonclient/default.nix
@@ -35,8 +35,11 @@ buildPythonPackage rec {
       inherit pname version format;
       python = "py3";
       dist = "py3";
-      platform = platforms.${stdenv.hostPlatform.system} or { };
-      sha256 = hashes.${stdenv.hostPlatform.system} or { };
+      platform =
+        platforms.${stdenv.hostPlatform.system}
+          or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+      sha256 =
+        hashes.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
     };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/vl-convert-python/librusty_v8.nix
+++ b/pkgs/development/python-modules/vl-convert-python/librusty_v8.nix
@@ -10,7 +10,9 @@ let
     fetchurl {
       name = "librusty_v8-${args.version}";
       url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
-      sha256 = args.shas.${stdenv.hostPlatform.system};
+      sha256 =
+        args.shas.${stdenv.hostPlatform.system}
+          or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
       meta = {
         inherit (args) version;
         sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -170,6 +170,7 @@ let
       "aarch64" = "AArch64";
     }
     .${llvmStdenv.targetPlatform.parsed.cpu.name}
+      or (throw "Unsupported CPU architecture: ${llvmStdenv.targetPlatform.parsed.cpu.name}")
   }";
   # -ffat-lto-objects = emit LTO object files that are compatible with non-LTO-supporting builds too
   # FatLTO objects are a special type of fat object file that contain LTO compatible IR in addition to generated object code,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1387,6 +1387,8 @@ with pkgs;
       pkgsCross.gnu32.callPackage ../applications/emulators/box86 args
     else if stdenv.hostPlatform.isAarch64 then
       pkgsCross.armv7l-hf-multiplatform.callPackage ../applications/emulators/box86 args
+    else if stdenv.hostPlatform.isRiscV64 then
+      pkgsCross.riscv32.callPackage ../applications/emulators/box86 args
     else
       throw "Don't know 32-bit platform for cross from: ${stdenv.hostPlatform.stdenv}";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Aside from box86, rocm, and swift, these packages only support a limited set of architectures or systems, and dereference a small attrset with the architecture name or the like. This works fine if you are only targeting x86_64 or amd64, however it doesn’t work on riscv. I have added `throw` fallbacks to the ones that cause failures in nixpkgs’ release checks.

rocm and swift use LLVM as the code generator, which does support RISC-V but I have not verified if they support RISC-V so i kept them disabled.

This doesn’t fully fix the errors, as many derivations require the `arch` property to be set in the parsed CPU info. It is unclear to me whether this is a bug in [lib/systems/parse.nix](https://github.com/DarkKirb/nixpkgs/commit/4a787ca2293d1400594d75fbc2d2b66cf36d6be7) or whether that property is just deprecated

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
