### PR TITLE
nushellPlugins.*: refactor, add checks, mark some as broken

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -20,6 +20,9 @@
 }:
 
 let
+  # NOTE: when updating this to a new non-patch version, please also try to
+  # update the plugins. Plugins only work if they are compiled for the same
+  # major/minor version.
   version = "0.105.1";
 in
 rustPlatform.buildRustPackage {

--- a/pkgs/shells/nushell/plugins/dbus.nix
+++ b/pkgs/shells/nushell/plugins/dbus.nix
@@ -11,18 +11,17 @@
   nushell_plugin_dbus,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_dbus";
   version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "devyn";
-    repo = pname;
-    rev = version;
+    repo = "nu_plugin_dbus";
+    tag = finalAttrs.version;
     hash = "sha256-Ga+1zFwS/v+3iKVEz7TFmJjyBW/gq6leHeyH2vjawto=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-7pD5LA1ytO7VqFnHwgf7vW9eS3olnZBgdsj+rmcHkbU=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
@@ -35,19 +34,19 @@ rustPlatform.buildRustPackage rec {
         nu = lib.getExe nushell;
         plugin = lib.getExe nushell_plugin_dbus;
       in
-      runCommand "${pname}-test" { } ''
+      runCommand "${finalAttrs.pname}-test" { } ''
         touch $out
         ${nu} -n -c "plugin add --plugin-config $out ${plugin}"
         ${nu} -n -c "plugin use --plugin-config $out dbus"
       '';
   };
 
-  meta = with lib; {
+  meta = {
     description = "Nushell plugin for communicating with D-Bus";
     mainProgram = "nu_plugin_dbus";
     homepage = "https://github.com/devyn/nu_plugin_dbus";
-    license = licenses.mit;
-    maintainers = with maintainers; [ aftix ];
-    platforms = with platforms; linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aftix ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/dbus.nix
+++ b/pkgs/shells/nushell/plugins/dbus.nix
@@ -1,14 +1,11 @@
 {
   stdenv,
-  runCommand,
   lib,
   rustPlatform,
   pkg-config,
   nix-update-script,
   fetchFromGitHub,
   dbus,
-  nushell,
-  nushell_plugin_dbus,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -27,19 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = [ dbus ];
 
-  passthru = {
-    updateScript = nix-update-script { };
-    tests.check =
-      let
-        nu = lib.getExe nushell;
-        plugin = lib.getExe nushell_plugin_dbus;
-      in
-      runCommand "${finalAttrs.pname}-test" { } ''
-        touch $out
-        ${nu} -n -c "plugin add --plugin-config $out ${plugin}"
-        ${nu} -n -c "plugin use --plugin-config $out dbus"
-      '';
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Nushell plugin for communicating with D-Bus";

--- a/pkgs/shells/nushell/plugins/dbus.nix
+++ b/pkgs/shells/nushell/plugins/dbus.nix
@@ -33,5 +33,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ aftix ];
     platforms = lib.platforms.linux;
+    # "Plugin `dbus` is compiled for nushell version 0.101.0, which is not
+    # compatible with version 0.105.1"
+    broken = true;
   };
 })

--- a/pkgs/shells/nushell/plugins/default.nix
+++ b/pkgs/shells/nushell/plugins/default.nix
@@ -3,28 +3,40 @@
   config,
   newScope,
   dbus,
+  versionCheckHook,
 }:
 
 lib.makeScope newScope (
   self:
-  with self;
-  {
-    gstat = callPackage ./gstat.nix { };
-    formats = callPackage ./formats.nix { };
-    polars = callPackage ./polars.nix { };
-    query = callPackage ./query.nix { };
-    net = callPackage ./net.nix { };
-    units = callPackage ./units.nix { };
-    highlight = callPackage ./highlight.nix { };
-    dbus = callPackage ./dbus.nix {
-      inherit dbus;
-      nushell_plugin_dbus = self.dbus;
-    };
-    skim = callPackage ./skim.nix { };
-    semver = callPackage ./semver.nix { };
-    hcl = callPackage ./hcl.nix { };
-  }
-  // lib.optionalAttrs config.allowAliases {
-    regex = throw "`nu_plugin_regex` is no longer compatible with the current Nushell release.";
-  }
+
+  lib.mapAttrs
+    (
+      _n: p:
+      p.overrideAttrs {
+        doInstallCheck = true;
+        nativeInstallCheckInputs = [ versionCheckHook ];
+      }
+    )
+    (
+      with self;
+      {
+        gstat = callPackage ./gstat.nix { };
+        formats = callPackage ./formats.nix { };
+        polars = callPackage ./polars.nix { };
+        query = callPackage ./query.nix { };
+        net = callPackage ./net.nix { };
+        units = callPackage ./units.nix { };
+        highlight = callPackage ./highlight.nix { };
+        dbus = callPackage ./dbus.nix {
+          inherit dbus;
+          nushell_plugin_dbus = self.dbus;
+        };
+        skim = callPackage ./skim.nix { };
+        semver = callPackage ./semver.nix { };
+        hcl = callPackage ./hcl.nix { };
+      }
+      // lib.optionalAttrs config.allowAliases {
+        regex = throw "`nu_plugin_regex` is no longer compatible with the current Nushell release.";
+      }
+    )
 )

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -7,32 +7,27 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nushell_plugin_formats";
   inherit (nushell) version src cargoHash;
