### PR TITLE
matrix-tuwunel: init at 1.2.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -36,6 +36,8 @@
 
 - [Chhoto URL](https://github.com/SinTan1729/chhoto-url), a simple, blazingly fast, selfhosted URL shortener with no unnecessary features, written in Rust. Available as [services.chhoto-url](#opt-services.chhoto-url.enable).
 
+- [tuwunel](https://matrix-construct.github.io/tuwunel/), a federated chat server implementing the Matrix protocol, forked from Conduwuit. Available as [services.matrix-tuwunel](#opt-services.matrix-tuwunel.enable).
+
 - [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).
 
 - Docker now defaults to 28.x, because version 27.x stopped receiving security updates and bug fixes after [May 2, 2025](https://github.com/moby/moby/pull/49910).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -781,6 +781,7 @@
   ./services/matrix/pantalaimon.nix
   ./services/matrix/synapse-auto-compressor.nix
   ./services/matrix/synapse.nix
+  ./services/matrix/tuwunel.nix
   ./services/misc/airsonic.nix
   ./services/misc/amazon-ssm-agent.nix
   ./services/misc/ananicy.nix

--- a/nixos/modules/services/matrix/tuwunel.nix
+++ b/nixos/modules/services/matrix/tuwunel.nix
@@ -1,0 +1,268 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.matrix-tuwunel;
+  defaultUser = "tuwunel";
+  defaultGroup = "tuwunel";
+
+  format = pkgs.formats.toml { };
+  configFile = format.generate "tuwunel.toml" cfg.settings;
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    scvalex
+  ];
+  options.services.matrix-tuwunel = {
+    enable = lib.mkEnableOption "tuwunel";
+
+    package = lib.mkPackageOption pkgs "matrix-tuwunel" { };
+
+    user = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      description = ''
+        The user {command}`tuwunel` is run as.  If left as the default, the user will
+        automatically be created by the service.
+      '';
+      example = "conduit";
+      default = defaultUser;
+    };
+
+    group = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      description = ''
+        The group {command}`tuwunel` is run as.  If left as the default, the group will
+        automatically be created by the service.
+      '';
+      example = "conduit";
+      default = defaultGroup;
+    };
+
+    stateDirectory = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      default = "tuwunel";
+      example = "matrix-conduit";
+      description = ''
+        The name of the directory under /var/lib/ where the database will be stored.
+
+        Note that `stateDirectory` cannot be changed once created because of the service's reliance on
+        systemd `StateDirectory`.
+      '';
+    };
+
+    extraEnvironment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      description = "Extra Environment variables to pass to the tuwunel server.";
+      default = { };
+      example = {
+        RUST_BACKTRACE = "yes";
+      };
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+        options = {
+          global.server_name = lib.mkOption {
+            type = lib.types.nonEmptyStr;
+            example = "example.com";
+            description = "The server_name is the name of this server. It is used as a suffix for user and room ids.";
+          };
+          global.address = lib.mkOption {
+            type = lib.types.nullOr (lib.types.listOf lib.types.nonEmptyStr);
+            default = null;
+            example = [
+              "127.0.0.1"
+              "::1"
+            ];
+            description = ''
+              Addresses (IPv4 or IPv6) to listen on for connections by the reverse proxy/tls terminator.
+              If set to `null`, tuwunel will listen on IPv4 and IPv6 localhost.
+              Must be `null` if `unix_socket_path` is set.
+            '';
+          };
+          global.port = lib.mkOption {
+            type = lib.types.listOf lib.types.port;
+            default = [ 6167 ];
+            description = ''
+              The port(s) tuwunel will be running on.
+              You need to set up a reverse proxy in your web server (e.g. apache or nginx),
+              so all requests to /_matrix on port 443 and 8448 will be forwarded to the tuwunel
+              instance running on this port.
+            '';
+          };
+          global.unix_socket_path = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+            description = ''
+              Listen on a UNIX socket at the specified path. If listening on a UNIX socket,
+              listening on an address will be disabled. The `address` option must be set to
+              `null` (the default value). The option {option}`services.tuwunel.group` must
+              be set to a group your reverse proxy is part of.
+            '';
+          };
+          global.unix_socket_perms = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 660;
+            description = "The default permissions (in octal) to create the UNIX socket with.";
+          };
+          global.max_request_size = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 20000000;
+            description = "Max request size in bytes. Don't forget to also change it in the proxy.";
+          };
+          global.allow_registration = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Whether new users can register on this server.
+
+              Registration with token requires `registration_token` or `registration_token_file` to be set.
+
+              If set to true without a token configured, and
+              `yes_i_am_very_very_sure_i_want_an_open_registration_server_prone_to_abuse`
+              is set to true, users can freely register.
+            '';
+          };
+          global.allow_encryption = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether new encrypted rooms can be created. Note: existing rooms will continue to work.";
+          };
+          global.allow_federation = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Whether this server federates with other servers.
+            '';
+          };
+          global.trusted_servers = lib.mkOption {
+            type = lib.types.listOf lib.types.nonEmptyStr;
+            default = [ "matrix.org" ];
+            description = ''
+              Servers listed here will be used to gather public keys of other servers
+              (notary trusted key servers).
+
+              Currently, tuwunel doesn't support inbound batched key requests, so
+              this list should only contain other Synapse servers.
+
+              Example: `[ "matrix.org" "constellatory.net" "tchncs.de" ]`
+            '';
+          };
+        };
+      };
+      default = { };
+      # TOML does not allow null values, so we use null to omit those fields
+      apply = lib.filterAttrsRecursive (_: v: v != null);
+      description = ''
+        Generates the tuwunel.toml configuration file. Refer to
+        <https://matrix-construct.github.io/tuwunel/configuration.html>
+        for details on supported values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.settings ? global.unix_socket_path) || !(cfg.settings ? global.address);
+        message = ''
+          In `services.matrix-tuwunel.settings.global`, `unix_socket_path` and `address` cannot be set at the
+          same time.
+          Leave one of the two options unset or explicitly set them to `null`.
+        '';
+      }
+      {
+        assertion = cfg.user != defaultUser -> config ? users.users.${cfg.user};
+        message = "If `services.matrix-tuwunel.user` is changed, the configured user must already exist.";
+      }
+      {
+        assertion = cfg.group != defaultGroup -> config ? users.groups.${cfg.group};
+        message = "If `services.matrix-tuwunel.group` is changed, the configured group must already exist.";
+      }
+      {
+        assertion = "/var/lib/${cfg.settings.global.database_path}" != cfg.stateDirectory;
+        message = "The `services.matrix-tuwunel.stateDirectory` and `services.matrix-tuwunel.settings.global.database_path` options must match.";
+      }
+    ];
+
+    users.users = lib.mkIf (cfg.user == defaultUser) {
+      ${defaultUser} = {
+        group = cfg.group;
+        home = cfg.settings.global.database_path;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == defaultGroup) {
+      ${defaultGroup} = { };
+    };
+
+    services.matrix-tuwunel.settings.global.database_path = "/var/lib/${cfg.stateDirectory}/";
+
+    systemd.services.tuwunel = {
+      description = "Tuwunel Matrix Server";
+      documentation = [ "https://matrix-construct.github.io/tuwunel/" ];
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      environment = lib.mkMerge [
+        { TUWUNEL_CONFIG = configFile; }
+        cfg.extraEnvironment
+      ];
+      startLimitBurst = 5;
+      startLimitIntervalSec = 60;
+      serviceConfig = {
+        DynamicUser = true;
+        User = cfg.user;
+        Group = cfg.group;
+
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        PrivateIPC = true;
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service @resources"
+          "~@clock @debug @module @mount @reboot @swap @cpu-emulation @obsolete @timer @chown @setuid @privileged @keyring @ipc"
+        ];
+        SystemCallErrorNumber = "EPERM";
+
+        StateDirectory = cfg.stateDirectory;
+        StateDirectoryMode = "0700";
+        RuntimeDirectory = "tuwunel";
+        RuntimeDirectoryMode = "0750";
+
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        RestartSec = 10;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -865,6 +865,7 @@ in
   matrix-continuwuity = runTest ./matrix/continuwuity.nix;
   matrix-synapse = runTest ./matrix/synapse.nix;
   matrix-synapse-workers = runTest ./matrix/synapse-workers.nix;
+  matrix-tuwunel = runTest ./matrix/tuwunel.nix;
   mautrix-discord = runTest ./matrix/mautrix-discord.nix;
   mattermost = handleTest ./mattermost { };
   mautrix-meta-postgres = runTest ./matrix/mautrix-meta-postgres.nix;

--- a/nixos/tests/matrix/tuwunel.nix
+++ b/nixos/tests/matrix/tuwunel.nix
@@ -1,0 +1,135 @@
+{ lib, pkgs, ... }:
+let
+  name = "tuwunel";
+in
+{
+  inherit name;
+
+  nodes = {
+    # Host1 is a fresh install of tuwunel
+    host1 = {
+      services.matrix-tuwunel = {
+        enable = true;
+        settings.global = {
+          server_name = name;
+          address = [ "0.0.0.0" ];
+          allow_registration = true;
+          yes_i_am_very_very_sure_i_want_an_open_registration_server_prone_to_abuse = true;
+        };
+        extraEnvironment.RUST_BACKTRACE = "yes";
+      };
+      networking.firewall.allowedTCPPorts = [ 6167 ];
+    };
+
+    # Host2 was upgraded from the matrix-conduit service
+    host2 = {
+      users.users.conduit = {
+        group = "conduit";
+        home = "/var/lib/matrix-conduit";
+        isSystemUser = true;
+      };
+      users.groups.conduit = { };
+      services.matrix-tuwunel = {
+        enable = true;
+        user = "conduit";
+        group = "conduit";
+        stateDirectory = "matrix-conduit";
+        settings.global = {
+          server_name = name;
+          address = [ "0.0.0.0" ];
+          allow_registration = true;
+          yes_i_am_very_very_sure_i_want_an_open_registration_server_prone_to_abuse = true;
+        };
+        extraEnvironment.RUST_BACKTRACE = "yes";
+      };
+      networking.firewall.allowedTCPPorts = [ 6167 ];
+    };
+
+    client =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [
+          (pkgs.writers.writePython3Bin "do_test" { libraries = [ pkgs.python3Packages.matrix-nio ]; } ''
+            import asyncio
+            import nio
+            import sys
+
+
+            async def main(host) -> None:
+                # Connect to server
+                client = nio.AsyncClient(f"http://{host}:6167", "alice")
+
+                # Register as user alice
+                response = await client.register("alice", "my-secret-password")
+
+                # Log in as user alice
+                response = await client.login("my-secret-password")
+
+                # Create a new room
+                response = await client.room_create(federate=False)
+                print("Matrix room create response:", response)
+                assert isinstance(response, nio.RoomCreateResponse)
+                room_id = response.room_id
+
+                # Join the room
+                response = await client.join(room_id)
+                print("Matrix join response:", response)
+                assert isinstance(response, nio.JoinResponse)
+
+                # Send a message to the room
+                response = await client.room_send(
+                    room_id=room_id,
+                    message_type="m.room.message",
+                    content={
+                        "msgtype": "m.text",
+                        "body": "Hello matrix!"
+                    }
+                )
+                print("Matrix room send response:", response)
+                assert isinstance(response, nio.RoomSendResponse)
+
+                # Sync responses
+                response = await client.sync(timeout=30000)
+                print("Matrix sync response:", response)
+                assert isinstance(response, nio.SyncResponse)
+
+                # Check the message was received by server
+                last_message = response.rooms.join[room_id].timeline.events[-1].body
+                assert last_message == "Hello matrix!"
+
+                # Leave the room
+                response = await client.room_leave(room_id)
+                print("Matrix room leave response:", response)
+                assert isinstance(response, nio.RoomLeaveResponse)
+
+                # Close the client
+                await client.close()
+
+
+            if __name__ == "__main__":
+                asyncio.run(main(sys.argv[1]))
+          '')
+        ];
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    with subtest("start tuwunel on host1"):
+          host1.wait_for_unit("tuwunel.service")
+          host1.wait_for_open_port(6167)
+
+    with subtest("start tuwunel on host2"):
+          host1.wait_for_unit("tuwunel.service")
+          host1.wait_for_open_port(6167)
+
+    with subtest("ensure messages can be sent to servers"):
+          client.succeed("do_test host1 >&2")
+          client.succeed("do_test host2 >&2")
+  '';
+
+  meta.maintainers = with lib.maintainers; [
+    scvalex
+  ];
+}

--- a/pkgs/by-name/ma/matrix-tuwunel/package.nix
+++ b/pkgs/by-name/ma/matrix-tuwunel/package.nix
@@ -1,0 +1,158 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  bzip2,
+  zstd,
+  stdenv,
+  rocksdb,
+  nix-update-script,
+  testers,
+  matrix-tuwunel,
+  enableBlurhashing ? true,
+  # upstream tuwunel enables jemalloc by default, so we follow suit
+  enableJemalloc ? true,
+  rust-jemalloc-sys,
+  enableLiburing ? stdenv.hostPlatform.isLinux,
+  liburing,
+  nixosTests,
+}:
+let
+  rust-jemalloc-sys' = rust-jemalloc-sys.override {
+    unprefixed = !stdenv.hostPlatform.isDarwin;
+  };
+  # tuwunel uses a modified version of rocksdb.  The following overrides take a lot from the
+  # official flake:
+  # https://github.com/matrix-construct/tuwunel/blob/main/flake.nix#L54
+  rocksdb' =
+    (rocksdb.override {
+      inherit enableLiburing;
+      # rocksdb does not support prefixed jemalloc, which is required on darwin
+      enableJemalloc = enableJemalloc && !stdenv.hostPlatform.isDarwin;
+      jemalloc = rust-jemalloc-sys';
+    }).overrideAttrs
+      (
+        final: old: {
+          src = fetchFromGitHub {
+            owner = "matrix-construct";
+            repo = "rocksdb";
+            # The commit on the rocksdb fork, tuwunel-changes branch referenced by the upstream
+            # tuwunel flake.lock:
+            # https://github.com/matrix-construct/tuwunel/blob/main/flake.lock#L557C17-L557C57
+            rev = "cf7f65d0b377af019661c240f9165b3ef60640c3";
+            hash = "sha256-ZSjvAZBfZkJrBIpw8ANZMbJVb8AeuogvuAipGVE4Qe4=";
+          };
+          version = "tuwunel-changes";
+          patches = [ ];
+          postPatch = "";
+          cmakeFlags =
+            lib.subtractLists [
+              # no real reason to have snappy or zlib, no one uses this
+              "-DWITH_SNAPPY=1"
+              "-DZLIB=1"
+              "-DWITH_ZLIB=1"
+              # we dont need to use ldb or sst_dump (core_tools)
+              "-DWITH_CORE_TOOLS=1"
+              # we dont need to build rocksdb tests
+              "-DWITH_TESTS=1"
+              # we use rust-rocksdb via C interface and dont need C++ RTTI
+              "-DUSE_RTTI=1"
+              # this doesn't exist in RocksDB, and USE_SSE is deprecated for
+              # PORTABLE=$(march)
+              "-DFORCE_SSE42=1"
+              # PORTABLE will get set in main/default.nix
+              "-DPORTABLE=1"
+            ] old.cmakeFlags
+            ++ [
+              # no real reason to have snappy, no one uses this
+              "-DWITH_SNAPPY=0"
+              "-DZLIB=0"
+              "-DWITH_ZLIB=0"
+              # we dont need to use ldb or sst_dump (core_tools)
+              "-DWITH_CORE_TOOLS=0"
+              # we dont need trace tools
+              "-DWITH_TRACE_TOOLS=0"
+              # we dont need to build rocksdb tests
+              "-DWITH_TESTS=0"
+              # we use rust-rocksdb via C interface and dont need C++ RTTI
+              "-DUSE_RTTI=0"
+            ];
+          outputs = [ "out" ];
+          preInstall = "";
+        }
+      );
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "matrix-tuwunel";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "matrix-construct";
+    repo = "tuwunel";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YiZuCdSs3f4Hlfdzhz/B/u8GLf8VPgaLN8KMPLjFoVk=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-y3JXG/5a9x/KM1PxGW1qmpCeRFvWXWHHplCi+MdjhQ8=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs =
+    [
+      bzip2
+      zstd
+    ]
+    ++ lib.optional enableJemalloc rust-jemalloc-sys'
+    ++ lib.optional enableLiburing liburing;
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+    ROCKSDB_INCLUDE_DIR = "${rocksdb'}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb'}/lib";
+  };
+
+  buildNoDefaultFeatures = true;
+  # See https://github.com/matrix-construct/tuwunel/blob/main/src/main/Cargo.toml
+  # for available features.
+  # We enable all default features except jemalloc, blurhashing, and io_uring, which
+  # we guard behind our own (default-enabled) flags.
+  buildFeatures =
+    [
+      "brotli_compression"
+      "direct_tls"
+      "element_hacks"
+      "gzip_compression"
+      "media_thumbnail"
+      "release_max_log_level"
+      "systemd"
+      "url_preview"
+      "zstd_compression"
+    ]
+    ++ lib.optional enableBlurhashing "blurhashing"
+    ++ lib.optional enableJemalloc [
+      "jemalloc"
+      "jemalloc_conf"
+    ]
+    ++ lib.optional enableLiburing "io_uring";
+
+  passthru = {
+    rocksdb = rocksdb'; # make used rocksdb version available (e.g., for backup scripts)
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Matrix homeserver written in Rust, official successor to conduwuit";
+    homepage = "https://github.com/matrix-construct/tuwunel";
+    changelog = "https://github.com/matrix-construct/tuwunel/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      scvalex
+    ];
+    mainProgram = "tuwunel";
+  };
+})

