### PR TITLE
nixVersions.nix_2_3: add knownVulnerabilities

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -18,7 +18,9 @@ let
 
   pkgs = import nixpkgs' {
     inherit system;
-    config = { };
+    config = {
+      permittedInsecurePackages = [ "nix-2.3.18" ];
+    };
     overlays = [ ];
   };
 

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -2,9 +2,16 @@
   # The pkgs used for dependencies for the testing itself
   # Don't test properties of pkgs.lib, but rather the lib in the parent directory
   system ? builtins.currentSystem,
-  pkgs ? import ../.. { inherit system; } // {
-    lib = throw "pkgs.lib accessed, but the lib tests should use nixpkgs' lib path directly!";
-  },
+  pkgs ?
+    import ../.. {
+      inherit system;
+      config = {
+        permittedInsecurePackages = [ "nix-2.3.18" ];
+      };
+    }
+    // {
+      lib = throw "pkgs.lib accessed, but the lib tests should use nixpkgs' lib path directly!";
+    },
   # For testing someone may edit impure.nix to return cross pkgs, use `pkgsBuildBuild` directly so everything here works.
   pkgsBB ? pkgs.pkgsBuildBuild,
   nix ? pkgs-nixVersions.stable,

--- a/pkgs/tools/package-management/nix/common-autoconf.nix
+++ b/pkgs/tools/package-management/nix/common-autoconf.nix
@@ -11,6 +11,7 @@
     inherit hash;
   },
   patches ? [ ],
+  knownVulnerabilities ? [ ],
   maintainers ? [
     lib.maintainers.lovesegfault
     lib.maintainers.artturin
@@ -335,7 +336,7 @@ let
       '';
       homepage = "https://nixos.org/";
       license = licenses.lgpl21Plus;
-      inherit maintainers teams;
+      inherit knownVulnerabilities maintainers teams;
       platforms = platforms.unix;
       outputsToInstall = [ "out" ] ++ optional enableDocumentation "man";
       mainProgram = "nix";

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -159,6 +159,15 @@ lib.makeExtensible (
             patch-monitorfdhup
           ];
           self_attribute_name = "nix_2_3";
+          knownVulnerabilities = [
+            "CVE-2024-38531"
+            "CVE-2024-47174"
+            "CVE-2025-46415"
+            "CVE-2025-46416"
+            "CVE-2025-52991"
+            "CVE-2025-52992"
+            "CVE-2025-52993"
+          ];
           maintainers = with lib.maintainers; [ flokli ];
           teams = [ ];
         }).overrideAttrs

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -3,7 +3,13 @@
   officialRelease,
   pkgs ? import nixpkgs.outPath { },
   nix ? pkgs.nix,
-  lib-tests ? import ../../lib/tests/release.nix { inherit pkgs; },
+  lib-tests ? import ../../lib/tests/release.nix {
+    pkgs = import nixpkgs.outPath {
+      config = {
+        permittedInsecurePackages = [ "nix-2.3.18" ];
+      };
+    };
+  },
 }:
 
 pkgs.releaseTools.sourceTarball {

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -95,8 +95,15 @@ let
     "aarch64"
   ] (arch: elem "${arch}-darwin" supportedSystems);
 
-  nonPackageJobs = {
-    tarball = import ./make-tarball.nix { inherit pkgs nixpkgs officialRelease; };
+  nonPackageJobs = rec {
+    tarball = import ./make-tarball.nix {
+      inherit
+        pkgs
+        lib-tests
+        nixpkgs
+        officialRelease
+        ;
+    };
 
     release-checks = import ./nixpkgs-basic-release-checks.nix {
       inherit pkgs nixpkgs supportedSystems;

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -86,6 +86,7 @@ let
     id
     isDerivation
     optionals
+    recursiveUpdate
     ;
 
   inherit (release-lib.lib.attrsets) unionOfDisjoint;
@@ -111,7 +112,20 @@ let
 
     manual = pkgs.nixpkgs-manual.override { inherit nixpkgs; };
     metrics = import ./metrics.nix { inherit pkgs nixpkgs; };
-    lib-tests = import ../../lib/tests/release.nix { inherit pkgs; };
+    lib-tests = import ../../lib/tests/release.nix {
+      pkgs = import nixpkgs (
+        recursiveUpdate
+          (recursiveUpdate {
+            inherit system;
+            config.allowUnsupportedSystem = true;
+          } nixpkgsArgs)
+          {
+            config.permittedInsecurePackages = nixpkgsArgs.config.permittedInsecurePackages or [ ] ++ [
+              "nix-2.3.18"
+            ];
+          }
+      );
+    };
     pkgs-lib-tests = import ../pkgs-lib/tests { inherit pkgs; };
 
     darwin-tested =


### PR DESCRIPTION
Hopefully somebody backports the patches, in which case we can revert this, and if not it will give us a good indication that nobody cares about getting Nix 2.3 from Nixpkgs and we can drop it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
