### PR TITLE
python3Packages.ibis-framework: disable duckdb test and implementation test

### DIFF
--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -171,6 +171,12 @@ buildPythonPackage rec {
 
     # AssertionError: value does not match the expected value in snapshot ibis/backends/tests/snapshots/test_sql/test_rewrite_context/sqlite/out.sql
     "test_rewrite_context"
+
+    # Assertion error comparing a calculated version string with the actual (during nixpkgs-review)
+    "test_builtin_scalar_noargs"
+
+    # duckdb ParserError: syntax error at or near "AT"
+    "test_90"
   ];
 
   # patch out tests that check formatting with black

--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -112,10 +112,6 @@ buildPythonPackage rec {
     hatchling
   ];
 
-  pythonRelaxDeps = [
-    # "toolz"
-  ];
-
   dependencies = [
     atpublic
     parsy
@@ -358,6 +354,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/ibis-project/ibis";
     changelog = "https://github.com/ibis-project/ibis/blob/${version}/docs/release_notes.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ cpcloud ];
+    maintainers = with lib.maintainers; [
+      cpcloud
+      sarahec
+    ];
   };
 }


### PR DESCRIPTION
Test failures while running `nixpkgs-review` on #409698. Disabled these tests.

### Probable obsolete duckdb error

```sh
D web_page.wp_char_count BETWEEN 5000 AND 5200\n) AS pt\nORDER BY\n  am_pm_ratio\nLIMIT 100'
kwargs = {}

    def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
        with contextlib.suppress(AttributeError):
            query = query.sql(dialect=self.name)
>       return self.con.execute(query, **kwargs)
E       duckdb.duckdb.ParserException: Parser Error: syntax error at or near "AT"

ibis/backends/duckdb/__init__.py:93: ParserException
```

Will revisit this once #409698 merges.

### Tests package version, but nix rewrites that version to a specific commit

```sh
__________________________ test_builtin_scalar_noargs __________________________
[gw20] linux -- Python 3.12.11 /nix/store/89laaz8x9pdydxzz74p0vd8vdj0szqbq-python3-3.12.11/bin/python3.12

con = <ibis.backends.duckdb.Backend object at 0x7fff0f27f470>

    def test_builtin_scalar_noargs(con):
        @udf.scalar.builtin
        def version() -> str: ...
    
        expr = version()
>       assert con.execute(expr) == f"v{con.version}"
E       AssertionError: assert 'v1.3.1' == 'v1.3.1+g2063...9c6248a907be6'
E         
E         - v1.3.1+g2063dda3e6bd955c364ce8e61939c6248a907be6
E         + v1.3.1

ibis/backends/duckdb/tests/test_udf.py:60: AssertionError
=========================== short test summary info ============================
FAILED ibis/backends/tests/tpc/ds/test_queries.py::test_90[duckdb] - duckdb.duckdb.ParserException: Parser Error: syntax error at or near "AT"
FAILED ibis/backends/duckdb/tests/test_udf.py::test_builtin_scalar_noargs - AssertionError: assert 'v1.3.1' == 'v1.3.1+g2063...9c6248a907be6'
  
  - v1.3.1+g2063dda3e6bd955c364ce8e61939c6248a907be6
  + v1.3.1
= 2 failed, 7757 passed, 242 skipped, 637 xfailed, 2 xpassed in 274.17s (0:04:34) =
(END)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
