### PR TITLE
ubootPythonTools: init at 0.0.7

### DIFF
--- a/pkgs/misc/uboot/binman-resources.patch
+++ b/pkgs/misc/uboot/binman-resources.patch
@@ -1,0 +1,72 @@
+(Patch from https://lists.denx.de/pipermail/u-boot/2024-July/559077.html)
+
+
+pkg_resources is deprecated long ago and being removed in python 3.12.
+
+Reimplement functions with importlib.resources.
+
+Link: https://docs.python.org/3/library/importlib.resources.html
+Signed-off-by: Jiaxun Yang <jiaxun.yang at flygoat.com>
+---
+ tools/binman/control.py | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/tools/binman/control.py b/tools/binman/control.py
+index 2f00279232b8..5549b0ad2185 100644
+--- a/tools/binman/control.py
++++ b/tools/binman/control.py
+@@ -8,12 +8,11 @@
+ from collections import OrderedDict
+ import glob
+ try:
+-    import importlib.resources
+-except ImportError:  # pragma: no cover
++    from importlib import resources
++except ImportError:
+     # for Python 3.6
+-    import importlib_resources
++    import importlib_resources as resources
+ import os
+-import pkg_resources
+ import re
+ 
+ import sys
+@@ -96,12 +95,12 @@ def _ReadMissingBlobHelp():
+             msg = ''
+         return tag, msg
+ 
+-    my_data = pkg_resources.resource_string(__name__, 'missing-blob-help')
++    my_data = resources.files(__package__).joinpath('missing-blob-help').read_text()
+     re_tag = re.compile('^([-a-z0-9]+):$')
+     result = {}
+     tag = None
+     msg = ''
+-    for line in my_data.decode('utf-8').splitlines():
++    for line in my_data.splitlines():
+         if not line.startswith('#'):
+             m_tag = re_tag.match(line)
+             if m_tag:
+@@ -151,8 +150,9 @@ def GetEntryModules(include_testing=True):
+     Returns:
+         Set of paths to entry class filenames
+     """
+-    glob_list = pkg_resources.resource_listdir(__name__, 'etype')
+-    glob_list = [fname for fname in glob_list if fname.endswith('.py')]
++    directory = resources.files("binman.etype")
++    glob_list = [entry.name for entry in directory.iterdir()
++                 if entry.name.endswith('.py')]
+     return set([os.path.splitext(os.path.basename(item))[0]
+                 for item in glob_list
+                 if include_testing or '_testing' not in item])
+@@ -735,7 +735,7 @@ def Binman(args):
+     global state
+ 
+     if args.full_help:
+-        with importlib.resources.path('binman', 'README.rst') as readme:
++        with resources.path('binman', 'README.rst') as readme:
+             tools.print_full_help(str(readme))
+         return 0
+ 
+
+-- 
+2.45.2

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -29,6 +29,7 @@
   armTrustedFirmwareS905,
   opensbi,
   buildPackages,
+  callPackages,
   darwin,
 }@pkgs:
 
@@ -198,8 +199,10 @@ in
 
     filesToInstall = [
       "tools/dumpimage"
+      "tools/fdt_add_pubkey"
       "tools/fdtgrep"
       "tools/kwboot"
+      "tools/mkeficapsule"
       "tools/mkenvimage"
       "tools/mkimage"
       "tools/env/fw_printenv"
@@ -210,6 +213,8 @@ in
       "tools/efivar.py" = (python3.withPackages (ps: [ ps.pyopenssl ]));
     };
   };
+
+  ubootPythonTools = lib.recurseIntoAttrs (callPackages ./python.nix { });
 
   ubootA20OlinuxinoLime = buildUBoot {
     defconfig = "A20-OLinuXino-Lime_defconfig";

--- a/pkgs/misc/uboot/python.nix
+++ b/pkgs/misc/uboot/python.nix
@@ -1,0 +1,160 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+  makeWrapper,
+
+  armTrustedFirmwareTools,
+  bzip2,
+  cbfstool,
+  gzip,
+  lz4,
+  lzop,
+  openssl,
+  ubootTools,
+  vboot_reference,
+  xilinx-bootgen,
+  xz,
+  zstd,
+}:
+
+let
+  # We are fetching from PyPI because the code in the repository seems to be
+  # lagging behind the PyPI releases somehow...
+  version = "0.0.7";
+in
+rec {
+
+  u_boot_pylib = python3Packages.buildPythonPackage rec {
+    pname = "u_boot_pylib";
+    inherit version;
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-A5r20Y8mgxhOhaKMpd5MJN5ubzPbkodAO0Tr0RN1SRA=";
+    };
+
+    build-system = with python3Packages; [
+      setuptools
+    ];
+
+    checkPhase = ''
+      ${python3Packages.python.interpreter} "src/$pname/__main__.py"
+      # There are some tests in other files, but they are broken
+    '';
+
+    pythonImportsCheck = [ "u_boot_pylib" ];
+  };
+
+  dtoc = python3Packages.buildPythonPackage rec {
+    pname = "dtoc";
+    inherit version;
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-NA96CznIxjqpw2Ik8AJpJkJ/ei+kQTCUExwFgssV+CM=";
+    };
+
+    build-system = with python3Packages; [
+      setuptools
+    ];
+
+    dependencies =
+      (with python3Packages; [
+        libfdt
+      ])
+      ++ [
+        u_boot_pylib
+      ];
+
+    pythonImportsCheck = [ "dtoc" ];
+  };
+
+  binman =
+    let
+      btools = [
+        armTrustedFirmwareTools
+        bzip2
+        cbfstool
+        # TODO: cst
+        gzip
+        lz4
+        # TODO: lzma_alone
+        lzop
+        openssl
+        ubootTools
+        vboot_reference
+        xilinx-bootgen
+        xz
+        zstd
+      ];
+    in
+    python3Packages.buildPythonApplication rec {
+      pname = "binary_manager";
+      inherit version;
+      pyproject = true;
+
+      src = fetchPypi {
+        inherit pname version;
+        hash = "sha256-llEBBhUoW5jTEQeoaTCjZN8y6Kj+PGNUSB3cKpgD06w=";
+      };
+
+      patches = [
+        ./binman-resources.patch
+      ];
+      patchFlags = [
+        "-p2"
+        "-d"
+        "src"
+      ];
+
+      build-system = with python3Packages; [
+        setuptools
+      ];
+
+      nativeBuildInputs = [ makeWrapper ];
+
+      dependencies =
+        (with python3Packages; [
+          jsonschema
+          pycryptodomex
+          pyelftools
+          yamllint
+        ])
+        ++ [
+          dtoc
+          u_boot_pylib
+        ];
+
+      preFixup = ''
+        wrapProgram "$out/bin/binman" --prefix PATH : "${lib.makeBinPath btools}"
+      '';
+    };
+
+  patman = python3Packages.buildPythonApplication rec {
+    pname = "patch_manager";
+    inherit version;
+    pyproject = true;
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-zD9e87fpWKynpUcfxobbdk6wbM6Ja3f8hEVHS7DGIKQ=";
+    };
+
+    build-system = with python3Packages; [
+      setuptools
+    ];
+
+    dependencies =
+      (with python3Packages; [
+        aiohttp
+        pygit2
+      ])
+      ++ [
+        u_boot_pylib
+      ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10782,6 +10782,7 @@ with pkgs;
   inherit (callPackage ../misc/uboot { })
     buildUBoot
     ubootTools
+    ubootPythonTools
     ubootA20OlinuxinoLime
     ubootA20OlinuxinoLime2EMMC
     ubootBananaPi


### PR DESCRIPTION
Package the Python tools that come with U-Boot, most importantly, `binman`.

We take the sources from PyPI because this is the official distribution channel and the versions there are somehow newer than in the U-Boot repository itself.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

ping U-Boot maintainers @bartsch @dezgeg @lopsided98 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
