### PR TITLE
vscode-extensions.chrischinchilla.vscode-pandoc: 0.4.8 -> 0.6.2

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/chrischinchilla.vscode-pandoc/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/chrischinchilla.vscode-pandoc/default.nix
@@ -10,8 +10,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "vscode-pandoc";
     publisher = "chrischinchilla";
-    version = "0.4.8";
-    hash = "sha256-+U6AtT2wf1mE92IR+mv4aKD9/78ULus2GuwwgxdCvBA=";
+    version = "0.6.2";
+    hash = "sha256-d2nVjVTwvVSQXnhTdqv5gLV44L6FWGbHGZtCplbUQz4=";
   };
   nativeBuildInputs = [
     jq


### PR DESCRIPTION

### Automatic Update for `vscode-extensions.chrischinchilla.vscode-pandoc`
- **Old version**: `0.4.8`
- **New version**: `0.6.2`
- This PR was generated by a GitHub Actions workflow.
