### PR TITLE
workflows/labels: a few fixes

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
+          retries: 3
           script: |
             const Bottleneck = require('bottleneck')
             const path = require('node:path')

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -390,7 +390,7 @@ jobs:
                   // so it should certainly be hit on the next iteration.
                   // TODO: Evaluate after a while, whether the above holds still true and potentially implement
                   // an overlap between runs.
-                  page: total_runs % Math.ceil(total_pulls / 100)
+                  page: (total_runs % Math.ceil(total_pulls / 100)) + 1
                 })).data
 
                 // Some items might be in both search results, so filtering out duplicates as well.

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -247,6 +247,7 @@ jobs:
                   .sort((a,b) => b-a)
                   .at(0) ?? item.created_at
                 )
+                log('latest_event_at', latest_event_at.toISOString())
 
                 const stale_at = new Date(new Date().setDate(new Date().getDate() - 180))
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -147,8 +147,6 @@ jobs:
                   ...context.repo,
                   workflow_id: 'pr.yml',
                   event: 'pull_request_target',
-                  // In pull_request contexts the workflow is still running.
-                  status: context.payload.pull_request ? undefined : 'success',
                   exclude_pull_requests: true,
                   head_sha: pull_request.head.sha
                 })).data.workflow_runs[0]?.id ??


### PR DESCRIPTION
This takes the 3 smaller fixes from #419878, because there is no need to wait merging them.

Also it tries to fix [random failures of the scheduled labels job](https://github.com/NixOS/nixpkgs/actions/workflows/labels.yml?query=event%3Aschedule%20is%3Afailure). Those happen a few times each day and each of them fails with a single HttpError of different sorts. I'm hoping that those would be caught by actions/github-script's `retries` option - and would work when retrying.

(I don't care much about those random failures in the log... but the annoying thing with a scheduled workflow is, that whoever touched it last will be *notified* about those failures. So I get multiple notifications each day for this...)

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
