### PR TITLE
buildGoModule: do not emit broken position-independent executables

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -415,6 +415,8 @@ buildGoModule rec {
     k3sBundle
   ];
 
+  hardeningDisable = [ "pie" ];
+
   # We override most of buildPhase due to peculiarities in k3s's build.
   # Specifically, it has a 'go generate' which runs part of the package. See
   # this comment:

--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -35,6 +35,8 @@ buildGoModule (finalAttrs: {
 
   doCheck = false;
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [
     makeWrapper
     which

--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -41,6 +41,8 @@ let
 
       doCheck = false;
 
+      hardeningDisable = [ "pie" ];
+
       BUILD_USER = "nix";
       BUILD_HOST = "nix";
 

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -195,8 +195,11 @@ in
     )
     ++ extraConfigureFlags;
 
-  # causes redefinition of _FORTIFY_SOURCE
-  hardeningDisable = [ "fortify3" ];
+  hardeningDisable = [
+    # causes redefinition of _FORTIFY_SOURCE
+    "fortify3"
+    "pie"
+  ];
 
   # Packages to provide fallback bin paths
   # to the Apptainer/Singularity container runtime default PATHs.

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -99,6 +99,9 @@ lib.extendMkDerivation {
 
             inherit (finalAttrs) src modRoot goSum;
 
+            # The Go linker does not support static PIE.
+            hardeningDisable = lib.optionals (!stdenv.hostPlatform.isStatic) [ "pie" ];
+
             # The following inheritance behavior is not trivial to expect, and some may
             # argue it's not ideal. Changing it may break vendor hashes in Nixpkgs and
             # out in the wild. In anycase, it's documented in:
@@ -273,6 +276,7 @@ lib.extendMkDerivation {
             # this will respect the `hardening{Disable,Enable}` flags if set
             if [[ $NIX_HARDENING_ENABLE =~ "pie" ]]; then
               export GOFLAGS="-buildmode=pie $GOFLAGS"
+              export ldflags="-I $(cat $NIX_CC/nix-support/dynamic-linker) $ldflags"
             fi
 
             runHook postConfigure

--- a/pkgs/by-name/cw/cwtch/package.nix
+++ b/pkgs/by-name/cw/cwtch/package.nix
@@ -22,6 +22,8 @@ buildGoModule rec {
     }
   );
 
+  hardeningDisable = [ "pie" ];
+
   postPatch = ''
     substituteInPlace Makefile \
       --replace-fail '$(shell git describe --tags)' v${version} \

--- a/pkgs/by-name/da/dae/package.nix
+++ b/pkgs/by-name/da/dae/package.nix
@@ -25,6 +25,7 @@ buildGoModule rec {
   nativeBuildInputs = [ clang ];
 
   hardeningDisable = [
+    "pie"
     "zerocallusedregs"
   ];
 

--- a/pkgs/by-name/da/daed/package.nix
+++ b/pkgs/by-name/da/daed/package.nix
@@ -69,7 +69,10 @@ buildGoModule rec {
 
   nativeBuildInputs = [ clang ];
 
-  hardeningDisable = [ "zerocallusedregs" ];
+  hardeningDisable = [
+    "pie"
+    "zerocallusedregs"
+  ];
 
   prePatch = ''
     substituteInPlace Makefile \

--- a/pkgs/by-name/di/direnv/package.nix
+++ b/pkgs/by-name/di/direnv/package.nix
@@ -25,6 +25,8 @@ buildGoModule rec {
   # we have no bash at the moment for windows
   BASH_PATH = lib.optionalString (!stdenv.hostPlatform.isWindows) "${bash}/bin/bash";
 
+  hardeningDisable = [ "pie" ];
+
   # replace the build phase to use the GNUMakefile instead
   buildPhase = ''
     make BASH_PATH=$BASH_PATH

--- a/pkgs/by-name/fl/flyctl/package.nix
+++ b/pkgs/by-name/fl/flyctl/package.nix
@@ -22,6 +22,8 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
+  hardeningDisable = [ "pie" ];
+
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/by-name/gi/git-lfs/package.nix
+++ b/pkgs/by-name/gi/git-lfs/package.nix
@@ -23,6 +23,8 @@ buildGoModule rec {
 
   vendorHash = "sha256-JT0r/hs7ZRtsYh4aXy+v8BjwiLvRJ10e4yRirqmWVW0=";
 
+  hardeningDisable = [ "pie" ];
+
   nativeBuildInputs = [
     asciidoctor
     installShellFiles

--- a/pkgs/by-name/ku/kubo-fs-repo-migrations/package.nix
+++ b/pkgs/by-name/ku/kubo-fs-repo-migrations/package.nix
@@ -28,6 +28,8 @@ let
       sourceRoot = "${src.name}/${pname}";
       vendorHash = null;
 
+      hardeningDisable = [ "pie" ];
+
       # Fix build on Go 1.17 and later: panic: qtls.ClientHelloInfo doesn't match
       # See https://github.com/ipfs/fs-repo-migrations/pull/163
       postPatch =

--- a/pkgs/by-name/li/lipo-go/package.nix
+++ b/pkgs/by-name/li/lipo-go/package.nix
@@ -18,6 +18,8 @@ buildGoModule (finalAttrs: {
   };
   vendorHash = "sha256-7M6CRxJd4fgYQLJDkNa3ds3f7jOp3dyloOZtwMtCBQk=";
 
+  hardeningDisable = [ "pie" ];
+
   buildPhase = ''
     runHook preBuild
 

--- a/pkgs/by-name/mo/mobsql/package.nix
+++ b/pkgs/by-name/mo/mobsql/package.nix
@@ -17,6 +17,8 @@ buildGoModule rec {
   };
   vendorHash = "sha256-YqduGY9c4zRQscjqze3ZOAB8EYj+0/6V7NceRwLe3DY=";
 
+  hardeningDisable = [ "pie" ];
+
   buildInputs = [ sqlite ];
 
   buildPhase = ''

--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -96,6 +96,8 @@ buildGoModule rec {
 
   doCheck = false;
 
+  hardeningDisable = [ "pie" ];
+
   outputs = [
     "out"
     "man"

--- a/pkgs/by-name/ss/ssh-to-age/package.nix
+++ b/pkgs/by-name/ss/ssh-to-age/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   checkPhase = ''
     runHook preCheck
-    go test ./...
+    buildGoDir test ./...
     runHook postCheck
   '';
 

--- a/pkgs/by-name/ti/tinygo/package.nix
+++ b/pkgs/by-name/ti/tinygo/package.nix
@@ -70,6 +70,8 @@ buildGoModule rec {
   doCheck = (stdenv.buildPlatform.canExecute stdenv.hostPlatform);
   inherit tinygoTests;
 
+  hardeningDisable = [ "pie" ];
+
   allowGoReference = true;
   ldflags = [
     "-X github.com/tinygo-org/tinygo/goenv.TINYGOROOT=${placeholder "out"}/share/tinygo"

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -95,6 +95,8 @@ buildGoModule {
 
   inherit frontend;
 
+  hardeningDisable = [ "pie" ];
+
   prePatch = ''
     cp -r ${frontend} frontend/dist
   '';

--- a/pkgs/by-name/wi/wireguard-go/package.nix
+++ b/pkgs/by-name/wi/wireguard-go/package.nix
@@ -31,6 +31,8 @@ buildGoModule (
 
     vendorHash = "sha256-RqZ/3+Xus5N1raiUTUpiKVBs/lrJQcSwr1dJib2ytwc=";
 
+    hardeningDisable = [ "pie" ];
+
     subPackages = [ "." ];
 
     ldflags = [ "-s" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
