### PR TITLE
go-sendxmpp: init at 0.14.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1250,7 +1250,7 @@ in
   privoxy = runTest ./privoxy.nix;
   prometheus = import ./prometheus { inherit runTest; };
   prometheus-exporters = handleTest ./prometheus-exporters.nix { };
-  prosody = handleTest ./xmpp/prosody.nix { };
+  prosody = runTest ./xmpp/prosody.nix;
   prosody-mysql = handleTest ./xmpp/prosody-mysql.nix { };
   proxy = runTest ./proxy.nix;
   prowlarr = runTest ./prowlarr.nix;

--- a/nixos/tests/xmpp/ejabberd.nix
+++ b/nixos/tests/xmpp/ejabberd.nix
@@ -2,7 +2,7 @@ let
   cert =
     pkgs:
     pkgs.runCommand "selfSignedCerts" { buildInputs = [ pkgs.openssl ]; } ''
-      openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -subj '/CN=example.com/CN=muc.example.com/CN=matrix.example.com' -days 36500
+      openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -subj '/CN=example.com/CN=muc.example.com/CN=matrix.example.com' -addext "subjectAltName = DNS:example.com,DNS:muc.example.com,DNS:matrix.example.com" -days 36500
       mkdir -p $out
       cp key.pem cert.pem $out
     '';
@@ -14,7 +14,18 @@ in
     maintainers = [ ];
   };
   nodes = {
-    client =
+    client-a =
+      { nodes, pkgs, ... }:
+      {
+        security.pki.certificateFiles = [ "${cert pkgs}/cert.pem" ];
+        networking.extraHosts = ''
+          ${nodes.server.networking.primaryIPAddress} example.com
+        '';
+
+        imports = [ ./go-sendxmpp-listen.nix ];
+      };
+
+    client-b =
       { nodes, pkgs, ... }:
       {
         security.pki.certificateFiles = [ "${cert pkgs}/cert.pem" ];
@@ -28,6 +39,7 @@ in
           })
         ];
       };
+
     server =
       { config, pkgs, ... }:
       {
@@ -310,7 +322,18 @@ in
           ejabberd_prefix + "register cthon98 example.com nothunter2",
       )
       server.fail(ejabberd_prefix + "register asdf wrong.domain")
-      client.succeed("send-message")
+
+      for machine in client_a, client_b:
+        machine.systemctl("start network-online.target")
+        machine.wait_for_unit("network-online.target")
+
+      client_a.wait_for_unit("go-sendxmpp-listen")
+      client_b.succeed("send-message")
+
+      client_a.wait_until_succeeds(
+        "journalctl -o cat -u go-sendxmpp-listen.service | grep 'cthon98@example.com: Hello, this is dog.'"
+      )
+
       server.succeed(
           ejabberd_prefix + "unregister cthon98 example.com",
           ejabberd_prefix + "unregister azurediamond example.com",

--- a/nixos/tests/xmpp/go-sendxmpp-listen.nix
+++ b/nixos/tests/xmpp/go-sendxmpp-listen.nix
@@ -1,0 +1,22 @@
+{ lib, pkgs, ... }:
+
+{
+  systemd.services.go-sendxmpp-listen = {
+    after = [ "network-online.target" ];
+    requires = [ "network-online.target" ];
+    wantedBy = [ "multi-user.target" ];
+
+    serviceConfig = {
+      ExecStart = ''
+        ${lib.getExe pkgs.go-sendxmpp} --username azurediamond@example.com --password hunter2 --listen
+      '';
+      Environment = [
+        "HOME=/var/lib/go-sendxmpp/"
+      ];
+      DynamicUser = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+      StateDirectory = "go-sendxmpp";
+    };
+  };
+}

--- a/nixos/tests/xmpp/prosody.nix
+++ b/nixos/tests/xmpp/prosody.nix
@@ -3,7 +3,7 @@ let
     pkgs:
     pkgs.runCommand "selfSignedCerts" { buildInputs = [ pkgs.openssl ]; } ''
       openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -days 365 \
-        -subj '/C=GB/CN=example.com' -addext "subjectAltName = DNS:example.com,DNS:uploads.example.com,DNS:conference.example.com"
+        -subj '/C=GB/CN=example.com/CN=uploads.example.com/CN=conference.example.com' -addext "subjectAltName = DNS:example.com,DNS:uploads.example.com,DNS:conference.example.com"
       mkdir -p $out
       cp key.pem cert.pem $out
     '';
@@ -32,7 +32,18 @@ in
 import ../make-test-python.nix {
   name = "prosody";
   nodes = {
-    client =
+    client-a =
+      { nodes, pkgs, ... }:
+      {
+        security.pki.certificateFiles = [ "${cert pkgs}/cert.pem" ];
+        networking.extraHosts = ''
+          ${nodes.server.networking.primaryIPAddress} example.com
+        '';
+
+        imports = [ ./go-sendxmpp-listen.nix ];
+      };
+
+    client-b =
       {
         nodes,
         pkgs,
@@ -93,7 +104,18 @@ import ../make-test-python.nix {
     server.succeed('prosodyctl status | grep "Prosody is running"')
 
     server.succeed("create-prosody-users")
-    client.succeed("send-message")
+
+    for machine in client_a, client_b:
+      machine.systemctl("start network-online.target")
+      machine.wait_for_unit("network-online.target")
+
+    client_a.wait_for_unit("go-sendxmpp-listen")
+    client_b.succeed("send-message")
+
+    client_a.wait_until_succeeds(
+      "journalctl -o cat -u go-sendxmpp-listen.service | grep 'cthon98@example.com: Hello, this is dog.'"
+    )
+
     server.succeed("delete-prosody-users")
   '';
 }

--- a/nixos/tests/xmpp/prosody.nix
+++ b/nixos/tests/xmpp/prosody.nix
@@ -1,3 +1,5 @@
+{ ... }:
+
 let
   cert =
     pkgs:
@@ -29,7 +31,7 @@ let
       prosodyctl deluser azurediamond@example.com
     '';
 in
-import ../make-test-python.nix {
+{
   name = "prosody";
   nodes = {
     client-a =

--- a/pkgs/by-name/go/go-sendxmpp/package.nix
+++ b/pkgs/by-name/go/go-sendxmpp/package.nix
@@ -1,0 +1,39 @@
+{
+  buildGoModule,
+  fetchFromGitLab,
+  lib,
+  nix-update-script,
+  testers,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-sendxmpp";
+  version = "0.14.1";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "mdosch";
+    repo = "go-sendxmpp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nQ2URhkOp0mb4u4IG3wzGIdhP6svDVMctbu2CHQXj2Y=";
+  };
+
+  vendorHash = "sha256-aMhUsYsQvnhEVkWbjbh84bbStQ4b/0ZHEvzEhXSlFyw=";
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Tool to send messages or files to an XMPP contact or MUC";
+    homepage = "https://salsa.debian.org/mdosch/go-sendxmpp";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      jpds
+    ];
+    mainProgram = "go-sendxmpp";
+  };
+})


### PR DESCRIPTION
Adds: https://salsa.debian.org/mdosch/go-sendxmpp

Prosody test migration for #386873

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
