### PR TITLE
Fix build with gcc-15 for some core software

### DIFF
--- a/pkgs/by-name/pk/pkg-config-unwrapped/gcc-15.patch
+++ b/pkgs/by-name/pk/pkg-config-unwrapped/gcc-15.patch
@@ -1,0 +1,35 @@
+From 4444e3e5b7130c1664d7617e079e776ac0437661 Mon Sep 17 00:00:00 2001
+From: Dmitry Bogatov <serenity@kaction.cc>
+Date: Thu, 26 Jun 2025 00:26:31 +0000
+Subject: [PATCH] Avoid using "bool" as identifier (was made a keyword in
+ gcc-15)
+
+---
+ glib/glib/goption.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/glib/glib/goption.c b/glib/glib/goption.c
+index 0a22f6f..bdd8837 100644
+--- a/glib/glib/goption.c
++++ b/glib/glib/goption.c
+@@ -166,7 +166,7 @@ typedef struct
+   gpointer arg_data;
+   union
+   {
+-    gboolean bool;
++    gboolean bool_value;
+     gint integer;
+     gchar *str;
+     gchar **array;
+@@ -1600,7 +1600,7 @@ free_changes_list (GOptionContext *context,
+           switch (change->arg_type)
+             {
+             case G_OPTION_ARG_NONE:
+-              *(gboolean *)change->arg_data = change->prev.bool;
++              *(gboolean *)change->arg_data = change->prev.bool_value;
+               break;
+             case G_OPTION_ARG_INT:
+               *(gint *)change->arg_data = change->prev.integer;
+-- 
+2.47.2
+

--- a/pkgs/by-name/pk/pkg-config-unwrapped/package.nix
+++ b/pkgs/by-name/pk/pkg-config-unwrapped/package.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation rec {
   # http://bugs.freedesktop.org/show_bug.cgi?id=4738, migrated to
   # https://gitlab.freedesktop.org/pkg-config/pkg-config/issues/28
   patches =
-    lib.optional (!vanilla) ./requires-private.patch
+    [ ./gcc-15.patch ]
+    ++ lib.optional (!vanilla) ./requires-private.patch
     ++ lib.optional stdenv.hostPlatform.isCygwin ./2.36.3-not-win32.patch;
 
   # These three tests fail due to a (desired) behavior change from our ./requires-private.patch

--- a/pkgs/by-name/un/unzip/package.nix
+++ b/pkgs/by-name/un/unzip/package.nix
@@ -86,6 +86,11 @@ stdenv.mkDerivation rec {
       sha256 = "67ab260ae6adf8e7c5eda2d1d7846929b43562943ec4aff629bd7018954058b1";
     });
 
+  # gcc-15 uses c23 standard, which removed non-prototype function declarations.
+  postPatch = ''
+    sed -i '/localtime()/ d' unix/unxcfg.h
+  '';
+
   nativeBuildInputs = [ bzip2 ];
   buildInputs = [ bzip2 ] ++ lib.optional enableNLS libnatspec;
 

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -162,6 +162,15 @@ stdenv.mkDerivation (
         -#define LIBIDN2_SONAME "libidn2.so.0"
         +#define LIBIDN2_SONAME "${lib.getLib libidn2}/lib/libidn2.so.0"
         EOF
+      ''
+      # For some reason, with gcc-15 build fails with the following error:
+      #
+      #     zic.c:3767:1: note: did you mean to specify it after ')' following function parameters?
+      #     zic.c:3781:1: error: standard 'reproducible' attribute can only be applied to function declarators or type specifiers with function type []
+      + ''
+        for path in timezone/zic.c timezone/zdump.c ; do
+          substituteInPlace $path  --replace-fail "ATTRIBUTE_REPRODUCIBLE" ""
+        done
       '';
 
     configureFlags =

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -48,6 +48,12 @@ let
     configureFlags =
       [
         "--with-pic"
+        # gcc-15 have c23 standard by default, where "void foo()" now means "void foo(void)".
+        #
+        # The "configure" script relies on c17 and below semantics for "long long
+        # reliability test 1" (defined in aclocal.m4)
+        "CFLAGS=-std=c99"
+
         (lib.enableFeature cxx "cxx")
         # Build a "fat binary", with routines for several sub-architectures
         # (x86), except on Solaris where some tests crash with "Memory fault".

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -133,10 +133,31 @@ lib.warnIf (withDocs != null)
 
     enableParallelBuilding = true;
 
-    makeFlags = lib.optionals stdenv.hostPlatform.isCygwin [
-      "LOCAL_LDFLAGS=-Wl,--export-all,--out-implib,libbash.dll.a"
-      "SHOBJ_LIBS=-lbash"
-    ];
+    makeFlags =
+      lib.optionals stdenv.hostPlatform.isCygwin [
+        "LOCAL_LDFLAGS=-Wl,--export-all,--out-implib,libbash.dll.a"
+        "SHOBJ_LIBS=-lbash"
+      ]
+      # GNU Bash extensively uses function prototypes with unspecified signature, like
+      #
+      #     extern void add_unwind_protect ()
+      #
+      # to implicitly cast all kinds of word-sized arguments. GCC-15 switched C standard
+      # from gnu17 to gnu23, which changed the meaning of the prototype above to
+      #
+      #     extern void add_unwind_protect (void)
+      #
+      # Note that Bash 5.3, quoting the release announcement:
+      #
+      # > The source code has been updated for C23 conformance. This means that bash
+      # > will no longer compile with K&R-style C compilers.
+      #
+      # So this workaround won't be necessary after upgrade to bash=5.3.
+      #
+      # => https://lists.gnu.org/archive/html/bug-bash/2025-07/msg00005.html
+      #
+      #      ~kaction 2025-07-19
+      ++ [ "LOCAL_CFLAGS=-std=c99" ];
 
     nativeCheckInputs = [ util-linux ];
     doCheck = false; # dependency cycle, needs to be interactive


### PR DESCRIPTION
# ncurses: fix build with gcc-15

This is zero-rebuild change for gcc-14, but fixes build with gcc-15, which can be
observed either by trying to build yourself:

```
:b ncurses.override { stdenv = gcc15Stdenv; }
```

or can be seen in [CI logs](https://builds.sr.ht/~kaction/job/1520835).
