### PR TITLE
star: add aarch64 and darwin support

### DIFF
--- a/pkgs/by-name/st/star/package.nix
+++ b/pkgs/by-name/st/star/package.nix
@@ -19,10 +19,6 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${src.name}/source";
 
-  postPatch = ''
-    substituteInPlace Makefile --replace "/bin/rm" "rm"
-  '';
-
   nativeBuildInputs = [ xxd ];
 
   buildInputs = [ zlib ];
@@ -44,7 +40,10 @@ stdenv.mkDerivation rec {
     description = "Spliced Transcripts Alignment to a Reference";
     homepage = "https://github.com/alexdobin/STAR";
     license = licenses.gpl3Plus;
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
     maintainers = [ maintainers.arcadio ];
   };
 }

--- a/pkgs/by-name/st/star/package.nix
+++ b/pkgs/by-name/st/star/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   xxd,
   zlib,
+  llvmPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ xxd ];
 
-  buildInputs = [ zlib ];
+  buildInputs = [ zlib ] ++ lib.optionals stdenv.isDarwin [ llvmPackages.openmp ];
 
   buildFlags = [
     "STAR"

--- a/pkgs/by-name/st/star/package.nix
+++ b/pkgs/by-name/st/star/package.nix
@@ -4,8 +4,10 @@
   fetchFromGitHub,
   xxd,
   zlib,
+  llvmPackages,
+  star,
+  testers,
 }:
-
 stdenv.mkDerivation rec {
   pname = "star";
   version = "2.7.11b";
@@ -21,7 +23,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ xxd ];
 
-  buildInputs = [ zlib ];
+  buildInputs = [ zlib ] ++ lib.optionals stdenv.isDarwin [ llvmPackages.openmp ];
+
+  makeFlags = [
+    "CXXFLAGS_SIMD="
+  ];
+
+  preBuild = ''
+    export CXXFLAGS="-std=c++14${lib.optionalString stdenv.isDarwin " -DSHM_NORESERVE=0"}"
+  '';
 
   buildFlags = [
     "STAR"
@@ -36,6 +46,12 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  passthru.tests.version = testers.testVersion {
+    package = star;
+    command = "STAR --version || true";
+    version = "${version}";
+  };
+
   meta = with lib; {
     description = "Spliced Transcripts Alignment to a Reference";
     homepage = "https://github.com/alexdobin/STAR";
@@ -43,6 +59,8 @@ stdenv.mkDerivation rec {
     platforms = [
       "x86_64-linux"
       "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
     ];
     maintainers = [ maintainers.arcadio ];
   };


### PR DESCRIPTION
Adds support for aarch64-linux and darwin to the star package.

Stacked on 

- #420855

Resolves 

- #420249 