### PR TITLE
sacnview: init at 2.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27962,6 +27962,11 @@
     githubId = 250877;
     name = "Elmar Athmer";
   };
+  zax71 = {
+    github = "zax71";
+    githubId = 67716263;
+    name = "Zax71";
+  };
   zazedd = {
     name = "Leonardo Santos";
     email = "leomendesantos@gmail.com";

--- a/pkgs/by-name/sa/sacnview/package.nix
+++ b/pkgs/by-name/sa/sacnview/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+let
+  pname = "sacnview";
+  version = "2.1.3";
+
+  src = fetchurl {
+    url = "https://github.com/docsteer/sacnview/releases/download/v${version}/sACNView_${version}-x86_64.AppImage";
+    hash = "sha256-9YmTYmrlGq5uJ8MWLRSEb4wtK834kURcAESH87JO4OA=";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  meta = {
+    description = "a tool for monitoring and sending the Streaming ACN lighting control protocol used in theatres, TV studios and architectural systems.";
+    changelog = "https://github.com/docsteer/sacnview/releases/tag/${version}";
+    homepage = "https://sacnview.org/";
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ zax71 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "sacnview";
+  };
+}


### PR DESCRIPTION
Adds [sACNView](https://sacnview.org/), a tool for sending and receiving the Streaming ACN control protocol - useful for debugging sACN.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
