### PR TITLE
fetchedMavenDeps: support proxy and custom cacerts

### DIFF
--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -193,8 +193,8 @@ rec {
     }:
     fetcher:
     let
-      inherit (lib.attrsets) genAttrs intersectAttrs removeAttrs;
-      inherit (lib.trivial) const functionArgs setFunctionArgs;
+      inherit (lib.attrsets) intersectAttrs removeAttrs;
+      inherit (lib.trivial) functionArgs setFunctionArgs;
 
       inherit (commonH hashTypes) hashSet;
       fArgs = functionArgs fetcher;

--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -39,6 +39,8 @@ let
 
       JAVA_HOME = mvnJdk;
 
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
       buildPhase =
         ''
           runHook preBuild

--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -57,6 +57,14 @@ let
             ${writeProxySettings} $mvnSettingsFile
             MAVEN_EXTRA_ARGS="-s=$mvnSettingsFile"
           fi
+
+          # handle cacert by populating a trust store on the fly
+          if [[ -n "''${NIX_SSL_CERT_FILE-}" ]] && [[ "''${NIX_SSL_CERT_FILE-}" != "/no-cert-file.crt" ]];then
+            keyStoreFile="$(mktemp -d)/keystore"
+            keyStorePwd="$(head -c10 /dev/random | base32)"
+            echo y | ${jdk}/bin/keytool -importcert -file "$NIX_SSL_CERT_FILE" -alias alias -keystore "$keyStoreFile" -storepass "$keyStorePwd"
+            MAVEN_EXTRA_ARGS="$MAVEN_EXTRA_ARGS -Djavax.net.ssl.trustStore=$keyStoreFile -Djavax.net.ssl.trustStorePassword=$keyStorePwd"
+          fi
         ''
         + lib.optionalString buildOffline ''
           mvn $MAVEN_EXTRA_ARGS de.qaware.maven:go-offline-maven-plugin:1.2.8:resolve-dependencies -Dmaven.repo.local=$out/.m2 ${mvnDepsParameters}

--- a/pkgs/by-name/ma/maven/maven-proxy.py
+++ b/pkgs/by-name/ma/maven/maven-proxy.py
@@ -1,0 +1,86 @@
+"""
+Maven doesn't honor HTTP[S]_PROXY and NO_PROXY env vars out of the box.
+Instead, it expects the user to configure a settings.xml file.
+We however impurely pass only these env vars in FODs.
+This creates the XML file on demand, if one or more env vars is set.
+"""
+
+import os
+import sys
+from urllib.parse import urlparse
+
+
+def parse_proxy_url(url):
+    if url is None:
+        return None
+    parsed = urlparse(url)
+
+    if parsed.hostname is None:
+        print(f"Failed to parse proxy URL {url}, ignoring", file=sys.stderr)
+        return None
+
+    return {
+        'protocol': parsed.scheme or 'http',
+        'host': parsed.hostname,
+        'port': parsed.port or (443 if parsed.scheme == 'https' else 80),
+        'username': parsed.username,
+        'password': parsed.password
+    }
+
+
+def format_proxy_block(proxy, id_suffix, non_proxy_hosts):
+    auth = ""
+    if proxy.get("username"):
+        auth += f"    <username>{proxy['username']}</username>\n"
+    if proxy.get("password"):
+        auth += f"    <password>{proxy['password']}</password>\n"
+
+    np_hosts = ""
+    if non_proxy_hosts:
+        np_hosts = f"    <nonProxyHosts>{non_proxy_hosts}</nonProxyHosts>\n"
+
+    return f"""  <proxy>
+    <id>{id_suffix}-proxy</id>
+    <active>true</active>
+    <protocol>{proxy['protocol']}</protocol>
+    <host>{proxy['host']}</host>
+    <port>{proxy['port']}</port>
+{auth}{np_hosts}  </proxy>"""
+
+
+def main(output_path):
+    http_proxy = parse_proxy_url(os.environ.get("HTTP_PROXY"))
+    https_proxy = parse_proxy_url(os.environ.get("HTTPS_PROXY"))
+    non_proxy_hosts = os.environ.get("NO_PROXY", "").replace(",", "|")
+
+    proxy_blocks = []
+
+    if http_proxy:
+        proxy_blocks.append(
+          format_proxy_block(http_proxy, "http", non_proxy_hosts)
+        )
+    if https_proxy and https_proxy != http_proxy:
+        proxy_blocks.append(
+          format_proxy_block(https_proxy, "https", non_proxy_hosts)
+        )
+
+    settings_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                  http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <proxies>
+{'\n'.join(proxy_blocks)}
+  </proxies>
+</settings>
+"""
+
+    with open(output_path, "w") as f:
+        f.write(settings_xml)
+
+    print(f"Generated Maven settings.xml at {output_path}")
+
+
+if __name__ == "__main__":
+    output_file = sys.argv[1] if len(sys.argv) > 1 else "settings.xml"
+    main(output_file)


### PR DESCRIPTION
Currently, packages using `maven.buildMavenPackage` do not honor impure environment variables like `HTTP[S]_PROXY`, `NO_PROXY` and `NIX_SSL_CERT_FILE`.

We normally propagate these env vars into FODs, so builds running in environments where such proxies are necessary can succeed.

This was not wired up for the maven FOD fetcher, most probably because maven does not honor these environment variables out of the box. Maven requires the user to configure an XML file with proxy settings, and pass a Java Keystore with custom CA certificates imported.

This now happens dynamically at runtime, if the common environment variables are detected.

I tested this (on NixOS) by doing the following:

 - start `mitmproxy` without any command line arguments
 - `nix-store --add ~/.mitmproxy/mitmproxy-ca-cert.pem`
 - `sudo systemctl edit --runtime nix-daemon.service && sudo systemctl restart nix-daemon.service`, adding `Environment=HTTP_PROXY=http://127.0.0.1:8080`, `Environment=HTTPS_PROXY=http://127.0.0.1:8080` and `Environment=NIX_SSL_CERT_FILE=/nix/store/…-mitmproxy-ca-cert.pem` to a new `[Service]` section.
 - starting off a build, listing the same `/nix/store/…-mitmproxy-ca-cert.pem` store path in the `ssl-cert-file` and `extra-sandbox-paths` again: `nix-build -A openrefine.fetchedMavenDeps --builders '' --check --option extra-sandbox-paths /nix/store/…-mitmproxy-ca-cert.pem`.
   Editing your global `nix.conf` and setting `ssl-cert-file` might be another way, [YMMV](https://git.lix.systems/lix-project/lix/issues/885).

With this done, I was able to see maven requesting assets through the proxy.

In the future, this tooling might be used to steer Maven to a MITM Caching Proxy, like it's done for Gradle in https://github.com/NixOS/nixpkgs/pull/272380, but that's left for a followup.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