-  useFetchCargoVendor = true;
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
-  cargoBuildFlags = [ "--package nu_plugin_formats" ];
 
-  checkPhase = ''
-    cargo test --manifest-path crates/nu_plugin_formats/Cargo.toml
-  '';
+  buildAndTestSubdir = "crates/nu_plugin_formats";
 
   passthru.updateScript = nix-update-script {
     # Skip the version check and only check the hash because we inherit version from nushell.
     extraArgs = [ "--version=skip" ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "Formats plugin for Nushell";
     mainProgram = "nu_plugin_formats";
-    homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_formats";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    homepage = "https://github.com/nushell/nushell/tree/${finalAttrs.version}/crates/nu_plugin_formats";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       viraptor
       aidalgol
     ];
-    platforms = with platforms; all;
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -8,7 +8,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nushell_plugin_formats";
+  pname = "nu_plugin_formats";
   inherit (nushell) version src cargoHash;
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -8,33 +8,28 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nushell_plugin_gstat";
   inherit (nushell) version src cargoHash;
-  useFetchCargoVendor = true;
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = [ openssl ];
-  cargoBuildFlags = [ "--package nu_plugin_gstat" ];
 
-  checkPhase = ''
-    cargo test --manifest-path crates/nu_plugin_gstat/Cargo.toml
-  '';
+  buildAndTestSubdir = "crates/nu_plugin_gstat";
 
   passthru.updateScript = nix-update-script {
     # Skip the version check and only check the hash because we inherit version from nushell.
     extraArgs = [ "--version=skip" ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "Git status plugin for Nushell";
     mainProgram = "nu_plugin_gstat";
-    homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_gstat";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    homepage = "https://github.com/nushell/nushell/tree/${finalAttrs.version}/crates/nu_plugin_gstat";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       mrkkrp
       aidalgol
     ];
-    platforms = with platforms; all;
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -9,7 +9,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nushell_plugin_gstat";
+  pname = "nu_plugin_gstat";
   inherit (nushell) version src cargoHash;
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];

--- a/pkgs/shells/nushell/plugins/hcl.nix
+++ b/pkgs/shells/nushell/plugins/hcl.nix
@@ -8,7 +8,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nushell_plugin_hcl";
+  pname = "nu_plugin_hcl";
   version = "0.105.1";
 
   src = fetchFromGitHub {

--- a/pkgs/shells/nushell/plugins/hcl.nix
+++ b/pkgs/shells/nushell/plugins/hcl.nix
@@ -22,6 +22,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 
+  # there are no tests
+  doCheck = false;
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/shells/nushell/plugins/hcl.nix
+++ b/pkgs/shells/nushell/plugins/hcl.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     tag = version;
     hash = "sha256-V1RKZ0Tqq0LTGbHS2lLMyf6M4AgAgWSzkDeFUighO4k=";
   };
-  useFetchCargoVendor = true;
+
   cargoHash = "sha256-UbqKfQxut+76yB9F1gT8FEapbX/kHvaShltHpWUdhgc=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];

--- a/pkgs/shells/nushell/plugins/hcl.nix
+++ b/pkgs/shells/nushell/plugins/hcl.nix
@@ -7,30 +7,28 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nushell_plugin_hcl";
   version = "0.105.1";
 
   src = fetchFromGitHub {
-    repo = "nu_plugin_hcl";
     owner = "Yethal";
-    tag = version;
+    repo = "nu_plugin_hcl";
+    tag = finalAttrs.version;
     hash = "sha256-V1RKZ0Tqq0LTGbHS2lLMyf6M4AgAgWSzkDeFUighO4k=";
   };
 
   cargoHash = "sha256-UbqKfQxut+76yB9F1gT8FEapbX/kHvaShltHpWUdhgc=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
-  cargoBuildFlags = [ "--package nu_plugin_hcl" ];
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Nushell plugin for parsing Hashicorp Configuration Language files";
     mainProgram = "nu_plugin_hcl";
     homepage = "https://github.com/Yethal/nu_plugin_hcl";
-    license = licenses.mit;
-    maintainers = with maintainers; [ yethal ];
-    platforms = with platforms; all;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yethal ];
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/highlight.nix
+++ b/pkgs/shells/nushell/plugins/highlight.nix
@@ -23,6 +23,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 
+  # there are no tests
+  doCheck = false;
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/shells/nushell/plugins/highlight.nix
+++ b/pkgs/shells/nushell/plugins/highlight.nix
@@ -7,36 +7,29 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nushell_plugin_highlight";
   version = "1.4.7+0.105.1";
 
   src = fetchFromGitHub {
-    repo = "nu-plugin-highlight";
     owner = "cptpiepmatz";
-    rev = "refs/tags/v${version}";
+    repo = "nu-plugin-highlight";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0jU0c2v3q3RXX/zZlwTBwAdO8HEaROFNV/F4GBFaMt0=";
     fetchSubmodules = true;
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-UD1IzegajAG13iAOERymDa10JbuhvORVZ8gHy9d6buE=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
-  cargoBuildFlags = [ "--package nu_plugin_highlight" ];
-
-  checkPhase = ''
-    cargo test
-  '';
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "A nushell plugin for syntax highlighting.";
     mainProgram = "nu_plugin_highlight";
     homepage = "https://github.com/cptpiepmatz/nu-plugin-highlight";
-    license = licenses.mit;
-    maintainers = with maintainers; [ mgttlinger ];
-    platforms = with platforms; all;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mgttlinger ];
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/highlight.nix
+++ b/pkgs/shells/nushell/plugins/highlight.nix
@@ -8,7 +8,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nushell_plugin_highlight";
+  pname = "nu_plugin_highlight";
   version = "1.4.7+0.105.1";
 
   src = fetchFromGitHub {

--- a/pkgs/shells/nushell/plugins/net.nix
+++ b/pkgs/shells/nushell/plugins/net.nix
@@ -7,7 +7,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nushell_plugin_net";
+  pname = "nu_plugin_net";
   version = "1.10.0";
 
   src = fetchFromGitHub {

--- a/pkgs/shells/nushell/plugins/net.nix
+++ b/pkgs/shells/nushell/plugins/net.nix
@@ -1,33 +1,33 @@
 {
+  stdenv,
   lib,
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nushell_plugin_net";
   version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "fennewald";
     repo = "nu_plugin_net";
-    rev = "refs/tags/${version}";
+    tag = "${finalAttrs.version}";
     hash = "sha256-HiNydU40FprxVmRRZtnXom2kFYI04mbeuGTq8+BMh7o=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-tq0XqY2B7tC2ep8vH6T3nkAqxqhniqzYnhbkfB3SbHU=";
 
-  nativeBuildInputs = [ rustPlatform.bindgenHook ];
+  nativeBuildInputs = lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "Nushell plugin to list system network interfaces";
     homepage = "https://github.com/fennewald/nu_plugin_net";
-    license = licenses.mit;
-    maintainers = with maintainers; [ happysalada ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ happysalada ];
     mainProgram = "nu_plugin_net";
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/net.nix
+++ b/pkgs/shells/nushell/plugins/net.nix
@@ -21,6 +21,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 
+  # there are no tests
+  doCheck = false;
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/shells/nushell/plugins/net.nix
+++ b/pkgs/shells/nushell/plugins/net.nix
@@ -32,5 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ happysalada ];
     mainProgram = "nu_plugin_net";
+    # "Plugin `net` is compiled for nushell version 0.104.0, which is not
+    # compatible with version 0.105.1"
+    broken = true;
   };
 })

