### PR TITLE
vscode-css-languageserver: init at 1.101.2

### DIFF
--- a/pkgs/by-name/vs/vscode-css-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-css-languageserver/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nodejs,
+  typescript,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "vscode-css-languageserver";
+  version = "1.101.2";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vscode";
+    tag = finalAttrs.version;
+    hash = "sha256-wdI6VlJ4WoSNnwgkb6dkVYcq/P/yzflv5mE9PuYBVx4=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/extensions/css-language-features/server";
+
+  npmDepsHash = "sha256-wGW2n+16NYHuFpYMq8nuvGgir8QwGc9Ud2yauR4ltIQ=";
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    typescript
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    tsc -p .
+    runHook postBuild
+  '';
+
+  dontNpmBuild = true;
+
+  postInstall = ''
+    makeBinaryWrapper ${nodejs}/bin/node $out/bin/vscode-css-languageserver \
+      --add-flags $out/lib/node_modules/vscode-css-languageserver/out/node/cssServerMain.js
+    ln -s $out/bin/vscode-css-languageserver $out/bin/vscode-css-language-server
+  '';
+
+  meta = {
+    description = "CSS language server";
+    homepage = "https://github.com/microsoft/vscode/tree/${finalAttrs.src.tag}/extensions/css-language-features/server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryota2357 ];
+    mainProgram = "vscode-css-languageserver";
+  };
+})


### PR DESCRIPTION
CSS language server under VSCode.

https://github.com/microsoft/vscode/tree/main/extensions/css-language-features/server

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
