### PR TITLE
nixos/networking: network.target depends on netdev service directly

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -311,6 +311,7 @@ let
             bindsTo = optional (!config.boot.isContainer) "dev-net-tun.device";
             after = optional (!config.boot.isContainer) "dev-net-tun.device" ++ [ "network-pre.target" ];
             wantedBy = [
+              "network.target"
               "network-setup.service"
               (subsystemDevice i.name)
             ];
@@ -337,6 +338,7 @@ let
             {
               description = "Bridge Interface ${n}";
               wantedBy = [
+                "network.target"
                 "network-setup.service"
                 (subsystemDevice n)
               ];
@@ -441,6 +443,7 @@ let
             {
               description = "Open vSwitch Interface ${n}";
               wantedBy = [
+                "network.target"
                 "network-setup.service"
                 (subsystemDevice n)
               ]
@@ -513,6 +516,7 @@ let
             {
               description = "Bond Interface ${n}";
               wantedBy = [
+                "network.target"
                 "network-setup.service"
                 (subsystemDevice n)
               ];
@@ -561,6 +565,7 @@ let
             {
               description = "MACVLAN Interface ${n}";
               wantedBy = [
+                "network.target"
                 "network-setup.service"
                 (subsystemDevice n)
               ];
@@ -604,6 +609,7 @@ let
             {
               description = "FOU endpoint ${n}";
               wantedBy = [
+                "network.target"
                 "network-setup.service"
                 (subsystemDevice n)
               ];
@@ -633,6 +639,7 @@ let
             {
               description = "IPv6 in IPv4 Tunnel Interface ${n}";
               wantedBy = [
+                "network.target"
                 "network-setup.service"
                 (subsystemDevice n)
               ];
@@ -675,6 +682,7 @@ let
             {
               description = "IP in IP Tunnel Interface ${n}";
               wantedBy = [
+                "network.target"
                 "network-setup.service"
                 (subsystemDevice n)
               ];
@@ -722,6 +730,7 @@ let
             {
               description = "GRE Tunnel Interface ${n}";
               wantedBy = [
+                "network.target"
                 "network-setup.service"
                 (subsystemDevice n)
               ];
@@ -756,6 +765,7 @@ let
             {
               description = "VLAN Interface ${n}";
               wantedBy = [
+                "network.target"
                 "network-setup.service"
                 (subsystemDevice n)
               ];


### PR DESCRIPTION
So we don't depend on addresses configured for an interface or network-setup.service existing anymore.

Fixes #349882


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
