### PR TITLE
librenms-agent: init, nixos/librenms-agent: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -192,6 +192,8 @@
 
 - [nixbit](https://github.com/pbek/nixbit), a GUI application for updating your NixOS system from a Nix Flakes Git repository. Available as [programs.nixbit](#opt-programs.nixbit.enable).
 
+- [librenms-agent](https://github.com/librenms/librenms-agent), the agent for the monitoring tool LibreNMS. Available as [services.librenms-agent](#opt-services.librenms-agent.enable).
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1005,6 +1005,7 @@
   ./services/monitoring/kapacitor.nix
   ./services/monitoring/karma.nix
   ./services/monitoring/kthxbye.nix
+  ./services/monitoring/librenms-agent.nix
   ./services/monitoring/librenms.nix
   ./services/monitoring/loki.nix
   ./services/monitoring/longview.nix

--- a/nixos/modules/services/monitoring/librenms-agent.nix
+++ b/nixos/modules/services/monitoring/librenms-agent.nix
@@ -1,0 +1,84 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.librenms-agent;
+in
+{
+  options.services.librenms-agent = {
+    enable = lib.mkEnableOption "LibreNMS agent";
+
+    package = lib.mkPackageOption pkgs "librenms-agent" { };
+
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra packages to add to the services' path.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 6556;
+      description = "Port where the LibreNMS Agent will listen.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Open port for LibreNMS Agent.
+      '';
+    };
+
+    ipAddressAllow = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      example = [ "192.168.1.0/24" ];
+      # Setting a secure and reasonable default is not possible
+      description = ''
+        Allows access to the LibreNMS Agent only for the given addresses.
+        An empty list will allow all.
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.sockets.librenms-agent = {
+      description = "Check_MK LibreNMS Agent Socket";
+      wantedBy = [ "sockets.target" ];
+      socketConfig = {
+        ListenStream = toString cfg.port;
+        Accept = "yes";
+      };
+    };
+
+    systemd.services."librenms-agent@" = {
+      description = "Check_MK LibreNMS Agent Service";
+      after = [
+        "network.target"
+        "librenms-agent.socket"
+      ];
+      path = cfg.extraPackages;
+      requires = [ "librenms-agent.socket" ];
+      serviceConfig = lib.mkMerge [
+        {
+          ExecStart = lib.getExe cfg.package;
+          StandardOutput = "socket";
+        }
+        (lib.mkIf (cfg.ipAddressAllow != [ ]) {
+          IPAddressDeny = "any";
+          IPAddressAllow = cfg.ipAddressAllow;
+        })
+      ];
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+  };
+
+  meta.maintainers = [ lib.maintainers.Nebucatnetzer ];
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -843,6 +843,7 @@ in
   lemurs-xorg-script = runTest ./lemurs/lemurs-xorg-script.nix;
   libinput = runTest ./libinput.nix;
   librenms = runTest ./librenms.nix;
+  librenms-agent = runTest ./librenms-agent.nix;
   libresprite = runTest ./libresprite.nix;
   libreswan = runTest ./libreswan.nix;
   libreswan-nat = runTest ./libreswan-nat.nix;

--- a/nixos/tests/librenms-agent.nix
+++ b/nixos/tests/librenms-agent.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+let
+  host = "127.0.0.1";
+  port = 6557;
+in
+{
+  name = "librenms-agent";
+
+  nodes.librenms-agent = {
+    environment.systemPackages = with pkgs; [
+      inetutils
+    ];
+
+    services.librenms-agent = {
+      enable = true;
+      port = port;
+      ipAddressAllow = [ host ];
+      openFirewall = true;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("sockets.target")
+    machine.succeed("telnet ${host} ${toString port} | grep AgentOS");
+  '';
+}

--- a/pkgs/by-name/li/librenms-agent/package.nix
+++ b/pkgs/by-name/li/librenms-agent/package.nix
@@ -1,0 +1,41 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  testers,
+  librenms-agent,
+}:
+
+stdenv.mkDerivation {
+  pname = "librenms-agent";
+  version = "1.2.6b5";
+
+  src = fetchFromGitHub {
+    owner = "librenms";
+    repo = "librenms-agent";
+    # upstream provides no git tags
+    rev = "def5f830b3672526c4353a92a1804485f645733c";
+    hash = "sha256-rzwSYJlor1LMGWDP4i/UYmuRccH0NflMC/fXDNd7QXA=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 0750 check_mk_agent -t $out/bin/
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion { package = librenms-agent; };
+  };
+
+  meta = {
+    description = "Agent that provides data to LibreNMS";
+    homepage = "https://github.com/librenms/librenms-agent";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.Nebucatnetzer ];
+    platforms = lib.platforms.linux;
+    mainProgram = "check_mk_agent";
+  };
+}

--- a/pkgs/by-name/li/librenms-agent/package.nix
+++ b/pkgs/by-name/li/librenms-agent/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  nixosTests,
   testers,
   librenms-agent,
 }:
@@ -27,6 +28,7 @@ stdenv.mkDerivation {
   '';
 
   passthru.tests = {
+    nixos = nixosTests.librenms-agent;
     version = testers.testVersion { package = librenms-agent; };
   };
 


### PR DESCRIPTION
pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/271427
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
