### PR TITLE
avalanche-cli: init at 1.9.2

### DIFF
--- a/pkgs/by-name/av/avalanche-cli/package.nix
+++ b/pkgs/by-name/av/avalanche-cli/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  blst,
+  libusb1,
+  stdenv,
+  buildPackages,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  installShellFiles,
+  makeWrapper,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "avalanche-cli";
+  version = "1.9.2";
+
+  src = fetchFromGitHub {
+    owner = "ava-labs";
+    repo = "avalanche-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/HwZUsggBeuSZLYQDWUU4rfktnvwVolE5mKiZW4IXXs=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-JQEWEqseg5q0b8rPlO/19V1BLbWBdXldoWgUiqI9Qh4=";
+
+  # Fix error: 'Caught SIGILL in blst_cgo_init'
+  # https://github.com/bnb-chain/bsc/issues/1521
+  CGO_CFLAGS = "-O -D__BLST_PORTABLE__";
+  CGO_CFLAGS_ALLOW = "-O -D__BLST_PORTABLE__";
+
+  ldflags = [
+    "-s"
+    "-X=github.com/ava-labs/avalanche-cli/cmd.Version=${finalAttrs.version}"
+  ];
+
+  buildInputs = [
+    blst
+    libusb1
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    writableTmpDirAsHomeHook
+  ];
+
+  patches = [ ./skip_min_version_check.patch ];
+
+  postInstall =
+    let
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/avalanche"
+        else
+          lib.getExe buildPackages.avalanche-cli;
+    in
+    ''
+      mv $out/bin/avalanche-cli $out/bin/avalanche
+      wrapProgram $out/bin/avalanche --add-flags "--skip-update-check"
+
+      mkdir $HOME/.avalanche-cli
+      echo "{ }" > $HOME/.avalanche-cli/config.json
+
+      installShellCompletion --cmd avalanche \
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/avalanche";
+  versionCheckProgramArg = "--version";
+
+  doCheck = false;
+
+  meta = {
+    description = "Command line tool that gives developers access to everything Avalanche";
+    homepage = "https://github.com/ava-labs/avalanche-cli";
+    changelog = "https://github.com/ava-labs/avalanche-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = with lib.maintainers; [ iamanaws ];
+    mainProgram = "avalanche";
+  };
+})

--- a/pkgs/by-name/av/avalanche-cli/skip_min_version_check.patch
+++ b/pkgs/by-name/av/avalanche-cli/skip_min_version_check.patch
@@ -1,0 +1,14 @@
+diff --git a/cmd/root.go b/cmd/root.go
+index c47518dd..9ae886eb 100644
+--- a/cmd/root.go
++++ b/cmd/root.go
+@@ -147,6 +147,9 @@ func createApp(cmd *cobra.Command, _ []string) error {
+ 		return err
+ 	}
+ 	if err := version.CheckCLIVersionIsOverMin(app, app.GetVersion()); err != nil {
++		if strings.Contains(cmd.CommandPath(), "completion") {
++			return nil
++		}
+ 		return err
+ 	}
+ 	return nil


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Old PR: https://github.com/NixOS/nixpkgs/pull/238096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
