### PR TITLE
linuxPackages.broadcom_sta: add fixes, patches for kernel 6.15, and security notices

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -96,7 +96,10 @@ stdenv.mkDerivation {
     description = "Kernel module driver for some Broadcom's wireless cards";
     homepage = "http://www.broadcom.com/support/802.11/linux_sta.php";
     license = lib.licenses.unfreeRedistributable;
-    maintainers = [ lib.maintainers.j0hax ];
+    maintainers = with lib.maintainers; [
+      j0hax
+      nullcube
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -111,5 +111,15 @@ stdenv.mkDerivation {
       "i686-linux"
       "x86_64-linux"
     ];
+    knownVulnerabilities = [
+      "CVE-2019-9501: heap buffer overflow, potentially allowing remote code execution by sending specially-crafted WiFi packets"
+      "CVE-2019-9502: heap buffer overflow, potentially allowing remote code execution by sending specially-crafted WiFi packets"
+      (
+        "The Broadcom STA wireless driver is not maintained "
+        + "and is incompatible with Linux kernel security mitigations. "
+        + "It is heavily recommended to replace the hardware and remove the driver. "
+        + "Proceed at your own risk!"
+      )
+    ];
   };
 }

--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -94,12 +94,15 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Kernel module driver for some Broadcom's wireless cards";
-    homepage = "http://www.broadcom.com/support/802.11/linux_sta.php";
+    homepage = "https://www.broadcom.com/support/download-search?pg=Legacy%20Products&pf=Legacy%20Wireless&pn&pa&po&dk&pl";
     license = lib.licenses.unfreeRedistributable;
     maintainers = with lib.maintainers; [
       j0hax
       nullcube
     ];
-    platforms = lib.platforms.linux;
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
   };
 }

--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -3,12 +3,15 @@
   stdenv,
   fetchurl,
   fetchFromGitHub,
-  fetchpatch2,
   kernel,
 }:
 
 let
   version = "6.30.223.271";
+  # Patchset release number from rpmfusion, to more easily differentiate
+  # versions and updates. See `wl-kmod.spec` file:
+  # https://github.com/rpmfusion/wl-kmod/blob/master/wl-kmod.spec#L19
+  release = "57";
   hashes = {
     i686-linux = "sha256-T4twspOsjMXHDlca1dGHjQ8p0TOkb+eGmGjZwZtQWM0=";
     x86_64-linux = "sha256-X3l3TVvuyPdja1nA+wegMQju8eP9MkVjiyCFjHFBRL4=";
@@ -21,8 +24,8 @@ let
   rpmFusionPatches = fetchFromGitHub {
     owner = "rpmfusion";
     repo = "wl-kmod";
-    rev = "9a5a0d7195e0f6b05ff97e948b97fb0b7427cbf2";
-    hash = "sha256-pOOkkOjc77KGqc9fWuRyRsymd90OpLEnbOvxBbeIdKQ=";
+    rev = "b0d19578ebd0daae9c5b7f9e9511a6d73ac4d957";
+    hash = "sha256-v7mZ2S/eVfGTEXrxpdiemHhrC+P3/sPOZqTBhRtins4=";
   };
   patchset = [
     "wl-kmod-001_wext_workaround.patch"
@@ -55,10 +58,14 @@ let
     "wl-kmod-028_kernel_6.12_adaptation.patch"
     "wl-kmod-029_kernel_6.13_adaptation.patch"
     "wl-kmod-030_kernel_6.14_adaptation.patch"
+    "wl-kmod-031_replace_EXTRA_CFLAGS_EXTRA_LDFLAGS_with_ccflags-y_ldflags-y.patch"
+    "wl-kmod-032_add_MODULE_DESCRIPTION_macro.patch"
+    "wl-kmod-033_disable_objtool_add_warning_unmaintained.patch"
+    "wl-kmod-034_kernel_6.15_adaptation_replace_del_timer_with_timer_delete.patch"
   ];
 in
 stdenv.mkDerivation {
-  name = "broadcom-sta-${version}-${kernel.version}";
+  name = "broadcom-sta-${version}-${release}-${kernel.version}";
 
   src = fetchurl {
     url = "https://docs.broadcom.com/docs-and-downloads/docs/linux_sta/${tarball}";


### PR DESCRIPTION
Fixes #392949

Added some more patches from this [RPMFusion Repo](https://github.com/rpmfusion/wl-kmod) (as mentioned in this issue comment: https://github.com/NixOS/nixpkgs/issues/392949#issuecomment-2853529286) to fix building broadcom_sta for kernel 6.15.

These patches fix both the "`typedefs.h`" error as well as the "`__warn_flushing_systemwide_wq();`" error, on at least kernel 6.15, and hopefully for future versions as well.

Also added myself as a maintainer, I will at least be able to source patches and test on the relevant hardware as my main laptop requires this module for it's WiFi.

I tested the updated package on my laptop, and it works correctly.

Added notice to `meta.knownVulnerabilities` that broadcom_sta is unmaintained.

Added notice of CVE's (also see https://github.com/NixOS/nixpkgs/pull/421163#issuecomment-3069799136):
https://www.cve.org/CVERecord?id=CVE-2019-9502
https://www.cve.org/CVERecord?id=CVE-2019-9501

Added the release number from rpmfusion to more easily differentiate package/patchset versions, sourced from `wl-kmod.spec`:
https://github.com/rpmfusion/wl-kmod/blob/master/wl-kmod.spec#L19

Set meta.platforms to correctly reflect the [supported platforms](https://github.com/NixOS/nixpkgs/blob/956617af519a7798428b264f60db83aeecbd643e/pkgs/os-specific/linux/broadcom-sta/default.nix#L16-L17).


Full changelog of patches:
https://github.com/rpmfusion/wl-kmod/compare/9a5a0d7195e0f6b05ff97e948b97fb0b7427cbf2..b0d19578ebd0daae9c5b7f9e9511a6d73ac4d957

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
