### PR TITLE
ci/check-cherry-picks: fix chained cherry-picks

### DIFF
--- a/ci/check-cherry-picks.sh
+++ b/ci/check-cherry-picks.sh
@@ -66,9 +66,11 @@ while read -r new_commit_sha ; do
   git rev-list --max-count=1 --format=medium "$new_commit_sha"
   echo "-------------------------------------------------"
 
+  # Using the last line with "cherry" + hash, because a chained backport
+  # can result in multiple of those lines. Only the last one counts.
   original_commit_sha=$(
     git rev-list --max-count=1 --format=format:%B "$new_commit_sha" \
-    | grep -Ei -m1 "cherry.*[0-9a-f]{40}" \
+    | grep -Ei "cherry.*[0-9a-f]{40}" | tail -n1 \
     | grep -Eoi -m1 '[0-9a-f]{40}' || true
   )
   if [ -z "$original_commit_sha" ] ; then


### PR DESCRIPTION
When backporting a PR from master -> 25.05 -> 24.11 in a chain, the last cherry-pick will have two references to different commits in it. If there was conflict resolution in the first step, the diff will show up again in the last step. This can be fixed by comparing against the right hash - always the last one.

Seen in https://github.com/NixOS/nixpkgs/pull/418351#pullrequestreview-2944849077

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
