### PR TITLE
endless-sky: 0.10.12 -> 0.10.14

### DIFF
--- a/pkgs/by-name/en/endless-sky/fixes.patch
+++ b/pkgs/by-name/en/endless-sky/fixes.patch
@@ -1,21 +1,8 @@
-diff --git a/SConstruct b/SConstruct
-index 48fd080..419b40d 100644
---- a/SConstruct
-+++ b/SConstruct
-@@ -55,7 +55,7 @@ sky = env.Program("endless-sky", Glob("build/" + env["mode"] + "/*.cpp"))
- 
- 
- # Install the binary:
--env.Install("$DESTDIR$PREFIX/games", sky)
-+env.Install("$DESTDIR$PREFIX/bin", sky)
- 
- # Install the desktop file:
- env.Install("$DESTDIR$PREFIX/share/applications", "endless-sky.desktop")
 diff --git a/source/Files.cpp b/source/Files.cpp
-index f5dec21..ad57c55 100644
+index bb03ecf..6e37336 100644
 --- a/source/Files.cpp
 +++ b/source/Files.cpp
-@@ -115,6 +115,7 @@ void Files::Init(const char * const *argv)
+@@ -135,6 +135,7 @@ void Files::Init(const char * const *argv)
  		else if(IsParent(STANDARD_PATH, resources))
  			resources = STANDARD_PATH / RESOURCE_PATH;
  #endif
@@ -23,3 +10,16 @@ index f5dec21..ad57c55 100644
  	}
  	// If the resources are not here, search in the directories containing this
  	// one. This allows, for example, a Mac app that does not actually have the
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 17f290163..169fef120 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -312,7 +312,7 @@ elseif(WIN32)
+ 	include(CPack)
+ elseif(UNIX)
+	# Install the binary.
+-	install(TARGETS EndlessSky CONFIGURATIONS Release RUNTIME DESTINATION games)
++	install(TARGETS EndlessSky CONFIGURATIONS Release RUNTIME DESTINATION bin)
+
+ 	# Install the desktop file.
+ 	install(FILES io.github.endless_sky.endless_sky.desktop DESTINATION share/applications)

--- a/pkgs/by-name/en/endless-sky/package.nix
+++ b/pkgs/by-name/en/endless-sky/package.nix
@@ -8,20 +8,22 @@
   libX11,
   glew,
   openal,
-  scons,
+  cmake,
+  pkg-config,
   libmad,
   libuuid,
+  minizip,
 }:
 
 stdenv.mkDerivation rec {
   pname = "endless-sky";
-  version = "0.10.12";
+  version = "0.10.14";
 
   src = fetchFromGitHub {
     owner = "endless-sky";
     repo = "endless-sky";
     tag = "v${version}";
-    hash = "sha256-cT/bklRGQnS9Nm8J0oH1mG20JQOe58FAAHToNDpvPpQ=";
+    hash = "sha256-/jW9TXmK2xgHUQe6H+WSCHPQthxvoNepdkdnOD3sXXo=";
   };
 
   patches = [
@@ -33,17 +35,14 @@ stdenv.mkDerivation rec {
     # endless sky naively joins the paths with string concatenation
     # so it's essential that there be a trailing slash on the resources path
     substituteInPlace source/Files.cpp \
-      --replace '%NIXPKGS_RESOURCES_PATH%' "$out/share/games/endless-sky/"
-  '';
-
-  preBuild = ''
-    export AR="${stdenv.cc.targetPrefix}gcc-ar"
+      --replace-fail '%NIXPKGS_RESOURCES_PATH%' "$out/share/games/endless-sky/"
   '';
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
-    scons
+    cmake
+    pkg-config
   ];
 
   buildInputs = [
@@ -55,9 +54,8 @@ stdenv.mkDerivation rec {
     openal
     libmad
     libuuid
+    minizip
   ];
-
-  prefixKey = "PREFIX=";
 
   meta = with lib; {
     description = "Sandbox-style space exploration game similar to Elite, Escape Velocity, or Star Control";
@@ -69,7 +67,10 @@ stdenv.mkDerivation rec {
       cc-by-sa-40
       publicDomain
     ];
-    maintainers = with maintainers; [ _360ied ];
+    maintainers = with maintainers; [
+      _360ied
+      lilacious
+    ];
     platforms = platforms.linux; # Maybe other non-darwin Unix
   };
 }


### PR DESCRIPTION
Upstream uses cmake now and deprecated SCons.
Closes #420836.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
