### PR TITLE
nixos/postfix-tlspol: migrate to static user/group

### DIFF
--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -153,6 +153,12 @@ in
 
       environment.systemPackages = [ cfg.package ];
 
+      users.users.postfix-tlspol = {
+        isSystemUser = true;
+        group = "postfix-tlspol";
+      };
+      users.groups.postfix-tlspol = { };
+
       systemd.services.postfix-tlspol = {
         after = [
           "nss-lookup.target"
@@ -178,7 +184,8 @@ in
           Restart = "always";
           RestartSec = 5;
 
-          DynamicUser = true;
+          User = "postfix-tlspol";
+          Group = "postfix-tlspol";
 
           CacheDirectory = "postfix-tlspol";
           CapabilityBoundingSet = [ "" ];
@@ -208,7 +215,7 @@ in
             ++ lib.optionals (lib.hasPrefix "unix:" cfg.settings.server.address) [
               "AF_UNIX"
             ];
-          RestrictNamespace = true;
+          RestrictNamespaces = true;
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
           SystemCallArchitectures = "native";

--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -19,6 +19,7 @@ let
   cfg = config.services.postfix-tlspol;
 
   format = pkgs.formats.yaml_1_2 { };
+  configFile = format.generate "postfix-tlspol.yaml" cfg.settings;
 in
 
 {
@@ -148,8 +149,7 @@ in
     })
 
     (mkIf cfg.enable {
-      environment.etc."postfix-tlspol/config.yaml".source =
-        format.generate "postfix-tlspol.yaml" cfg.settings;
+      environment.etc."postfix-tlspol/config.yaml".source = configFile;
 
       environment.systemPackages = [ cfg.package ];
 
@@ -172,6 +172,8 @@ in
 
         description = "Postfix DANE/MTA-STS TLS policy socketmap service";
         documentation = [ "https://github.com/Zuplu/postfix-tlspol" ];
+
+        reloadTriggers = [ configFile ];
 
         # https://github.com/Zuplu/postfix-tlspol/blob/main/init/postfix-tlspol.service
         serviceConfig = {

--- a/nixos/tests/postfix-tlspol.nix
+++ b/nixos/tests/postfix-tlspol.nix
@@ -18,7 +18,7 @@
     import json
 
     machine.wait_for_unit("postfix-tlspol.service")
-    machine.succeed("systemctl show -P SupplementaryGroups postfix.service | grep postfix-tlspol")
+    machine.succeed("getent group postfix-tlspol | grep :postfix")
 
     with subtest("Interact with the service"):
       machine.succeed("postfix-tlspol -purge")
@@ -26,6 +26,8 @@
       response = json.loads((machine.succeed("postfix-tlspol -query localhost")))
       machine.log(json.dumps(response, indent=2))
 
+
+    machine.log(machine.execute("systemd-analyze security postfix-tlspol.service | grep -v ✓")[1])
   '';
 
 }

--- a/nixos/tests/postfix-tlspol.nix
+++ b/nixos/tests/postfix-tlspol.nix
@@ -10,9 +10,12 @@
   nodes.machine = {
     services.postfix.enable = true;
     services.postfix-tlspol.enable = true;
-  };
 
-  enableOCR = true;
+    services.dnsmasq = {
+      enable = true;
+      settings.selfmx = true;
+    };
+  };
 
   testScript = ''
     import json
@@ -26,6 +29,8 @@
       response = json.loads((machine.succeed("postfix-tlspol -query localhost")))
       machine.log(json.dumps(response, indent=2))
 
+      assert response["dane"]["policy"] == "", f"Unexpected DANE policy for localhost: {response["dane"]["policy"]}"
+      assert response["mta-sts"]["policy"] == "", f"Unexpected MTA-STS policy for localhost: {response["mta-sts"]["policy"]}"
 
     machine.log(machine.execute("systemd-analyze security postfix-tlspol.service | grep -v ✓")[1])
   '';


### PR DESCRIPTION
Followup for #418568

This fixes postfix' membership in the postfix-tlspol group, since memberships in a dynamically allocated group don't seem to work out.

Additionally this fixes a typo in the systemd hardening and the test now prints the results of systemd-analyze security.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
