### PR TITLE
[Backport release-25.05] mimir: 2.16.0 -> 2.16.1; replace pname with string

### DIFF
--- a/pkgs/by-name/mi/mimir/package.nix
+++ b/pkgs/by-name/mi/mimir/package.nix
@@ -10,9 +10,9 @@ buildGoModule rec {
   version = "2.16.0";
 
   src = fetchFromGitHub {
-    rev = "${pname}-${version}";
+    rev = "mimir-${version}";
     owner = "grafana";
-    repo = pname;
+    repo = "mimir";
     hash = "sha256-75KHS+jIPEvcB7SHBBcBi5uycwY7XR4RNc1khNYVZFE=";
   };
 

--- a/pkgs/by-name/mi/mimir/package.nix
+++ b/pkgs/by-name/mi/mimir/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule rec {
   pname = "mimir";
-  version = "2.16.0";
+  version = "2.16.1";
 
   src = fetchFromGitHub {
     rev = "mimir-${version}";
     owner = "grafana";
     repo = "mimir";
-    hash = "sha256-75KHS+jIPEvcB7SHBBcBi5uycwY7XR4RNc1khNYVZFE=";
+    hash = "sha256-+GFsWBjZHxRe3a2/ZT0zkoRXDTR4qopTUcU5Fx9t5xA=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
Manual backport of #410679 (partially) and #420821 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.