### PR TITLE
.git-blame-ignore-revs: add formatting change for READMEs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -269,3 +269,9 @@ a034fb50f79816c6738fb48b48503b09ea3b0132
 
 # nixos/redmine: Get rid of global lib expansions
 d7f1102f04c58b2edfc74c9a1d577e3aebfca775
+
+# **/README.md: one sentence per line
+3d505c03610b6102af6d870ae3506a151cef1f68
+60e35e4ded6e91524364a74b3b4ec233ed9321f2
+99f2e655d9db009ee0b4ede3edced5f6c882c7f4
+b4532efe93882ae2e3fc579929a42a5a56544146


### PR DESCRIPTION
As discussed in https://github.com/NixOS/nixpkgs/pull/421062#issuecomment-3016937428.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
