### PR TITLE
treewide: add knownVulnerabilities to old libxml2

### DIFF
--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -90,13 +90,18 @@ let
     '';
   };
 
-  libxml2' = libxml2.overrideAttrs rec {
+  libxml2' = libxml2.overrideAttrs (oldAttrs: rec {
     version = "2.13.8";
     src = fetchurl {
       url = "mirror://gnome/sources/libxml2/${lib.versions.majorMinor version}/libxml2-${version}.tar.xz";
       hash = "sha256-J3KUyzMRmrcbK8gfL0Rem8lDW4k60VuyzSsOhZoO6Eo=";
     };
-  };
+    meta = oldAttrs.meta // {
+      knownVulnerabilities = oldAttrs.meta.knownVulnerabilities or [ ] ++ [
+        "CVE-2025-6021"
+      ];
+    };
+  });
 
 in
 

--- a/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
@@ -50,13 +50,18 @@ let
     ];
   };
 
-  libxml2' = libxml2.overrideAttrs rec {
+  libxml2' = libxml2.overrideAttrs (oldAttrs: rec {
     version = "2.13.8";
     src = fetchurl {
       url = "mirror://gnome/sources/libxml2/${lib.versions.majorMinor version}/libxml2-${version}.tar.xz";
       hash = "sha256-J3KUyzMRmrcbK8gfL0Rem8lDW4k60VuyzSsOhZoO6Eo=";
     };
-  };
+    meta = oldAttrs.meta // {
+      knownVulnerabilities = oldAttrs.meta.knownVulnerabilities or [ ] ++ [
+        "CVE-2025-6021"
+      ];
+    };
+  });
 
   fhs = buildFHSEnv {
     pname = "packettracer7";

--- a/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
@@ -41,13 +41,18 @@ let
     "8.2.2" = "CiscoPacketTracer822_amd64_signed.deb";
   };
 
-  libxml2' = libxml2.overrideAttrs rec {
+  libxml2' = libxml2.overrideAttrs (oldAttrs: rec {
     version = "2.13.8";
     src = fetchurl {
       url = "mirror://gnome/sources/libxml2/${lib.versions.majorMinor version}/libxml2-${version}.tar.xz";
       hash = "sha256-J3KUyzMRmrcbK8gfL0Rem8lDW4k60VuyzSsOhZoO6Eo=";
     };
-  };
+    meta = oldAttrs.meta // {
+      knownVulnerabilities = oldAttrs.meta.knownVulnerabilities or [ ] ++ [
+        "CVE-2025-6021"
+      ];
+    };
+  });
 
   unwrapped = stdenvNoCC.mkDerivation {
     name = "ciscoPacketTracer8-unwrapped";


### PR DESCRIPTION
Users should be informed if they're using packages that are deliberately opting in to using old versions of dependencies with vulnerabilities that have otherwise been fixed in Nixpkgs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
