### PR TITLE
dwm: fix static build

### DIFF
--- a/pkgs/applications/window-managers/dwm/default.nix
+++ b/pkgs/applications/window-managers/dwm/default.nix
@@ -6,6 +6,7 @@
   libXinerama,
   libXft,
   writeText,
+  pkg-config,
   patches ? [ ],
   conf ? null,
   # update script dependencies
@@ -21,6 +22,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Ideev6ny+5MUGDbCZmy4H0eExp1k5/GyNS+blwuglyk=";
   };
 
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isStatic pkg-config;
+
   buildInputs = [
     libX11
     libXinerama
@@ -29,6 +32,10 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     sed -i "s@/usr/local@$out@" config.mk
+  '';
+
+  preBuild = lib.optional stdenv.hostPlatform.isStatic ''
+    makeFlagsArray+=(LDFLAGS="$(${stdenv.cc.targetPrefix}pkg-config --static --libs x11 xinerama xft)")
   '';
 
   # Allow users set their own list of patches


### PR DESCRIPTION
# dwm: fix static build

```
dwm: fix static build
```

## Build info of packages affected directly
### dwm

<details><summary>content of dwm.out</summary>

```
/nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5
├── bin
│   └── dwm
└── share
    └── man
        └── man1
            └── dwm.1.gz

5 directories, 2 files
```
</details>

<details><summary>build log of dwm</summary>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/brlx3b56rmmd83k16qfwxnjr6wsi609i-dwm-6.5.tar.gz
source root is dwm-6.5
setting SOURCE_DATE_EPOCH to timestamp 1710847492 of file "dwm-6.5/util.h"
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
build flags: SHELL=/nix/store/00zrahbb32nzawrmv9sjxn36h7qk9vrs-bash-5.2p37/bin/bash CC=cc
cp config.def.h config.h
cc -c -std=c99 -pedantic -Wall -Wno-deprecated-declarations -Os -I/usr/X11R6/include -I/usr/include/freetype2 -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE=700L -DVERSION=\"6.5\" -DXINERAMA drw.c
cc -c -std=c99 -pedantic -Wall -Wno-deprecated-declarations -Os -I/usr/X11R6/include -I/usr/include/freetype2 -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE=700L -DVERSION=\"6.5\" -DXINERAMA dwm.c
cc -c -std=c99 -pedantic -Wall -Wno-deprecated-declarations -Os -I/usr/X11R6/include -I/usr/include/freetype2 -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE=700L -DVERSION=\"6.5\" -DXINERAMA util.c
cc -o dwm drw.o dwm.o util.o -L/usr/X11R6/lib -lX11 -lXinerama -lfontconfig -lXft
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
install flags: SHELL=/nix/store/00zrahbb32nzawrmv9sjxn36h7qk9vrs-bash-5.2p37/bin/bash CC=cc install
mkdir -p /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5/bin
cp -f dwm /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5/bin
chmod 755 /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5/bin/dwm
mkdir -p /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5/share/man/man1
sed "s/VERSION/6.5/g" < dwm.1 > /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5/share/man/man1/dwm.1
chmod 644 /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5/share/man/man1/dwm.1
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5
shrinking /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5/bin/dwm
checking for references to /build/ in /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5...
gzipping man pages under /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5/share/man/
patching script interpreter paths in /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5
stripping (with command strip and flags -S -p) in  /nix/store/lbrdjjib24fcplmwm28j6nnnz2ng09ky-dwm-6.5/bin
```
</details>
