### PR TITLE
stdenv: allow preserving meta fields in derivation

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -314,6 +314,9 @@
 
 - `meta.mainProgram`: Changing this `meta` entry can lead to a package rebuild due to being used to determine the `NIX_MAIN_PROGRAM` environment variable.
 
+-  mkDerivation populates a `nixMeta` field  on the derivation containing the following `meta` fields if present: `mainProgram`, `license`, `vendor`, `identifiers`.
+   `nixMeta` is an attribute set if `__structuredAttrs` is true otherwise it's a JSON string of the same.
+
 - `forgejo-runner`: The upgrade to version 11 brings a license change from MIT to GPLv3-or-later.
 
 - `waydroid-nftables`: New variant of `waydroid` that supports nftables instead of iptables.

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -278,7 +278,7 @@ lib.warnIf (withDocs != null)
       mainProgram = "bash";
       identifiers.cpeParts =
         let
-          versionSplit = lib.split "p" version;
+          versionSplit = lib.split "p" fa.version;
         in
         {
           vendor = "gnu";

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -820,10 +820,7 @@ let
           };
           nixMeta = intersectAttrs preserveMetaFields meta;
           nixMetaJSON = builtins.toJSON nixMeta;
-          nixMetaJSONContext = builtins.getContext nixMetaJSON;
         in
