### PR TITLE
python3Packages.pynng: init at 0.8.1-unstable-2025-05-14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -723,6 +723,12 @@
     githubId = 10677343;
     name = "Eugene";
   };
+  afermg = {
+    email = "afer.mg@gmail.com";
+    github = "afermg";
+    githubId = 14353896;
+    name = "Alan Munoz";
+  };
   afh = {
     email = "surryhill+nix@gmail.com";
     github = "afh";

--- a/pkgs/development/python-modules/pynng/default.nix
+++ b/pkgs/development/python-modules/pynng/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  cmake,
+  ninja,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  cffi,
+  sniffio,
+  pytest,
+  trio,
+  pytest-trio,
+  pytest-asyncio,
+}:
+let
+  nng = fetchFromGitHub {
+    owner = "nanomsg";
+    repo = "nng";
+    tag = "v1.6.0";
+    sha256 = "sha256-Kq8QxPU6SiTk0Ev2IJoktSPjVOlAS4/e1PQvw2+e8UA=";
+  };
+
+  mbedtls = fetchFromGitHub {
+    owner = "ARMmbed";
+    repo = "mbedtls";
+    tag = "v3.5.1";
+    sha256 = "sha256-HxsHcGbSExp1aG5yMR/J3kPL4zqnmNoN5T5wfV3APaw=";
+  };
+
+in
+buildPythonPackage {
+  pname = "pynng";
+  version = "0.8.1-unstable-2025-05-14";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "codypiersall";
+    repo = "pynng";
+    rev = "2179328f8a858bbb3e177f66ac132bde4a5aa859";
+    sha256 = "sha256-TxIVcqc+4bro+krc1AWgLdZKGGuQ2D6kybHnv5z1oHg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  preBuild = ''
+    cp -r ${mbedtls} mbedtls
+    chmod -R +w mbedtls
+    cp -r ${nng} nng
+    chmod -R +w nng
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  dependencies = [
+    cffi
+    sniffio
+    pytest
+    trio
+    pytest-trio
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [
+    "pynng"
+  ];
+
+  meta = {
+    description = "Python bindings for Nanomsg Next Generation";
+    homepage = "https://github.com/codypiersall/pynng";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ afermg ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13191,6 +13191,8 @@ self: super: with self; {
 
   pynndescent = callPackage ../development/python-modules/pynndescent { };
 
+  pynng = callPackage ../development/python-modules/pynng { };
+
   pynobo = callPackage ../development/python-modules/pynobo { };
 
   pynordpool = callPackage ../development/python-modules/pynordpool { };


### PR DESCRIPTION
I added a Python package that provides bindings for nnm (nanomessage next generation), [pynnm](https://github.com/codypiersall/pynng).
## Things done



- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

I tested the relevant functionality in the readme and that pytests run fine.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
