### PR TITLE
nixos-rebuild-ng: fix test failure introduced in #420352

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -111,6 +111,10 @@ python3Packages.buildPythonApplication rec {
       };
 
       tests = {
+        with_reexec = nixos-rebuild-ng.override {
+          withReexec = true;
+          withNgSuffix = false;
+        };
         with_nix_latest = nixos-rebuild-ng.override {
           nix = nixVersions.latest;
         };
@@ -122,11 +126,9 @@ python3Packages.buildPythonApplication rec {
           nix = nixVersions.nix_2_3;
         };
         with_lix_latest = nixos-rebuild-ng.override {
-          # oldest / minimum supported version in nixpkgs
           nix = lixPackageSets.latest.lix;
         };
         with_lix_stable = nixos-rebuild-ng.override {
-          # oldest / minimum supported version in nixpkgs
           nix = lixPackageSets.stable.lix;
         };
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -132,7 +132,7 @@ def test_parse_args() -> None:
 @patch("os.execve", autospec=True)
 @patch(get_qualified_name(nr.nix.build), autospec=True)
 def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(nr, "EXECUTABLE", "nixos-rebuild-ng")
+    monkeypatch.setattr(nr.services, "EXECUTABLE", "nixos-rebuild-ng")
     argv = ["/path/bin/nixos-rebuild-ng", "switch", "--no-flake"]
     args, _ = nr.parse_args(argv)
     mock_build.return_value = Path("/path")
@@ -178,7 +178,7 @@ def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -
 def test_reexec_flake(
     mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(nr, "EXECUTABLE", "nixos-rebuild-ng")
+    monkeypatch.setattr(nr.services, "EXECUTABLE", "nixos-rebuild-ng")
     argv = ["/path/bin/nixos-rebuild-ng", "switch", "--flake"]
     args, _ = nr.parse_args(argv)
     mock_build.return_value = Path("/path")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix a test failure introduced in #420352 when `nixos-rebuild-ng` is built with `withReexec = true; withNgSuffix = false;` (that is the default when building it for NixOS, but not as a package).

This error was not caught in the tests, this is why we are adding a new test to make sure this case is tested.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
