### PR TITLE
html2text: fix build with gettext 0.25; 2.2.3 -> 2.3.0

### DIFF
--- a/pkgs/by-name/ht/html2text/gettext-0.25.patch
+++ b/pkgs/by-name/ht/html2text/gettext-0.25.patch
@@ -12,13 +12,13 @@ index af28077..e746147 100644
  
  bin_PROGRAMS = html2text
 diff --git a/configure.ac b/configure.ac
-index af3ce8e..a80d1fd 100644
+index 999c6fe..30c2536 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -15,8 +15,11 @@
  
  AC_PREREQ([2.71])
- AC_INIT([html2text], [2.2.3], [BUG-REPORT-ADDRESS])
+ AC_INIT([html2text], [2.3.0], [BUG-REPORT-ADDRESS])
 +AC_CONFIG_MACRO_DIRS([m4])
  AM_INIT_AUTOMAKE
  AM_MAINTAINER_MODE([disable])

--- a/pkgs/by-name/ht/html2text/gettext-0.25.patch
+++ b/pkgs/by-name/ht/html2text/gettext-0.25.patch
@@ -1,0 +1,29 @@
+diff --git a/Makefile.am b/Makefile.am
+index af28077..e746147 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -13,6 +13,8 @@
+ AUTOMAKE_OPTIONS = foreign
+ ACLOCAL_AMFLAGS = -I m4
+ 
++SUBDIRS =
++
+ AM_YFLAGS = -d -Wno-yacc
+ 
+ bin_PROGRAMS = html2text
+diff --git a/configure.ac b/configure.ac
+index af3ce8e..a80d1fd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -15,8 +15,11 @@
+ 
+ AC_PREREQ([2.71])
+ AC_INIT([html2text], [2.2.3], [BUG-REPORT-ADDRESS])
++AC_CONFIG_MACRO_DIRS([m4])
+ AM_INIT_AUTOMAKE
+ AM_MAINTAINER_MODE([disable])
++AM_GNU_GETTEXT_VERSION([0.20])
++AM_GNU_GETTEXT([external])
+ AM_ICONV
+ #AC_CONFIG_SRCDIR([html.h])
+ #AC_CONFIG_HEADERS([config.h])

--- a/pkgs/by-name/ht/html2text/package.nix
+++ b/pkgs/by-name/ht/html2text/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitLab,
   autoreconfHook,
+  gettext,
   libiconv,
 }:
 
@@ -17,7 +18,15 @@ stdenv.mkDerivation rec {
     hash = "sha256-7Ch51nJ5BeRqs4PEIPnjCGk+Nm2ydgJQCtkcpihXun8=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    gettext
+  ];
+
+  # These changes have all been made in HEAD, across several commits
+  # amongst other changes.
+  # See https://gitlab.com/grobian/html2text/-/merge_requests/57
+  patches = [ ./gettext-0.25.patch ];
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin libiconv;
 

--- a/pkgs/by-name/ht/html2text/package.nix
+++ b/pkgs/by-name/ht/html2text/package.nix
@@ -2,24 +2,28 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  autoconf-archive,
   autoreconfHook,
+  bison,
   gettext,
   libiconv,
 }:
 
 stdenv.mkDerivation rec {
   pname = "html2text";
-  version = "2.2.3";
+  version = "2.3.0";
 
   src = fetchFromGitLab {
     owner = "grobian";
     repo = "html2text";
     rev = "v${version}";
-    hash = "sha256-7Ch51nJ5BeRqs4PEIPnjCGk+Nm2ydgJQCtkcpihXun8=";
+    hash = "sha256-e/KWyc7lOdWhtFC7ZAD7sYgCsO3JzGkLUThVI7edqIQ=";
   };
 
   nativeBuildInputs = [
+    autoconf-archive
     autoreconfHook
+    bison
     gettext
   ];
 


### PR DESCRIPTION
gettext 0.25 is currently on staging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
