### PR TITLE
exploitdb: 2025-06-21 -> 2025-06-27

### DIFF
--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -5,14 +5,14 @@
   makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "exploitdb";
   version = "2025-06-27";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
-    rev = "refs/tags/${version}";
+    tag = finalAttrs.version;
     hash = "sha256-Gm3SRdt6a3hSe64iP7j+5HQ5bGZ6s3eKvxFlCkQWZHo=";
   };
 
@@ -26,19 +26,19 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Archive of public exploits and corresponding vulnerable software";
     homepage = "https://gitlab.com/exploit-database/exploitdb";
-    license = with licenses; [
+    license = with lib.licenses; [
       gpl2Plus
       gpl3Plus
       mit
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       applePrincess
       fab
     ];
     mainProgram = "searchsploit";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ex/exploitdb/package.nix
+++ b/pkgs/by-name/ex/exploitdb/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "exploitdb";
-  version = "2025-06-21";
+  version = "2025-06-27";
 
   src = fetchFromGitLab {
     owner = "exploit-database";
     repo = "exploitdb";
     rev = "refs/tags/${version}";
-    hash = "sha256-6mXku+SW6xmSYxd40Ilis8H/2Ozm6eUecLQHy1xeKtM=";
+    hash = "sha256-Gm3SRdt6a3hSe64iP7j+5HQ5bGZ6s3eKvxFlCkQWZHo=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Diff: https://gitlab.com/exploit-database/exploitdb/-/compare/refs/tags/2025-06-21...2025-06-27


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
