### PR TITLE
python3Packages.fast-array-utils: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/fast-array-utils/default.nix
+++ b/pkgs/development/python-modules/fast-array-utils/default.nix
@@ -1,0 +1,70 @@
+{
+  buildPythonPackage,
+  dask,
+  fetchFromGitHub,
+  hatch-docstring-description,
+  hatch-fancy-pypi-readme,
+  hatch-min-requirements,
+  hatch-vcs,
+  hatchling,
+  lib,
+  numba,
+  numpy,
+  pytest-codspeed,
+  pytest-doctestplus,
+  pytestCheckHook,
+  scipy,
+}:
+
+buildPythonPackage rec {
+  pname = "fast-array-utils";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "scverse";
+    repo = "fast-array-utils";
+    tag = "v${version}";
+    hash = "sha256-SQaumXgjFn2+/MqllEs0zRnl2t7m2JZyOd+39vZPU2U=";
+  };
+
+  # hatch-min-requirements tries to talk to PyPI by default. See https://github.com/tlambert03/hatch-min-requirements?tab=readme-ov-file#environment-variables.
+  env.MIN_REQS_OFFLINE = "1";
+
+  build-system = [
+    hatch-docstring-description
+    hatch-fancy-pypi-readme
+    hatch-min-requirements
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  nativeCheckInputs = [
+    dask
+    numba
+    pytest-codspeed
+    pytest-doctestplus
+    pytestCheckHook
+    scipy
+  ];
+
+  pythonImportsCheck = [
+    "fast_array_utils.conv"
+    "fast_array_utils.types"
+    "fast_array_utils.typing"
+    "fast_array_utils"
+  ];
+
+  meta = {
+    description = "Fast array utilities";
+    homepage = "https://icb-fast-array-utils.readthedocs-hosted.com";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      samuela
+    ];
+  };
+}

--- a/pkgs/development/python-modules/hatch-docstring-description/default.nix
+++ b/pkgs/development/python-modules/hatch-docstring-description/default.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+  lib,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "hatch-docstring-description";
+  version = "1.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "flying-sheep";
+    repo = "hatch-docstring-description";
+    tag = "v${version}";
+    hash = "sha256-ouor0FV3qdXYJx5EWFUWSKp8Cc/EuD1WXrtLvbYG+XI=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    # See https://github.com/flying-sheep/hatch-docstring-description/issues/107
+    "test_e2e[.]"
+    "test_e2e[src]"
+  ];
+
+  pythonImportsCheck = [ "hatch_docstring_description" ];
+
+  meta = {
+    description = "Derive PyPI package description from Python package docstring";
+    homepage = "https://github.com/flying-sheep/hatch-docstring-description";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
+      samuela
+    ];
+  };
+}

--- a/pkgs/development/python-modules/hatch-min-requirements/default.nix
+++ b/pkgs/development/python-modules/hatch-min-requirements/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+  lib,
+}:
+
+buildPythonPackage rec {
+  pname = "hatch-min-requirements";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tlambert03";
+    repo = "hatch-min-requirements";
+    tag = "v${version}";
+    hash = "sha256-7/6Es0DHDJ8jZ76kVbWkQjWFd8hWuB+PwCbOmIjzK5o=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  # As of v0.1.0 all tests attempt to use the network
+  doCheck = false;
+
+  pythonImportsCheck = [ "hatch_min_requirements" ];
+
+  meta = {
+    description = "Hatchling plugin to create optional-dependencies pinned to minimum versions";
+    homepage = "https://github.com/tlambert03/hatch-min-requirements";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      samuela
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4882,6 +4882,8 @@ self: super: with self; {
 
   farama-notifications = callPackage ../development/python-modules/farama-notifications { };
 
+  fast-array-utils = callPackage ../development/python-modules/fast-array-utils { };
+
   fast-histogram = callPackage ../development/python-modules/fast-histogram { };
 
   fastai = callPackage ../development/python-modules/fastai { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6363,6 +6363,8 @@ self: super: with self; {
 
   hatch-jupyter-builder = callPackage ../development/python-modules/hatch-jupyter-builder { };
 
+  hatch-min-requirements = callPackage ../development/python-modules/hatch-min-requirements { };
+
   hatch-nodejs-version = callPackage ../development/python-modules/hatch-nodejs-version { };
 
   hatch-odoo = callPackage ../development/python-modules/hatch-odoo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6355,6 +6355,10 @@ self: super: with self; {
 
   hatch-babel = callPackage ../development/python-modules/hatch-babel { };
 
+  hatch-docstring-description =
+    callPackage ../development/python-modules/hatch-docstring-description
+      { };
+
   hatch-fancy-pypi-readme = callPackage ../development/python-modules/hatch-fancy-pypi-readme { };
 
   hatch-jupyter-builder = callPackage ../development/python-modules/hatch-jupyter-builder { };


### PR DESCRIPTION
In pursuit of https://github.com/NixOS/nixpkgs/issues/313389

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
