### PR TITLE
wavpack: fix build

### DIFF
--- a/pkgs/by-name/wa/wavpack/Fix-autoreconf-with-gettext-0.25.patch
+++ b/pkgs/by-name/wa/wavpack/Fix-autoreconf-with-gettext-0.25.patch
@@ -1,0 +1,48 @@
+From ae8d7708e8e28b0d32ef00d18dbd65ed93853811 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Fri, 27 Jun 2025 12:27:58 +0200
+Subject: [PATCH] Fix autoreconf with gettext 0.25
+
+Since gettext 0.25, the AM_ICONV macro is installed into the m4
+directory, so we need to add that autoconf config directory.  We also
+need to make sure autoreconf recognizes that it needs to run autopoint
+to install the gettext macros, which it does heuristically by checking
+whether AM_GNU_GETTEXT_VERSION is used, so add that and the minimum
+amount of other stuff required to make it happy.  The version of
+gettext we say we use shouldn't matter, so I just went with the
+version in ubuntu:latest since that's what CI uses.
+
+Link: https://github.com/dbry/WavPack/pull/205
+---
+ Makefile.am  | 2 ++
+ configure.ac | 3 +++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index ec20499..6c18f61 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,3 +1,5 @@
++SUBDIRS =
++
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = wavpack.pc
+ 
+diff --git a/configure.ac b/configure.ac
+index e35bb72..7fb0ebb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2,7 +2,10 @@ dnl wavpack 5.8.1 configure.ac
+ 
+ AC_INIT([wavpack], [5.8.1], [bryant@wavpack.com])
+ AC_CONFIG_SRCDIR([src/pack.c])
++AC_CONFIG_MACRO_DIRS([m4])
+ AM_INIT_AUTOMAKE([-Wall 1.15 serial-tests subdir-objects foreign no-dist-gzip dist-xz])
++AM_GNU_GETTEXT_VERSION([0.21])
++AM_GNU_GETTEXT([external])
+ AM_MAINTAINER_MODE
+ 
+ LIBWAVPACK_MAJOR=5
+-- 
+2.49.0
+

--- a/pkgs/by-name/wa/wavpack/package.nix
+++ b/pkgs/by-name/wa/wavpack/package.nix
@@ -19,9 +19,6 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [ libiconv ];
 
-  # autogen.sh:9
-  preAutoreconf = "cp ${gettext}/share/gettext/config.rpath .";
-
   src = fetchFromGitHub {
     owner = "dbry";
     repo = "WavPack";

--- a/pkgs/by-name/wa/wavpack/package.nix
+++ b/pkgs/by-name/wa/wavpack/package.nix
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    gettext
+  ];
   buildInputs = [ libiconv ];
 
   # autogen.sh:9
@@ -25,6 +28,8 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-V9jRIuDpZYIBohJRouGr2TI32BZMXSNVfavqPl56YO0=";
   };
+
+  patches = [ ./Fix-autoreconf-with-gettext-0.25.patch ];
 
   outputs = [
     "out"


### PR DESCRIPTION
Patch has been submitted upstream but we'll need to fix this in some way for the next cycle regardless.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