--- a/pkgs/shells/nushell/plugins/polars.nix
+++ b/pkgs/shells/nushell/plugins/polars.nix
@@ -8,33 +8,29 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nushell_plugin_polars";
   inherit (nushell) version src cargoHash;
 
-  useFetchCargoVendor = true;
-
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = [ openssl ];
-  cargoBuildFlags = [ "--package nu_plugin_polars" ];
 
-  checkPhase = ''
-    # test failed without enough columns
-    cargo test --manifest-path crates/nu_plugin_polars/Cargo.toml -- \
-      --skip=dataframe::command::core::to_repr::test::test_examples
-  '';
+  buildAndTestSubdir = "crates/nu_plugin_polars";
+
+  checkFlags = [
+    "--skip=dataframe::command::core::to_repr::test::test_examples"
+  ];
 
   passthru.updateScript = nix-update-script {
     # Skip the version check and only check the hash because we inherit version from nushell.
     extraArgs = [ "--version=skip" ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "Nushell dataframe plugin commands based on polars";
     mainProgram = "nu_plugin_polars";
-    homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_polars";
-    license = licenses.mit;
-    maintainers = with maintainers; [ joaquintrinanes ];
-    platforms = with platforms; all;
+    homepage = "https://github.com/nushell/nushell/tree/${finalAttrs.version}/crates/nu_plugin_polars";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ joaquintrinanes ];
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/polars.nix
+++ b/pkgs/shells/nushell/plugins/polars.nix
@@ -9,7 +9,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nushell_plugin_polars";
+  pname = "nu_plugin_polars";
   inherit (nushell) version src cargoHash;
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -9,21 +9,17 @@
   curl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nushell_plugin_query";
   inherit (nushell) version src cargoHash;
-  useFetchCargoVendor = true;
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = [
     openssl
     curl
   ];
-  cargoBuildFlags = [ "--package nu_plugin_query" ];
 
-  checkPhase = ''
-    cargo test --manifest-path crates/nu_plugin_query/Cargo.toml
-  '';
+  buildAndTestSubdir = "crates/nu_plugin_query";
 
   passthru.updateScript = nix-update-script {
     # Skip the version check and only check the hash because we inherit version from nushell.
@@ -33,12 +29,11 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Nushell plugin to query JSON, XML, and various web data";
     mainProgram = "nu_plugin_query";
-    homepage = "https://github.com/nushell/nushell/tree/${version}/crates/nu_plugin_query";
+    homepage = "https://github.com/nushell/nushell/tree/${finalAttrs.version}/crates/nu_plugin_query";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       happysalada
       aidalgol
     ];
-    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -10,7 +10,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nushell_plugin_query";
+  pname = "nu_plugin_query";
   inherit (nushell) version src cargoHash;
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];

