### PR TITLE
nixos/mautrix-whatsapp: upgrade default config 

### DIFF
--- a/nixos/modules/services/matrix/mautrix-whatsapp.md
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.md
@@ -1,0 +1,32 @@
+# Mautrix-Whatsapp {#module-services-mautrix-whatsapp}
+
+[Mautrix-Whatsapp](https://github.com/mautrix/whatsapp) is a Matrix-Whatsapp puppeting bridge.
+
+## Configuration {#module-services-mautrix-whatsapp-configuration}
+
+1. Set [](#opt-services.mautrix-whatsapp.enable) to `true`. The service will use
+   SQLite by default.
+2. To create your configuration check the default configuration for
+   [](#opt-services.mautrix-whatsapp.settings). To obtain the complete default
+   configuration, run
+   `nix-shell -p mautrix-whatsapp --run "mautrix-whatsapp -c default.yaml -e"`.
+
+::: {.warning}
+Mautrix-Whatsapp allows for some options like `encryption.pickle_key`,
+`provisioning.shared_secret`, allow the value `generate` to be set.
+Since the configuration file is regenerated on every start of the
+service, the generated values would be discarded and might break your
+installation. Instead, set those values via
+[](#opt-services.mautrix-whatsapp.environmentFile).
+:::
+
+## Migrating from an older configuration {#module-services-mautrix-whatsapp-migrate-configuration}
+
+With Mautrix-Whatsapp v0.11.0 the configuration has been rearranged. Mautrix-Whatsapp
+performs an automatic configuration migration so your pre-0.7.0 configuration
+should just continue to work.
+
+In case you want to update your NixOS configuration, compare the migrated configuration
+at `/var/lib/mautrix-whatsapp/config.yaml` with the default configuration
+(`nix-shell -p mautrix-whatsapp --run "mautrix-whatsapp -c example.yaml -e"`) and
+update your module configuration accordingly.

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -177,7 +177,7 @@ in
     };
 
     # Note: this is defined here to avoid the docs depending on `config`
-    services.kabbone_mautrix-whatsapp.settings.homeserver = optOneOf (
+    services.mautrix-whatsapp.settings.homeserver = optOneOf (
       with config.services;
       [
         (lib.mkIf matrix-synapse.enable (mkDefaults {

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -8,34 +8,55 @@ let
   cfg = config.services.mautrix-whatsapp;
   dataDir = "/var/lib/mautrix-whatsapp";
   registrationFile = "${dataDir}/whatsapp-registration.yaml";
-  settingsFile = "${dataDir}/config.json";
+  settingsFile = "${dataDir}/config.yaml";
   settingsFileUnsubstituted = settingsFormat.generate "mautrix-whatsapp-config-unsubstituted.json" cfg.settings;
   settingsFormat = pkgs.formats.json { };
   appservicePort = 29318;
 
+  # to be used with a list of lib.mkIf values
+  optOneOf = lib.lists.findFirst (value: value.condition) (lib.mkIf false null);
   mkDefaults = lib.mapAttrsRecursive (n: v: lib.mkDefault v);
   defaultConfig = {
+    network = {
+      displayname_template = "{{or .BusinessName .PushName .Phone}} (WA)";
+      identity_change_notices = true;
+      history_sync = {
+        request_full_sync = true;
+      };
+    };
+    bridge = {
+      command_prefix = "!wa";
+      relay.enabled = true;
+      permissions."*" = "relay";
+    };
+    database = {
+      type = "sqlite3";
+      uri = "file:${dataDir}/mautrix-whatsapp.db?_txlock=immediate";
+    };
     homeserver.address = "http://localhost:8448";
     appservice = {
       hostname = "[::]";
       port = appservicePort;
-      database.type = "sqlite3";
-      database.uri = "${dataDir}/mautrix-whatsapp.db";
       id = "whatsapp";
-      bot.username = "whatsappbot";
-      bot.displayname = "WhatsApp Bridge Bot";
+      bot = {
+        username = "whatsappbot";
+        displayname = "WhatsApp Bridge Bot";
+      };
       as_token = "";
       hs_token = "";
-    };
-    bridge = {
       username_template = "whatsapp_{{.}}";
-      displayname_template = "{{if .BusinessName}}{{.BusinessName}}{{else if .PushName}}{{.PushName}}{{else}}{{.JID}}{{end}} (WA)";
-      double_puppet_server_map = { };
-      login_shared_secret_map = { };
-      command_prefix = "!wa";
-      permissions."*" = "relay";
-      relay.enabled = true;
     };
+    double_puppet = {
+      servers = { };
+      secrets = { };
+    };
+    # By default, the following keys/secrets are set to `generate`. This would break when the service
+    # is restarted, since the previously generated configuration will be overwritten everytime.
+    # If encryption is enabled, it's recommended to set those keys via `environmentFile`.
+    encryption.pickle_key = "";
+    provisioning.shared_secret = "";
+    public_media.signing_key = "";
+    direct_media.server_key = "";
     logging = {
       min_level = "info";
       writers = lib.singleton {
@@ -49,74 +70,87 @@ let
 in
 {
   options.services.mautrix-whatsapp = {
-    enable = lib.mkEnableOption "mautrix-whatsapp, a puppeting/relaybot bridge between Matrix and WhatsApp";
+    enable = lib.mkEnableOption "mautrix-whatsapp, a Matrix-Whatsapp puppeting bridge";
 
     package = lib.mkPackageOption pkgs "mautrix-whatsapp" { };
 
     settings = lib.mkOption {
+      apply = lib.recursiveUpdate defaultConfig;
       type = settingsFormat.type;
       default = defaultConfig;
       description = ''
         {file}`config.yaml` configuration as a Nix attribute set.
-        Configuration options should match those described in
-        [example-config.yaml](https://github.com/mautrix/whatsapp/blob/master/example-config.yaml).
+        Configuration options should match those described in the example configuration.
+        Get an example configuration by executing `mautrix-whatsapp -c example.yaml --generate-example-config`
         Secret tokens should be specified using {option}`environmentFile`
         instead of this world-readable attribute set.
       '';
       example = {
-        appservice = {
-          database = {
-            type = "postgres";
-            uri = "postgresql:///mautrix_whatsapp?host=/run/postgresql";
-          };
-          id = "whatsapp";
-          ephemeral_events = false;
-        };
         bridge = {
-          history_sync = {
-            request_full_sync = true;
-          };
           private_chat_portal_meta = true;
-          mute_bridging = true;
-          encryption = {
-            allow = true;
-            default = true;
-            require = true;
-          };
-          provisioning = {
-            shared_secret = "disable";
-          };
+          mute_only_on_create = false;
           permissions = {
             "example.com" = "user";
           };
         };
+        database = {
+          type = "postgres";
+          uri = "postgresql:///mautrix_whatsapp?host=/run/postgresql";
+        };
+        homeserver = {
+          address = "http://[::1]:8008";
+          domain = "my-domain.tld";
+        };
+        appservice = {
+          id = "whatsapp";
+          ephemeral_events = false;
+        };
+        matrix.message_status_events = true;
+        provisioning = {
+          shared_secret = "disable";
+        };
+        backfill.enabled = true;
+        encryption = {
+          allow = true;
+          default = true;
+          require = true;
+          pickle_key = "$ENCRYPTION_PICKLE_KEY";
+        };
       };
     };
+
     environmentFile = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
-        File containing environment variables to be passed to the mautrix-whatsapp service,
-        in which secret tokens can be specified securely by optionally defining a value for
-        `MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET`.
+        File containing environment variables to be passed to the mautrix-signal service.
+        If an environment variable `MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET` is set,
+        then its value will be used in the configuration file for the option
+        `double_puppet.secrets` without leaking it to the store, using the configured
+        `homeserver.domain` as key.
       '';
     };
 
     serviceDependencies = lib.mkOption {
       type = with lib.types; listOf str;
-      default = lib.optional config.services.matrix-synapse.enable config.services.matrix-synapse.serviceUnit;
+      default =
+        (lib.optional config.services.matrix-synapse.enable config.services.matrix-synapse.serviceUnit)
+        ++ (lib.optional config.services.matrix-conduit.enable "conduit.service");
       defaultText = lib.literalExpression ''
-        optional config.services.matrix-synapse.enable config.services.matrix-synapse.serviceUnits
+        (optional config.services.matrix-synapse.enable config.services.matrix-synapse.serviceUnit)
+        ++ (optional config.services.matrix-conduit.enable "conduit.service")
       '';
       description = ''
-        List of Systemd services to require and wait for when starting the application service.
+        List of systemd units to require and wait for when starting the application service.
       '';
     };
 
     registerToSynapse = lib.mkOption {
       type = lib.types.bool;
       default = config.services.matrix-synapse.enable;
-      defaultText = lib.literalExpression "config.services.matrix-synapse.enable";
+      defaultText = lib.literalExpression ''
+        config.services.matrix-synapse.enable
+      '';
       description = ''
         Whether to add the bridge's app service registration file to
         `services.matrix-synapse.settings.app_service_config_files`.
@@ -130,7 +164,7 @@ in
       isSystemUser = true;
       group = "mautrix-whatsapp";
       home = dataDir;
-      description = "Mautrix-WhatsApp bridge user";
+      description = "Mautrix-Whatsapp bridge user";
     };
 
     users.groups.mautrix-whatsapp = { };
@@ -142,20 +176,28 @@ in
       serviceConfig.SupplementaryGroups = [ "mautrix-whatsapp" ];
     };
 
-    services.mautrix-whatsapp.settings = lib.mkMerge (
-      map mkDefaults [
-        defaultConfig
-        # Note: this is defined here to avoid the docs depending on `config`
-        { homeserver.domain = config.services.matrix-synapse.settings.server_name; }
+    # Note: this is defined here to avoid the docs depending on `config`
+    services.kabbone_mautrix-whatsapp.settings.homeserver = optOneOf (
+      with config.services;
+      [
+        (lib.mkIf matrix-synapse.enable (mkDefaults {
+          domain = matrix-synapse.settings.server_name;
+        }))
+        (lib.mkIf matrix-conduit.enable (mkDefaults {
+          domain = matrix-conduit.settings.global.server_name;
+          address = "http://localhost:${toString matrix-conduit.settings.global.port}";
+        }))
       ]
     );
 
     systemd.services.mautrix-whatsapp = {
-      description = "Mautrix-WhatsApp Service - A WhatsApp bridge for Matrix";
+      description = "mautrix-whatsapp, a Matrix-Whatsapp puppeting bridge.";
 
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ] ++ cfg.serviceDependencies;
       after = [ "network-online.target" ] ++ cfg.serviceDependencies;
+      # ffmpeg is required for conversion of voice messages
+      path = [ pkgs.ffmpeg-headless ];
 
       preStart = ''
         # substitute the settings file by environment variables
@@ -179,13 +221,13 @@ in
 
         umask 0177
         # 1. Overwrite registration tokens in config
-        # 2. If environment variable MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET
+        # 2. If environment variable MAUTRIX_SIGNAL_BRIDGE_LOGIN_SHARED_SECRET
         #    is set, set it as the login shared secret value for the configured
         #    homeserver domain.
         ${pkgs.yq}/bin/yq -s '.[0].appservice.as_token = .[1].as_token
           | .[0].appservice.hs_token = .[1].hs_token
           | .[0]
-          | if env.MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET then .bridge.login_shared_secret_map.[.homeserver.domain] = env.MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET else . end' \
+          | if env.MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET then .double_puppet.secrets.[.homeserver.domain] = env.MAUTRIX_WHATSAPP_BRIDGE_LOGIN_SHARED_SECRET else . end' \
           '${settingsFile}' '${registrationFile}' > '${settingsFile}.tmp'
         mv '${settingsFile}.tmp' '${settingsFile}'
         umask $old_umask
@@ -203,7 +245,6 @@ in
           --registration='${registrationFile}'
         '';
         LockPersonality = true;
-        MemoryDenyWriteExecute = true;
         NoNewPrivileges = true;
         PrivateDevices = true;
         PrivateTmp = true;
@@ -229,5 +270,12 @@ in
       restartTriggers = [ settingsFileUnsubstituted ];
     };
   };
-  meta.maintainers = with lib.maintainers; [ frederictobiasc ];
+  meta = {
+    buildDocsInSandbox = false;
+    doc = ./mautrix-whatsapp.md;
+    maintainers = with lib.maintainers; [
+      pentane
+      frederictobiasc
+    ];
+  };
 }


### PR DESCRIPTION
Since #350448 seems stale I created a new attempt to update the config for mautrix-whatsapp. I basically took the mautrix-signal code and adapted it since they share kind of a similar config.
I guess for the future it could make sense to use a same base for both.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
