### PR TITLE
python3Packages.hickle: fix testing with numpy 2.3

### DIFF
--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -34,6 +34,9 @@ buildPythonPackage rec {
       url = "https://github.com/cjwatson/hickle/commit/246d8e82c805e2e49ea0abd39abc9b2d800bde59.patch";
       hash = "sha256-IEVw2K7S1nCkzgn9q0xghm4brfXcallNjzXpt2cRq1M=";
     })
+    # fixes test failing with numpy 2.3 as ndarray.tostring was deleted
+    # FIXME: delete once https://github.com/telegraphic/hickle/pull/187 is merged
+    ./numpy-2.3-ndarray-tostring.patch
   ];
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/hickle/default.nix
+++ b/pkgs/development/python-modules/hickle/default.nix
@@ -30,10 +30,7 @@ buildPythonPackage rec {
   patches = [
     # fixes support for numpy 2.x, the PR is not yet merged https://github.com/telegraphic/hickle/pull/186
     # FIXME: Remove this patch when the numpy 2.x support arrives
-    (fetchpatch {
-      url = "https://github.com/cjwatson/hickle/commit/246d8e82c805e2e49ea0abd39abc9b2d800bde59.patch";
-      hash = "sha256-IEVw2K7S1nCkzgn9q0xghm4brfXcallNjzXpt2cRq1M=";
-    })
+    ./numpy-2.x-support.patch
     # fixes test failing with numpy 2.3 as ndarray.tostring was deleted
     # FIXME: delete once https://github.com/telegraphic/hickle/pull/187 is merged
     ./numpy-2.3-ndarray-tostring.patch

--- a/pkgs/development/python-modules/hickle/numpy-2.3-ndarray-tostring.patch
+++ b/pkgs/development/python-modules/hickle/numpy-2.3-ndarray-tostring.patch
@@ -1,0 +1,33 @@
+From 7a0d0e625dd9e92159a145a26dd68ef3b61fde6e Mon Sep 17 00:00:00 2001
+From: Sergey Volkov <taranarmo@gmail.com>
+Date: Sun, 29 Jun 2025 10:54:00 +0200
+Subject: [PATCH] replace `ndarray.tostring` with `ndarray.tobytes`
+
+`ndarray.tostring` is deprecated since numpy 1.19 and removed in numpy 2.3
+https://numpy.org/doc/stable/release/2.3.0-notes.html
+---
+ hickle/tests/test_06_load_astropy.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hickle/tests/test_06_load_astropy.py b/hickle/tests/test_06_load_astropy.py
+index 628a4b3..b630bfd 100755
+--- a/hickle/tests/test_06_load_astropy.py
++++ b/hickle/tests/test_06_load_astropy.py
+@@ -166,7 +166,7 @@ def test_astropy_time_array(h5_data,compression_kwargs):
+         assert reloaded.format == t1.format
+         assert reloaded.scale == t1.scale
+         for index in range(len(t1)):
+-             assert reloaded.value[index].tostring() == t1.value[index].tostring()
++             assert reloaded.value[index].tobytes() == t1.value[index].tobytes()
+         del h_dataset.attrs['np_dtype']
+ 
+         reloaded = load_astropy.load_astropy_time_dataset(h_dataset,b'astropy_time',t1.__class__)
+@@ -174,7 +174,7 @@ def test_astropy_time_array(h5_data,compression_kwargs):
+         assert reloaded.format == t1.format
+         assert reloaded.scale == t1.scale
+         for index in range(len(t1)):
+-            assert reloaded.value[index].tostring() == t1.value[index].tostring()
++            assert reloaded.value[index].tobytes() == t1.value[index].tobytes()
+         loop_counter += 1
+ 
+ 

--- a/pkgs/development/python-modules/hickle/numpy-2.x-support.patch
+++ b/pkgs/development/python-modules/hickle/numpy-2.x-support.patch
@@ -1,0 +1,92 @@
+From 246d8e82c805e2e49ea0abd39abc9b2d800bde59 Mon Sep 17 00:00:00 2001
+From: Colin Watson <cjwatson@debian.org>
+Date: Mon, 3 Feb 2025 15:28:10 +0000
+Subject: [PATCH] Support numpy 2.0
+
+See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword
+---
+ hickle/legacy_v3/loaders/load_numpy.py | 2 +-
+ hickle/loaders/load_builtins.py        | 4 ++--
+ hickle/loaders/load_numpy.py           | 2 +-
+ hickle/tests/test_02_hickle_lookup.py  | 6 +++---
+ 4 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/hickle/legacy_v3/loaders/load_numpy.py b/hickle/legacy_v3/loaders/load_numpy.py
+index 0fd6c0a4..d17044bc 100644
+--- a/hickle/legacy_v3/loaders/load_numpy.py
++++ b/hickle/legacy_v3/loaders/load_numpy.py
+@@ -115,7 +115,7 @@ def load_np_scalar_dataset(h_node):
+ 
+ def load_ndarray_dataset(h_node):
+     py_type, data = get_type_and_data(h_node)
+-    return np.array(data, copy=False)
++    return np.asarray(data)
+ 
+ def load_ndarray_masked_dataset(h_node):
+     py_type, data = get_type_and_data(h_node)
+diff --git a/hickle/loaders/load_builtins.py b/hickle/loaders/load_builtins.py
+index 7cfbf281..53b74429 100644
+--- a/hickle/loaders/load_builtins.py
++++ b/hickle/loaders/load_builtins.py
+@@ -170,7 +170,7 @@ def create_listlike_dataset(py_obj, h_group, name,list_len = -1,item_dtype = Non
+         # strings and bytes are stored as array of bytes with strings encoded
+         # using utf8 encoding
+         string_data = bytearray(py_obj,"utf8") if isinstance(py_obj,str) else memoryview(py_obj)
+-        string_data = np.array(string_data,copy=False)
++        string_data = np.asarray(string_data)
+         string_data.dtype = 'S1'
+         dataset = h_group.create_dataset( name, data = string_data,shape = (1,string_data.size), **kwargs)
+         dataset.attrs["str_type"] = py_obj.__class__.__name__.encode("ascii")
+@@ -385,7 +385,7 @@ def load_list_dataset(h_node,base_type,py_obj_type):
+         if h_node.dtype.itemsize > 1 and 'bytes' in h_node.dtype.name:
+ 
+             # string dataset 4.0.x style convert it back to python string
+-            content = np.array(content, copy=False, dtype=str).tolist()
++            content = np.asarray(content, dtype=str).tolist()
+         else:
+ 
+             # decode bytes representing python string before final conversion
+diff --git a/hickle/loaders/load_numpy.py b/hickle/loaders/load_numpy.py
+index a4c76e91..bff98187 100644
+--- a/hickle/loaders/load_numpy.py
++++ b/hickle/loaders/load_numpy.py
+@@ -232,7 +232,7 @@ def load_ndarray_dataset(h_node,base_type,py_obj_type):
+             # not converted to list of string but saved as ar consequently
+             # itemsize of dtype is > 1
+             string_data = bytes(string_data).decode("utf8")
+-        return np.array(string_data,copy=False,dtype=dtype)
++        return np.asarray(string_data,dtype=dtype)
+     if issubclass(py_obj_type,np.matrix):
+         return py_obj_type(data=h_node[()],dtype=dtype)
+     # TODO how to restore other ndarray derived object_types
+diff --git a/hickle/tests/test_02_hickle_lookup.py b/hickle/tests/test_02_hickle_lookup.py
+index 628a2b12..dd91ffd1 100644
+--- a/hickle/tests/test_02_hickle_lookup.py
++++ b/hickle/tests/test_02_hickle_lookup.py
+@@ -816,7 +816,7 @@ def test_ReferenceManager_get_root(h5_data):
+     content = data_group.create_dataset('mydata',data=12)
+     type_table = root_group.create_group('hickle_types_table')
+     int_pickle_string = bytearray(pickle.dumps(int))
+-    int_np_entry = np.array(int_pickle_string,copy=False)
++    int_np_entry = np.asarray(int_pickle_string)
+     int_np_entry.dtype = 'S1'
+     int_entry = type_table.create_dataset(str(len(type_table)),data = int_np_entry,shape =(1,int_np_entry.size))
+     int_base_type = b'int'
+@@ -878,7 +878,7 @@ def test_ReferenceManager(h5_data):
+     with pytest.raises(lookup.ReferenceError):
+         reference_manager = lookup.ReferenceManager(false_root)
+     int_pickle_string = bytearray(pickle.dumps(int))
+-    int_np_entry = np.array(int_pickle_string,copy=False)
++    int_np_entry = np.asarray(int_pickle_string)
+     int_np_entry.dtype = 'S1'
+     int_entry = type_table.create_dataset(str(len(type_table)),data = int_np_entry,shape =(1,int_np_entry.size))
+     int_base_type = b'int'
+@@ -1052,7 +1052,7 @@ def test_ReferenceManager_store_type(h5_data,compression_kwargs):
+ @pytest.mark.no_compression
+ def test_ReferenceManager_get_manager(h5_data):
+     h_node = h5_data.create_group('some_list')
+-    item_data = np.array(memoryview(b'hallo welt lore grueszet dich ipsum aus der lore von ipsum gelort in ipsum'),copy=False)
++    item_data = np.asarray(memoryview(b'hallo welt lore grueszet dich ipsum aus der lore von ipsum gelort in ipsum'))
+     item_data.dtype = 'S1'
+     h_item = h_node.create_dataset('0',data=item_data,shape=(1,item_data.size))
+     with lookup.ReferenceManager.create_manager(h5_data) as memo:


### PR DESCRIPTION
`hickle` is failing on testing against numpy 2.3, this PR fetches [the upstream patch](https://github.com/telegraphic/hickle/pull/187)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
