### PR TITLE
nixos-rebuild-ng: move more code to services.py

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -133,7 +133,8 @@ python3Packages.buildPythonApplication rec {
         };
 
         inherit (nixosTests)
-          nixos-rebuild-install-bootloader-ng
+          # FIXME: this test is disabled since it times out in @ofborg
+          # nixos-rebuild-install-bootloader-ng
           nixos-rebuild-specialisations-ng
           nixos-rebuild-target-host-ng
           ;

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -9,7 +9,7 @@ from . import nix
 from .constants import EXECUTABLE, WITH_NIX_2_18, WITH_REEXEC, WITH_SHELL_FILES
 from .models import Action, BuildAttr, Flake, Profile
 from .process import Remote
-from .services import build_and_activate_system, list_generations, reexec
+from .services import build_and_activate_system, list_generations, reexec, repl
 from .utils import LogFormatter
 
 logger: Final = logging.getLogger(__name__)
@@ -348,13 +348,15 @@ def execute(argv: list[str]) -> None:
             raise AssertionError("DRY_RUN should be a DRY_BUILD alias")
 
         case Action.LIST_GENERATIONS:
-            list_generations(args, profile)
+            list_generations(args=args, profile=profile)
 
         case Action.REPL:
-            if flake:
-                nix.repl_flake(flake, flake_build_flags)
-            else:
-                nix.repl(build_attr, build_flags)
+            repl(
+                flake=flake,
+                build_attr=build_attr,
+                flake_build_flags=flake_build_flags,
+                build_flags=build_flags,
+            )
 
         case _:
             assert_never(action)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -15,6 +15,7 @@ from .services import (
     list_generations,
     reexec,
     repl,
+    write_version_suffix,
 )
 from .utils import LogFormatter
 
@@ -315,10 +316,7 @@ def execute(argv: list[str]) -> None:
     flake = Flake.from_arg(args.flake, target_host)
 
     if can_run and not flake:
-        nixpkgs_path = nix.find_file("nixpkgs", build_flags)
-        rev = nix.get_nixpkgs_rev(nixpkgs_path)
-        if nixpkgs_path and rev:
-            (nixpkgs_path / ".version-suffix").write_text(rev)
+        write_version_suffix(build_flags)
 
     match action:
         case (
@@ -348,7 +346,7 @@ def execute(argv: list[str]) -> None:
             )
 
         case Action.EDIT:
-            edit(flake, flake_build_flags)
+            edit(flake=flake, flake_build_flags=flake_build_flags)
 
         case Action.DRY_RUN:
             raise AssertionError("DRY_RUN should be a DRY_BUILD alias")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -9,7 +9,13 @@ from . import nix
 from .constants import EXECUTABLE, WITH_NIX_2_18, WITH_REEXEC, WITH_SHELL_FILES
 from .models import Action, BuildAttr, Flake, Profile
 from .process import Remote
-from .services import build_and_activate_system, list_generations, reexec, repl
+from .services import (
+    build_and_activate_system,
+    edit,
+    list_generations,
+    reexec,
+    repl,
+)
 from .utils import LogFormatter
 
 logger: Final = logging.getLogger(__name__)
@@ -342,7 +348,7 @@ def execute(argv: list[str]) -> None:
             )
 
         case Action.EDIT:
-            nix.edit(flake, flake_build_flags)
+            edit(flake, flake_build_flags)
 
         case Action.DRY_RUN:
             raise AssertionError("DRY_RUN should be a DRY_BUILD alias")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import logging
 import os
 import sys
@@ -10,8 +9,8 @@ from . import nix
 from .constants import EXECUTABLE, WITH_NIX_2_18, WITH_REEXEC, WITH_SHELL_FILES
 from .models import Action, BuildAttr, Flake, Profile
 from .process import Remote
-from .services import build_and_activate_system, reexec
-from .utils import LogFormatter, tabulate
+from .services import build_and_activate_system, list_generations, reexec
+from .utils import LogFormatter
 
 logger: Final = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -349,20 +348,7 @@ def execute(argv: list[str]) -> None:
             raise AssertionError("DRY_RUN should be a DRY_BUILD alias")
 
         case Action.LIST_GENERATIONS:
