### PR TITLE
Add maintainer x71c9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27285,6 +27285,13 @@
     github = "x3rAx";
     githubId = 2268851;
   };
+  x71c9 = {
+    email = "mail@x71c9.com";
+    github = "x71c9";
+    githubId = 108585118;
+    matrix = "@x71c9:matrix.org";
+    name = "Andrea Reni";
+  };
   x807x = {
     name = "x807x";
     email = "s10855168@gmail.com";


### PR DESCRIPTION
<!-- ^ Please summarise the changes you have done and explain why they are necessary here ^ -->

Add myself (x71c9) to maintainers/maintainer-list.nix in order to be referenced in upcoming package contributions, following Nixpkgs contribution guidelines which require this to be done in a separate pull request.
