### PR TITLE
python3Packages.gymnasium: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/gymnasium/default.nix
+++ b/pkgs/development/python-modules/gymnasium/default.nix
@@ -16,6 +16,7 @@
   importlib-metadata,
 
   # tests
+  array-api-compat,
   dill,
   flax,
   jax,
@@ -28,11 +29,12 @@
   pygame,
   pytestCheckHook,
   scipy,
+  torch,
 }:
 
 buildPythonPackage rec {
   pname = "gymnasium";
-  version = "1.1.1";
+  version = "1.2.0";
 
   pyproject = true;
 
@@ -40,7 +42,7 @@ buildPythonPackage rec {
     owner = "Farama-Foundation";
     repo = "gymnasium";
     tag = "v${version}";
-    hash = "sha256-5uE6ANOxVCeV5GMDGG+0j5JY2t++jw+mZFFHGl+sTfw=";
+    hash = "sha256-fQsz1Qpef9js+iqkqbfxrTQgcZT+JKjwpEiWewju2Dc=";
   };
 
   build-system = [ setuptools ];
@@ -55,6 +57,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "gymnasium" ];
 
   nativeCheckInputs = [
+    array-api-compat
     dill
     flax
     jax
@@ -67,6 +70,7 @@ buildPythonPackage rec {
     pygame
     pytestCheckHook
     scipy
+    torch
   ];
 
   # if `doCheck = true` on Darwin, `jaxlib` is evaluated, which is both
@@ -94,15 +98,6 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    # Fails since jax 0.6.0
-    # Fixed on master https://github.com/Farama-Foundation/Gymnasium/commit/94019feee1a0f945b9569cddf62780f4e1a224a5
-    # TODO: un-skip at the next release
-    "test_all_env_api"
-    "test_env_determinism_rollout"
-    "test_jax_to_numpy_wrapper"
-    "test_pickle_env"
-    "test_roundtripping"
-
     # Succeeds for most environments but `test_render_modes[Reacher-v4]` fails because it requires
     # OpenGL access which is not possible inside the sandbox.
     "test_render_mode"

--- a/pkgs/development/python-modules/stable-baselines3/default.nix
+++ b/pkgs/development/python-modules/stable-baselines3/default.nix
@@ -32,6 +32,13 @@ buildPythonPackage rec {
     hash = "sha256-VnoQ8cKqPcZPpR9c3M6xJDdG7gnO9fxIa4v2kxd9Nzg=";
   };
 
+  postPatch =
+    # Environment version v0 for `CliffWalking` is deprecated
+    ''
+      substituteInPlace "tests/test_vec_normalize.py" \
+        --replace-fail "CliffWalking-v0" "CliffWalking-v1"
+    '';
+
   build-system = [ setuptools ];
 
   pythonRelaxDeps = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/Farama-Foundation/gymnasium/compare/refs/tags/v1.1.1...refs/tags/v1.2.0
Changelog: https://github.com/Farama-Foundation/Gymnasium/releases/tag/v1.2.0

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
