### PR TITLE
python3Packages.ase: fix build

### DIFF
--- a/pkgs/development/python-modules/ase/default.nix
+++ b/pkgs/development/python-modules/ase/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchFromGitLab,
   buildPythonPackage,
   isPy27,
   fetchPypi,
@@ -28,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "ase";
-  version = "3.25.0";
+  version = "3.25.0-unstable-2025-06-24";
   pyproject = true;
 
-  disabled = isPy27;
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-N0z4yp/liPBdboVto8nBfvJi3JaAJ7Ix1EkzQUDJYsI=";
+  src = fetchFromGitLab {
+    owner = "ase";
+    repo = "ase";
+    rev = "4e22dabfbe7ae2329e50260ca1b6f08a83527ac3";
+    hash = "sha256-ehMyVtPxfTxT8T418VyLGnUEyYip4LPTTaGL0va7qgM=";
   };
 
   build-system = [ setuptools ];
@@ -62,10 +63,6 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # AssertionError: assert (1 != 0) == False
-    # TypeError: list indices must be integers or slices, not numpy.bool
-    "test_long"
-
     "test_fundamental_params"
     "test_ase_bandstructure"
     "test_imports"

--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -13,11 +13,13 @@
   glibcLocales,
 
   # dependencies
+  bibtexparser,
   joblib,
   matplotlib,
   monty,
   networkx,
   numpy,
+  orjson,
   palettable,
   pandas,
   plotly,
@@ -50,7 +52,7 @@
 
 buildPythonPackage rec {
   pname = "pymatgen";
-  version = "2025.1.24";
+  version = "2025.6.14";
   pyproject = true;
 
   disabled = pythonAtLeast "3.13";
@@ -59,7 +61,7 @@ buildPythonPackage rec {
     owner = "materialsproject";
     repo = "pymatgen";
     tag = "v${version}";
-    hash = "sha256-0P3/M6VI2RKPArMwXD95sjW7dYOTXxUeu4tOliN0IGk=";
+    hash = "sha256-HMYYhXT5k/EjG1sIBq/53K9ogeSk8ZEJQBrDHCgz+SA=";
   };
 
   build-system = [ setuptools ];
@@ -70,11 +72,13 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    bibtexparser
     joblib
     matplotlib
     monty
     networkx
     numpy
+    orjson
     palettable
     pandas
     plotly
@@ -115,6 +119,11 @@ buildPythonPackage rec {
   };
 
   pythonImportsCheck = [ "pymatgen" ];
+
+  pytestFlagsArray = [
+    # We have not packaged moyopy yet.
+    "--deselect=tests/analysis/test_prototypes.py::test_get_protostructure_label_from_moyopy"
+  ];
 
   nativeCheckInputs = [
     addBinToPathHook
@@ -158,6 +167,9 @@ buildPythonPackage rec {
       "test_proj_bandstructure_plot"
       "test_structure"
       "test_structure_environments"
+
+      # attempt to insert nil object from objects[1]
+      "test_timer_10_2_7"
     ];
 
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/pyscf/coerce-numpy-to-int.patch
+++ b/pkgs/development/python-modules/pyscf/coerce-numpy-to-int.patch
@@ -1,0 +1,19 @@
+commit 6df405512d33d432bb45553ddcffbc70edec51f6
+Author: Lein Matsumaru <applePrincess@applePrincess.io>
+Date:   Sun Jun 29 12:59:57 2025 +0000
+
+    Coerce int
+
+diff --git a/pyscf/ci/gcisd.py b/pyscf/ci/gcisd.py
+index d58e0364c..050f83962 100644
+--- a/pyscf/ci/gcisd.py
++++ b/pyscf/ci/gcisd.py
+@@ -197,7 +197,7 @@ def from_fcivec(ci0, nelec, orbspin, frozen=None):
+              numpy.count_nonzero(orbspin[:nelec] == 1))
+     ucisdvec = ucisd.from_fcivec(ci0, norb//2, nelec, frozen)
+     nocc = numpy.count_nonzero(~frozen_mask[:sum(nelec)])
+-    return from_ucisdvec(ucisdvec, nocc, orbspin[~frozen_mask])
++    return from_ucisdvec(ucisdvec, int(nocc), orbspin[~frozen_mask])
+ 
+ 
+ def make_rdm1(myci, civec=None, nmo=None, nocc=None, ao_repr=False):

--- a/pkgs/development/python-modules/pyscf/default.nix
+++ b/pkgs/development/python-modules/pyscf/default.nix
@@ -2,15 +2,23 @@
   buildPythonPackage,
   lib,
   fetchFromGitHub,
+
+  # build-sysetm
   cmake,
+
+  # build inputs
   blas,
   libcint,
   libxc,
   xcfun,
+
+  # dependencies
   cppe,
   h5py,
   numpy,
   scipy,
+
+  # tests
   pytestCheckHook,
 }:
 
@@ -25,6 +33,12 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-UTeZXlNuSWDOcBRVbUUWJ3mQnZZQr17aTw6rRA5DRNI=";
   };
+
+  patches = [
+    # Converts numpy.int64 to int where necessary.
+    # Upstream issue: https://github.com/pyscf/pyscf/issues/2878
+    ./coerce-numpy-to-int.patch
+  ];
 
   # setup.py calls Cmake and passes the arguments in CMAKE_CONFIGURE_ARGS to cmake.
   build-system = [ cmake ];
@@ -60,6 +74,7 @@ buildPythonPackage rec {
 
   # Numerically slightly off tests
   disabledTests = [
+    "test_rdm_trace"
     "test_tdhf_singlet"
     "test_ab_hf"
     "test_ea"
@@ -99,14 +114,15 @@ buildPythonPackage rec {
     "--ignore-glob=pyscf/grad/test/test_casscf.py"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python-based simulations of chemistry framework";
     homepage = "https://github.com/pyscf/pyscf";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     platforms = [
       "x86_64-linux"
       "x86_64-darwin"
+      "aarch64-darwin"
     ];
-    maintainers = [ maintainers.sheepforce ];
+    maintainers = [ lib.maintainers.sheepforce ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- update ase to unstable-2025-06-24
  The fix could be fetchpatch [a45d0a23c46b2bea4ad02ee2bca40d0f287848d7](https://gitlab.com/ase/ase/-/commit/a45d0a23c46b2bea4ad02ee2bca40d0f287848d7)
- update pymatgen to 2025.6.24 (I don't know why this is triggered by nixpkgs-review though.)
- Fix pyscf by applying similar to the patch above. Again I don't know why this needs to be built from this patch.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
