### PR TITLE
gstreamer: 1.26.0 -> 1.26.3

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -113,7 +113,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-bad";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "out"
@@ -122,21 +122,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${finalAttrs.version}.tar.xz";
-    hash = "sha256-+Ch6hMX2Y2ilpQ2l+WmZSgLEfyAiD/4coxVBk+Za8hY=";
+    hash = "sha256-lcSNrK8UJ29OWV9MvKlLPP6/wiKF52XiqlbQpydddWE=";
   };
 
   patches = [
     # Add fallback paths for nvidia userspace libraries
     (replaceVars ./fix-paths.patch {
       inherit (addDriverRunpath) driverLink;
-    })
-
-    # Fix Requires in gstreamer-analytics-1.0.pc
-    # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/8661
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/bc93bbf5c87ec994ea136bb40accc09dfa35ae98.patch";
-      stripLen = 2;
-      hash = "sha256-QQDpHe363iPxTuthITRbLUKaAXS2F9s5zfCn/ps14WE=";
     })
   ];
 

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -50,7 +50,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-base";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "out"
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${finalAttrs.version}.tar.xz";
-    hash = "sha256-4jGJ++0uxIZpA4LRBVwZ7q9arj6V4ldvxMiE2WqQ5p4=";
+    hash = "sha256-Tvn57wkCUwjOIg4t0iqJ5MmS2MpxuWjjxwrwY07CeTM=";
   };
 
   strictDeps = true;

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -40,7 +40,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstreamer";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "bin"
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Gy7kAoAQwlt3bv+nw5bH4+GGG2C5QX5Bb0kUq83/J58=";
+    hash = "sha256-3GYWAyISk9zMdAhiQl61T7vtYPsp0IyAHUQKaj/4JoA=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/gstreamer/devtools/default.nix
+++ b/pkgs/development/libraries/gstreamer/devtools/default.nix
@@ -28,7 +28,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-devtools";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "out"
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-devtools/gst-devtools-${finalAttrs.version}.tar.xz";
-    hash = "sha256-7/M9fcKSuwdKJ4jqiHtigzmP/e+vpJ+30I7+ZlimVkg=";
+    hash = "sha256-T94Zw8FEg0+MsFwso/FLOlDTlbrSA9F/mKbnDBZy8ro=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
@@ -47,17 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
       cargoRoot
       ;
     name = "gst-devtools-${finalAttrs.version}";
-    hash = "sha256-GLxevEwoTgS7kmDlul0AA2wIFRY7js8Ij4UIu1ZQf8I=";
+    hash = "sha256-AgxvFMq37a8NuOHY1QIUGOAo8aSBt4HVeSCHNUYa1tQ=";
   };
 
   patches = [
-    # Fix Requires in gstreamer-validate-1.0.pc
-    # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/8661
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/13c0f44dd546cd058c39f32101a361b3a7746f73.patch";
-      stripLen = 2;
-      hash = "sha256-CpBFTmdn+VO6ZeNe6NZR6ELvakZqQdaF3o3G5TSDuUU=";
-    })
     # dots-viewer: sort static files
     # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9208
     (fetchpatch {

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-editing-services";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "out"
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-editing-services/gst-editing-services-${finalAttrs.version}.tar.xz";
-    hash = "sha256-r1sn9ck2MCc3IQDKwLrxkFUoBynfHMWN1ORU72mOsf8=";
+    hash = "sha256-3SCpPSw0aLahAk/wySeIayGTe9E7jLjxdfhjc2DRb9I=";
   };
 
   nativeBuildInputs =

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -74,7 +74,7 @@ assert raspiCameraSupport -> hostSupportsRaspiCamera;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-good";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "out"
@@ -83,20 +83,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${finalAttrs.version}.tar.xz";
-    hash = "sha256-nhjxOe9prQhnwt+7j+HRc2123xGqyD9g6NOtseLq8Ds=";
+    hash = "sha256-/k7JZw7f5rseXycWmuFFtawt0hismL2CUcj7pBrTPFM=";
   };
 
   patches = [
     # dlopen libsoup_3 with an absolute path
     (replaceVars ./souploader.diff {
       nixLibSoup3Path = "${lib.getLib libsoup_3}/lib";
-    })
-
-    (fetchpatch {
-      name = "musl.patch";
-      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/dd1fc2b7931f5789815e17dda2ef7c31b9fba563.patch";
-      stripLen = 2;
-      hash = "sha256-m2h1F6M2hzw3HxizmCyEEqkUQe0ccLWFBvgT2f+GjNE=";
     })
   ];
 

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-libav";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${finalAttrs.version}.tar.xz";
-    hash = "sha256-cHqLaH/1/dzuWwJBXi7JtxtKxE0Leuw7R3Nkzuy/Hs8=";
+    hash = "sha256-Otp+UKO5uLo+QFsUxAIeJfuxA3n3fSzkkKoWUj7Sck0=";
   };
 
   nativeBuildInputs =

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-rtsp-server";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-rtsp-server/gst-rtsp-server-${finalAttrs.version}.tar.xz";
-    hash = "sha256-6YPAOUluP3XjlpZVTOdNtBIOJGXeF6ocw3FgVo6bQLw=";
+    hash = "sha256-QV6KU6mER4l3DdTxFqwuOkoz3kJnPFeswlxboPRAb8U=";
   };
 
   nativeBuildInputs =

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-plugins-ugly";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${finalAttrs.version}.tar.xz";
-    hash = "sha256-qGtRyEVKgTEghIyANCHzJ9jAeqvK5GHgWXzEk5jA/N4=";
+    hash = "sha256-QX9e6JX3NKwDQbNxnBdf/xa0yOrogG4p4XCzvLPZ26U=";
   };
 
   nativeBuildInputs =

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -30,7 +30,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gstreamer-vaapi";
-  version = "1.26.0";
+  version = "1.26.3";
 
   outputs = [
     "out"
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://gstreamer.freedesktop.org/src/gstreamer-vaapi/gstreamer-vaapi-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Vzkx1FX1qW9j23yNNdUTIrjSh4FujGp32Ez7ufoTUfE=";
+    hash = "sha256-LWQ/vRQgKX2lpNaUXRHwpbT4L+6lTqauyTaNQpldiwM=";
   };
 
   nativeBuildInputs =


