### PR TITLE
nixos/installer: ship the minimal ISO with networkmanager

### DIFF
--- a/nixos/doc/manual/configuration/profiles/installation-device.section.md
+++ b/nixos/doc/manual/configuration/profiles/installation-device.section.md
@@ -14,8 +14,8 @@ NixOS manual is shown automatically on TTY 8, udisks is disabled.
 Autologin is enabled as `nixos` user, while passwordless
 login as both `root` and `nixos` is possible.
 Passwordless `sudo` is enabled too.
-[wpa_supplicant](#opt-networking.wireless.enable) is
-enabled, but configured to not autostart.
+[NetworkManager](#opt-networking.networkmanager.enable) is
+enabled and can be configured interactively with `nmtui`.
 
 It is explained how to login, start the ssh server, and if available,
 how to start the display manager.

--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -154,53 +154,12 @@ The boot process should have brought up networking (check `ip
 a`). Networking is necessary for the installer, since it will
 download lots of stuff (such as source tarballs or Nixpkgs channel
 binaries). It's best if you have a DHCP server on your network.
-Otherwise configure networking manually using `ifconfig`.
+Otherwise configure networking manually using `ip`.
 
-On the graphical installer, you can configure the network, wifi
-included, through NetworkManager. Using the `nmtui` program, you can do
-so even in a non-graphical session. If you prefer to configure the
-network manually, disable NetworkManager with
+You can configure the network, Wi-Fi included, through NetworkManager.
+Using the `nmtui` program, you can do so even in a non-graphical session.
+ If you prefer to configure the network manually, disable NetworkManager with
 `systemctl stop NetworkManager`.
-
-On the minimal installer, NetworkManager is not available, so
-configuration must be performed manually. To configure the wifi, first
-start wpa_supplicant with `sudo systemctl start wpa_supplicant`, then
-run `wpa_cli`. For most home networks, you need to type in the following
-commands:
-
-```plain
-> add_network
-0
-> set_network 0 ssid "myhomenetwork"
-OK
-> set_network 0 psk "mypassword"
-OK
-> enable_network 0
-OK
-```
-
-For enterprise networks, for example *eduroam*, instead do:
-
-```plain
-> add_network
-0
-> set_network 0 ssid "eduroam"
-OK
-> set_network 0 identity "myname@example.com"
-OK
-> set_network 0 password "mypassword"
-OK
-> enable_network 0
-OK
-```
-
-When successfully connected, you should see a line such as this one
-
-```plain
-<3>CTRL-EVENT-CONNECTED - Connection to 32:85:ab:ef:24:5c completed [id=0 id_str=]
-```
-
-you can now leave `wpa_cli` by typing `quit`.
 
 If you would like to continue the installation from a different machine
 you can use activated SSH daemon. You need to copy your ssh key to

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -20,10 +20,6 @@
 
   services.xserver.enable = true;
 
-  # Provide networkmanager for easy wireless configuration.
-  networking.networkmanager.enable = true;
-  networking.wireless.enable = lib.mkImageMediaOverride false;
-
   # KDE complains if power management is disabled (to be precise, if
   # there is no power management backend such as upower).
   powerManagement.enable = true;

--- a/nixos/modules/installer/netboot/netboot-minimal.nix
+++ b/nixos/modules/installer/netboot/netboot-minimal.nix
@@ -11,5 +11,5 @@
   documentation.man.enable = lib.mkOverride 500 true;
   hardware.enableRedistributableFirmware = lib.mkOverride 70 false;
   system.extraDependencies = lib.mkOverride 70 [ ];
-  networking.wireless.enable = lib.mkOverride 500 false;
+  networking.networkmanager.enable = lib.mkOverride 500 false;
 }

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -69,9 +69,7 @@ with lib;
         with `passwd` (prefix with `sudo` for "root"), or add your public key to
         /home/nixos/.ssh/authorized_keys or /root/.ssh/authorized_keys.
 
-        If you need a wireless connection, type
-        `sudo systemctl start wpa_supplicant` and configure a
-        network using `wpa_cli`. See the NixOS manual for details.
+        To set up a wireless connection, run `nmtui`.
       ''
       + optionalString config.services.xserver.enable ''
 
@@ -89,10 +87,8 @@ with lib;
       settings.PermitRootLogin = mkDefault "yes";
     };
 
-    # Enable wpa_supplicant, but don't start it by default.
-    networking.wireless.enable = mkDefault true;
-    networking.wireless.userControlled.enable = true;
-    systemd.services.wpa_supplicant.wantedBy = mkOverride 50 [ ];
+    # Provide networkmanager for easy network configuration.
+    networking.networkmanager.enable = true;
 
     # Tell the Nix evaluator to garbage collect more aggressively.
     # This is desirable in memory-constrained environments that don't


### PR DESCRIPTION
With networkmanager we can provide a much more welcoming network setup experience in the installer and it costs us less than 10 MB[1] with this configuration on the minimal ISO.

By default, for new profiles it will enable DHCP and RA and allow interactive reconfiguration through `nmtui` or `nmcli`. Especially the TUI interface is very easy to pick up and removes the need for typing in manual commands when setting up the WLAN connection.

See https://github.com/NixOS/nixpkgs/pull/420923#issuecomment-3016692716 for various attempts at reducing the size that lead to this.

[1] with https://github.com/NixOS/nixpkgs/pull/421042

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
