### PR TITLE
aclpubcheck: init at 0.2.0-unstable-2025-05-16

### DIFF
--- a/pkgs/by-name/ac/aclpubcheck/package.nix
+++ b/pkgs/by-name/ac/aclpubcheck/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  callPackage,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "aclpubcheck";
+  version = "0.2.0-unstable-2025-05-16";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "acl-org";
+    repo = "aclpubcheck";
+    rev = "a340fc0a1a7d1c9808f08ab1dab1d228f63af405"; # No Git Tags
+    hash = "sha256-yj+EX+oL2WgsPJePrJQgRAIYWPEodDmG+GDG0K2gjhs=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    tqdm
+    termcolor
+    pandas
+    pdfplumber
+    rebiber
+    pybtex
+    pylatexenc
+    unidecode
+    tsv
+  ];
+
+  passthru.tests = {
+    example-pdf = callPackage ./test { };
+  };
+
+  strictDeps = true;
+
+  meta = {
+    description = "Tool for checking ACL paper submissions";
+    homepage = "https://github.com/acl-org/aclpubcheck";
+    license = with lib.licenses; [ mit ];
+    mainProgram = "aclpubcheck";
+    maintainers = with lib.maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/by-name/ac/aclpubcheck/test/default.nix
+++ b/pkgs/by-name/ac/aclpubcheck/test/default.nix
@@ -1,0 +1,29 @@
+{
+  runCommand,
+  aclpubcheck,
+}:
+runCommand "aclpubcheck-test-example-pdf" { nativeBuildInputs = [ aclpubcheck ]; } ''
+  # aclpubcheck prints out the path that was passed to it, which may change over time if it is a Nix store path.
+  # Since we're comparing the output of aclpubcheck, this would break the test.
+  # To avoid this, pass aclpubcheck a relative path to a symlink in the current working directory instead of the absolute path.
+  # Simply using `cd` to change directories into the example directory does not work,
+  # since aclpubcheck wants to write some files to the current working directory.
+  ln -s '${aclpubcheck.src}/example/2023.acl-tutorials.1.pdf' 2023.acl-tutorials.1.pdf
+
+  aclpubcheck --paper_type long 2023.acl-tutorials.1.pdf > actual-output.txt
+
+  exit_code="$?"
+  if [ "$exit_code" != 0 ]; then
+    echo "Exit code of aclpubcheck was $exit_code while 0 was expected."
+    exit 1
+  fi
+
+  if ! diff '${./expected-output.txt}' actual-output.txt; then
+    echo
+    echo "ERROR: The output was different than expected!"
+    echo "The diff is above."
+    exit 1
+  fi
+
+  touch "$out"
+''

--- a/pkgs/by-name/ac/aclpubcheck/test/expected-output.txt
+++ b/pkgs/by-name/ac/aclpubcheck/test/expected-output.txt
@@ -1,0 +1,28 @@
+Checking 2023.acl-tutorials.1.pdf
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Found text violation:	Margin.BOTTOM	{'top': 780, 'bottom': 841}
+Errors. Check errors-2023.acl-tutorials.1.json for details.
+Error (Margin): Text on page 1 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+Error (Margin): Text on page 2 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+Error (Margin): Text on page 3 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+Error (Margin): Text on page 4 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+Error (Margin): Text on page 5 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+Error (Margin): Text on page 6 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+Error (Margin): Text on page 7 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+Error (Margin): Text on page 8 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+Error (Margin): Text on page 9 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+Error (Margin): Text on page 10 bleeds into the bottom margin. It should be empty (e.g., without page number) and populated when building the proceedings.
+
+We detected 10 errors and 0 warnings in your paper.
+In general, it is required that you fix errors for your paper to be published. Fixing warnings is optional, but recommended.
+Important: Some of the margin errors may be spurious. The library detects the location of images, but not whether they have a white background that blends in.
+Important: Some of the warnings generated for citations may be spurious and inaccurate, due to parsing and indexing errors.
+We encourage you to double check the citations and update them depending on the latest source. If you believe that your citation is updated and correct, then please ignore those warnings.

--- a/pkgs/development/python-modules/rebiber/default.nix
+++ b/pkgs/development/python-modules/rebiber/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  bibtexparser,
+  tqdm,
+}:
+
+buildPythonPackage {
+  pname = "rebiber";
+  version = "1.1.3-unstable-2025-05-22";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "yuchenlin";
+    repo = "rebiber";
+    rev = "f5e7a2b4b4bac7c8b111c1b75080c1bcb5c8b08d";
+    hash = "sha256-SzVyY9L/tFImJP0GOVMNcvlccyyQvL4UURoqwpT0qL0=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    bibtexparser
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "rebiber" ];
+
+  meta = {
+    description = "Simple tool to update bib entries with their official information (e.g., DBLP or the ACL anthology)";
+    homepage = "https://github.com/yuchenlin/rebiber";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/development/python-modules/tsv/default.nix
+++ b/pkgs/development/python-modules/tsv/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage {
+  pname = "tsv";
+  version = "1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adamnovak";
+    repo = "tsv";
+    rev = "379189e9da4c1b65d0587bb32f3b51e6a7c936c8"; # No Git Tags
+    hash = "sha256-Axs597Ir7h4mB07Vfy3Xiqwag2rimqBAnodPrO1Lxa4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "tsv" ];
+
+  meta = {
+    description = "Tab-Separated Value IO Library";
+    homepage = "https://github.com/adamnovak/tsv";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18648,6 +18648,8 @@ self: super: with self; {
 
   tsplib95 = callPackage ../development/python-modules/tsplib95 { };
 
+  tsv = callPackage ../development/python-modules/tsv { };
+
   ttach = callPackage ../development/python-modules/ttach { };
 
   ttfautohint-py = callPackage ../development/python-modules/ttfautohint-py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15628,6 +15628,8 @@ self: super: with self; {
 
   realtime = callPackage ../development/python-modules/realtime { };
 
+  rebiber = callPackage ../development/python-modules/rebiber { };
+
   rebulk = callPackage ../development/python-modules/rebulk { };
 
   recipe-scrapers = callPackage ../development/python-modules/recipe-scrapers { };


### PR DESCRIPTION
Add https://github.com/acl-org/aclpubcheck, a program to check scientific papers before submitting them to an ACL conference.
Also package two dependencies.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