### PR DESCRIPTION
On the way of a bug tracking after updating to 25.05 (gstreamer 1.24.10 -> 1.26.0), I updated gstreamer with the hope it would fix my issue, but an vain. Anyway I thought sharing the work could be interesting and save someone else the time.

This PR mostly update tags and shas. I also removed patch that I think got merged. Anyway they were causing conflict upon merging.

In case anyone wonder, here is also an overlay I used to port this PR in my flake:

```nix
(final: prev: {
  gst_all_1 = prev.gst_all_1 // {
    gstreamer = prev.gst_all_1.gstreamer.overrideAttrs (oldAttrs: rec {
      version = "1.26.3";
      src = final.fetchurl {
        url = "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${version}.tar.xz";
        hash = "sha256-3GYWAyISk9zMdAhiQl61T7vtYPsp0IyAHUQKaj/4JoA=";
      };
    });
    gst-plugins-base =
      (prev.gst_all_1.gst-plugins-base.override {
        gstreamer = final.gst_all_1.gstreamer;
      }).overrideAttrs
        (oldAttrs: rec {
          version = "1.26.3";
          src = final.fetchurl {
            url = "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${version}.tar.xz";
            hash = "sha256-Tvn57wkCUwjOIg4t0iqJ5MmS2MpxuWjjxwrwY07CeTM=";
          };
        });
    gst-plugins-good =
      (prev.gst_all_1.gst-plugins-good.override {
        gst-plugins-base = final.gst_all_1.gst-plugins-base;
      }).overrideAttrs
        (oldAttrs: rec {
          version = "1.26.3";
          src = final.fetchurl {
            url = "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${version}.tar.xz";
            hash = "sha256-/k7JZw7f5rseXycWmuFFtawt0hismL2CUcj7pBrTPFM=";
          };
          # only keep the first patch in the list
          patches = [
            (builtins.elemAt oldAttrs.patches 0)
          ];
        });
    gst-plugins-bad =
      (prev.gst_all_1.gst-plugins-bad.override {
        gstreamer = final.gst_all_1.gstreamer;
        gst-plugins-base = final.gst_all_1.gst-plugins-base;
      }).overrideAttrs
        (oldAttrs: rec {
          version = "1.26.3";
          src = final.fetchurl {
            url = "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${version}.tar.xz";
            hash = "sha256-lcSNrK8UJ29OWV9MvKlLPP6/wiKF52XiqlbQpydddWE=";
          };
          # only keep the first patch in the list
          patches = [
            (builtins.elemAt oldAttrs.patches 0)
          ];
        });
    gst-plugins-ugly =
      (prev.gst_all_1.gst-plugins-ugly.override {
        gst-plugins-base = final.gst_all_1.gst-plugins-base;
      }).overrideAttrs
        (oldAttrs: rec {
          version = "1.26.3";
          src = final.fetchurl {
            url = "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${version}.tar.xz";
            hash = "sha256-QX9e6JX3NKwDQbNxnBdf/xa0yOrogG4p4XCzvLPZ26U=";
          };
        });
    gst-plugins-rs = (
      prev.gst_all_1.gst-plugins-rs.override {
        gstreamer = final.gst_all_1.gstreamer;
        gst-plugins-base = final.gst_all_1.gst-plugins-base;
        gst-plugins-good = final.gst_all_1.gst-plugins-good;
        gst-plugins-bad = final.gst_all_1.gst-plugins-bad;
      }
    );
  };
})
```


Also a side note unrelated if someone end up here looking for the same bug as me: https://github.com/standard-ai/tracing-gstreamer/issues/25
