### PR TITLE
[Backport release-25.05] nixosTests.pixelfed.standard: handleTestOn -> runTestOn

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -785,7 +785,7 @@ in
   mariadb-galera = handleTest ./mysql/mariadb-galera.nix { };
   marytts = handleTest ./marytts.nix { };
   mastodon = pkgs.recurseIntoAttrs (handleTest ./web-apps/mastodon { inherit handleTestOn; });
-  pixelfed = discoverTests (import ./web-apps/pixelfed { inherit handleTestOn; });
+  pixelfed = import ./web-apps/pixelfed { inherit runTestOn; };
   mate = handleTest ./mate.nix { };
   mate-wayland = handleTest ./mate-wayland.nix { };
   matter-server = handleTest ./matter-server.nix { };

--- a/nixos/tests/web-apps/pixelfed/default.nix
+++ b/nixos/tests/web-apps/pixelfed/default.nix
@@ -1,14 +1,12 @@
 {
-  system ? builtins.currentSystem,
-  handleTestOn,
+  runTestOn,
 }:
 let
   supportedSystems = [
     "x86_64-linux"
     "i686-linux"
   ];
-
 in
 {
-  standard = handleTestOn supportedSystems ./standard.nix { inherit system; };
+  standard = runTestOn supportedSystems ./standard.nix;
 }

--- a/nixos/tests/web-apps/pixelfed/standard.nix
+++ b/nixos/tests/web-apps/pixelfed/standard.nix
@@ -1,4 +1,4 @@
-import ../../make-test-python.nix {
+{
   name = "pixelfed-standard";
   meta.maintainers = [ ];
 


### PR DESCRIPTION
Manual backport of #420281 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.