-        assert assertMsg (nixMetaJSONContext == { })
-          "String context not allowed in nixMeta of ${attrs.name or (attrs.pname + "-" + attrs.version or "none")}: ${builtins.toJSON nixMetaJSONContext}";
         makeDerivationArgument (
           removeAttrs attrs [
             "meta"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -17,11 +17,11 @@ let
     elemAt
     extendDerivation
     filter
-    filterAttrs
     findFirst
     getDev
     head
     imap1
+    intersectAttrs
     isAttrs
     isBool
     isDerivation
@@ -812,13 +812,13 @@ let
 
       derivationArg =
         let
-          preserveMetaFields = [
-            "identifiers"
-            "license"
-            "mainProgram"
-            "vendor"
-          ];
-          nixMeta = filterAttrs (n: _: (elem n preserveMetaFields)) meta;
+          preserveMetaFields = {
+            identifiers = null;
+            license = null;
+            mainProgram = null;
+            vendor = null;
+          };
+          nixMeta = intersectAttrs preserveMetaFields meta;
           nixMetaJSON = builtins.toJSON nixMeta;
           nixMetaJSONContext = builtins.getContext nixMetaJSON;
         in
@@ -851,7 +851,7 @@ let
 
       checkedEnv =
         let
-          overlappingNames = attrNames (builtins.intersectAttrs env' derivationArg);
+          overlappingNames = attrNames (intersectAttrs env' derivationArg);
           prettyPrint = lib.generators.toPretty { };
           makeError =
             name:


### PR DESCRIPTION
## Changes
* Preserve `identifiers`, `license`, `mainProgram`, and `vendor` fields from the `mkDerivation` attrSet under a new `nixMeta` field in the derivation.
* `nixMeta` respects `__structuredAttrs`; if enabled the existing attribute structure of the aforementioned attributes is preserved. If `__structuredAttrs` is false, the attributes will be encoded as a JSON string.
* A evaluation error will occur if any string-context is present in `nixMeta`. 

<details>
<summary> Example Derivation output </summary>

For example, a derivation's `env` will look like this if `__structuredAttrs` is false:
```json
{
  "/nix/store/aflkbqqs7f8hyp0l6przb3bpxr5xs1dh-hello-2.12.2.drv": {
    "args": [
      "-e",
      "/nix/store/l622p70vy8k5sh7y5wizi5f2mic6ynpg-source-stdenv.sh",
      "/nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02r39-default-builder.sh"
    ],
    "builder": "/nix/store/mfy6cpswaknpqj1jv7h5s27dh60ziv3p-bash-5.3p3/bin/bash",
    "env": {
      "nixMeta": "{\"identifiers\":{\"cpeParts\":{\"edition\":\"*\",\"language\":\"*\",\"other\":\"*\",\"part\":\"a\",\"product\":\"hello\",\"sw_edition\":\"*\",\"target_hw\":\"*\",\"target_sw\":\"*\",\"vendor\":\"gnu\"},\"possibleCPEs\":[{\"cpe\":\"cpe:2.3:a:gnu:hello:2.12.2:*:*:*:*:*:*:*\",\"cpeParts\":{\"edition\":\"*\",\"language\":\"*\",\"other\":\"*\",\"part\":\"a\",\"product\":\"hello\",\"sw_edition\":\"*\",\"target_hw\":\"*\",\"target_sw\":\"*\",\"update\":\"*\",\"vendor\":\"gnu\",\"version\":\"2.12.2\"}},{\"cpe\":\"cpe:2.3:a:gnu:hello:2.12:2:*:*:*:*:*:*\",\"cpeParts\":{\"edition\":\"*\",\"language\":\"*\",\"other\":\"*\",\"part\":\"a\",\"product\":\"hello\",\"sw_edition\":\"*\",\"target_hw\":\"*\",\"target_sw\":\"*\",\"update\":\"2\",\"vendor\":\"gnu\",\"version\":\"2.12\"}}],\"v1\":{\"cpeParts\":{\"edition\":\"*\",\"language\":\"*\",\"other\":\"*\",\"part\":\"a\",\"product\":\"hello\",\"sw_edition\":\"*\",\"target_hw\":\"*\",\"target_sw\":\"*\",\"vendor\":\"gnu\"},\"possibleCPEs\":[{\"cpe\":\"cpe:2.3:a:gnu:hello:2.12.2:*:*:*:*:*:*:*\",\"cpeParts\":{\"edition\":\"*\",\"language\":\"*\",\"other\":\"*\",\"part\":\"a\",\"product\":\"hello\",\"sw_edition\":\"*\",\"target_hw\":\"*\",\"target_sw\":\"*\",\"update\":\"*\",\"vendor\":\"gnu\",\"version\":\"2.12.2\"}},{\"cpe\":\"cpe:2.3:a:gnu:hello:2.12:2:*:*:*:*:*:*\",\"cpeParts\":{\"edition\":\"*\",\"language\":\"*\",\"other\":\"*\",\"part\":\"a\",\"product\":\"hello\",\"sw_edition\":\"*\",\"target_hw\":\"*\",\"target_sw\":\"*\",\"update\":\"2\",\"vendor\":\"gnu\",\"version\":\"2.12\"}}]}},\"license\":{\"deprecated\":false,\"free\":true,\"fullName\":\"GNU General Public License v3.0 or later\",\"redistributable\":true,\"shortName\":\"gpl3Plus\",\"spdxId\":\"GPL-3.0-or-later\",\"url\":\"https://spdx.org/licenses/GPL-3.0-or-later.html\"},\"mainProgram\":\"hello\"}",
      "out": "/nix/store/23p192rg0c8r0lzqgrr0gykk6vlwlzj5-hello-2.12.2",
      [...]
      "system": "x86_64-linux",
      "version": "2.12.2"
    },
    "inputDrvs": {},
    [...]
}
```
If `__structuredAttrs` is enabled, then `nixMeta` is added as a attrSet.
```json
{
  "/nix/store/5gpn6haap01zy2l8xdnx84my6lafshkn-hello-2.12.2.drv": {
    "args": [
      "-e",
      "/nix/store/l622p70vy8k5sh7y5wizi5f2mic6ynpg-source-stdenv.sh",
      "/nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02r39-default-builder.sh"
    ],
    "builder": "/nix/store/mfy6cpswaknpqj1jv7h5s27dh60ziv3p-bash-5.3p3/bin/bash",
    "env": {
      "out": "/nix/store/g45fpaampg8hfwf8cj61y8pl1nbjwsfs-hello-2.12.2"
    },
    "inputDrvs": {
     [...]
      }
    },
    "inputSrcs": [...],
    "name": "hello-2.12.2",
    "outputs": {
      "out": {
        "path": "/nix/store/g45fpaampg8hfwf8cj61y8pl1nbjwsfs-hello-2.12.2"
      }
    },
    "structuredAttrs": {
      [...]
      "name": "hello-2.12.2",
      "nativeBuildInputs": [
        "/nix/store/671cssvzsgf47jqxm8zcl7lgpnbqivm3-version-check-hook"
      ],
      "nixMeta": {
        "identifiers": {
          "cpeParts": {
            "edition": "*",
            "language": "*",
            "other": "*",
            "part": "a",
            "product": "hello",
            "sw_edition": "*",
            "target_hw": "*",
            "target_sw": "*",
            "vendor": "gnu"
          },
          "possibleCPEs": [
            {
              "cpe": "cpe:2.3:a:gnu:hello:2.12.2:*:*:*:*:*:*:*",
              "cpeParts": {
                "edition": "*",
                "language": "*",
                "other": "*",
                "part": "a",
                "product": "hello",
                "sw_edition": "*",
                "target_hw": "*",
                "target_sw": "*",
                "update": "*",
                "vendor": "gnu",
                "version": "2.12.2"
              }
            },
            {
              "cpe": "cpe:2.3:a:gnu:hello:2.12:2:*:*:*:*:*:*",
              "cpeParts": {
                "edition": "*",
                "language": "*",
                "other": "*",
                "part": "a",
                "product": "hello",
                "sw_edition": "*",
                "target_hw": "*",
                "target_sw": "*",
                "update": "2",
                "vendor": "gnu",
                "version": "2.12"
              }
            }
          ],
          "v1": {
            "cpeParts": {
              "edition": "*",
              "language": "*",
              "other": "*",
              "part": "a",
              "product": "hello",
              "sw_edition": "*",
              "target_hw": "*",
              "target_sw": "*",
              "vendor": "gnu"
            },
            "possibleCPEs": [
              {
                "cpe": "cpe:2.3:a:gnu:hello:2.12.2:*:*:*:*:*:*:*",
                "cpeParts": {
                  "edition": "*",
                  "language": "*",
                  "other": "*",
                  "part": "a",
                  "product": "hello",
                  "sw_edition": "*",
                  "target_hw": "*",
                  "target_sw": "*",
                  "update": "*",
                  "vendor": "gnu",
                  "version": "2.12.2"
                }
              },
              {
                "cpe": "cpe:2.3:a:gnu:hello:2.12:2:*:*:*:*:*:*",
                "cpeParts": {
                  "edition": "*",
                  "language": "*",
                  "other": "*",
                  "part": "a",
                  "product": "hello",
                  "sw_edition": "*",
                  "target_hw": "*",
                  "target_sw": "*",
                  "update": "2",
                  "vendor": "gnu",
                  "version": "2.12"
                }
              }
            ]
          }
        },
        "license": {
          "deprecated": false,
          "free": true,
          "fullName": "GNU General Public License v3.0 or later",
          "redistributable": true,
          "shortName": "gpl3Plus",
          "spdxId": "GPL-3.0-or-later",
          "url": "https://spdx.org/licenses/GPL-3.0-or-later.html"
        },
        "mainProgram": "hello"
      },
      "outputChecks": {
        "out": {}
      },
      "outputs": [
        "out"
      ],
      "patches": [],
      "pname": "hello",
   [...]
  }
```
</details>

<details>
<summary> Proposal Background </summary>

Currently, package metadata is stripped before creating the derivation. Generally, we only retain the package name and version in the derivation and we loosely retain this is the nix store paths except reconstructing the exact name and version is imprecise.

This lost of meta information makes generating correct and complete SBOMs nearly impossible. Tools like `sbomnix` require matching store paths and derivations to the correct `meta` information solely on the package name and version which often leads to incorrect matches and incomplete SBOM reports.

An existing PR (#409797)  to improve the state of CVE tracking will add the complete CPE identifier to the `meta` attribute set.  While this is a great improvement, nixpkgs still lacks method to query the meta/CPE information for a given derivation or store-path. A previous PR #256296, attempted to resolve this by including the *entire* `meta` attrSet in the derivation but concerns over the risk of mass-rebuilds due to minor changes (such as to the maintainers list) stalled it's adoption.

Instead of including all meta attributes, this PR includes subset of meta attributes; `identifiers`, `license`, `mainProgram`, and `vendor` . Changes to these attributes are in-frequent or would involve a rebuild anyway (e.g updating `mainProgram`).
</details>