### PR TITLE
tup: Fix static build

### DIFF
--- a/pkgs/by-name/tu/tup/package.nix
+++ b/pkgs/by-name/tu/tup/package.nix
@@ -38,7 +38,19 @@ stdenv.mkDerivation rec {
   patches = [ ./fusermount-setuid.patch ];
 
   configurePhase = ''
-    substituteInPlace  src/tup/link.sh --replace '`git describe' '`echo ${version}'
+    substituteInPlace  src/tup/link.sh --replace-fail '`git describe' '`echo ${version}'
+
+    for path in Tupfile build.sh src/tup/server/Tupfile ; do
+      substituteInPlace  $path  --replace-fail "pkg-config" "${stdenv.cc.targetPrefix}pkg-config"
+    done
+
+    # Replace "pcre2-config --libs8" => "pkg-config libpcre2-8 --libs".
+    #
+    # There is prefixed pkg-config for cross-compilation, but no prefixed "pcre2-config".
+    for path in Tupfile Tuprules.tup ; do
+      substituteInPlace  $path --replace-fail "pcre2-config" "${stdenv.cc.targetPrefix}pkg-config libpcre2-8 "
+    done
+    substituteInPlace  Tupfile --replace-fail "--libs8" "--libs"
 
     cat << EOF > tup.config
     CONFIG_CC=${stdenv.cc.targetPrefix}cc


### PR DESCRIPTION
# tup: Fix static build

```
tup: Fix static build
```

## Build info of packages affected directly
### tup

<details><summary>content of tup.bin</summary>

```
/nix/store/9pk8wv5dizj43g7n61i0hbmvcg9qdxmc-tup-0.8-bin
└── bin
    └── tup

2 directories, 1 file
```
</details>

<details><summary>content of tup.man</summary>

```
/nix/store/d62liz4yv742jqws5js9z44s0jay7qgr-tup-0.8-man
└── share
    └── man
        └── man1
            └── tup.1.gz

4 directories, 1 file
```
</details>

<details><summary>content of tup.out</summary>

```
/nix/store/i052zk8z16xp7ddh2c6qs4d0dx7zwnjq-tup-0.8
└── nix-support
    ├── propagated-build-inputs
    └── setup-hook

2 directories, 2 files
```
</details>

<details><summary>build log of tup</summary>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/s8fcv3q1h5n79qsai2d64f6r6swnay8h-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
applying patch /nix/store/icckhmkn5s7l0j2ylj3hjama9iggr362-fusermount-setuid.patch
patching file src/tup/server/fuse_server.c
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
  mkdir build
  cd build
  bootstrap CC  ../src/lua/lapi.c
  bootstrap CC  ../src/lua/lauxlib.c
  bootstrap CC  ../src/lua/lbaselib.c
  bootstrap CC  ../src/lua/lcode.c
  bootstrap CC  ../src/lua/lcorolib.c
  bootstrap CC  ../src/lua/lctype.c
  bootstrap CC  ../src/lua/ldblib.c
  bootstrap CC  ../src/lua/ldebug.c
  bootstrap CC  ../src/lua/ldo.c
  bootstrap CC  ../src/lua/ldump.c
  bootstrap CC  ../src/lua/lfunc.c
  bootstrap CC  ../src/lua/lgc.c
  bootstrap CC  ../src/lua/linit.c
  bootstrap CC  ../src/lua/liolib.c
  bootstrap CC  ../src/lua/llex.c
  bootstrap CC  ../src/lua/lmathlib.c
  bootstrap CC  ../src/lua/lmem.c
  bootstrap CC  ../src/lua/loadlib.c
  bootstrap CC  ../src/lua/lobject.c
  bootstrap CC  ../src/lua/lopcodes.c
  bootstrap CC  ../src/lua/loslib.c
  bootstrap CC  ../src/lua/lparser.c
  bootstrap CC  ../src/lua/lstate.c
  bootstrap CC  ../src/lua/lstring.c
  bootstrap CC  ../src/lua/lstrlib.c
  bootstrap CC  ../src/lua/ltable.c
  bootstrap CC  ../src/lua/ltablib.c
  bootstrap CC  ../src/lua/ltm.c
  bootstrap CC  ../src/lua/lua.c
  bootstrap CC  ../src/lua/luac.c
  bootstrap CC  ../src/lua/lundump.c
  bootstrap CC  ../src/lua/lutf8lib.c
  bootstrap CC  ../src/lua/lvm.c
  bootstrap CC  ../src/lua/lzio.c
  link lua
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/bin.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/ccache.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/colors.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/config.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/create_name_file.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/db.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/debug.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/delete_name_file.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/dircache.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/entry.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/environ.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/estring.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/file.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/fslurp.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/graph.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/if_stmt.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/init.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/lock.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/logging.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/luaparser.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/mempool.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/option.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/parser.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/path.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/pel_group.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/platform.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/progress.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/send_event.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/string_tree.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/tent_list.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/tent_tree.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/thread_tree.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/timespan.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/tupid_list.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/tupid_tree.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/updater.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/vardb.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/vardict.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/variant.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/varsed.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/tup/main.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/monitor/inotify.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/flock/fcntl.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/inih/ini.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_auto_possess.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_chartables.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_compile.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_config.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_context.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_convert.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_dfa_match.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_error.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_extuni.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_find_bracket.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_jit_compile.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_maketables.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_match.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_match_data.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_newline.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_ord2utf.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_pattern_info.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_script_run.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_serialize.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_string_utils.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_study.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_substitute.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_substring.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_tables.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_ucd.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_valid_utf.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/pcre/pcre2_xclass.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/server/fuse_fs.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/server/fuse_server.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/server/master_fork.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/tup/server/symlink.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/compat/dummy.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/compat/utimensat_linux.c
  bootstrap CC  -DTUP_SERVER="fuse3" -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H ../src/sqlite3/sqlite3.c
  bootstrap LD tup  -lm
.tup repository initialized: .tup/db
.tup repository initialized: :memory:
Scanning...
Reading tup.config...
Parsing...
 ~ 2% .github/workflows
 ~ 5% .github
 ~ 8% contrib/debian/source
 ~11% contrib/debian
 ~14% contrib/syntax
 ~17% contrib
 ~20% docs/html/pub/win32
 ~22% docs/html/pub
 ~25% docs/html
 ~28% docs
 ~31% lib32
 ~34% local-build-configs
 ~37% src/bsd
 ~40% src/compat/win32/detect
 ~42% src/compat/win32/sys
 ~45% src/compat/win32
 ~48% src/compat
 ~51% src/dllinject
 ~54% src/inih
 ~57% src/ldpreload
 ~60% src/lua
 ~62% src/luabuiltin
 ~65% src/pcre
 ~68% src/sqlite3
 ~71% src/tup/flock
 ~74% src/tup/monitor
 ~77% src/tup/server
 ~80% src/tup/tup
 ~82% src/tup
 ~85% src
 ~88% test/make_v_tup
 ~91% test
 ~94% build/luabuiltin
 ~97% build
 100% .
Generate: script.sh
buildPhase completed in 42 seconds
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/9pk8wv5dizj43g7n61i0hbmvcg9qdxmc-tup-0.8-bin
shrinking /nix/store/9pk8wv5dizj43g7n61i0hbmvcg9qdxmc-tup-0.8-bin/bin/tup
checking for references to /build/ in /nix/store/9pk8wv5dizj43g7n61i0hbmvcg9qdxmc-tup-0.8-bin...
patching script interpreter paths in /nix/store/9pk8wv5dizj43g7n61i0hbmvcg9qdxmc-tup-0.8-bin
stripping (with command strip and flags -S -p) in  /nix/store/9pk8wv5dizj43g7n61i0hbmvcg9qdxmc-tup-0.8-bin/bin
shrinking RPATHs of ELF executables and libraries in /nix/store/d62liz4yv742jqws5js9z44s0jay7qgr-tup-0.8-man
checking for references to /build/ in /nix/store/d62liz4yv742jqws5js9z44s0jay7qgr-tup-0.8-man...
gzipping man pages under /nix/store/d62liz4yv742jqws5js9z44s0jay7qgr-tup-0.8-man/share/man/
patching script interpreter paths in /nix/store/d62liz4yv742jqws5js9z44s0jay7qgr-tup-0.8-man
```
</details>
