### PR TITLE
zulu24: 24.0.0 -> 24.0.1

### DIFF
--- a/pkgs/development/compilers/zulu/24.nix
+++ b/pkgs/development/compilers/zulu/24.nix
@@ -5,8 +5,8 @@
 }@args:
 
 let
-  # For 24 JDK FX is newer than regular JDK?
-  zuluVersion = if enableJavaFX then "24.28.85" else "24.28.83";
+  # For 24 JDK FX is newer than regular JDK
+  zuluVersion = if enableJavaFX then "24.30.13" else "24.30.11";
 in
 callPackage ./common.nix (
   {
@@ -15,42 +15,42 @@ callPackage ./common.nix (
     dists = {
       x86_64-linux = {
         inherit zuluVersion;
-        jdkVersion = "24.0.0";
+        jdkVersion = "24.0.1";
         hash =
           if enableJavaFX then
-            "sha256-y8jiE5yECh96pHYZFM0Q/JTiVcm5a0PONYJDLYydCT0="
+            "sha256-jbpWNE+X5GJABQERq126ediyzGRQE9NZy9oMW/sPUa0="
           else
-            "sha256-Kf6gF8A8ZFIhujEgjlENeuSPVzW6QWnVZcRst35/ZvI=";
+            "sha256-EvaVfDoqdNNtaSz+467rlJ8VtdgNrQi/DT7ZMNZthlk=";
       };
 
       aarch64-linux = {
         inherit zuluVersion;
-        jdkVersion = "24.0.0";
+        jdkVersion = "24.0.1";
         hash =
           if enableJavaFX then
-            "sha256-H6YD8uhk9rTpd+3/S1+7QVzpCi6jykWKyu7RPxMx/sI="
+            "sha256-N9VOweloyX/2bFPH3L+Iw7nTkbiE7LvDNnTNM1b8Ghc="
           else
-            "sha256-6J7szd/ax9xCMNA9efw9Bhgv/VwQFXz5glWIoj+UYIc=";
+            "sha256-4R5K5XTgpR9kq9WWE3SgvqVTq8CFvyb943zAiSsq3k0=";
       };
 
       x86_64-darwin = {
         inherit zuluVersion;
-        jdkVersion = "24.0.0";
+        jdkVersion = "24.0.1";
         hash =
           if enableJavaFX then
-            "sha256-lMdbPkUdXyNcye8uMxGIhZTErrTI0P0SnqMS+8+Rjqg="
+            "sha256-c6Gwj8ol2YLfo4sMeCMGfYQvtDz7029L0Yj1dqVQvsw="
           else
-            "sha256-e7KJtJ9+mFFSdKCj68thfTXguWH5zXaSSb9phzXf/lQ=";
+            "sha256-VhGOiZaspXeVVLEp0MJZXxj/+ovGgmy+gRb2BZ9OuhY=";
       };
 
       aarch64-darwin = {
         inherit zuluVersion;
-        jdkVersion = "24.0.0";
+        jdkVersion = "24.0.1";
         hash =
           if enableJavaFX then
-            "sha256-oR2x0vphBGgh3KkEkLAcmtIMNONny9/b32z9jLR98X0="
+            "sha256-Sac+DxNyGqsiStpc/wZYd2K7rvPEjo901kOYERYi+Sw="
           else
-            "sha256-7yXLOJCK0RZ8V1vsexOGxGR9NAwi/pCl95BlO8E8nGU=";
+            "sha256-pJsq2gKcTy44zbFbSAj6Kd5VZi095jKGkZqd8ceIz7E=";
       };
     };
   }


### PR DESCRIPTION
Update zulu24 to 24.0.1, currently the latest version seen using the API at: https://api.azul.com/metadata/v1/zulu/packages

This should resolve Issue #420014

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
