### PR TITLE
alpaca: 6.1.7 -> 7.7.5

### DIFF
--- a/pkgs/by-name/al/alpaca/package.nix
+++ b/pkgs/by-name/al/alpaca/package.nix
@@ -15,19 +15,23 @@
   ollama,
   vte-gtk4,
   libspelling,
+  gst_all_1,
+  pipewire,
+  libportal,
+
   nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "alpaca";
-  version = "6.1.7";
+  version = "7.7.5";
   pyproject = false; # Built with meson
 
   src = fetchFromGitHub {
     owner = "Jeffser";
     repo = "Alpaca";
     tag = version;
-    hash = "sha256-9UXaJpkz9F2D490bMKU/xv+rgfrxstm1DuDwpMmydI0=";
+    hash = "sha256-GA6gBMltS37HBjAe5a6BxJnH592fn6Srf1gY7AdJvuo=";
   };
 
   nativeBuildInputs = [
@@ -45,24 +49,40 @@ python3Packages.buildPythonApplication rec {
     gtksourceview5
     vte-gtk4
     libspelling
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    pipewire
+    libportal
   ];
 
-  dependencies = with python3Packages; [
-    pygobject3
-    requests
-    pillow
-    html2text
-    youtube-transcript-api
-    pydbus
-    odfpy
-    pyicu
-    matplotlib
-    openai
-    markitdown
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      pygobject3
+      requests
+      pillow
+      html2text
+      youtube-transcript-api
+      pydbus
+      odfpy
+      pyicu
+      matplotlib
+      openai
+      markitdown
+      opencv4
+      duckduckgo-search
+      rembg
+    ]
+    ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   optional-dependencies = {
-    speech-to-text = [ python3Packages.openai-whisper ];
+    speech-to-text = [
+      python3Packages.kokoro
+      python3Packages.openai-whisper
+      python3Packages.pyaudio
+      python3Packages.sounddevice
+      python3Packages.spacy-models.en_core_web_sm
+    ];
   };
 
   dontWrapGApps = true;


### PR DESCRIPTION
Changelog: https://github.com/Jeffser/Alpaca/releases/tag/7.0.0
Diff: https://github.com/Jeffser/Alpaca/compare/6.1.7...7.0.0
https://github.com/Jeffser/Alpaca/compare/7.0.1...7.5.1
https://github.com/Jeffser/Alpaca/compare/7.5.1...7.5.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
