### PR TITLE
dbeaver-bin: remove bundled jre on darwin

### DIFF
--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -55,18 +55,29 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontConfigure = true;
   dontBuild = true;
 
-  prePatch = ''
-    substituteInPlace ${lib.optionalString stdenvNoCC.hostPlatform.isDarwin "Contents/Eclipse/"}dbeaver.ini \
-      --replace-fail '-Xmx1024m' '-Xmx${override_xmx}'
-  '';
+  prePatch =
+    ''
+      substituteInPlace ${lib.optionalString stdenvNoCC.hostPlatform.isDarwin "Contents/Eclipse/"}dbeaver.ini \
+        --replace-fail '-Xmx1024m' '-Xmx${override_xmx}'
+    ''
+    # remove the bundled JRE configuration on Darwin
+    # dont use substituteInPlace here because it would match "-vmargs"
+    + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+      sed -i -e '/^-vm$/ { N; d; }' Contents/Eclipse/dbeaver.ini
+    '';
 
-  preInstall = ''
-    # most directories are for different architectures, only keep what we need
-    shopt -s extglob
-    pushd ${lib.optionalString stdenvNoCC.hostPlatform.isDarwin "Contents/Eclipse/"}plugins/com.sun.jna_*/com/sun/jna/
-    rm -r !(ptr|internal|linux-x86-64|linux-aarch64|darwin-x86-64|darwin-aarch64)/
-    popd
-  '';
+  preInstall =
+    ''
+      # most directories are for different architectures, only keep what we need
+      shopt -s extglob
+      pushd ${lib.optionalString stdenvNoCC.hostPlatform.isDarwin "Contents/Eclipse/"}plugins/com.sun.jna_*/com/sun/jna/
+      rm -r !(ptr|internal|linux-x86-64|linux-aarch64|darwin-x86-64|darwin-aarch64)/
+      popd
+    ''
+    # remove the bundled JRE on Darwin
+    + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+      rm -r Contents/Eclipse/jre/
+    '';
 
   installPhase =
     if !stdenvNoCC.hostPlatform.isDarwin then


### PR DESCRIPTION
Remove the bundled JRE environment on darwin.

Closure size: 160854960 (~153MB) -> 100268000 (~95MB)

<img width="440" alt="image" src="https://github.com/user-attachments/assets/5eae79c3-8715-44fa-87e3-a022aacb0cd2" />


<details>
<summary>startup log</summary>

```console
› ./result/bin/dbeaver
WARNING: Using incubator modules: jdk.incubator.vector
> Start DBeaver Application Standalone [org.jkiss.dbeaver.ui.app.standalone 25.1.1.202506221557]
> Start Eclipse Jobs Mechanism [org.eclipse.core.jobs 3.15.600.v20250513-1234]
> Start Eclipse IDE UI Application [org.eclipse.ui.ide.application 1.5.700.v20250514-1719]
> Start DBeaver Command Line Model [org.jkiss.dbeaver.model.cli 1.0.2.202506221557]
> Start Eclipse IDE UI [org.eclipse.ui.ide 3.22.600.v20250523-1502]
> Start DBeaver Model Registry [org.jkiss.dbeaver.registry 1.0.151.202506221557]
> Start jna [com.sun.jna 5.17.0.v20250316-1700]
> Start DBeaver UI Editors - Base [org.jkiss.dbeaver.ui.editors.base 1.0.157.202506221557]
> Start DBeaver UI [org.jkiss.dbeaver.ui 5.1.172.202506221557]
> Start Expression Language [org.eclipse.core.expressions 3.9.400.v20240413-1529]
> Start DBeaver Usage Statistics [org.jkiss.dbeaver.ui.statistics 1.0.53.202506221557]
> Start DBeaver UI Editors - Connections [org.jkiss.dbeaver.ui.editors.connection 1.0.148.202506221557]
> Start DBeaver Desktop Application Core [org.jkiss.dbeaver.core 25.1.1.202506221557]
2025-06-30 21:52:19.360 - DBeaver 25.1.1.202506221557 is starting
2025-06-30 21:52:19.360 - OS: Mac OS X 15.4.1 (aarch64)
2025-06-30 21:52:19.360 - Java version: 21.0.4 by Azul Systems, Inc. (64bit)
2025-06-30 21:52:19.360 - Install path: '/nix/store/gwfhvnrg13h5snxb8zsj0n3gbynsi6kl-dbeaver-bin-25.1.1/Applications/dbeaver.app/Contents/Eclipse'
2025-06-30 21:52:19.361 - Instance path: 'file:/Users/yzx9/Library/DBeaverData/workspace6/'
2025-06-30 21:52:19.361 - Memory available 66Mb/1024Mb
2025-06-30 21:52:19.367 - Create display
2025-06-30 21:52:19.533 - Initialize desktop platform...
2025-06-30 21:52:19.599 - BounceCastle bundle found. Use JCE provider BC
```
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
