### PR TITLE
jib-cli: init at 0.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24351,6 +24351,12 @@
     githubId = 332289;
     name = "Rafał Łasocha";
   };
+  sxmair = {
+    email = "sumairhasan99@gmail.com";
+    github = "sxmair";
+    githubId = 127287939;
+    name = "Syed Sumairul Hasan";
+  };
   syberant = {
     email = "sybrand@neuralcoding.com";
     github = "syberant";

--- a/pkgs/by-name/ji/jib-cli/package.nix
+++ b/pkgs/by-name/ji/jib-cli/package.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  fetchzip,
+  lib,
+  makeWrapper,
+  jre,
+  stripJavaArchivesHook,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jib-cli";
+  version = "0.13.0";
+
+  src = fetchzip {
+    url = "https://github.com/GoogleContainerTools/jib/releases/download/v${finalAttrs.version}-cli/jib-jre-${finalAttrs.version}.zip";
+    hash = "sha256-3/wKpwVHVBU86GJfR4YGM5ba8pOOfLL+fKU7zwwU+Qc=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    stripJavaArchivesHook
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  buildInputs = [ jre ];
+
+  dontBuild = true;
+  doInstallCheck = true;
+
+  versionCheckProgram = "${placeholder "out"}/bin/jib";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r lib $out/
+    jarPaths=$(find $out/lib -name '*.jar' | tr '\n' ':' | sed 's/:$//')
+    makeWrapper ${jre}/bin/java $out/bin/jib \
+      --add-flags "-cp \"$jarPaths\" com.google.cloud.tools.jib.cli.JibCli"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Container image builder for Java using Jib CLI";
+    homepage = "https://github.com/GoogleContainerTools/jib";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      sxmair
+    ];
+    mainProgram = "jib";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


### Motivation for this addition

Adds jib-cli, a container image builder for Java at version `0.13.0`, to Nixpkgs.

jib-cli enables building optimized OCI and Docker images for Java applications without a Docker daemon, useful for reproducible Java container builds in CI/CD pipelines.

We are using the official prebuilt binary because building from source would require dealing with a complex Gradle setup and many dependencies, making it difficult to package and maintain in Nixpkgs.


###### Notes

Upstream: https://github.com/GoogleContainerTools/jib


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
### Tests performed (with reference to "Tested basic functionality" checkbox above):
- [x] Verified result/bin/jib symlink is correct and executable.
- [x]  ./result/bin/jib --version and ./result/bin/jib --help commands running successfully
- [x] Confirmed end-to-end functionality by building a test container image with ./result/bin/jib build --target=docker://jib-cli-quickstart . ([source for testing jib-cli](https://github.com/GoogleContainerTools/jib/blob/master/jib-cli/README.md#quickstart))


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
