### PR TITLE
tsnet-serve: init at 1.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1475,6 +1475,12 @@
     github = "an-empty-string";
     githubId = 681716;
   };
+  ananthb = {
+    email = "nixos-maint@devhuman.net";
+    github = "ananthb";
+    githubId = 3133350;
+    name = "Ananth Bhaskararaman";
+  };
   anas = {
     email = "anas.elgarhy.dev@gmail.com";
     github = "0x61nas";

--- a/pkgs/by-name/ts/tsnet-serve/package.nix
+++ b/pkgs/by-name/ts/tsnet-serve/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "tsnet-serve";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "shayne";
+    repo = "tsnet-serve";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4kFh2Gh3XQOVHzZJCvGNE2eacvBGuhiCw+7Rid/fIT4=";
+    leaveDotGit = true;
+    postFetch = ''
+      git -C $out show --format='%h' HEAD --quiet > $out/ldflags_revision
+      date --utc --date="@$(git -C $out show --format='%ct' HEAD --quiet)" +'%Y-%m-%dT%H:%M:%SZ' > $out/ldflags_buildDate
+      rm -rf $out/.git
+    '';
+  };
+
+  vendorHash = "sha256-29u6OFErZXI/oWLJIB4oyvr+hNMQPKREtm2OlnyL+6Y=";
+
+  # Add version information fetched from the repository to ldflags.
+  ldflags = [
+    "-X main.version=v${finalAttrs.version}"
+  ];
+  preBuild = ''
+    ldflags+=" -X main.revision=$(cat ldflags_revision)"
+    ldflags+=" -X main.buildDate=$(cat ldflags_buildDate)"
+  '';
+
+  meta = {
+    description = "Expose HTTP applications to a Tailscale Tailnet network";
+    homepage = "https://github.com/shayne/tsnet-serve";
+    changelog = "https://github.com/shayne/tsnet-serve/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "tsnet-serve";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ananthb ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the [tsnet-serve](https://github.com/shayne/tsnet-serve) package to nixpkgs.
HTTP reverse proxy to expose services on your Tailscale Tailnet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
