### PR TITLE
python313Packages.tensorpotential: init at 0.5.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -152,6 +152,11 @@ lib.mapAttrs mkLicense (
       fullName = "Artistic License 2.0";
     };
 
+    asl = {
+      fullName = "Academic Software License";
+      url = "https://github.com/ACEsuit/ACE.jl/blob/main/ASL.md";
+    };
+
     asl20 = {
       spdxId = "Apache-2.0";
       fullName = "Apache License 2.0";

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -152,11 +152,6 @@ lib.mapAttrs mkLicense (
       fullName = "Artistic License 2.0";
     };
 
-    asl = {
-      fullName = "Academic Software License";
-      url = "https://github.com/ACEsuit/ACE.jl/blob/main/ASL.md";
-    };
-
     asl20 = {
       spdxId = "Apache-2.0";
       fullName = "Apache License 2.0";

--- a/pkgs/development/python-modules/tensorpotential/default.nix
+++ b/pkgs/development/python-modules/tensorpotential/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "tensorpotential";
+  version = "0.5.1";
+  setuptools = true;
+
+  src = fetchFromGitHub {
+    owner = "ICAMS";
+    repo = "grace-tensorpotential";
+    rev = "0.5.1";
+    hash = "sha256-nVIHW2aiV79Ul07lqt/juGc8oPYJUeb7TLtqMyOQjGs=";
+  };
+
+  meta = with lib; {
+    description = "GRACE models and gracemaker (as implemented in TensorPotential package)";
+    homepage = "https://github.com/ICAMS/grace-tensorpotential";
+    changelog = "https://github.com/ICAMS/grace-tensorpotential/releases/tag/${version}";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ sh4k0 ];
+  };
+}

--- a/pkgs/development/python-modules/tensorpotential/default.nix
+++ b/pkgs/development/python-modules/tensorpotential/default.nix
@@ -9,20 +9,33 @@
 buildPythonPackage rec {
   pname = "tensorpotential";
   version = "0.5.1";
-  setuptools = true;
+  pyproject = true;
+
+  build-system = [ setuptools ];
 
   src = fetchFromGitHub {
     owner = "ICAMS";
     repo = "grace-tensorpotential";
-    rev = "0.5.1";
+    tag = "0.5.1";
     hash = "sha256-nVIHW2aiV79Ul07lqt/juGc8oPYJUeb7TLtqMyOQjGs=";
   };
+  dependencies = with pkgs.python312Packages; [
+    tf-keras
+    scipy
+    numpy #<2.0.0
+    sumpy
+    #matscipy
+    pandas #<3.0.0
+    ase
+    pyyaml #>=6.0.2
+    tqdm
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "GRACE models and gracemaker (as implemented in TensorPotential package)";
     homepage = "https://github.com/ICAMS/grace-tensorpotential";
     changelog = "https://github.com/ICAMS/grace-tensorpotential/releases/tag/${version}";
-    license = with licenses; [ gpl2Only ];
-    maintainers = with maintainers; [ sh4k0 ];
+    license = with lib.licenses; [ gpl2Only ];
+    maintainers = with lib.maintainers; [ sh4k0 ];
   };
 }

--- a/pkgs/development/python-modules/tensorpotential/default.nix
+++ b/pkgs/development/python-modules/tensorpotential/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     description = "GRACE models and gracemaker (as implemented in TensorPotential package)";
     homepage = "https://github.com/ICAMS/grace-tensorpotential";
     changelog = "https://github.com/ICAMS/grace-tensorpotential/releases/tag/${version}";
-    license = with lib.licenses; [ gpl2Only ];
+    license = with lib.licenses; [ asl ];
     maintainers = with lib.maintainers; [ sh4k0 ];
   };
 }

--- a/pkgs/development/python-modules/tensorpotential/default.nix
+++ b/pkgs/development/python-modules/tensorpotential/default.nix
@@ -35,7 +35,10 @@ buildPythonPackage rec {
     description = "GRACE models and gracemaker (as implemented in TensorPotential package)";
     homepage = "https://github.com/ICAMS/grace-tensorpotential";
     changelog = "https://github.com/ICAMS/grace-tensorpotential/releases/tag/${version}";
-    license = with lib.licenses; [ asl ];
+    license = {
+      fullName = "Academic Software License";
+      url = "https://github.com/ACEsuit/ACE.jl/blob/main/ASL.md";
+    };
     maintainers = with lib.maintainers; [ sh4k0 ];
   };
 }

--- a/pkgs/development/python-modules/tensorpotential/default.nix
+++ b/pkgs/development/python-modules/tensorpotential/default.nix
@@ -38,6 +38,7 @@ buildPythonPackage rec {
     license = {
       fullName = "Academic Software License";
       url = "https://github.com/ACEsuit/ACE.jl/blob/main/ASL.md";
+      free = false;
     };
     maintainers = with lib.maintainers; [ sh4k0 ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17552,6 +17552,8 @@ self: super: with self; {
 
   tensorly = callPackage ../development/python-modules/tensorly { };
 
+  tensorpotential = callPackage ../development/python-modules/tensorpotential { };
+
   tensorrt = callPackage ../development/python-modules/tensorrt {
     cudaPackages = pkgs.cudaPackages_11;
   };


### PR DESCRIPTION
I wish to contribute this scientific python library to Nixpkgs. It is a tool to generate machine-learned interatomic potentials. The derivation builds successfully on NixOS and nixpkgs 25.05.

### Important:
The original license of the package (ASL, _Academic Software License_) is not present in `lib.licenses`. It has been changed to `gpl2Only` in my expression just to get it to evaluate, but this needs to be corrected.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
