### PR TITLE
protonmail-export: init at 1.0.5

### DIFF
--- a/pkgs/by-name/pr/protonmail-export/package.nix
+++ b/pkgs/by-name/pr/protonmail-export/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildGoModule,
+
+  cmake,
+  curl,
+  go,
+  unzip,
+  zip,
+
+  catch2,
+  cxxopts,
+  fmt,
+
+  versionCheckHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "protonmail-export";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "ProtonMail";
+    repo = "proton-mail-export";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-rpfTI3vcZlEK1TrxRMMHFKutwC/YqAZrZCFiUsfMafc=";
+  };
+
+  goModules =
+    (buildGoModule {
+      pname = "protonmail-export-go-modules";
+      inherit (finalAttrs) src version;
+      sourceRoot = "${finalAttrs.src.name}/go-lib";
+      vendorHash = "sha256-rKi3PNsYsZA+MLcLTVrVI3T2SUBZCiq9Zxtf+1SGArk=";
+
+      nativeBuildInputs = [ unzip ];
+
+      proxyVendor = true;
+    }).goModules;
+
+  postPatch = ''
+    echo "" > vcpkg/scripts/buildsystems/vcpkg.cmake
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'include(clang_tidy)' ''' \
+      --replace-fail 'include(clang_format)' '''
+
+    substituteInPlace lib/CMakeLists.txt \
+      --replace-fail 'add_subdirectory(tests)' '''
+
+    substituteInPlace cli/bin/main.cpp --replace-fail \
+      'execPath = etcpp::getExecutableDir();' 'execPath = std::filesystem::u8path(std::getenv("HOME")) / ".config" / "protonmail-export";'
+  '';
+
+  preConfigure = ''
+    export GOCACHE=$TMPDIR/go-cache
+    export GOPATH=$TMPDIR/go
+    export GOPROXY=file://$goModules
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    curl
+    go
+    unzip
+    zip
+  ];
+
+  buildInputs = [
+    fmt
+    catch2
+    cxxopts
+  ];
+
+  postInstall =
+    let
+      so = "proton-mail-export${stdenv.hostPlatform.extensions.library}";
+    in
+    ''
+      install -Dm644 $out/bin/${so} -t $out/lib
+      rm -f $out/bin/${so}
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install_name_tool -change @loader_path/${so} \
+        $out/lib/${so} \
+        $out/bin/proton-mail-export-cli
+    '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/proton-mail-export-cli";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Export your Proton Mail emails as eml files";
+    homepage = "https://github.com/ProtonMail/proton-mail-export";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.ryand56 ];
+    mainProgram = "proton-mail-export-cli";
+  };
+})


### PR DESCRIPTION
Adds [proton-mail-export](https://github.com/ProtonMail/proton-mail-export), allows you to export your Proton Mail emails as eml files.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
