### PR TITLE
atar: init at 0.1.25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27285,6 +27285,13 @@
     github = "x3rAx";
     githubId = 2268851;
   };
+  x71c9 = {
+    email = "mail@x71c9.com";
+    github = "x71c9";
+    githubId = 108585118;
+    matrix = "@x71c9:matrix.org";
+    name = "Andrea Reni";
+  };
   x807x = {
     name = "x807x";
     email = "s10855168@gmail.com";

--- a/pkgs/by-name/at/atar/package.nix
+++ b/pkgs/by-name/at/atar/package.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-6q+0YQeY38tVQdnJw3x80binLw4dLQNGNMX0PH/+KjA=";
 
-  nativeInstallCheckInputs = [ lib.versionCheckHook ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Ephemeral Terraform runner that applies a configuration on start, displays output variables, and automatically destroys all resources on exit or failure";

--- a/pkgs/by-name/at/atar/package.nix
+++ b/pkgs/by-name/at/atar/package.nix
@@ -31,13 +31,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "atar";
   };
 
-  passthru = {
-    versionCheckHook = true;
-    updateScript = lib.nix-update-script {
-      extraArgs = [
-        "--version-regex"
-        "v([0-9.]+)"
-      ];
-    };
-  };
+  passthru.updateScript = nix-update-script { };
 })

--- a/pkgs/by-name/at/atar/package.nix
+++ b/pkgs/by-name/at/atar/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "atar";
+  version = "0.1.25";
+
+  src = fetchFromGitHub {
+    owner = "x71c9";
+    repo = "atar";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aMOovfJ9Srex/dBHz7hRMYmDkCbpXPOFHjU+VM/qqi8=";
+  };
+
+  cargoHash = "sha256-6q+0YQeY38tVQdnJw3x80binLw4dLQNGNMX0PH/+KjA=";
+
+  nativeInstallCheckInputs = [ lib.versionCheckHook ];
+
+  meta = {
+    description = "Ephemeral Terraform runner that applies a configuration on start, displays output variables, and automatically destroys all resources on exit or failure";
+    homepage = "https://github.com/x71c9/atar";
+    changelog = "https://github.com/x71c9/atar/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ x71c9 ];
+    mainProgram = "atar";
+  };
+
+  passthru = {
+    versionCheckHook = true;
+    updateScript = lib.nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "v([0-9.]+)"
+      ];
+    };
+  };
+})

--- a/pkgs/by-name/at/atar/package.nix
+++ b/pkgs/by-name/at/atar/package.nix
@@ -2,6 +2,8 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {


### PR DESCRIPTION
Ephemeral Terraform runner that applies a configuration on start, displays output variables, and automatically destroys all resources on exit or failure.

Homepage: [https://github.com/x71c9/atar](https://github.com/x71c9/atar)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [x] Basic functionality (manual run tested on both Linux and macOS)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] (Package updates) Added a release notes entry if the change is major or breaking
- [x] (Module updates) Added a release notes entry if the change is significant
- [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)
