### PR TITLE
super-productivity: 13.0.10 -> 14.0.5

### DIFF
--- a/pkgs/by-name/su/super-productivity/package.nix
+++ b/pkgs/by-name/su/super-productivity/package.nix
@@ -7,25 +7,66 @@
   makeDesktopItem,
   nix-update-script,
   npm-lockfile-fix,
+  prefetch-npm-deps,
+  rsync,
   stdenv,
 }:
 
 buildNpmPackage rec {
   pname = "super-productivity";
-  version = "13.0.10";
+  version = "14.0.5";
 
   src = fetchFromGitHub {
     owner = "johannesjo";
     repo = "super-productivity";
     tag = "v${version}";
-    hash = "sha256-2K/6T4f9tLlrKimT/DPSdoz8LHij5nsaF6BWSQf6u7U=";
+    hash = "sha256-VoE86uBl6DM6aXz7MLYekEzfixVSLjLL3yYgc2vBhp0=";
 
     postFetch = ''
-      ${lib.getExe npm-lockfile-fix} -r $out/package-lock.json
+      find $out -name package-lock.json -exec ${lib.getExe npm-lockfile-fix} -r {} \;
     '';
   };
 
-  npmDepsHash = "sha256-l9P11ZvLYiTu/cVPQIw391ZTJ0K+cNPUzoVMsdze2uo=";
+  # Use custom fetcher for deps because super-productivity uses multiple
+  # package-lock.json files to manage plugins.  It checks all lock
+  # files and produces a merged output.  This should still be compatible
+  # with nix-update.
+  npmDeps = stdenv.mkDerivation (
+    lib.fetchers.normalizeHash { } {
+      pname = "super-productivity-deps";
+      inherit version src;
+
+      nativeBuildInputs = [
+        prefetch-npm-deps
+        rsync
+      ];
+
+      # Some lockfiles do not include any dependencies to install so
+      # prefertch-npm-deps produces an error.  Those can be ignored with
+      # this flag.
+      env.FORCE_EMPTY_CACHE = true;
+
+      buildPhase = ''
+        mkdir -p $out
+        find -name package-lock.json | while read -r lockfile; do
+          prefetch-npm-deps $lockfile /tmp/cache
+          # Merge output
+          rsync -a /tmp/cache/ $out
+          rm -rf /tmp/cache
+        done
+        # Ensure that the root package-lock.json is placed in the output.
+        # This means only the root lockfile is checked for consistancy,
+        # but that should not be an issue.
+        cp package-lock.json $out
+      '';
+
+      dontInstall = true;
+
+      outputHashMode = "recursive";
+      hash = "sha256-Jj7ulTjC19Q9PmOeVui/FAyfpsSviGLHiiz8gwsLXAg=";
+    }
+  );
+
   makeCacheWritable = true;
 
   env = {
@@ -64,13 +105,13 @@ buildNpmPackage rec {
       if stdenv.hostPlatform.isDarwin then
         ''
           mkdir -p $out/Applications
-          cp -r "app-builds/mac"*"/Super Productivity.app" "$out/Applications"
+          cp -r ".tmp/app-builds/mac"*"/Super Productivity.app" "$out/Applications"
           makeWrapper "$out/Applications/Super Productivity.app/Contents/MacOS/Super Productivity" "$out/bin/super-productivity"
         ''
       else
         ''
           mkdir -p $out/share/{super-productivity,icons/hicolor/scalable/apps}
-          cp -r app-builds/*-unpacked/resources/app.asar $out/share/super-productivity
+          cp -r .tmp/app-builds/*-unpacked/resources/app.asar $out/share/super-productivity
           cp electron/assets/icons/ico-circled.svg $out/share/icons/hicolor/scalable/apps/super-productivity.svg
 
           makeWrapper '${lib.getExe electron}' "$out/bin/super-productivity" \


### PR DESCRIPTION
Updates Super Productivity.
I had to write a custom fetcher for npmDeps, because the update introduced multiple package-lock.json files for plugins. The custom fetcher merges all the dependencies.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
