### PR TITLE
python3Packages.{plotly,chart-studio}: fixes

### DIFF
--- a/pkgs/development/python-modules/chart-studio/default.nix
+++ b/pkgs/development/python-modules/chart-studio/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage {
     description = "Utilities for interfacing with Plotly's Chart Studio service";
     homepage = "https://github.com/plotly/chart-studio";
     license = with lib.licenses; [ mit ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ sarahec ];
   };
 }

--- a/pkgs/development/python-modules/chart-studio/default.nix
+++ b/pkgs/development/python-modules/chart-studio/default.nix
@@ -10,21 +10,17 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "chart-studio";
-  version = "1.1.0-unstable-2024-07-23";
+  version = "1.1.0-unstable-2025-01-30";
   pyproject = true;
 
-  # chart-studio was split from plotly
   src = fetchFromGitHub {
     owner = "plotly";
-    repo = "plotly.py";
-    # We use plotly's upstream version as it's the same repo, but chart studio has its own version number.
-    rev = "v5.23.0";
-    hash = "sha256-K1hEs00AGBCe2fgytyPNWqE5M0jU5ESTzynP55kc05Y=";
+    repo = "chart-studio";
+    rev = "44c7c43be0fe7e031ec281c86ee7dae0efa0619e";
+    hash = "sha256-RekcZzUcunIqXOSriW+RvpLdvATQWTeRAiR8LFodfQg=";
   };
-
-  sourceRoot = "${src.name}/packages/python/chart-studio";
 
   build-system = [ setuptools ];
 
@@ -36,6 +32,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     mock
+    plotly
     pytestCheckHook
   ];
 
@@ -46,12 +43,11 @@ buildPythonPackage rec {
   # most tests talk to a network service, so only run ones that don't do that.
   pytestFlagsArray = [
     "chart_studio/tests/test_core"
-    "chart_studio/tests/test_plot_ly/test_api"
   ];
 
   meta = {
     description = "Utilities for interfacing with Plotly's Chart Studio service";
-    homepage = "https://github.com/plotly/plotly.py/tree/master/packages/python/chart-studio";
+    homepage = "https://github.com/plotly/chart-studio";
     license = with lib.licenses; [ mit ];
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -38,14 +38,14 @@
 
 buildPythonPackage rec {
   pname = "plotly";
-  version = "6.1.2";
+  version = "6.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "plotly";
     repo = "plotly.py";
     tag = "v${version}";
-    hash = "sha256-+vIq//pDLaaTmRGW+oytho3TfMmLCtuIoHeFenLVcek=";
+    hash = "sha256-Vfj5jG0AkBjivExOx7oMoocTopWl0yMc1INpEbtlgTc=";
   };
 
   postPatch = ''
@@ -105,27 +105,34 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    # fails to launch kaleido subprocess
-    "tests/test_optional/test_kaleido"
-    # numpy2 related error, RecursionError
-    # See: https://github.com/plotly/plotly.py/issues/4852
-    "tests/test_plotly_utils/validators/test_angle_validator.py"
-    "tests/test_plotly_utils/validators/test_any_validator.py"
-    "tests/test_plotly_utils/validators/test_color_validator.py"
-    "tests/test_plotly_utils/validators/test_colorlist_validator.py"
-    "tests/test_plotly_utils/validators/test_colorscale_validator.py"
-    "tests/test_plotly_utils/validators/test_dataarray_validator.py"
-    "tests/test_plotly_utils/validators/test_enumerated_validator.py"
-    "tests/test_plotly_utils/validators/test_fig_deepcopy.py"
-    "tests/test_plotly_utils/validators/test_flaglist_validator.py"
-    "tests/test_plotly_utils/validators/test_infoarray_validator.py"
-    "tests/test_plotly_utils/validators/test_integer_validator.py"
-    "tests/test_plotly_utils/validators/test_number_validator.py"
-    "tests/test_plotly_utils/validators/test_pandas_series_input.py"
-    "tests/test_plotly_utils/validators/test_string_validator.py"
-    "tests/test_plotly_utils/validators/test_xarray_input.py"
-  ];
+  disabledTestPaths =
+    [
+      # Broken imports
+      "plotly/matplotlylib/mplexporter/tests"
+      # Fails to catch error when serializing document
+      "tests/test_optional/test_kaleido/test_kaleido.py::test_defaults"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # fails to launch kaleido subprocess
+      "tests/test_optional/test_kaleido"
+      # numpy2 related error, RecursionError
+      # See: https://github.com/plotly/plotly.py/issues/4852
+      "tests/test_plotly_utils/validators/test_angle_validator.py"
+      "tests/test_plotly_utils/validators/test_any_validator.py"
+      "tests/test_plotly_utils/validators/test_color_validator.py"
+      "tests/test_plotly_utils/validators/test_colorlist_validator.py"
+      "tests/test_plotly_utils/validators/test_colorscale_validator.py"
+      "tests/test_plotly_utils/validators/test_dataarray_validator.py"
+      "tests/test_plotly_utils/validators/test_enumerated_validator.py"
+      "tests/test_plotly_utils/validators/test_fig_deepcopy.py"
+      "tests/test_plotly_utils/validators/test_flaglist_validator.py"
+      "tests/test_plotly_utils/validators/test_infoarray_validator.py"
+      "tests/test_plotly_utils/validators/test_integer_validator.py"
+      "tests/test_plotly_utils/validators/test_number_validator.py"
+      "tests/test_plotly_utils/validators/test_pandas_series_input.py"
+      "tests/test_plotly_utils/validators/test_string_validator.py"
+      "tests/test_plotly_utils/validators/test_xarray_input.py"
+    ];
 
   pythonImportsCheck = [ "plotly" ];
 

--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -142,6 +142,9 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/plotly/plotly.py";
     changelog = "https://github.com/plotly/plotly.py/blob/master/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pandapip1 ];
+    maintainers = with lib.maintainers; [
+      pandapip1
+      sarahec
+    ];
   };
 }


### PR DESCRIPTION
Plotly: version bump; add maintainer
chart-studio: point to its new repo, version bump, disabled new tests that require local server. Add maintainer.

Part of fixing`nixpkgs-review` for #409698 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
