### PR TITLE
libredirect: use `meta.badPlatforms` to report unsupported uses

### DIFF
--- a/pkgs/by-name/li/libredirect/package.nix
+++ b/pkgs/by-name/li/libredirect/package.nix
@@ -6,136 +6,133 @@
   coreutils,
 }:
 
-if stdenv.hostPlatform.isStatic then
-  throw ''
-    libredirect is not available on static builds.
+stdenv.mkDerivation {
+  pname = "libredirect";
+  version = "0";
 
-    Please fix your derivation to not depend on libredirect on static
-    builds, using something like following:
+  unpackPhase = ''
+    cp ${./libredirect.c} libredirect.c
+    cp ${./test.c} test.c
+  '';
 
-      nativeBuildInputs =
-        lib.optional (!stdenv.buildPlatform.isStatic) libredirect;
+  outputs = [
+    "out"
+    "hook"
+  ];
 
-    and disable tests as necessary, although fixing tests to work without
-    libredirect is even better.
+  env.libName = "libredirect${stdenv.hostPlatform.extensions.sharedLibrary or ""}";
 
-    libredirect uses LD_PRELOAD feature of dynamic loader and does not
-    work on static builds where dynamic loader is not used.
-  ''
-else
-  stdenv.mkDerivation {
-    pname = "libredirect";
-    version = "0";
+  buildPhase = ''
+    runHook preBuild
 
-    unpackPhase = ''
-      cp ${./libredirect.c} libredirect.c
-      cp ${./test.c} test.c
-    '';
+    ${
+      if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
+        ''
+          # We need the unwrapped binutils and clang:
+          # We also want to build a fat library with x86_64, arm64, arm64e in there.
+          # Because we use the unwrapped tools, we need to provide -isystem for headers
+          # and the library search directory for libdl.
+          # We can't build this on x86_64, because the libSystem we point to doesn't
+          # like arm64(e).
+          PATH=${bintools-unwrapped}/bin:${llvmPackages.clang-unwrapped}/bin:$PATH \
+            clang -arch x86_64 -arch arm64 -arch arm64e \
+            -isystem "$SDKROOT/usr/include" \
+            -isystem ${lib.getLib llvmPackages.libclang}/lib/clang/*/include \
+            "-L$SDKROOT/usr/lib" \
+            -Wl,-install_name,$out/lib/$libName \
+            -Wall -std=c99 -O3 -fPIC libredirect.c \
+            -shared -o "$libName"
+        ''
+      else if stdenv.hostPlatform.isDarwin then
+        ''
+          $CC -Wall -std=c99 -O3 -fPIC libredirect.c \
+            -Wl,-install_name,$out/lib/$libName \
+            -shared -o "$libName"
+        ''
+      else
+        ''
+          $CC -Wall -std=c99 -O3 -fPIC libredirect.c \
+            -shared -o "$libName"
+        ''
+    }
 
-    outputs = [
-      "out"
-      "hook"
-    ];
+    if [ -n "$doInstallCheck" ]; then
+      $CC -Wall -std=c99 \
+        ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "-D_GNU_SOURCE"} \
+        -O3 test.c -o test
+    fi
 
-    libName = "libredirect" + stdenv.hostPlatform.extensions.sharedLibrary;
+    runHook postBuild
+  '';
 
-    buildPhase = ''
-      runHook preBuild
+  # We want to retain debugging info to be able to use GDB on libredirect.so
+  # to more easily investigate which function overrides are missing or why
+  # existing ones do not have the intended effect.
+  dontStrip = true;
 
+  installPhase =
+    ''
+      runHook preInstall
+
+      install -vD "$libName" "$out/lib/$libName"
+
+    ''
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
+      # dylib will be rejected unless dylib rpath gets explicitly set
+      install_name_tool \
+        -change $libName $out/lib/$libName \
+        $out/lib/$libName
+    ''
+    + ''
+      # Provide a setup hook that injects our library into every process.
+      mkdir -p "$hook/nix-support"
+      cat <<SETUP_HOOK > "$hook/nix-support/setup-hook"
+      echo "Setting up libredirect"
       ${
-        if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 then
+        if stdenv.hostPlatform.isDarwin then
           ''
-            # We need the unwrapped binutils and clang:
-            # We also want to build a fat library with x86_64, arm64, arm64e in there.
-            # Because we use the unwrapped tools, we need to provide -isystem for headers
-            # and the library search directory for libdl.
-            # We can't build this on x86_64, because the libSystem we point to doesn't
-            # like arm64(e).
-            PATH=${bintools-unwrapped}/bin:${llvmPackages.clang-unwrapped}/bin:$PATH \
-              clang -arch x86_64 -arch arm64 -arch arm64e \
-              -isystem "$SDKROOT/usr/include" \
-              -isystem ${lib.getLib llvmPackages.libclang}/lib/clang/*/include \
-              "-L$SDKROOT/usr/lib" \
-              -Wl,-install_name,$out/lib/$libName \
-              -Wall -std=c99 -O3 -fPIC libredirect.c \
-              -shared -o "$libName"
-          ''
-        else if stdenv.hostPlatform.isDarwin then
-          ''
-            $CC -Wall -std=c99 -O3 -fPIC libredirect.c \
-              -Wl,-install_name,$out/lib/$libName \
-              -shared -o "$libName"
+            export DYLD_INSERT_LIBRARIES="$out/lib/$libName"
           ''
         else
           ''
-            $CC -Wall -std=c99 -O3 -fPIC libredirect.c \
-              -shared -o "$libName"
+            export LD_PRELOAD="$out/lib/$libName"
           ''
       }
+      SETUP_HOOK
 
-      if [ -n "$doInstallCheck" ]; then
-        $CC -Wall -std=c99 \
-          ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "-D_GNU_SOURCE"} \
-          -O3 test.c -o test
-      fi
-
-      runHook postBuild
+      runHook postInstall
     '';
 
-    # We want to retain debugging info to be able to use GDB on libredirect.so
-    # to more easily investigate which function overrides are missing or why
-    # existing ones do not have the intended effect.
-    dontStrip = true;
+  doInstallCheck = true;
 
-    installPhase =
-      ''
-        runHook preInstall
+  installCheckPhase = ''
+    (
+      source "$hook/nix-support/setup-hook"
+      NIX_REDIRECTS="/foo/bar/test=${coreutils}/bin/true:/bar/baz=$(mktemp -d)" ./test
+    )
+  '';
 
-        install -vD "$libName" "$out/lib/$libName"
-
-      ''
-      + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
-        # dylib will be rejected unless dylib rpath gets explicitly set
-        install_name_tool \
-          -change $libName $out/lib/$libName \
-          $out/lib/$libName
-      ''
-      + ''
-        # Provide a setup hook that injects our library into every process.
-        mkdir -p "$hook/nix-support"
-        cat <<SETUP_HOOK > "$hook/nix-support/setup-hook"
-        echo "Setting up libredirect"
-        ${
-          if stdenv.hostPlatform.isDarwin then
-            ''
-              export DYLD_INSERT_LIBRARIES="$out/lib/$libName"
-            ''
-          else
-            ''
-              export LD_PRELOAD="$out/lib/$libName"
-            ''
-        }
-        SETUP_HOOK
-
-        runHook postInstall
-      '';
-
-    doInstallCheck = true;
-
-    installCheckPhase = ''
-      (
-        source "$hook/nix-support/setup-hook"
-        NIX_REDIRECTS="/foo/bar/test=${coreutils}/bin/true:/bar/baz=$(mktemp -d)" ./test
-      )
+  meta = with lib; {
+    platforms = platforms.unix;
+    # libredirect uses LD_PRELOAD feature of dynamic loader and does not
+    # work on static builds where dynamic loader is not used.
+    #
+    # libredirect users should make their use conditional on availability:
+    #
+    #   nativeBuildInputs = lib.optional (
+    #     lib.meta.availableOn stdenv.hostPlatform libredirect
+    #   ) libredirect;
+    #
+    # and disable tests as necessary, although fixing tests to work without
+    # libredirect is even better. Tools which work with Linux namespaces, such
+    # as `unshare` offer similar (but not identical) functionality.
+    #
+    badPlatforms = [ lib.systems.inspect.platformPatterns.isStatic ];
+    description = "LD_PRELOAD library to intercept and rewrite the paths in glibc calls";
+    longDescription = ''
+      libredirect is an LD_PRELOAD library to intercept and rewrite the paths in
+      glibc calls based on the value of $NIX_REDIRECTS, a colon-separated list
+      of path prefixes to be rewritten, e.g. "/src=/dst:/usr/=/nix/store/".
     '';
-
-    meta = with lib; {
-      platforms = platforms.unix;
-      description = "LD_PRELOAD library to intercept and rewrite the paths in glibc calls";
-      longDescription = ''
-        libredirect is an LD_PRELOAD library to intercept and rewrite the paths in
-        glibc calls based on the value of $NIX_REDIRECTS, a colon-separated list
-        of path prefixes to be rewritten, e.g. "/src=/dst:/usr/=/nix/store/".
-      '';
-    };
-  }
+  };
+}


### PR DESCRIPTION
see <https://github.com/NixOS/nixpkgs/pull/420469> for context.

many users of `libredirect` are already gated, in such a way that `libredirect` is evaluated, but not built/used.

`meta.badPlatforms` will still alert on unsupported uses, but provides an escape hatch by which to bypass the enforcement (`NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1`) as packagers work out more longterm solutions. e.g. `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-build -A pkgsStatic.openssh` successfully builds.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
