### PR TITLE
reactive-resume: init at 4.4.4

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1669,6 +1669,7 @@
   ./services/web-apps/pretix.nix
   ./services/web-apps/privatebin.nix
   ./services/web-apps/prosody-filer.nix
+  ./services/web-apps/reactive-resume.nix
   ./services/web-apps/readeck.nix
   ./services/web-apps/reposilite.nix
   ./services/web-apps/rimgo.nix

--- a/nixos/modules/services/web-apps/reactive-resume.nix
+++ b/nixos/modules/services/web-apps/reactive-resume.nix
@@ -1,0 +1,185 @@
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}:
+{
+  options.services.reactive-resume = {
+    enable = lib.mkEnableOption "Reactive Resume";
+
+    package = lib.mkPackageOption pkgs "reactive-resume" { };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3000;
+      description = "TCP port number where the service will be available.";
+    };
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open {option}`services.reactive-resume.port` in the firewall.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "reactive-resume";
+      description = "User under which the service should run. Also used for the DB username and database name.";
+    };
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "reactive-resume";
+      description = "User under which the service should run.";
+    };
+
+    storageBucket = lib.mkOption {
+      type = lib.types.str;
+      default = "reactive-resume";
+      description = "Bucket name";
+    };
+
+    chromeUrl = lib.mkOption {
+      type = lib.types.str;
+      description = "Chrome WebSocket URL";
+    };
+
+    secretsFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        File containing secrets necessary to run this service. This requires at a minimum:
+
+        ```
+        # Authentication
+        ACCESS_TOKEN_SECRET='my access token secret'
+        REFRESH_TOKEN_SECRET='my refresh token secret'
+
+        # Chrome
+        CHROME_TOKEN='my Chrome token'
+
+        # Storage
+        STORAGE_ACCESS_KEY='my storage access key'
+        STORAGE_SECRET_KEY='my storage secret key'
+        ```
+      '';
+      example = "/run/secrets/reactive-resume";
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = ''
+        Additional configuration values;
+        see [upstream example](https://github.com/AmruthPillai/Reactive-Resume/blob/master/.env.example).
+      '';
+      example = lib.literalExpression ''
+        {
+          MAIL_FROM = "noreply@localhost";
+        }
+      '';
+    };
+  };
+
+  config =
+    let
+      cfg = config.services.reactive-resume;
+      databaseName = cfg.user;
+    in
+    lib.mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+
+      networking.firewall = lib.mkIf cfg.openFirewall {
+        allowedTCPPorts = [ cfg.port ];
+      };
+
+      services = {
+        postgresql = {
+          enable = true;
+          ensureUsers = [
+            {
+              name = databaseName;
+              ensureDBOwnership = true;
+            }
+          ];
+          ensureDatabases = [ databaseName ];
+        };
+      };
+
+      systemd.services.reactive-resume = {
+        description = "Reactive Resume server";
+        enable = true;
+        environment =
+          let
+            minioCfg = config.services.minio;
+            minioListenAddressHostAndPort = lib.strings.splitString ":" minioCfg.listenAddress;
+          in
+          assert (lib.lists.length minioListenAddressHostAndPort) == 2;
+          let
+            storageHost =
+              let
+                address = builtins.elemAt minioListenAddressHostAndPort 0;
+              in
+              if address == "" then "127.0.0.1" else address;
+            storagePort = builtins.elemAt minioListenAddressHostAndPort 1;
+          in
+          {
+            # Environment
+            NODE_ENV = "production";
+
+            # Ports
+            PORT = toString cfg.port;
+
+            # URLs
+            PUBLIC_URL = "http://127.0.0.1:${builtins.toString cfg.port}";
+            STORAGE_URL = "http://${storageHost}:${storagePort}/${cfg.storageBucket}";
+
+            # Database
+            DATABASE_URL = "postgresql://${cfg.user}@localhost:5432/${databaseName}?schema=public";
+
+            # Chrome Browser (for printing)
+            CHROME_URL = cfg.chromeUrl;
+
+            # Storage
+            STORAGE_ENDPOINT = storageHost;
+            STORAGE_PORT = storagePort;
+            STORAGE_BUCKET = cfg.storageBucket;
+          }
+          // cfg.extraConfig;
+        serviceConfig = {
+          ExecStart = "${lib.getExe pkgs.nodejs} ${cfg.package}/apps/server/main";
+          EnvironmentFile = cfg.secretsFile;
+          User = cfg.user;
+          Group = cfg.group;
+          Restart = "always";
+          # Hardening options
+          AmbientCapabilities = [ ];
+          CapabilityBoundingSet = [ ];
+          LockPersonality = true;
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          ProtectControlGroups = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectSystem = "strict";
+          RestartSec = 5;
+          RestrictNamespaces = true;
+          RestrictSUIDSGID = true;
+          UMask = "0007";
+          WorkingDirectory = cfg.package;
+        };
+        wantedBy = [ "multi-user.target" ];
+        wants = [ "network-online.target" ];
+        after = [ "network-online.target" ];
+      };
+      users = {
+        groups.${cfg.group} = { };
+        users.${cfg.user} = {
+          isSystemUser = true;
+          inherit (cfg) group;
+        };
+      };
+    };
+
+  meta.maintainers = with lib.maintainers; [ l0b0 ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1270,6 +1270,7 @@ in
   ragnarwm = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./ragnarwm.nix;
   rasdaemon = runTest ./rasdaemon.nix;
   rathole = runTest ./rathole.nix;
+  reactive-resume = runTest ./reactive-resume.nix;
   readarr = runTest ./readarr.nix;
   realm = runTest ./realm.nix;
   readeck = runTest ./readeck.nix;

--- a/nixos/tests/reactive-resume.nix
+++ b/nixos/tests/reactive-resume.nix
@@ -1,0 +1,31 @@
+{ lib, pkgs, ... }:
+let
+  nodeName = "machine";
+in
+{
+  name = "reactive-resume";
+
+  nodes.${nodeName}.services.reactive-resume = {
+    chromeUrl = "ws://127.0.0.1:8080";
+    enable = true;
+    secretsFile = pkgs.writeText "reactive-resume-secrets" ''
+      # Authentication
+      ACCESS_TOKEN_SECRET='my access token secret'
+      REFRESH_TOKEN_SECRET='my refresh token secret'
+
+      # Chrome
+      CHROME_TOKEN='my Chrome token'
+
+      # Storage
+      STORAGE_ACCESS_KEY='my storage access key'
+      STORAGE_SECRET_KEY='my storage secret key'
+    '';
+  };
+
+  testScript = ''
+    start_all()
+    ${nodeName}.wait_for_unit("reactive-resume")
+  '';
+
+  meta.maintainers = with lib.maintainers; [ l0b0 ];
+}

--- a/pkgs/by-name/re/reactive-resume/package.nix
+++ b/pkgs/by-name/re/reactive-resume/package.nix
@@ -1,0 +1,69 @@
+{
+  faketty,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  nodejs,
+  openssl,
+  pnpm,
+  prisma-engines,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "reactive-resume";
+  version = "4.4.4";
+
+  src = fetchFromGitHub {
+    owner = "AmruthPillai";
+    repo = "Reactive-Resume";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-A+pa+9kj0G/RpvKoiwS3X8NPDNzvsfAaWMrZEy7RZ40=";
+  };
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 1;
+    hash = "sha256-l5cUyAH/Fg/8T3JrneoIrfqkMWBrhIuf1PCIBkb9X4A=";
+  };
+
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [
+    faketty
+    nodejs
+    pnpm.configHook
+    prisma-engines
+  ];
+
+  # `faketty` workaround for https://github.com/nrwl/nx/issues/22445
+  buildPhase = ''
+    runHook preBuild
+
+    faketty pnpm run build --disableRemoteCache=true --nxBail=true --outputStyle=static --tui=false
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp --recursive dist "$out"
+    cp --recursive node_modules "$out/apps/server"
+    chmod a-x "$out"/apps/client/templates/jpg/*.jpg # https://github.com/AmruthPillai/Reactive-Resume/pull/2346
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Resume builder";
+    homepage = "https://rxresu.me/";
+    changelog = "https://github.com/AmruthPillai/Reactive-Resume/releases";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      l0b0
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
[Reactive-Resume](https://github.com/AmruthPillai/Reactive-Resume), open source "resume builder that keeps your privacy in mind".

To do:

- [x] Get rid of `chmod` command by [removing executable bit from images upstream](https://github.com/AmruthPillai/Reactive-Resume/pull/2346)
- [ ] Create a NixOS module to serve the website
- [x] Find a [better workaround than `${util-linux}/bin/script -c "pnpm build" /dev/null`](https://github.com/nrwl/nx/issues/22445) for `nx` crash:
   ```
   > nx run-many -t build
   
   
   thread '<unnamed>' panicked at packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs:61:27:
   Failed to enter raw terminal mode: Os { code: 6, kind: Uncategorized, message: "No such device or address" }
   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
   thread '<unnamed>' panicked at core/src/panicking.rs:221:5:
   panic in a function that cannot unwind
   stack backtrace:
      0:     0x7ffff1a10f09 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h5b6bd5631a6d1f6b
      1:     0x7ffff1714893 - core::fmt::write::h7550c97b06c86515
      2:     0x7ffff19d6202 - std::io::Write::write_fmt::h7b09c64fe0be9c84
      3:     0x7ffff1a135e2 - std::sys::backtrace::BacktraceLock::print::h2395ccd2c84ba3aa
      4:     0x7ffff1a1344b - std::panicking::default_hook::{{closure}}::he19d4c7230e07961
      5:     0x7ffff1a13af1 - std::panicking::rust_panic_with_hook::h8942133a8b252070
      6:     0x7ffff1a13685 - std::panicking::begin_panic_handler::{{closure}}::hb5f5963570096b29
      7:     0x7ffff1a13619 - std::sys::backtrace::__rust_end_short_backtrace::h6208cedc1922feda
      8:     0x7ffff1a1360c - rust_begin_unwind
      9:     0x7ffff167920c - core::panicking::panic_nounwind_fmt::h357fc035dc231634
     10:     0x7ffff167926c - core::panicking::panic_nounwind::hd0dad372654c389a
     11:     0x7ffff167921c - core::panicking::panic_cannot_unwind::h65aefd062253eb19
     12:     0x7ffff17ea036 - nx::native::pseudo_terminal::rust_pseudo_terminal::__napi_impl_helper__RustPseudoTerminal__7::__napi__new::h9f1cb28b2f2a6ee4
     13:           0xe23964 - _ZN6v8impl12_GLOBAL__N_123FunctionCallbackWrapper6InvokeERKN2v820FunctionCallbackInfoINS2_5ValueEEE
     14:          0x11b1985 - _ZN2v88internal12_GLOBAL__N_119HandleApiCallHelperILb1EEENS0_11MaybeHandleINS0_6ObjectEEEPNS0_7IsolateENS0_6HandleINS0_10HeapObjectEEENS8_INS0_20FunctionTemplateInfoEEENS8_IS4_EEPmi.isra.0
     15:          0x11b1d1d - _ZN2v88internal26Builtin_HandleApiConstructEiPmPNS0_7IsolateE
     16:     0x7fffebeac3b6 - <unknown>
   thread caused non-unwinding panic. aborting.
   ```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
