### PR TITLE
unicode-paracode: 2.9 -> 3.2.1, make it work with Python 3.13, add test

### DIFF
--- a/pkgs/by-name/un/unicode-paracode/package.nix
+++ b/pkgs/by-name/un/unicode-paracode/package.nix
@@ -9,14 +9,15 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "unicode";
-  version = "2.9";
+  version = "3.2"; # From `debian/changelog` in the repo
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "garabik";
     repo = "unicode";
-    rev = "v${version}";
-    sha256 = "sha256-FHAlZ5HID/FE9+YR7Dmc3Uh7E16QKORoD8g9jgTeQdY=";
+    # TODO: Change back to "v${version}" after https://github.com/garabik/unicode/issues/27 is fixed.
+    rev = "fa4fa6118d68c693ee14b97df6bf12d2fdbb37df";
+    sha256 = "sha256-wgPJKzblwntRRD2062TPEth28KDycVqWheMTz0v5BVE=";
   };
 
   ucdtxt = fetchurl {
@@ -29,8 +30,11 @@ python3Packages.buildPythonApplication rec {
   build-system = with python3Packages; [ setuptools ];
 
   postFixup = ''
+    mkdir -p "$out/share/unicode"
+    ln -s "$ucdtxt" "$out/share/unicode/UnicodeData.txt"
+    # We want to keep /usr/share/unicode in the list for the Unihan files
     substituteInPlace "$out/bin/.unicode-wrapped" \
-      --replace-fail "/usr/share/unicode/UnicodeData.txt" "$ucdtxt"
+      --replace-fail "'/usr/share/unicode', " "'$out/share/unicode', '/usr/share/unicode', "
   '';
 
   postInstall = ''

--- a/pkgs/by-name/un/unicode-paracode/package.nix
+++ b/pkgs/by-name/un/unicode-paracode/package.nix
@@ -8,6 +8,7 @@
 }:
 
 python3Packages.buildPythonApplication rec {
+  # We want `pname = "unicode"` so that `nix run nixpkgs#unicode-paracode -- z` runs the `unicode` binary.
   pname = "unicode";
   version = "3.2"; # From `debian/changelog` in the repo
   pyproject = true;
@@ -39,6 +40,15 @@ python3Packages.buildPythonApplication rec {
 
   postInstall = ''
     installManPage paracode.1 unicode.1
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    echo Testing: $out/bin/unicode --brief z
+    diff -u <(echo z U+007A LATIN SMALL LETTER Z) <($out/bin/unicode --brief z 2>&1) && echo Success
+
+    runHook postCheck
   '';
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };


### PR DESCRIPTION
The main goal is to fix https://github.com/NixOS/nixpkgs/issues/419447

Unfortunately, the latest release is not tagged in the upstream repo,
so I picked the commit based on the changelog update. See also
https://github.com/garabik/unicode/issues/27

Cc @dotlambda @woffs @kilianar @dtzWill



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
