### PR TITLE
Revert "python3Packages.pathvalidate: 3.2.3 -> 3.3.1"

### DIFF
--- a/pkgs/development/python-modules/pathvalidate/default.nix
+++ b/pkgs/development/python-modules/pathvalidate/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pathvalidate";
-  version = "3.3.1";
+  version = "3.2.3";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-sYwHISv+rWJDRbuOHWFBzc8Vo5c2mU6guUA1rSsboXc=";
+    hash = "sha256-WbW5J44wOC1tITSXYjBD6+Y/EOKQVb5EGanATHIXOcs=";
   };
 
   build-system = [ setuptools-scm ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#417694

Incompatible with #420266