### PR TITLE
babeltrace2: 2.0.6 -> 2.1.1

### DIFF
--- a/pkgs/by-name/ba/babeltrace2/package.nix
+++ b/pkgs/by-name/ba/babeltrace2/package.nix
@@ -22,33 +22,14 @@
 
 stdenv.mkDerivation rec {
   pname = "babeltrace2";
-  version = "2.0.6";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "efficios";
     repo = "babeltrace";
     rev = "v${version}";
-    hash = "sha256-L4YTqPxvWynUBnmAQnlJ2RNbEv9MhBxQOsqbWix8ZwU=";
+    hash = "sha256-ppSPly4HR/oemsX069o6VqwSB1AU1mKRwRepwPORf7I=";
   };
-
-  patches = [
-    # Patches needed for Python 3.12
-    (fetchpatch {
-      # python: Use standalone 'sysconfig' module
-      url = "https://github.com/efficios/babeltrace/commit/452480eb6820df9973d50431a479ca547815ae08.patch";
-      hash = "sha256-YgUKHJzdliNUsTY29E0xxcUjqVWn4EvxyTs0B+O+jrI=";
-    })
-    (fetchpatch {
-      # python: replace distutils with setuptools
-      url = "https://github.com/efficios/babeltrace/commit/6ec97181a525a3cd64cedbcd0df905ed9e84ba03.patch";
-      hash = "sha256-1hlEkPcRUpf2+iEXqHXcCDOaLTg+eaVcahqZlA8m5QY=";
-    })
-    (fetchpatch {
-      # fix: python: monkey patch the proper sysconfig implementation
-      url = "https://github.com/efficios/babeltrace/commit/927263e4ea62877af7240cfdb1514ae949dbfc2e.patch";
-      hash = "sha256-HNRQ7uw26FUKCQ/my6//OL2xsHdOGlQUq5zIKtg9OGw=";
-    })
-  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
Updates babeltrace2 from 2.0.6 to 2.1.1. Looks like all of the patches have already been upstreamed. Not sure exactly what functionality to test, seems to basically work.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `479305951f01e8107bc8287608ce1aa70eb1f076`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 9 packages built:</summary>
  <ul>
    <li>babeltrace2</li>
    <li>babeltrace2.dev</li>
    <li>babeltrace2.man</li>
    <li>python312Packages.babeltrace2</li>
    <li>python312Packages.babeltrace2.dev</li>
    <li>python312Packages.babeltrace2.man</li>
    <li>python313Packages.babeltrace2</li>
    <li>python313Packages.babeltrace2.dev</li>
    <li>python313Packages.babeltrace2.man</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
