### PR TITLE
yt-dlp: use fetchFromGitHub, use `nix-update-script`, generate manpages with pandoc

### DIFF
--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -5,6 +5,8 @@
   ffmpeg-headless,
   rtmpdump,
   atomicparsley,
+  pandoc,
+  installShellFiles,
   atomicparsleySupport ? true,
   ffmpegSupport ? true,
   rtmpSupport ? true,
@@ -27,8 +29,11 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-dwBe6oXh7G67kfiI6BqiC0ZHzleR7QlfMiTVXWYW85I=";
   };
 
-  build-system = with python3Packages; [
-    hatchling
+  build-system = with python3Packages; [ hatchling ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    pandoc
   ];
 
   # expose optional-dependencies, but provide all features
@@ -53,6 +58,21 @@ python3Packages.buildPythonApplication rec {
 
   pythonRelaxDeps = [ "websockets" ];
 
+  preBuild = ''
+    python devscripts/make_lazy_extractors.py
+  '';
+
+  postBuild = ''
+    python devscripts/prepare_manpage.py yt-dlp.1.temp.md
+    pandoc -s -f markdown-smart -t man yt-dlp.1.temp.md -o yt-dlp.1
+    rm yt-dlp.1.temp.md
+
+    mkdir -p completions/{bash,fish,zsh}
+    python devscripts/bash-completion.py completions/bash/yt-dlp
+    python devscripts/zsh-completion.py completions/zsh/_yt-dlp
+    python devscripts/fish-completion.py completions/fish/yt-dlp.fish
+  '';
+
   # Ensure these utilities are available in $PATH:
   # - ffmpeg: post-processing & transcoding support
   # - rtmpdump: download files over RTMP
@@ -69,16 +89,23 @@ python3Packages.buildPythonApplication rec {
       ''--prefix PATH : "${lib.makeBinPath packagesToBinPath}"''
     ];
 
-  setupPyBuildFlags = [
-    "build_lazy_extractors"
-  ];
-
   # Requires network
   doCheck = false;
 
-  postInstall = lib.optionalString withAlias ''
-    ln -s "$out/bin/yt-dlp" "$out/bin/youtube-dl"
-  '';
+  postInstall =
+    ''
+      installManPage yt-dlp.1
+
+      installShellCompletion \
+        --bash completions/bash/yt-dlp \
+        --fish completions/fish/yt-dlp.fish \
+        --zsh completions/zsh/_yt-dlp
+
+      install -Dm644 Changelog.md README.md -t "$out/share/doc/yt_dlp"
+    ''
+    + lib.optionalString withAlias ''
+      ln -s "$out/bin/yt-dlp" "$out/bin/youtube-dl"
+    '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
   ffmpeg-headless,
   rtmpdump,
   atomicparsley,
@@ -17,13 +17,14 @@ python3Packages.buildPythonApplication rec {
   # The websites yt-dlp deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
-  version = "2025.6.30";
+  version = "2025.06.30";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit version;
-    pname = "yt_dlp";
-    hash = "sha256-bQroVcClW/zCjf+6gE7IUlublV00pBGRoVYaTOwD2L0=";
+  src = fetchFromGitHub {
+    owner = "yt-dlp";
+    repo = "yt-dlp";
+    tag = version;
+    hash = "sha256-dwBe6oXh7G67kfiI6BqiC0ZHzleR7QlfMiTVXWYW85I=";
   };
 
   build-system = with python3Packages; [
@@ -95,7 +96,7 @@ python3Packages.buildPythonApplication rec {
       youtube-dl is released to the public domain, which means
       you can modify it, redistribute it or use it however you like.
     '';
-    changelog = "https://github.com/yt-dlp/yt-dlp/blob/HEAD/Changelog.md";
+    changelog = "https://github.com/yt-dlp/yt-dlp/blob/${version}/Changelog.md";
     license = licenses.unlicense;
     maintainers = with maintainers; [
       SuperSandro2000

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -9,7 +9,7 @@
   ffmpegSupport ? true,
   rtmpSupport ? true,
   withAlias ? false, # Provides bin/youtube-dl for backcompat
-  update-python-libraries,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -80,10 +80,7 @@ python3Packages.buildPythonApplication rec {
     ln -s "$out/bin/yt-dlp" "$out/bin/youtube-dl"
   '';
 
-  passthru.updateScript = [
-    update-python-libraries
-    (toString ./.)
-  ];
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     homepage = "https://github.com/yt-dlp/yt-dlp/";

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -110,8 +110,10 @@ python3Packages.buildPythonApplication rec {
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
-    homepage = "https://github.com/yt-dlp/yt-dlp/";
+    changelog = "https://github.com/yt-dlp/yt-dlp/blob/${version}/Changelog.md";
     description = "Command-line tool to download videos from YouTube.com and other sites (youtube-dl fork)";
+    homepage = "https://github.com/yt-dlp/yt-dlp/";
+    license = licenses.unlicense;
     longDescription = ''
       yt-dlp is a youtube-dl fork based on the now inactive youtube-dlc.
 
@@ -120,12 +122,10 @@ python3Packages.buildPythonApplication rec {
       youtube-dl is released to the public domain, which means
       you can modify it, redistribute it or use it however you like.
     '';
-    changelog = "https://github.com/yt-dlp/yt-dlp/blob/${version}/Changelog.md";
-    license = licenses.unlicense;
+    mainProgram = "yt-dlp";
     maintainers = with maintainers; [
       SuperSandro2000
       donteatoreo
     ];
-    mainProgram = "yt-dlp";
   };
 }

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -109,11 +109,11 @@ python3Packages.buildPythonApplication rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/yt-dlp/yt-dlp/blob/${version}/Changelog.md";
     description = "Command-line tool to download videos from YouTube.com and other sites (youtube-dl fork)";
     homepage = "https://github.com/yt-dlp/yt-dlp/";
-    license = licenses.unlicense;
+    license = lib.licenses.unlicense;
     longDescription = ''
       yt-dlp is a youtube-dl fork based on the now inactive youtube-dlc.
 
@@ -123,7 +123,7 @@ python3Packages.buildPythonApplication rec {
       you can modify it, redistribute it or use it however you like.
     '';
     mainProgram = "yt-dlp";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       SuperSandro2000
       donteatoreo
     ];


### PR DESCRIPTION
## Things done

Changelog: https://github.com/yt-dlp/yt-dlp/releases/tag/2025.06.30
Diff: https://github.com/yt-dlp/yt-dlp/compare/2025.06.25...2025.06.30

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc