### PR TITLE
python3Packages.ruamel-yaml: some improvements

### DIFF
--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -41,13 +41,6 @@ let
           ];
           postPatch = null;
         });
-        ruamel-yaml = prev.ruamel-yaml.overridePythonAttrs (prev: rec {
-          version = "0.17.21";
-          src = prev.src.override {
-            inherit version;
-            hash = "sha256-i3zml6LyEnUqNcGsQURx3BbEJMlXO+SSa1b/P10jt68=";
-          };
-        });
         urllib3 = prev.urllib3.overridePythonAttrs (prev: rec {
           version = "1.26.18";
           build-system = with final; [
@@ -109,7 +102,7 @@ py.pkgs.buildPythonApplication rec {
     jmespath
     prompt-toolkit
     python-dateutil
-    ruamel-yaml
+    ruamel-yaml_0_17_21
     urllib3
   ];
 

--- a/pkgs/by-name/fd/fdroidserver/package.nix
+++ b/pkgs/by-name/fd/fdroidserver/package.nix
@@ -75,13 +75,7 @@ python3Packages.buildPythonApplication rec {
     pyyaml
     qrcode
     requests
-    (ruamel-yaml.overrideAttrs (old: {
-      src = fetchPypi {
-        pname = "ruamel.yaml";
-        version = "0.17.21";
-        hash = "sha256-i3zml6LyEnUqNcGsQURx3BbEJMlXO+SSa1b/P10jt68=";
-      };
-    }))
+    ruamel-yaml_0_17_21
     sdkmanager
     yamllint
   ];

--- a/pkgs/by-name/ya/yamlpath/package.nix
+++ b/pkgs/by-name/ya/yamlpath/package.nix
@@ -19,7 +19,7 @@ python3.pkgs.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3.pkgs; [
     python-dateutil
-    ruamel-yaml
+    ruamel-yaml_0_17_21
   ];
 
   nativeCheckInputs = with python3.pkgs; [
@@ -47,9 +47,5 @@ python3.pkgs.buildPythonApplication rec {
     '';
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ Flakebi ];
-
-    # No support for ruamel.yaml > 0.17.21
-    # https://github.com/wwkimball/yamlpath/issues/217
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/ruamel-yaml/automagic-detect.patch
+++ b/pkgs/development/python-modules/ruamel-yaml/automagic-detect.patch
@@ -1,0 +1,89 @@
+From c870efed8a11b744429ae26b3c9f2dd3976e4906 Mon Sep 17 00:00:00 2001
+From: Gavin John <gavinnjohn@gmail.com>
+Date: Mon, 30 Jun 2025 13:36:05 -0400
+Subject: [PATCH] Automagic plugin detection with sys.path
+
+---
+ main.py | 48 +++++++++++++++++++++++++++++-------------------
+ 1 file changed, 29 insertions(+), 19 deletions(-)
+
+diff --git a/main.py b/main.py
+index 06f1a17..38e8e59 100644
+--- a/main.py
++++ b/main.py
+@@ -5,6 +5,7 @@
+ import os
+ import warnings
+ import glob
++import importlib.util
+ from importlib import import_module
+ 
+ 
+@@ -38,7 +39,7 @@
+ if False:  # MYPY
+     from typing import List, Set, Dict, Tuple, Union, Any, Callable, Optional, Text, Type  # NOQA
+     from ruamel.yaml.compat import StreamType, StreamTextType, VersionType  # NOQA
+-    from types import TracebackType
++    from types import TracebackType, ModuleType
+     from pathlib import Path
+ 
+ try:
+@@ -81,10 +82,11 @@ def __init__(
+         self._output = output
+         self._context_manager: Any = None
+ 
+-        self.plug_ins: List[Any] = []
+-        for pu in ([] if plug_ins is None else plug_ins) + self.official_plug_ins():
+-            file_name = pu.replace(os.sep, '.')
+-            self.plug_ins.append(import_module(file_name))
++        self.plug_ins: List[Any] = self.find_plug_ins()
++        if plug_ins is not None:
++            for pu in plug_ins:
++                file_name = pu.replace(os.sep, '.')
++                self.plug_ins.append(import_module(file_name))
+         self.Resolver: Any = ruamel.yaml.resolver.VersionedResolver
+         self.allow_unicode = True
+         self.Reader: Any = None
+@@ -758,20 +760,28 @@ def seq(self, *args: Any) -> Any:
+             return list(*args)
+ 
+     # helpers
+-    def official_plug_ins(self) -> Any:
+-        """search for list of subdirs that are plug-ins, if __file__ is not available, e.g.
+-        single file installers that are not properly emulating a file-system (issue 324)
+-        no plug-ins will be found. If any are packaged, you know which file that are
+-        and you can explicitly provide it during instantiation:
+-            yaml = ruamel.yaml.YAML(plug_ins=['ruamel/yaml/jinja2/__plug_in__'])
+-        """
+-        try:
+-            bd = os.path.dirname(__file__)
+-        except NameError:
+-            return []
+-        gpbd = os.path.dirname(os.path.dirname(bd))
+-        res = [x.replace(gpbd, "")[1:-3] for x in glob.glob(bd + '/*/__plug_in__.py')]
+-        return res
++    def find_plug_ins(self) -> list[ModuleType]:
++        """search for list of subdirs that are plug-ins, using sys.path"""
++        plugins: list[ModuleType] = []
++        for base in sys.path:
++            yaml_dir = os.path.join(base, "ruamel", "yaml")
++            if not os.path.isdir(yaml_dir):
++                continue
++            for name in os.listdir(yaml_dir):
++                plugin_path = os.path.join(yaml_dir, name, "__plug_in__.py")
++                if not os.path.isfile(plugin_path):
++                    continue
++                spec = importlib.util.spec_from_file_location(
++                    name = f"ruamel.yaml.{name}.__plug_in__",
++                    location = plugin_path,
++                    submodule_search_locations = [ os.path.dirname(plugin_path) ]
++                )
++                if spec and spec.loader:
++                    mod = importlib.util.module_from_spec(spec)
++                    spec.loader.exec_module(mod)
++                    plugins.append(mod)
++    
++        return plugins
+ 
+     def register_class(self, cls: Any) -> Any:
+         """

--- a/pkgs/development/python-modules/ruamel-yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel-yaml/default.nix
@@ -5,6 +5,7 @@
   setuptools,
   ruamel-base,
   ruamel-yaml-clib,
+  nix-update-script,
   isPyPy,
 }:
 
@@ -35,6 +36,8 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonImportsCheck = [ "ruamel.yaml" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";

--- a/pkgs/development/python-modules/ruamel-yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel-yaml/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchhg,
   setuptools,
   ruamel-base,
   ruamel-yaml-clib,
@@ -13,10 +13,11 @@ buildPythonPackage rec {
   version = "0.18.10";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "ruamel.yaml";
-    inherit version;
-    hash = "sha256-IMhqsprCFT+ApCjhJUqK32htM4PfBEkFFMo7eaNi21g=";
+  src = fetchhg {
+    url = "http://hg.code.sf.net/p/ruamel-yaml/code";
+    # tag = version;
+    rev = version;
+    hash = "sha256-bO+UMnIKZHz1+cPrrnhyzowUCLFsWV/OHaGmfipYt7c=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/ruamel-yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel-yaml/default.nix
@@ -35,11 +35,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ruamel.yaml" ];
 
-  meta = with lib; {
+  meta = {
     description = "YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order";
     homepage = "https://sourceforge.net/projects/ruamel-yaml/";
     changelog = "https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree/CHANGES";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ruamel-yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel-yaml/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "ruamel-yaml";
-  version = "0.18.10";
+  version = "0.18.14";
   pyproject = true;
 
   src = fetchhg {
     url = "http://hg.code.sf.net/p/ruamel-yaml/code";
     # tag = version;
     rev = version;
-    hash = "sha256-bO+UMnIKZHz1+cPrrnhyzowUCLFsWV/OHaGmfipYt7c=";
+    hash = "sha256-HDkPPp1xI3uoGYlS9mwPp1ZjG2gKvx6vog0Blj6tBuI=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/ruamel-yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel-yaml/default.nix
@@ -19,12 +19,19 @@ buildPythonPackage rec {
     hash = "sha256-IMhqsprCFT+ApCjhJUqK32htM4PfBEkFFMo7eaNi21g=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  patches = [
+    # TODO: Upstream
+    ./automagic-detect.patch
+  ];
+
+  build-system = [ setuptools ];
+  dependencies = [
+    setuptools # pkg_resources
+    ruamel-base
+  ] ++ lib.optionals (!isPyPy) [ ruamel-yaml-clib ];
 
   # Tests use relative paths
   doCheck = false;
-
-  propagatedBuildInputs = [ ruamel-base ] ++ lib.optional (!isPyPy) ruamel-yaml-clib;
 
   pythonImportsCheck = [ "ruamel.yaml" ];
 

--- a/pkgs/development/python-modules/ruamel-yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel-yaml/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     homepage = "https://sourceforge.net/projects/ruamel-yaml/";
     changelog = "https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree/CHANGES";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pandapip1 ];
   };
 }

--- a/pkgs/development/python-modules/ruamel-yaml/default.nix
+++ b/pkgs/development/python-modules/ruamel-yaml/default.nix
@@ -16,7 +16,6 @@ buildPythonPackage rec {
 
   src = fetchhg {
     url = "http://hg.code.sf.net/p/ruamel-yaml/code";
-    # tag = version;
     rev = version;
     hash = "sha256-HDkPPp1xI3uoGYlS9mwPp1ZjG2gKvx6vog0Blj6tBuI=";
   };

--- a/pkgs/development/python-modules/ruamel-yaml/version_0_17_21.nix
+++ b/pkgs/development/python-modules/ruamel-yaml/version_0_17_21.nix
@@ -1,0 +1,14 @@
+{
+  ruamel-yaml,
+}:
+
+ruamel-yaml.overrideAttrs (prev: rec {
+  version = "0.17.21";
+
+  patches = [ ];
+
+  src = prev.src.overrideAttrs {
+    rev = version;
+    hash = "sha256-6PV0NyPQfd+4RBqoj5vJaOHShx+TJVHD2IamRinU0VU=";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15806,6 +15806,10 @@ self: super: with self; {
 
   ruamel-yaml-string = callPackage ../development/python-modules/ruamel-yaml-string { };
 
+  # There's a breaking change between 0.17.21 and 0.17.22
+  # Yes, really.
+  ruamel-yaml_0_17_21 = callPackage ../development/python-modules/ruamel-yaml/version_0_17_21.nix { };
+
   rubicon-objc = callPackage ../development/python-modules/rubicon-objc { };
 
   rubymarshal = callPackage ../development/python-modules/rubymarshal { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Split off from https://github.com/NixOS/nixpkgs/pull/421301 after it became clear that ruamel-yaml, while not requiring world to be rebuilt, causes a significant (>5000) amount of rebuilds. The main fix, https://github.com/NixOS/nixpkgs/pull/421301/commits/58bf870cbfef09c6fde1714bb1a4234af9680c0c, is present in both.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