--- a/pkgs/shells/nushell/plugins/skim.nix
+++ b/pkgs/shells/nushell/plugins/skim.nix
@@ -1,12 +1,9 @@
 {
   stdenv,
-  runCommand,
   lib,
   rustPlatform,
   nix-update-script,
   fetchFromGitHub,
-  nushell,
-  skim,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -24,19 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 
-  passthru = {
-    updateScript = nix-update-script { };
-    tests.check =
-      let
-        nu = lib.getExe nushell;
-        plugin = lib.getExe skim;
-      in
-      runCommand "${finalAttrs.pname}-test" { } ''
-        touch $out
-        ${nu} -n -c "plugin add --plugin-config $out ${plugin}"
-        ${nu} -n -c "plugin use --plugin-config $out skim"
-      '';
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "A nushell plugin that adds integrates the skim fuzzy finder";

--- a/pkgs/shells/nushell/plugins/skim.nix
+++ b/pkgs/shells/nushell/plugins/skim.nix
@@ -9,21 +9,20 @@
   skim,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu_plugin_skim";
   version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "idanarye";
-    repo = pname;
-    tag = "v${version}";
+    repo = "nu_plugin_skim";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-8gO6pT40zBlFxPRapIO9qpMI9whutttqYgOPr91B9Ec=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-2poE7Nnwe5rRoU8WknEgzX68z+y9ZplX53v8FURzxmE=";
 
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ rustPlatform.bindgenHook ];
+  nativeBuildInputs = lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
 
   passthru = {
     updateScript = nix-update-script { };
@@ -32,19 +31,18 @@ rustPlatform.buildRustPackage rec {
         nu = lib.getExe nushell;
         plugin = lib.getExe skim;
       in
-      runCommand "${pname}-test" { } ''
+      runCommand "${finalAttrs.pname}-test" { } ''
         touch $out
         ${nu} -n -c "plugin add --plugin-config $out ${plugin}"
         ${nu} -n -c "plugin use --plugin-config $out skim"
       '';
   };
 
-  meta = with lib; {
+  meta = {
     description = "A nushell plugin that adds integrates the skim fuzzy finder";
     mainProgram = "nu_plugin_skim";
     homepage = "https://github.com/idanarye/nu_plugin_skim";
-    license = licenses.mit;
-    maintainers = with maintainers; [ aftix ];
-    platforms = platforms.all;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aftix ];
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/units.nix
+++ b/pkgs/shells/nushell/plugins/units.nix
@@ -7,30 +7,28 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nushell_plugin_units";
   version = "0.1.6";
 
   src = fetchFromGitHub {
-    repo = "nu_plugin_units";
     owner = "JosephTLyons";
-    rev = "v${version}";
+    repo = "nu_plugin_units";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-1KyuUaWN+OiGpo8Ohc/8B+nisdb8uT+T3qBu+JbaVYo=";
   };
-  useFetchCargoVendor = true;
+
   cargoHash = "sha256-LYVwFM8znN96LwOwRnauehrucSqHnKNPoMzl2HRczww=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
-  cargoBuildFlags = [ "--package nu_plugin_units" ];
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
-    description = "A nushell plugin for easily converting between common units.";
+  meta = {
+    description = "Nushell plugin for easily converting between common units";
     mainProgram = "nu_plugin_units";
     homepage = "https://github.com/JosephTLyons/nu_plugin_units";
-    license = licenses.mit;
-    maintainers = with maintainers; [ mgttlinger ];
-    platforms = with platforms; all;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mgttlinger ];
   };
-}
+})

