### PR TITLE
airi: init at 0.7.0

### DIFF
--- a/pkgs/by-name/ai/airi/package.nix
+++ b/pkgs/by-name/ai/airi/package.nix
@@ -1,0 +1,181 @@
+{
+  config,
+  lib,
+  stdenvNoCC,
+  rustPlatform,
+  fetchFromGitHub,
+
+  autoPatchelfHook,
+  cargo-tauri,
+  cudaPackages,
+  pkg-config,
+  pnpm,
+  wrapGAppsHook3,
+
+  alsa-lib,
+  atk,
+  cacert,
+  glib,
+  libayatana-appindicator,
+  nodejs,
+  onnxruntime,
+  openssl,
+  webkitgtk_4_1,
+
+  cudaSupport ? config.cudaSupport,
+  debugBuild ? false,
+}:
+
+rustPlatform.buildRustPackage (final: {
+  pname = "airi";
+  version = "0.7.0-alpha.1";
+
+  src = fetchFromGitHub {
+    owner = "moeru-ai";
+    repo = "airi";
+    rev = "v${final.version}"; # TODO: update to 0.7.0
+    hash = "sha256-QWpHQ0sVRWZrST//OymoPgs5ls4FiLvFLaktzZZDjto=";
+  };
+
+  cargoHash = "sha256-4NzMs3livelYmYBNUAWNrtEvcsuP0+9+mx49hsP+ym0=";
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (final) pname version src;
+    fetcherVersion = 1;
+    hash = "sha256-ZtIR3vkxxBdIiKgZQrmvlO66OK/NkIM2o6NUvv1vuFs=";
+  };
+
+  # Cache of assets downloaded during vite build
+  assets = stdenvNoCC.mkDerivation {
+    pname = "${final.pname}-assets";
+    inherit (final) version src pnpmDeps;
+
+    nativeBuildInputs = [
+      cacert # For network request
+      nodejs
+      pnpm.configHook
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      pnpm run build:packages
+      pnpm -F @proj-airi/stage-tamagotchi run build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r apps/stage-tamagotchi/.cache/assets $out
+
+      runHook postInstall
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = "sha256-QDGx5sWlWwgMWvG/umkNY+Ct9i5zl+eKEJnvA2whPkY=";
+  };
+
+  nativeBuildInputs =
+    [
+      autoPatchelfHook
+      cargo-tauri.hook
+      nodejs
+      pkg-config
+      pnpm.configHook
+      wrapGAppsHook3
+    ]
+    ++ lib.optionals cudaSupport [
+      cudaPackages.cuda_nvcc # Used by cudarc and bindgen_cuda
+    ];
+
+  buildInputs =
+    [
+      alsa-lib # Used by alsa-sys
+      atk # Used by atk-sys
+      glib # Used by glib-sys
+      libayatana-appindicator # Used by libappindicator-sys
+      onnxruntime # Used by ort-sys
+      openssl # Used by openssl-sys
+      webkitgtk_4_1
+    ]
+    ++ lib.optionals cudaSupport [
+      cudaPackages.cuda_cccl # For nv/target used by bindgen_cuda
+      cudaPackages.cuda_cudart # For cuda.h used by cudarc
+      cudaPackages.cuda_nvrtc
+      cudaPackages.libcublas
+      cudaPackages.libcurand
+    ];
+
+  env = lib.optionalAttrs cudaSupport {
+    # For bindgen_cuda
+    CUDA_COMPUTE_CAP = builtins.replaceStrings [ "." ] [ "" ] (
+      builtins.head cudaPackages.flags.cudaCapabilities
+    );
+  };
+
+  configurePhase = ''
+    runHook preConfigure
+
+    echo Setting up asset cache
+    mkdir apps/stage-tamagotchi/.cache
+    cp -r $assets/assets apps/stage-tamagotchi/.cache
+
+    ${lib.optionalString cudaSupport ''
+      echo Patching cudarc build script to find CUDA
+      # In configurePhase because CUDA is set up in a pre configure hook
+      # cudarc searches in a few environment variables, but they can't be used because they don't
+      # support the CUDAToolkit_ROOT format (semicolon-separated list of paths).
+      # https://github.com/coreylowman/cudarc/blob/main/build.rs#L211
+      substituteInPlace ../cargo-vendor-dir/cudarc-*/build.rs \
+        --replace-fail /usr/lib/cuda "$(echo "$CUDAToolkit_ROOT" | sed 's/;/", "/g')"
+
+      echo Patching bindgen_cuda to find CUDA # Used by candle-kernels
+      # bindgen_cuda copies the pathfinding logic from cudarc
+      # https://github.com/Narsil/bindgen_cuda/blob/main/src/lib.rs#L436
+      substituteInPlace ../cargo-vendor-dir/bindgen_cuda-*/src/lib.rs \
+        --replace-fail /usr/lib/cuda "$(echo "$CUDAToolkit_ROOT" | sed 's/;/", "/g')"
+    ''}
+
+    runHook postConfigure
+  '';
+
+  preBuild = ''
+    pnpm run build:packages
+  '';
+
+  buildAndTestSubdir = "apps/stage-tamagotchi";
+  buildType = if debugBuild then "debug" else "release";
+  cargoBuildFeatures = lib.optional cudaSupport "cuda";
+
+  postInstall = ''
+    mv $out/bin/app $out/bin/airi
+  '';
+
+  # Add missing runtime dependency
+  preFixup = ''
+    patchelf --add-needed libayatana-appindicator3.so.1 $out/bin/airi
+  '';
+
+  meta = {
+    description = "Self-hostable AI waifu / companion / VTuber";
+    longDescription = ''
+      AIRI is a container of souls of AI waifu / virtual characters to bring them into our worlds,
+      wishing to achieve Neuro-sama's altitude, completely LLM and AI driven, capable of realtime
+      voice chat, Minecraft playing, Factorio playing. It can be run in Browser or Desktop.
+    '';
+    homepage = "https://github.com/moeru-ai/airi";
+    changelog = "https://github.com/moeru-ai/airi/releases/tag/v${final.version}";
+    # While airi itself is licensed under MIT, it uses the nonfree Cubism SDK. Whether it's
+    # redistributable remains a question, so we say it's not.
+    license = lib.licenses.unfree;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "airi";
+    maintainers = with lib.maintainers; [ weathercold ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add package for [airi](https://github.com/moeru-ai/airi)

There is currently a bug where the default model doesn't show up. Also the rendering of certain UI elements is broken on wayland. I don't know if this is a software or packaging issue. Any help is appreciated! I might come back and fix it later.

(I also got `EGL_BAD_PARAMETER` on xubuntu likely due to https://github.com/gitbutlerapp/gitbutler/issues/5282, but it's not a packaging issue)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
