### PR TITLE
nix-fast-build: added bashInteractive as runtime dependency

### DIFF
--- a/pkgs/by-name/ni/nix-fast-build/package.nix
+++ b/pkgs/by-name/ni/nix-fast-build/package.nix
@@ -6,6 +6,7 @@
   nix-eval-jobs,
   nix-output-monitor,
   nix-update-script,
+  bashInteractive,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -28,6 +29,7 @@ python3Packages.buildPythonApplication rec {
         [
           nix-eval-jobs
           nix-eval-jobs.nix
+          bashInteractive
         ]
         ++ lib.optional (lib.meta.availableOn stdenv.buildPlatform nix-output-monitor.compiler) nix-output-monitor
       )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

When I ran nix-fast-build in a systemd service I noticed that it's missing bash.

<details>
<summary> error log:</summary>

```

Jun 28 03:52:17 t70 nix-fast-build[17115]: warning: 'show-config' is a deprecated alias for 'config show'
Jun 28 03:52:17 t70 nix-fast-build[16686]: INFO:nix_fast_build:run nix-eval-jobs --gc-roots-dir /tmp/tmpptbwr_pz/gcroots --force-recurse --max-memory-size 4096 --workers 8 --flake 'github:>
Jun 28 03:52:17 t70 nix-fast-build[16686]: Traceback (most recent call last):
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8r7zhkcwxz8r8v9q0lrg5qgb3g1bzivw-nix-fast-build-1.1.0/bin/.nix-fast-build-wrapped", line 9, in <module>
Jun 28 03:52:17 t70 nix-fast-build[16686]:     sys.exit(main())
Jun 28 03:52:17 t70 nix-fast-build[16686]:              ^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8r7zhkcwxz8r8v9q0lrg5qgb3g1bzivw-nix-fast-build-1.1.0/lib/python3.12/site-packages/nix_fast_build/__init__.py", line 1217, in >
Jun 28 03:52:17 t70 nix-fast-build[16686]:     sys.exit(asyncio.run(async_main(sys.argv[1:])))
Jun 28 03:52:17 t70 nix-fast-build[16686]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/runners.py", line 195, in run
Jun 28 03:52:17 t70 nix-fast-build[16686]:     return runner.run(main)
Jun 28 03:52:17 t70 nix-fast-build[16686]:            ^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/runners.py", line 118, in run
Jun 28 03:52:17 t70 nix-fast-build[16686]:     return self._loop.run_until_complete(task)
Jun 28 03:52:17 t70 nix-fast-build[16686]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
Jun 28 03:52:17 t70 nix-fast-build[16686]:     return future.result()
Jun 28 03:52:17 t70 nix-fast-build[16686]:            ^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8r7zhkcwxz8r8v9q0lrg5qgb3g1bzivw-nix-fast-build-1.1.0/lib/python3.12/site-packages/nix_fast_build/__init__.py", line 1210, in >
Jun 28 03:52:17 t70 nix-fast-build[16686]:     return await run(stack, opts)
Jun 28 03:52:17 t70 nix-fast-build[16686]:            ^^^^^^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8r7zhkcwxz8r8v9q0lrg5qgb3g1bzivw-nix-fast-build-1.1.0/lib/python3.12/site-packages/nix_fast_build/__init__.py", line 967, in r>
Jun 28 03:52:17 t70 nix-fast-build[16686]:     output_monitor = await stack.enter_async_context(nix_output_monitor(pipe, opts))
Jun 28 03:52:17 t70 nix-fast-build[16686]:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/contextlib.py", line 659, in enter_async_context
Jun 28 03:52:17 t70 nix-fast-build[16686]:     result = await _enter(cm)
Jun 28 03:52:17 t70 nix-fast-build[16686]:              ^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/contextlib.py", line 210, in __aenter__
Jun 28 03:52:17 t70 nix-fast-build[16686]:     return await anext(self.gen)
Jun 28 03:52:17 t70 nix-fast-build[16686]:            ^^^^^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8r7zhkcwxz8r8v9q0lrg5qgb3g1bzivw-nix-fast-build-1.1.0/lib/python3.12/site-packages/nix_fast_build/__init__.py", line 513, in n>
Jun 28 03:52:17 t70 nix-fast-build[16686]:     proc = await asyncio.create_subprocess_exec(*cmd, stdin=pipe.read_file)
Jun 28 03:52:17 t70 nix-fast-build[16686]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/subprocess.py", line 224, in create_subprocess_exec
Jun 28 03:52:17 t70 nix-fast-build[16686]:     transport, protocol = await loop.subprocess_exec(
Jun 28 03:52:17 t70 nix-fast-build[16686]:                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/base_events.py", line 1756, in subprocess_exec
Jun 28 03:52:17 t70 nix-fast-build[16686]:     transport = await self._make_subprocess_transport(
Jun 28 03:52:17 t70 nix-fast-build[16686]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/unix_events.py", line 211, in _make_subprocess_transpo>
Jun 28 03:52:17 t70 nix-fast-build[16686]:     transp = _UnixSubprocessTransport(self, protocol, args, shell,
Jun 28 03:52:17 t70 nix-fast-build[16686]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/base_subprocess.py", line 36, in __init__
Jun 28 03:52:17 t70 nix-fast-build[16686]:     self._start(args=args, shell=shell, stdin=stdin, stdout=stdout,
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/unix_events.py", line 820, in _start
Jun 28 03:52:17 t70 nix-fast-build[16686]:     self._proc = subprocess.Popen(
Jun 28 03:52:17 t70 nix-fast-build[16686]:                  ^^^^^^^^^^^^^^^^^
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/subprocess.py", line 1026, in __init__
Jun 28 03:52:17 t70 nix-fast-build[16686]:     self._execute_child(args, executable, preexec_fn, close_fds,
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/subprocess.py", line 1955, in _execute_child
Jun 28 03:52:17 t70 nix-fast-build[16686]:     raise child_exception_type(errno_num, err_msg, err_filename)
Jun 28 03:52:17 t70 nix-fast-build[16686]: FileNotFoundError: [Errno 2] No such file or directory: 'bash'
Jun 28 03:52:17 t70 nix-fast-build[16686]: Exception ignored in: <function BaseSubprocessTransport.__del__ at 0x7fd651e6afc0>
Jun 28 03:52:17 t70 nix-fast-build[16686]: Traceback (most recent call last):
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/base_subprocess.py", line 126, in __del__
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/base_subprocess.py", line 104, in close
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/unix_events.py", line 568, in close
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/unix_events.py", line 592, in _close
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/base_events.py", line 799, in call_soon
Jun 28 03:52:17 t70 nix-fast-build[16686]:   File "/nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/lib/python3.12/asyncio/base_events.py", line 545, in _check_closed
Jun 28 03:52:17 t70 nix-fast-build[16686]: RuntimeError: Event loop is closed

```
</details>

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
