### PR TITLE
warp-terminal: 0.2025.06.20.22.47.stable_05 -> 0.2025.06.25.08.12.sta…

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-UJAirS6JFFLW0OsOYj8RNUfG85dRHnxXasNw2QHX1Xs=",
-    "version": "0.2025.06.20.22.47.stable_05"
+    "hash": "sha256-7/gSUR9h9PzBrTgxERXNjqzJDtqxebjmD0cF3Vx2ySY=",
+    "version": "0.2025.06.25.08.12.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-h0ODaO3SJcZAxFRFBYYjWXQYsRAemGizn/YA7AF36pw=",
-    "version": "0.2025.06.20.22.47.stable_05"
+    "hash": "sha256-2VQzEBAAu6YasottOTu3YjQvvXR5gT3DAjGhp63wMNo=",
+    "version": "0.2025.06.25.08.12.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-H4xldFBMpfu6UFGFA/IkA1zPFqhFN6abhfHTRdYNpGA=",
-    "version": "0.2025.06.20.22.47.stable_05"
+    "hash": "sha256-5jpW7mUHLshGZUWigAJ8QgmpYnfosJN1JpRLeNvVK3Y=",
+    "version": "0.2025.06.25.08.12.stable_01"
   }
 }


### PR DESCRIPTION
This should fix a bug introduced in https://github.com/NixOS/nixpkgs/pull/419615#issuecomment-3016665007.

warp-terminal is currently broken in NixOS:

```haskell
error: hash mismatch in fixed-output derivation '/nix/store/dw4pnv5qz5wvvmpkffqhzb30znyz3kyk-warp-terminal-v0.2025.06.20.22.47.stable_05-1-x86_64.pkg.tar.zst.drv':
         specified: sha256-h0ODaO3SJcZAxFRFBYYjWXQYsRAemGizn/YA7AF36pw=
            got:    sha256-yrwS6rqSGkiWNjr17MVyH+ZQL2CTUqt6coi8qWfq0Gg=
error: 1 dependencies of derivation '/nix/store/3r6s5gvgmnvzlz6jdd3kkdv6mx568ss7-warp-terminal-0.2025.06.20.22.47.stable_05.drv' failed to build
error: 1 dependencies of derivation '/nix/store/i3ppszvizwg1m0dp54l4y1dkp0xvn5vh-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/vs7ls5490vqpm7bwq47cqz59hz30rdq6-home-manager-generation.drv' failed to build
error: 1 dependencies of derivation '/nix/store/jss2xr8ri1m2xzx57hk8brw3g31c9yk2-user-environment.drv' failed to build
error: 1 dependencies of derivation '/nix/store/gn9h9nz5j1y32lipb3ha5cl7aa7kh0zy-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/9bjgcwhgab9g1zwrly0hnixajrv72ksg-nixos-system-zvictor-i7-25.05.20250626.a676066.drv' failed to build
```

---

warp-terminal: 2025.06.25 (v0.2025.06.25.08.12)

New Features

 *   Git branch and directory chip now are searchable.

Improvements

  *  Added support for HCL syntax highlighting in Terraform files.

Bug Fixes

  *  Fixed potential crash when displaying context chips with Unicode characters in file paths.

*    Fixed a rendering issue with line numbers in suggested diffs.

 *   Attach context chip no longer appears if there is no context you can attach.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
