### PR TITLE
nitter: match about page's version string with upstream

### DIFF
--- a/pkgs/by-name/ni/nitter/package.nix
+++ b/pkgs/by-name/ni/nitter/package.nix
@@ -6,7 +6,7 @@
   replaceVars,
   unstableGitUpdater,
 }:
-buildNimPackage (finalAttrs: prevAttrs: rec {
+buildNimPackage (finalAttrs: rec {
   date = "2025-05-01";
 
   pname = "nitter";

--- a/pkgs/by-name/ni/nitter/package.nix
+++ b/pkgs/by-name/ni/nitter/package.nix
@@ -6,57 +6,52 @@
   replaceVars,
   unstableGitUpdater,
 }:
+buildNimPackage (finalAttrs: prevAttrs: rec {
+  date = "2025-05-01";
 
-buildNimPackage (
-  finalAttrs: prevAttrs:
-  let
-    date = "2025-05-01";
-  in
-  {
-    pname = "nitter";
-    version = "0-unstable-${date}";
+  pname = "nitter";
+  version = "0-unstable-${date}";
 
-    src = fetchFromGitHub {
-      owner = "zedeus";
-      repo = "nitter";
-      rev = "e40c61a6ae76431c570951cc4925f38523b00a82";
-      hash = "sha256-YOwoN3sC5g9oV1gbIu2TQE4SCAoNDONvEQy9xvzKD/c=";
-    };
+  src = fetchFromGitHub {
+    owner = "zedeus";
+    repo = "nitter";
+    rev = "e40c61a6ae76431c570951cc4925f38523b00a82";
+    hash = "sha256-YOwoN3sC5g9oV1gbIu2TQE4SCAoNDONvEQy9xvzKD/c=";
+  };
 
-    lockFile = ./lock.json;
+  lockFile = ./lock.json;
 
-    patches = [
-      (replaceVars ./nitter-version.patch {
-        version = lib.replaceString "-" "." date;
-        rev = builtins.substring 0 7 finalAttrs.src.rev;
-        url = builtins.replaceStrings [ "archive" ".tar.gz" ] [ "commit" "" ] finalAttrs.src.url;
-      })
+  patches = [
+    (replaceVars ./nitter-version.patch {
+      version = lib.replaceString "-" "." date;
+      rev = builtins.substring 0 7 finalAttrs.src.rev;
+      url = builtins.replaceStrings [ "archive" ".tar.gz" ] [ "commit" "" ] finalAttrs.src.url;
+    })
+  ];
+
+  postBuild = ''
+    nim compile ${toString finalAttrs.nimFlags} -r tools/gencss
+    nim compile ${toString finalAttrs.nimFlags} -r tools/rendermd
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/nitter
+    cp -r public $out/share/nitter/public
+  '';
+
+  passthru = {
+    tests = { inherit (nixosTests) nitter; };
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/zedeus/nitter";
+    description = "Alternative Twitter front-end";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [
+      erdnaxe
+      infinidoge
     ];
-
-    postBuild = ''
-      nim compile ${toString finalAttrs.nimFlags} -r tools/gencss
-      nim compile ${toString finalAttrs.nimFlags} -r tools/rendermd
-    '';
-
-    postInstall = ''
-      mkdir -p $out/share/nitter
-      cp -r public $out/share/nitter/public
-    '';
-
-    passthru = {
-      tests = { inherit (nixosTests) nitter; };
-      updateScript = unstableGitUpdater { };
-    };
-
-    meta = with lib; {
-      homepage = "https://github.com/zedeus/nitter";
-      description = "Alternative Twitter front-end";
-      license = licenses.agpl3Only;
-      maintainers = with maintainers; [
-        erdnaxe
-        infinidoge
-      ];
-      mainProgram = "nitter";
-    };
-  }
-)
+    mainProgram = "nitter";
+  };
+})

--- a/pkgs/by-name/ni/nitter/package.nix
+++ b/pkgs/by-name/ni/nitter/package.nix
@@ -8,9 +8,13 @@
 }:
 
 buildNimPackage (
-  finalAttrs: prevAttrs: {
+  finalAttrs: prevAttrs:
+  let
+    date = "2025-05-01";
+  in
+  {
     pname = "nitter";
-    version = "0-unstable-2025-05-01";
+    version = "0-unstable-${date}";
 
     src = fetchFromGitHub {
       owner = "zedeus";
@@ -23,8 +27,8 @@ buildNimPackage (
 
     patches = [
       (replaceVars ./nitter-version.patch {
-        inherit (finalAttrs) version;
-        inherit (finalAttrs.src) rev;
+        version = lib.replaceString "-" "." date;
+        rev = builtins.substring 0 7 finalAttrs.src.rev;
         url = builtins.replaceStrings [ "archive" ".tar.gz" ] [ "commit" "" ] finalAttrs.src.url;
       })
     ];


### PR DESCRIPTION
The /about page in upstream uses the format "YYYY.MM.DD-<short commit hash>" in the footer. However, the nix package currently uses the nix version string for reproducibility. This causes issues with the [nitter instance status page](https://status.d420.de) not being able to detect the version of any instance running with nix, so this commit tries to make it match what the impure upstream version would do. See the .patch file in the nitter directory for more details.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
