### PR TITLE
monero: allow pruning with option

### DIFF
--- a/nixos/modules/services/networking/monero.nix
+++ b/nixos/modules/services/networking/monero.nix
@@ -45,6 +45,11 @@ let
       ${listToConf "add-priority-node" priorityNodes}
       ${listToConf "add-exclusive-node" exclusiveNodes}
 
+      ${lib.optionalString prune ''
+        prune-blockchain=1
+        sync-pruned-blocks=1
+      ''}
+
       ${extraConfig}
     '';
 
@@ -209,6 +214,15 @@ in
         description = ''
           List of peer IP addresses to connect to *only*.
           If given the other peer options will be ignored.
+        '';
+      };
+
+      prune = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to prune the blockchain.
+          https://www.getmonero.org/resources/moneropedia/pruning.html
         '';
       };
 


### PR DESCRIPTION
Adds an option to monerod to allow for pruning for faster initial syncs but less contribution to the blockchain.

https://www.getmonero.org/resources/moneropedia/pruning.html
https://docs.getmonero.org/interacting/monero-config-file/#monerodconf