### PR TITLE
libiio: 0.24 -> 0.26

### DIFF
--- a/pkgs/by-name/li/libiio/cmake-fix-libxml2-find-package.patch
+++ b/pkgs/by-name/li/libiio/cmake-fix-libxml2-find-package.patch
@@ -1,13 +1,13 @@
-diff --color -ur a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt	2022-06-02 02:57:01.503340155 +0300
-+++ b/CMakeLists.txt	2022-06-02 02:54:33.726941188 +0300
-@@ -378,7 +378,7 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d5313c50..0ef102bf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -408,7 +408,7 @@ if (WITH_XML_BACKEND)
  	# So, try first to find the CMake module provided by libxml2 package, then fallback
  	# on the CMake's FindLibXml2.cmake module (which can lack some definition, especially
  	# in static build case).
--	find_package(LibXml2 QUIET NO_MODULE)
+-	find_package(LibXml2 QUIET NO_MODULE NO_SYSTEM_ENVIRONMENT_PATH)
 +	find_package(LibXml2 QUIET MODULE)
  	if(DEFINED LIBXML2_VERSION_STRING)
  		set(LIBXML2_FOUND ON)
  		set(LIBXML2_INCLUDE_DIR ${LIBXML2_INCLUDE_DIRS})
-Seulement dans b: good.patch

--- a/pkgs/by-name/li/libiio/hardcode-library-path.patch
+++ b/pkgs/by-name/li/libiio/hardcode-library-path.patch
@@ -1,38 +1,19 @@
 diff --git a/bindings/python/iio.py b/bindings/python/iio.py
-index 5306daa..f8962ee 100644
+index b91260cc..04bcfa7f 100644
 --- a/bindings/python/iio.py
 +++ b/bindings/python/iio.py
-@@ -229,9 +229,9 @@ if "Windows" in _system():
-     _iiolib = "libiio.dll"
- else:
-     # Non-windows, possibly Posix system
--    _iiolib = "iio"
-+    _iiolib = "@libiio@"
+@@ -218,13 +218,7 @@ _ChannelPtr = _POINTER(_Channel)
+ _BufferPtr = _POINTER(_Buffer)
+ _DataFormatPtr = _POINTER(DataFormat)
  
+-if "Windows" in _system():
+-    _iiolib = "libiio.dll"
+-else:
+-    # Non-windows, possibly Posix system
+-    _iiolib = "iio"
+-
 -_lib = _cdll(find_library(_iiolib), use_errno=True, use_last_error=True)
-+_lib = _cdll(_iiolib, use_errno=True, use_last_error=True)
++_lib = _cdll("@libiio@", use_errno=True, use_last_error=True)
  
  _get_backends_count = _lib.iio_get_backends_count
  _get_backends_count.restype = c_uint
-diff --git a/bindings/python/setup.py.cmakein b/bindings/python/setup.py.cmakein
-index cd14e2e..516c409 100644
---- a/bindings/python/setup.py.cmakein
-+++ b/bindings/python/setup.py.cmakein
-@@ -62,7 +62,7 @@ class InstallWrapper(install):
-             _iiolib = "libiio.dll"
-         else:
-             # Non-windows, possibly Posix system
--            _iiolib = "iio"
-+            _iiolib = "@libiio@"
-         try:
-             import os
- 
-@@ -72,7 +72,7 @@ class InstallWrapper(install):
-                 fulllibpath = find_recursive(destdir, "libiio.so")
-                 _lib = _cdll(fulllibpath, use_errno=True, use_last_error=True)
-             else:
--                _lib = _cdll(find_library(_iiolib), use_errno=True, use_last_error=True)
-+                _lib = _cdll(_iiolib, use_errno=True, use_last_error=True)
-             if not _lib._name:
-                 raise OSError
-         except OSError:


### PR DESCRIPTION
Diff: https://github.com/analogdevicesinc/libiio/compare/v0.24...v0.26

Changelog:
https://github.com/analogdevicesinc/libiio/releases/tag/v0.25
           https://github.com/analogdevicesinc/libiio/releases/tag/v0.26

fixes https://github.com/NixOS/nixpkgs/issues/420199
cc @Peter3579 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