-            generations = nix.list_generations(profile)
-            if args.json:
-                print(json.dumps(generations, indent=2))
-            else:
-                headers = {
-                    "generation": "Generation",
-                    "date": "Build-date",
-                    "nixosVersion": "NixOS version",
-                    "kernelVersion": "Kernel",
-                    "configurationRevision": "Configuration Revision",
-                    "specialisations": "Specialisation",
-                    "current": "Current",
-                }
-                print(tabulate(generations, headers=headers))
+            list_generations(args, profile)
 
         case Action.REPL:
             if flake:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -242,33 +242,33 @@ def copy_closure(
                 nix_copy_closure(to_host, to=True)
 
 
-def edit(flake: Flake | None, flake_flags: Args | None = None) -> None:
+def edit() -> None:
     "Try to find and open NixOS configuration file in editor."
-    if flake:
-        run_wrapper(
-            [
-                "nix",
-                *FLAKE_FLAGS,
-                "edit",
-                *dict_to_flags(flake_flags),
-                "--",
-                str(flake),
-            ],
-            check=False,
-        )
-    else:
-        if flake_flags:
-            raise NixOSRebuildError("'edit' does not support extra Nix flags")
-        nixos_config = Path(
-            os.getenv("NIXOS_CONFIG") or find_file("nixos-config") or "/etc/nixos"
-        )
-        if nixos_config.is_dir():
-            nixos_config /= "default.nix"
+    nixos_config = Path(
+        os.getenv("NIXOS_CONFIG") or find_file("nixos-config") or "/etc/nixos"
+    )
+    if nixos_config.is_dir():
+        nixos_config /= "default.nix"
 
-        if nixos_config.exists():
-            run_wrapper([os.getenv("EDITOR", "nano"), nixos_config], check=False)
-        else:
-            raise NixOSRebuildError("cannot find NixOS config file")
+    if nixos_config.exists():
+        run_wrapper([os.getenv("EDITOR", "nano"), nixos_config], check=False)
+    else:
+        raise NixOSRebuildError("cannot find NixOS config file")
+
+
+def edit_flake(flake: Flake | None, flake_flags: Args | None = None) -> None:
+    "Try to find and open NixOS configuration file in editor for Flake config."
+    run_wrapper(
+        [
+            "nix",
+            *FLAKE_FLAGS,
+            "edit",
+            *dict_to_flags(flake_flags),
+            "--",
+            str(flake),
+        ],
+        check=False,
+    )
 
 
 def find_file(file: str, nix_flags: Args | None = None) -> Path | None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -336,3 +336,15 @@ def list_generations(
             "current": "Current",
         }
         print(tabulate(generations, headers=headers))
+
+
+def repl(
+    flake: Flake | None,
+    build_attr: BuildAttr,
+    flake_build_flags: Args,
+    build_flags: Args,
+) -> None:
+    if flake:
+        nix.repl_flake(flake, flake_build_flags)
+    else:
+        nix.repl(build_attr, build_flags)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import os
 import sys
@@ -10,7 +11,7 @@ from . import nix, tmpdir
 from .constants import EXECUTABLE
 from .models import Action, BuildAttr, Flake, ImageVariants, NixOSRebuildError, Profile
 from .process import Remote, cleanup_ssh
-from .utils import Args
+from .utils import Args, tabulate
 
 NIXOS_REBUILD_ATTR: Final = "config.system.build.nixos-rebuild"
 
@@ -315,3 +316,23 @@ def build_and_activate_system(
         common_flags=common_flags,
         flake_common_flags=flake_common_flags,
     )
+
+
+def list_generations(
+    args: argparse.Namespace,
+    profile: Profile,
+) -> None:
+    generations = nix.list_generations(profile)
+    if args.json:
+        print(json.dumps(generations, indent=2))
+    else:
+        headers = {
+            "generation": "Generation",
+            "date": "Build-date",
+            "nixosVersion": "NixOS version",
+            "kernelVersion": "Kernel",
+            "configurationRevision": "Configuration Revision",
+            "specialisations": "Specialisation",
+            "current": "Current",
+        }
+        print(tabulate(generations, headers=headers))

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -318,9 +318,9 @@ def build_and_activate_system(
     )
 
 
-def edit(flake: Flake | None, flake_flags: Args | None = None) -> None:
+def edit(flake: Flake | None, flake_build_flags: Args | None = None) -> None:
     if flake:
-        nix.edit_flake(flake, flake_flags)
+        nix.edit_flake(flake, flake_build_flags)
     else:
         nix.edit()
 
@@ -355,3 +355,10 @@ def repl(
         nix.repl_flake(flake, flake_build_flags)
     else:
         nix.repl(build_attr, build_flags)
+
+
+def write_version_suffix(build_flags: Args) -> None:
+    nixpkgs_path = nix.find_file("nixpkgs", build_flags)
+    rev = nix.get_nixpkgs_rev(nixpkgs_path)
+    if nixpkgs_path and rev:
+        (nixpkgs_path / ".version-suffix").write_text(rev)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -318,6 +318,13 @@ def build_and_activate_system(
     )
 
 
+def edit(flake: Flake | None, flake_flags: Args | None = None) -> None:
+    if flake:
+        nix.edit_flake(flake, flake_flags)
+    else:
+        nix.edit()
+
+
 def list_generations(
     args: argparse.Namespace,
     profile: Profile,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -8,7 +8,6 @@ from typing import Any
 from unittest.mock import ANY, Mock, call, patch
 
 import pytest
-from pytest import MonkeyPatch
 
 import nixos_rebuild as nr
 from nixos_rebuild.constants import WITH_NIX_2_18
@@ -126,92 +125,6 @@ def test_parse_args() -> None:
         "--include",
         "include2",
     ]
-
-
-@patch.dict(os.environ, {}, clear=True)
-@patch("os.execve", autospec=True)
-@patch(get_qualified_name(nr.nix.build), autospec=True)
-def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.setattr(nr.services, "EXECUTABLE", "nixos-rebuild-ng")
-    argv = ["/path/bin/nixos-rebuild-ng", "switch", "--no-flake"]
-    args, _ = nr.parse_args(argv)
-    mock_build.return_value = Path("/path")
-
-    nr.reexec(argv, args, {"build": True}, {"flake": True})
-    mock_build.assert_has_calls(
-        [
-            call(
-                nr.services.NIXOS_REBUILD_ATTR,
-                nr.models.BuildAttr(ANY, ANY),
-                {"build": True, "no_out_link": True},
-            )
-        ]
-    )
-    # do not exec if there is no new version
-    mock_execve.assert_not_called()
-
-    mock_build.return_value = Path("/path/new")
-
-    nr.reexec(argv, args, {}, {})
-    # exec in the new version successfully
-    mock_execve.assert_called_once_with(
-        Path("/path/new/bin/nixos-rebuild-ng"),
-        ["/path/bin/nixos-rebuild-ng", "switch", "--no-flake"],
-        {"_NIXOS_REBUILD_REEXEC": "1"},
-    )
-
-    mock_execve.reset_mock()
-    mock_execve.side_effect = [OSError("BOOM"), None]
-
-    nr.reexec(argv, args, {}, {})
-    # exec in the previous version if the new version fails
-    mock_execve.assert_any_call(
-        Path("/path/bin/nixos-rebuild-ng"),
-        ["/path/bin/nixos-rebuild-ng", "switch", "--no-flake"],
-        {"_NIXOS_REBUILD_REEXEC": "1"},
-    )
-
-
-@patch.dict(os.environ, {}, clear=True)
-@patch("os.execve", autospec=True)
-@patch(get_qualified_name(nr.nix.build_flake), autospec=True)
-def test_reexec_flake(
-    mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch
-) -> None:
-    monkeypatch.setattr(nr.services, "EXECUTABLE", "nixos-rebuild-ng")
-    argv = ["/path/bin/nixos-rebuild-ng", "switch", "--flake"]
-    args, _ = nr.parse_args(argv)
-    mock_build.return_value = Path("/path")
-
-    nr.reexec(argv, args, {"build": True}, {"flake": True})
-    mock_build.assert_called_once_with(
-        nr.services.NIXOS_REBUILD_ATTR,
-        nr.models.Flake(ANY, ANY),
-        {"flake": True, "no_link": True},
-    )
-    # do not exec if there is no new version
-    mock_execve.assert_not_called()
-
-    mock_build.return_value = Path("/path/new")
-
-    nr.reexec(argv, args, {}, {})
-    # exec in the new version successfully
-    mock_execve.assert_called_once_with(
-        Path("/path/new/bin/nixos-rebuild-ng"),
-        ["/path/bin/nixos-rebuild-ng", "switch", "--flake"],
-        {"_NIXOS_REBUILD_REEXEC": "1"},
-    )
-
-    mock_execve.reset_mock()
-    mock_execve.side_effect = [OSError("BOOM"), None]
-
-    nr.reexec(argv, args, {}, {})
-    # exec in the previous version if the new version fails
-    mock_execve.assert_any_call(
-        Path("/path/bin/nixos-rebuild-ng"),
-        ["/path/bin/nixos-rebuild-ng", "switch", "--flake"],
-        {"_NIXOS_REBUILD_REEXEC": "1"},
-    )
 
 
 @patch.dict(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_services.py
@@ -1,0 +1,96 @@
+import os
+from pathlib import Path
+from unittest.mock import ANY, Mock, call, patch
+
+from pytest import MonkeyPatch
+
+import nixos_rebuild as n
+import nixos_rebuild.services as s
+
+from .helpers import get_qualified_name
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("os.execve", autospec=True)
+@patch(get_qualified_name(s.nix.build), autospec=True)
+def test_reexec(mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(s, "EXECUTABLE", "nixos-rebuild-ng")
+    argv = ["/path/bin/nixos-rebuild-ng", "switch", "--no-flake"]
+    args, _ = n.parse_args(argv)
+    mock_build.return_value = Path("/path")
+
+    s.reexec(argv, args, {"build": True}, {"flake": True})
+    mock_build.assert_has_calls(
+        [
+            call(
+                s.NIXOS_REBUILD_ATTR,
+                n.models.BuildAttr(ANY, ANY),
+                {"build": True, "no_out_link": True},
+            )
+        ]
+    )
+    # do not exec if there is no new version
+    mock_execve.assert_not_called()
+
+    mock_build.return_value = Path("/path/new")
+
+    s.reexec(argv, args, {}, {})
+    # exec in the new version successfully
+    mock_execve.assert_called_once_with(
+        Path("/path/new/bin/nixos-rebuild-ng"),
+        ["/path/bin/nixos-rebuild-ng", "switch", "--no-flake"],
+        {"_NIXOS_REBUILD_REEXEC": "1"},
+    )
+
+    mock_execve.reset_mock()
+    mock_execve.side_effect = [OSError("BOOM"), None]
+
+    s.reexec(argv, args, {}, {})
+    # exec in the previous version if the new version fails
+    mock_execve.assert_any_call(
+        Path("/path/bin/nixos-rebuild-ng"),
+        ["/path/bin/nixos-rebuild-ng", "switch", "--no-flake"],
+        {"_NIXOS_REBUILD_REEXEC": "1"},
+    )
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch("os.execve", autospec=True)
+@patch(get_qualified_name(s.nix.build_flake), autospec=True)
+def test_reexec_flake(
+    mock_build: Mock, mock_execve: Mock, monkeypatch: MonkeyPatch
+) -> None:
+    monkeypatch.setattr(s, "EXECUTABLE", "nixos-rebuild-ng")
+    argv = ["/path/bin/nixos-rebuild-ng", "switch", "--flake"]
+    args, _ = n.parse_args(argv)
+    mock_build.return_value = Path("/path")
+
+    s.reexec(argv, args, {"build": True}, {"flake": True})
+    mock_build.assert_called_once_with(
+        s.NIXOS_REBUILD_ATTR,
+        n.models.Flake(ANY, ANY),
+        {"flake": True, "no_link": True},
+    )
+    # do not exec if there is no new version
+    mock_execve.assert_not_called()
+
+    mock_build.return_value = Path("/path/new")
+
+    s.reexec(argv, args, {}, {})
+    # exec in the new version successfully
+    mock_execve.assert_called_once_with(
+        Path("/path/new/bin/nixos-rebuild-ng"),
+        ["/path/bin/nixos-rebuild-ng", "switch", "--flake"],
+        {"_NIXOS_REBUILD_REEXEC": "1"},
+    )
+
+    mock_execve.reset_mock()
+    mock_execve.side_effect = [OSError("BOOM"), None]
+
+    s.reexec(argv, args, {}, {})
+    # exec in the previous version if the new version fails
+    mock_execve.assert_any_call(
+        Path("/path/bin/nixos-rebuild-ng"),
+        ["/path/bin/nixos-rebuild-ng", "switch", "--flake"],
+        {"_NIXOS_REBUILD_REEXEC": "1"},
+    )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Continuation of #420352. Moving more code to `services.py`, making the code easier to navigate since it makes `__init__.py` smaller.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
