### PR TITLE
rocqPackages.parseque init at 0.3.0

### DIFF
--- a/pkgs/development/coq-modules/parseque/default.nix
+++ b/pkgs/development/coq-modules/parseque/default.nix
@@ -1,13 +1,14 @@
 {
   lib,
   mkCoqDerivation,
+  rocqPackages,
   which,
   coq,
   version ? null,
 }:
 
 with lib;
-mkCoqDerivation {
+(mkCoqDerivation {
   pname = "parseque";
   repo = "parseque";
   owner = "rocq-community";
@@ -19,7 +20,7 @@ mkCoqDerivation {
       [ coq.coq-version ]
       [
         {
-          cases = [ (range "8.16" "8.20") ];
+          cases = [ (range "8.16" "9.0") ];
           out = "0.2.2";
         }
       ]
@@ -30,8 +31,26 @@ mkCoqDerivation {
   releaseRev = v: "v${v}";
 
   meta = {
-    description = "Total parser combinators in Rocq";
+    description = "Total parser combinators in Coq/Rocq";
     maintainers = with maintainers; [ womeier ];
     license = licenses.mit;
   };
-}
+}).overrideAttrs
+  (
+    o:
+    # this is just a wrapper for rocPackages.parseque for Rocq >= 9.0
+    lib.optionalAttrs
+      (coq.version != null && (coq.version == "dev" || lib.versions.isGe "9.0" coq.version))
+      {
+        configurePhase = ''
+          echo no configuration
+        '';
+        buildPhase = ''
+          echo building nothing
+        '';
+        installPhase = ''
+          echo installing nothing
+        '';
+        propagatedBuildInputs = [ rocqPackages.parseque ];
+      }
+  )

--- a/pkgs/development/rocq-modules/parseque/default.nix
+++ b/pkgs/development/rocq-modules/parseque/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  mkRocqDerivation,
+  which,
+  stdlib,
+  rocq-core,
+  version ? null,
+}:
+
+with lib;
+mkRocqDerivation {
+  pname = "parseque";
+  repo = "parseque";
+  owner = "rocq-community";
+
+  inherit version;
+  defaultVersion =
+    with versions;
+    switch
+      [ rocq-core.rocq-version ]
+      [
+        {
+          cases = [ (range "9.0" "9.0") ];
+          out = "0.3.0";
+        }
+      ]
+      null;
+
+  release."0.3.0".sha256 = "sha256-W2eenv5Q421eVn2ubbninFmmdT875f3w/Zs7yGHUKP4=";
+
+  propagatedBuildInputs = [ stdlib ];
+
+  releaseRev = v: "v${v}";
+
+  meta = {
+    description = "Total parser combinators in Rocq";
+    maintainers = with maintainers; [ womeier ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -38,6 +38,7 @@ let
 
       bignums = callPackage ../development/rocq-modules/bignums { };
       hierarchy-builder = callPackage ../development/rocq-modules/hierarchy-builder { };
+      parseque = callPackage ../development/rocq-modules/parseque { };
       rocq-elpi = callPackage ../development/rocq-modules/rocq-elpi { };
       stdlib = callPackage ../development/rocq-modules/stdlib { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
