### PR TITLE
fuse: fix build

### DIFF
--- a/pkgs/os-specific/linux/fuse/common.nix
+++ b/pkgs/os-specific/linux/fuse/common.nix
@@ -31,8 +31,6 @@ stdenv.mkDerivation rec {
     inherit hash;
   };
 
-  preAutoreconf = "touch config.rpath";
-
   patches =
     lib.optional (!isFuse3 && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isLoongArch64))
       (fetchpatch {
@@ -52,6 +50,7 @@ stdenv.mkDerivation rec {
             url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-fs/fuse/files/fuse-2.9.9-closefrom-glibc-2-34.patch?id=8a970396fca7aca2d5a761b8e7a8242f1eef14c9";
             sha256 = "sha256-ELYBW/wxRcSMssv7ejCObrpsJHtOPJcGq33B9yHQII4=";
           })
+          ./fuse2-gettext-0.25.patch
         ]
     );
 
@@ -107,9 +106,6 @@ stdenv.mkDerivation rec {
       # No need to use the SUID wrapper.
       substituteInPlace util/mount.fuse.c \
         --replace-fail '"su"' '"${lib.getBin shadow.su}/bin/su"'
-      substituteInPlace makeconf.sh \
-        --replace-fail 'CONFIG_RPATH=/usr/share/gettext/config.rpath' 'CONFIG_RPATH=${lib.getLib gettext}/share/gettext/config.rpath'
-      ./makeconf.sh
     '';
 
   # v2: no tests, v3: all tests get skipped in a sandbox

--- a/pkgs/os-specific/linux/fuse/fuse2-gettext-0.25.patch
+++ b/pkgs/os-specific/linux/fuse/fuse2-gettext-0.25.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 9946a0e..4621771 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4,6 +4,8 @@ AC_PREREQ(2.59d)
+ AC_CONFIG_MACRO_DIR([m4])
+ AC_CANONICAL_TARGET
+ AM_INIT_AUTOMAKE([foreign])
++AM_GNU_GETTEXT_VERSION([0.25])
++AM_GNU_GETTEXT([external])
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
+ AC_CONFIG_HEADERS(include/config.h)
+ 


### PR DESCRIPTION
configure.ac uses the AM_ICONV macro, which is part of gettext.  The patch makes autoreconf recognise the project as using gettext, which has the added benefit of meaning we no longer need to run makeconf.sh, and can rely on just the autoreconf from autoreconfHook.

Previously, we were actually doing autoreconf twice; once from the hook and once from the script, which I doubt was intentional…


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
