### PR TITLE
tinygo: 0.37.0 -> 0.39.0

### DIFF
--- a/pkgs/by-name/ti/tinygo/0001-GNUmakefile.patch
+++ b/pkgs/by-name/ti/tinygo/0001-GNUmakefile.patch
@@ -1,11 +1,12 @@
 diff --git a/GNUmakefile b/GNUmakefile
+index f078bde5..901c8e08 100644
 --- a/GNUmakefile
 +++ b/GNUmakefile
-@@ -14,11 +14,6 @@ LLVM_VERSIONS = 19 18 17 16 15
+@@ -21,11 +21,6 @@ LLVM_VERSIONS = 19 18 17 16 15
  errifempty = $(if $(1),$(1),$(error $(2)))
  detect = $(shell which $(call errifempty,$(firstword $(foreach p,$(2),$(shell command -v $(p) 2> /dev/null && echo $(p)))),failed to locate $(1) at any of: $(2)))
  toolSearchPathsVersion = $(1)-$(2)
--ifeq ($(shell uname -s),Darwin)
+-ifeq ($(uname),Darwin)
 -	# Also explicitly search Brew's copy, which is not in PATH by default.
 -	BREW_PREFIX := $(shell brew --prefix)
 -	toolSearchPathsVersion += $(BREW_PREFIX)/opt/llvm@$(2)/bin/$(1)-$(2) $(BREW_PREFIX)/opt/llvm@$(2)/bin/$(1)
@@ -13,19 +14,19 @@ diff --git a/GNUmakefile b/GNUmakefile
  # First search for a custom built copy, then move on to explicitly version-tagged binaries, then just see if the tool is in path with its normal name.
  findLLVMTool = $(call detect,$(1),$(abspath llvm-build/bin/$(1)) $(foreach ver,$(LLVM_VERSIONS),$(call toolSearchPathsVersion,$(1),$(ver))) $(1))
  CLANG ?= $(call findLLVMTool,clang)
-@@ -939,10 +934,9 @@ endif
+@@ -942,10 +937,9 @@ endif
  wasmtest:
  	$(GO) test ./tests/wasm
  
--build/release: tinygo gen-device wasi-libc $(if $(filter 1,$(USE_SYSTEM_BINARYEN)),,binaryen)
+-build/release: tinygo gen-device $(if $(filter 1,$(USE_SYSTEM_BINARYEN)),,binaryen)
 +build/release:
  	@mkdir -p build/release/tinygo/bin
  	@mkdir -p build/release/tinygo/lib/bdwgc
 -	@mkdir -p build/release/tinygo/lib/clang/include
  	@mkdir -p build/release/tinygo/lib/CMSIS/CMSIS
  	@mkdir -p build/release/tinygo/lib/macos-minimal-sdk
