### PR TITLE
Update cross-compilation.chapter.md

### DIFF
--- a/doc/stdenv/cross-compilation.chapter.md
+++ b/doc/stdenv/cross-compilation.chapter.md
@@ -108,7 +108,7 @@ Only nine dependency types matter in practice:
 
 Let's use `g++` as an example to make this table clearer.  `g++` is a C++ compiler written in C.  Suppose we are building `g++` with a `(build, host, target)` platform triple of `(foo, bar, baz)`.  This means we are using a `foo`-machine to build a copy of `g++` which will run on a `bar`-machine and emit binaries for the `baz`-machine.
 
-* `g++` links against the host platform's `glibc` C library, which is a "host→ *" dependency with a triple of `(bar, bar, *)`.  Since it is a library, not a compiler, it has no "target".
+* `g++` links against the host platform's `glibc` C library, which is a "host→ *" dependency with a triple of `(foo, bar, *)`.  Since it is a library, not a compiler, it has no "target".
 
 * Since `g++` is written in C, the `gcc` compiler used to compile it is a "build→ host" dependency of `g++` with a triple of `(foo, foo, bar)`.  This compiler runs on the build platform and emits code for the host platform.
 


### PR DESCRIPTION
I would assume that every dependency of a  (foo, bar, baz)  type build is always built with the triple  ( *foo*, <host>, <target>)

