### PR TITLE
papermc: add 1.21.6-47 support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5482,6 +5482,12 @@
     github = "d4rkstar";
     githubId = 4957015;
   };
+  D7TUN6 = {
+    email = "d7tun6@gmail.com";
+    github = "D7TUN6";
+    githubId = 207599818;
+    name = "D7TUN6";
+  };
   da-luce = {
     email = "daltonluce42@gmail.com";
     github = "da-luce";

--- a/pkgs/games/papermc/derivation.nix
+++ b/pkgs/games/papermc/derivation.nix
@@ -58,6 +58,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       aaronjanse
       neonfuz
       MayNiklas
+      D7TUN6
     ];
     mainProgram = "minecraft-server";
   };

--- a/pkgs/games/papermc/versions.json
+++ b/pkgs/games/papermc/versions.json
@@ -74,5 +74,9 @@
     "1.21.5": {
         "hash": "sha256-fgI/FO2CzTvUm58G0DKirnQa5ztElxOIGw1r4CbzC4M=",
         "version": "1.21.5-112"
+    },
+    "1.21.6": {
+        "hash": "sha256-xL/DN+CRAP39Bgo2tmF0voc3DZl1rOTijkXYc86ZLGI=",
+        "version": "1.21.6-47"
     }
 }


### PR DESCRIPTION
## PaperMC 1.21.6-47 support.

My PR adds support for PaperMC 1.21.6-47 server version. This is my first PR - critics and advice are welcome.

### Changes.
- Added PaperMC 1.21.6-47 build.
- Updated SHA256 hash for the new version.
- Added myself to maintainers list
- Updated derivation maintainers field

### Verification.
- Built package locally: `nix-build -A papermc`.
- Server starts and shows correct version: `./result/bin/minecraft-server --version`.
- Server starts successfully with result/bin/minecraft-server

### Maintainer Addition.
I'm adding myself as maintainer to ensure timely updates for PaperMC in the future. I will monitor and update PaperMC regularly.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.