--- a/pkgs/by-name/ma/matrix-tuwunel/package.nix
+++ b/pkgs/by-name/ma/matrix-tuwunel/package.nix
@@ -143,6 +143,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     rocksdb = rocksdb'; # make used rocksdb version available (e.g., for backup scripts)
     updateScript = nix-update-script { };
+    tests =
+      {
+        version = testers.testVersion {
+          inherit (finalAttrs) version;
+          package = matrix-tuwunel;
+        };
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        inherit (nixosTests) matrix-tuwunel;
+      };
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds `tuwunel`, a matrix server and ["the official successor to `conduwuit`"](https://girlboss.ceo/~strawberry/conduwuit.txt) (which was in turn a fork of `conduit`).  The package itself is called `matrix-tuwunel` to keep with the nixpkgs naming convention.

https://github.com/matrix-construct/tuwunel/

The derivation is a copy of the `continuwuity` one (another fork of `conduwuit`), except `tuwunel` also uses a fork of `rocksdb` which some extra functions and other changes.  This `rocksdb` fork is kind of annoying because it's just a set of commits in a github repo—there's no "release" of it so to speak—so, we have to reference a repo and a particular revision.

We also add the `matrix-tuwunel` service.  Again, it's mostly a copy of the `matrix-continuwuity` one, with the following differences:
  - All references to continuwuity have been changed to tuwunel,
  - The `allow_announcements_check` setting was removed because it doesn't exist in tuwunel,
  - Replace `services.matrix-tuwunel.settings.global.database_path` with `services.matrix-tuwunel.stateDirectory`.  The latter controls the name of the `/var/lib/<StateDirectory>` directory and it automatically sets the former.  This allows one to switch from the `matrix-conduit` or `matrix-continuwuity` services without having to copy and chown directories.

This PR also adds some basic nixos tests (mostly copied from `continuwuity` again).

I have also cherry-picked this commit into my own 25.05 tree, deployed it, and it seems to work fine (as a replacement for the `tuwunel` flake and as an upgrade to `conduwuit-0.4.6`).

Closes #415469 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
