### PR TITLE
cargoSetupHook, rustc: Force frame pointers for !isx86_32

### DIFF
--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -91,13 +91,21 @@
         lib.optionalString (stdenv.hostPlatform.config != stdenv.targetPlatform.config) ''
           [target."${stdenv.targetPlatform.rust.rustcTarget}"]
           "linker" = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc"
-          "rustflags" = [ "-C", "target-feature=${
-            if pkgsTargetTarget.stdenv.targetPlatform.isStatic then "+" else "-"
-          }crt-static" ]
+          "rustflags" = [ ${
+            lib.concatStringsSep ", " (
+              [
+                ''"-Ctarget-feature=${if stdenv.targetPlatform.isStatic then "+" else "-"}crt-static"''
+              ]
+              ++ lib.optional (!stdenv.targetPlatform.isx86_32) ''"-Cforce-frame-pointers=yes"''
+            )
+          } ]
         ''
         + ''
           [target."${stdenv.hostPlatform.rust.rustcTarget}"]
           "linker" = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
+          "rustflags" = [ ${
+            lib.optionalString (!stdenv.hostPlatform.isx86_32) ''"-Cforce-frame-pointers=yes"''
+          } ]
         '';
     };
 

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -260,6 +260,17 @@ stdenv.mkDerivation (finalAttrs: {
       # https://github.com/NixOS/nixpkgs/issues/311930
       "--llvm-libunwind=${if withBundledLLVM then "in-tree" else "system"}"
       "--enable-use-libcxx"
+    ]
+    ++ optionals (!stdenv.hostPlatform.isx86_32) [
+      # This enables frame pointers for the compiler itself.
+      #
+      # Note that when compiling std, frame pointers (or at least non-leaf
+      # frame pointers, depending on version) are unconditionally enabled and
+      # cannot be overridden, so we do not touch that. (Also note this only
+      # applies to functions that can be immediately compiled when building
+      # std. Generic functions that do codegen when called in user code obey
+      # -Cforce-frame-pointers specified then, if any)
+      "--set rust.frame-pointers"
     ];
 
   # if we already have a rust compiler for build just compile the target std


### PR DESCRIPTION
We did this for C in #399014 but not Rust. Add this to cargoSetupHook.

Also add to rustc because the bootstrap doesn't use cargoSetupHook.

To test:

```nix
nix build -f . rustc cargo pkgsCross.riscv64.pay-respects
objdump -j .text -d ...

# Get this from pkgsCross.riscv64.stdenv.cc
riscv64-unknown-linux-gnu-objdump -j .text -d ...
```

(There may be wrapper scripts that you need to get behind)

Patterns to look for to confirm usage of frame pointers

```
# x86_64

000000000040aa00 <_ZL28find_plugindir_spec_functioniPPKc>:
  40aa00:       55                      push   %rbp
  40aa01:       48 89 e5                mov    %rsp,%rbp  # <- Good
```

```
# aarch64

000000000016a3a4 <_ZN3std3sys12thread_local6native4lazy20Storage$LT$T$C$D$GT$10initialize17h53f3010de99a7b15E>:
  16a3a4:       d10143ff        sub     sp, sp, #0x50
  16a3a8:       a9037bfd        stp     x29, x30, [sp, #48] # <- Note x29, x30 and number
  16a3ac:       f90023f3        str     x19, [sp, #64]
  16a3b0:       9100c3fd        add     x29, sp, #0x30      # <- Good, number same as above but hex
```

```
# riscv64

000000000000e5ee <_ZN3std3sys12thread_local6native4lazy20Storage$LT$T$C$D$GT$10initialize17h151587489d666680E>:
    e5ee:       1141                    addi    sp,sp,-16 # <- Note this number
    e5f0:       e406                    sd      ra,8(sp)
    e5f2:       e022                    sd      s0,0(sp)
    e5f4:       0800                    addi    s0,sp,16  # <- Good, number same as above but positive
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
