### PR TITLE
atlauncher: build from a binary release to resolve #396123

### DIFF
--- a/pkgs/by-name/at/atlauncher/package.nix
+++ b/pkgs/by-name/at/atlauncher/package.nix
@@ -22,11 +22,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "atlauncher";
-  version = "3.4.40.1";
+  version = "3.4.40.2";
 
   src = fetchurl {
     url = "https://github.com/ATLauncher/ATLauncher/releases/download/v${finalAttrs.version}/ATLauncher-${finalAttrs.version}.jar";
-    hash = "sha256-AvToGfn0u8yJ4/rxRPGmowH7WZtufscQD1shqPOylSo=";
+    hash = "sha256-tE/4w9o1/wNrIWPwEhiO5byvWXY1TY0Zt2Gfk0jZiuA=";
   };
 
   env.ICON = fetchurl {

--- a/pkgs/by-name/at/atlauncher/package.nix
+++ b/pkgs/by-name/at/atlauncher/package.nix
@@ -1,8 +1,9 @@
 {
-  fetchFromGitHub,
-  gradle_8,
+  copyDesktopItems,
+  fetchurl,
   jre,
   lib,
+  makeDesktopItem,
   makeWrapper,
   stdenvNoCC,
 
@@ -18,43 +19,26 @@
   udev,
   xorg,
 }:
-let
-  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
-  gradle = gradle_8;
-in
+
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "atlauncher";
   version = "3.4.38.2";
 
-  src = fetchFromGitHub {
-    owner = "ATLauncher";
-    repo = "ATLauncher";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-x8ch8BdUckweuwEvsOxYG2M5UmbW4fRjF/jJ6feIjIA=";
+  src = fetchurl {
+    url = "https://github.com/ATLauncher/ATLauncher/releases/download/v${finalAttrs.version}/ATLauncher-${finalAttrs.version}.jar";
+    hash = "sha256-IKaHQwyT8DcLgwbanazkqIMUVGTsy4lqCwr5bvfHWGQ=";
   };
 
-  postPatch = ''
-    # exclude UI tests
-    sed -i "/test {/a\    exclude '**/BasicLauncherUiTest.class'" build.gradle
-  '';
+  env.ICON = fetchurl {
+    url = "https://atlauncher.com/assets/images/logo.svg";
+    hash = "sha256-XoqpsgLmkpa2SdjZvPkgg6BUJulIBIeu6mBsJJCixfo=";
+  };
+
+  dontUnpack = true;
 
   nativeBuildInputs = [
-    gradle
+    copyDesktopItems
     makeWrapper
-  ];
-
-  mitmCache = gradle.fetchDeps {
-    inherit (finalAttrs) pname;
-    data = ./deps.json;
-  };
-
-  doCheck = true;
-
-  gradleBuildTask = "shadowJar";
-
-  gradleFlags = [
-    "--exclude-task"
-    "createExe"
   ];
 
   installPhase =
@@ -75,8 +59,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ''
       runHook preInstall
 
-      mkdir -p $out/{bin,share/java}
-      cp build/libs/ATLauncher-${finalAttrs.version}.jar $out/share/java/ATLauncher.jar
+      mkdir -p $out/bin $out/share/java
+      cp $src $out/share/java/ATLauncher.jar
 
       makeWrapper ${lib.getExe jre} $out/bin/atlauncher \
         --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibraries}" \
@@ -84,22 +68,23 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         --add-flags "--working-dir \"\''${XDG_DATA_HOME:-\$HOME/.local/share}/ATLauncher\"" \
         --add-flags "--no-launcher-update"
 
+      mkdir -p $out/share/icons/hicolor/scalable/apps
+      cp $ICON $out/share/icons/hicolor/scalable/apps/atlauncher.svg
+
       runHook postInstall
     '';
 
-  postInstall =
-    let
-      packagingDir = "${finalAttrs.src}/packaging/linux/_common";
-    in
-    ''
-      install -D -m444 ${packagingDir}/atlauncher.desktop -t $out/share/applications
-      install -D -m444 ${packagingDir}/atlauncher.metainfo.xml -t $out/share/metainfo
-      install -D -m444 ${packagingDir}/atlauncher.png -t $out/share/pixmaps
-      install -D -m444 ${packagingDir}/atlauncher.svg -t $out/share/icons/hicolor/scalable/apps
-    '';
+  desktopItems = [
+    (makeDesktopItem {
+      categories = [ "Game" ];
+      desktopName = "ATLauncher";
+      exec = "atlauncher";
+      icon = "atlauncher";
+      name = "atlauncher";
+    })
+  ];
 
   meta = {
-    broken = stdenvNoCC.hostPlatform.isDarwin; # https://github.com/NixOS/nixpkgs/issues/356259
     changelog = "https://github.com/ATLauncher/ATLauncher/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Simple and easy to use Minecraft launcher which contains many different modpacks for you to choose from and play";
     downloadPage = "https://atlauncher.com/downloads";
@@ -108,9 +93,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mainProgram = "atlauncher";
     maintainers = with lib.maintainers; [ getpsyched ];
     platforms = lib.platforms.all;
-    sourceProvenance = with lib.sourceTypes; [
-      fromSource
-      binaryBytecode # mitm cache
-    ];
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };
 })

--- a/pkgs/by-name/at/atlauncher/package.nix
+++ b/pkgs/by-name/at/atlauncher/package.nix
@@ -22,11 +22,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "atlauncher";
-  version = "3.4.38.2";
+  version = "3.4.40.1";
 
   src = fetchurl {
     url = "https://github.com/ATLauncher/ATLauncher/releases/download/v${finalAttrs.version}/ATLauncher-${finalAttrs.version}.jar";
-    hash = "sha256-IKaHQwyT8DcLgwbanazkqIMUVGTsy4lqCwr5bvfHWGQ=";
+    hash = "sha256-AvToGfn0u8yJ4/rxRPGmowH7WZtufscQD1shqPOylSo=";
   };
 
   env.ICON = fetchurl {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Reverted to using a binary release file with logic that was used before https://github.com/NixOS/nixpkgs/commit/c6ede05a87d84a2a5a3589e2d75b0123faf17061

And bumped the version to [3.4.40.1](https://github.com/ATLauncher/ATLauncher/releases/tag/v3.4.40.1)

Resolves #396123 as suggested in https://github.com/NixOS/nixpkgs/issues/396123#issuecomment-2918448613
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