- 	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/lib-common
-@@ -964,7 +958,6 @@ ifneq ($(USE_SYSTEM_BINARYEN),1)
+ 	@mkdir -p build/release/tinygo/lib/mingw-w64/mingw-w64-crt/crt
+@@ -968,7 +962,6 @@ ifneq ($(USE_SYSTEM_BINARYEN),1)
  	@cp -p  build/wasm-opt$(EXE)         build/release/tinygo/bin
  endif
  	@cp -rp lib/bdwgc/*                  build/release/tinygo/lib/bdwgc
@@ -33,9 +34,9 @@ diff --git a/GNUmakefile b/GNUmakefile
  	@cp -rp lib/CMSIS/CMSIS/Include      build/release/tinygo/lib/CMSIS/CMSIS
  	@cp -rp lib/CMSIS/README.md          build/release/tinygo/lib/CMSIS
  	@cp -rp lib/macos-minimal-sdk/*      build/release/tinygo/lib/macos-minimal-sdk
-@@ -1026,8 +1019,7 @@ endif
- 	@cp -rp lib/wasi-libc/libc-top-half/musl/include                build/release/tinygo/lib/wasi-libc/libc-top-half/musl
- 	@cp -rp lib/wasi-libc/sysroot                                   build/release/tinygo/lib/wasi-libc/sysroot
+@@ -1060,8 +1053,7 @@ endif
+ 	@cp -rp lib/wasi-libc/libc-top-half/musl/src/unistd             build/release/tinygo/lib/wasi-libc/libc-top-half/musl/src
+ 	@cp -rp lib/wasi-libc/libc-top-half/sources                     build/release/tinygo/lib/wasi-libc/libc-top-half
  	@cp -rp lib/wasi-cli/wit                                        build/release/tinygo/lib/wasi-cli/wit
 -	@cp -rp llvm-project/compiler-rt/lib/builtins build/release/tinygo/lib/compiler-rt-builtins
 -	@cp -rp llvm-project/compiler-rt/LICENSE.TXT  build/release/tinygo/lib/compiler-rt-builtins
@@ -43,6 +44,3 @@ diff --git a/GNUmakefile b/GNUmakefile
  	@cp -rp src                          build/release/tinygo/src
  	@cp -rp targets                      build/release/tinygo/targets
  
--- 
-2.48.1
-

--- a/pkgs/by-name/ti/tinygo/package.nix
+++ b/pkgs/by-name/ti/tinygo/package.nix
@@ -4,7 +4,7 @@
   buildGoModule,
   fetchFromGitHub,
   makeWrapper,
-  llvmPackages,
+  llvmPackages_20,
   go,
   xar,
   binaryen,
@@ -16,8 +16,10 @@
 }:
 
 let
+  # nixpkgs typically updates default llvm version faster than tinygo releases
+  # which ends up breaking this build. Use fixed version for each release.
   llvmMajor = lib.versions.major llvm.version;
-  inherit (llvmPackages)
+  inherit (llvmPackages_20)
     llvm
     clang
     compiler-rt
@@ -34,13 +36,13 @@ in
 
 buildGoModule rec {
   pname = "tinygo";
-  version = "0.37.0";
+  version = "0.39.0";
 
   src = fetchFromGitHub {
     owner = "tinygo-org";
     repo = "tinygo";
     tag = "v${version}";
-    hash = "sha256-I/9JXjt6aF/80Mh3iRgUYXv4l+m3XIpmKsIBviOuWCo=";
+    hash = "sha256-uooBZl4u9EHfs1DTI/dQ9Uz1uVOmRcIClEMB7D1q8Lk=";
     fetchSubmodules = true;
     # The public hydra server on `hydra.nixos.org` is configured with
     # `max_output_size` of 3GB. The purpose of this `postFetch` step
@@ -51,7 +53,7 @@ buildGoModule rec {
     '';
   };
 
-  vendorHash = "sha256-juADakh+s8oEY9UXUwxknvVeL1TgB/zRi8Xtzt/4qPA=";
+  vendorHash = "sha256-Vae7IFACioxH4E61GX/X7G19/ITbajp96VNUhliV8ls=";
 
   patches = [
     ./0001-GNUmakefile.patch
@@ -76,6 +78,7 @@ buildGoModule rec {
     "-X github.com/tinygo-org/tinygo/goenv.TINYGOROOT=${placeholder "out"}/share/tinygo"
     "-X github.com/tinygo-org/tinygo/goenv.clangResourceDir=${clang.cc.lib}/lib/clang/${llvmMajor}"
   ];
+  tags = [ "llvm${llvmMajor}" ];
   subPackages = [ "." ];
 
   # Output contains static libraries for different arm cpus
@@ -104,14 +107,6 @@ buildGoModule rec {
     # Move binary
     mkdir -p build
     mv $GOPATH/bin/tinygo build/tinygo
-
-    # Build our own custom wasi-libc.
-    # This is necessary because we modify the build a bit for our needs (disable
-    # heap, enable debug symbols, etc).
-    make wasi-libc \
-      CLANG="${lib.getBin clang.cc}/bin/clang -resource-dir ${clang.cc.lib}/lib/clang/${llvmMajor}" \
-      LLVM_AR=${lib.getBin llvm}/bin/llvm-ar \
-      LLVM_NM=${lib.getBin llvm}/bin/llvm-nm
 
     make gen-device -j $NIX_BUILD_CORES
 


### PR DESCRIPTION
## Things done

https://github.com/tinygo-org/tinygo/releases/tag/v0.38.0
https://github.com/tinygo-org/tinygo/releases/tag/v0.39.0

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