--- a/pkgs/shells/nushell/plugins/units.nix
+++ b/pkgs/shells/nushell/plugins/units.nix
@@ -8,7 +8,7 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "nushell_plugin_units";
+  pname = "nu_plugin_units";
   version = "0.1.6";
 
   src = fetchFromGitHub {

--- a/pkgs/shells/nushell/plugins/units.nix
+++ b/pkgs/shells/nushell/plugins/units.nix
@@ -30,5 +30,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/JosephTLyons/nu_plugin_units";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mgttlinger ];
+    # "Plugin `units` is compiled for nushell version 0.104.0, which is not
+    # compatible with version 0.105.1"
+    broken = true;
   };
 })


### PR DESCRIPTION
This PR modernizes the 12 existing nushell plugins in the repo. I noticed a lot of copy-pasting has been done, with a lot of the same problems in it, so I did all of it in one go.

The new packages should be functionally equivalent, because all I did was reformat/rearrange things. 

Summary:
- Did some trivial stuff like use `finalAttrs` and remove `with lib;`
- Removed `useCargoFetchVendor`
- Some packages had weird testing/workspace practices. Replaced those with `buildAndtestSubdir`, `checkFlags` etc. instead of a manual `checkPhase`
- Renamed `nushell_plugin_*` -> `nu_plugin_*` to reflect the main binary name (for `versionCheckHook` and consistency because there were already files with `nu_plugin_*` as pname)
- Removed `meta.platforms.all`
- Removed references to `pname`
- Added `versionCheckHook` to all of them
- Added a check that tries to load the plugin to all of them

I did all of it manually, which is error-prone but I didn't think it was worth automating.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
