### PR TITLE
zulu25: init at 25.0.0-beta.34

### DIFF
--- a/pkgs/development/compilers/zulu/25.nix
+++ b/pkgs/development/compilers/zulu/25.nix
@@ -1,0 +1,58 @@
+{
+  callPackage,
+  enableJavaFX ? false,
+  ...
+}@args:
+
+let
+  # For Zulu 25-EA, FX and non-FX versions can differ (but are currently the same)
+  zuluVersion = if enableJavaFX then "25.0.47" else "25.0.47";
+in
+callPackage ./common.nix (
+  {
+    # Details from https://www.azul.com/downloads/?version=java-24&package=jdk
+    # Note that the latest build may differ by platform
+    dists = {
+      x86_64-linux = {
+        inherit zuluVersion;
+        jdkVersion = "25.0.0-beta.34";
+        hash =
+          if enableJavaFX then
+            throw "JavaFX not currently available in 25(EA)"
+          else
+            "sha256-sRwmddaZfT/L7y1CBwiuTx3cl/9CRsEqOKTJ+NA1rR4=";
+      };
+
+      aarch64-linux = {
+        inherit zuluVersion;
+        jdkVersion = "25.0.0-beta.34";
+        hash =
+          if enableJavaFX then
+            throw "JavaFX not currently available in 25(EA)"
+          else
+            "sha256-qPZd3Kmt/bEqauSWhP56c35kdDRapMclYQ5G0G6qe7k=";
+      };
+
+      x86_64-darwin = {
+        inherit zuluVersion;
+        jdkVersion = "25.0.0-beta.34";
+        hash =
+          if enableJavaFX then
+            throw "JavaFX not currently available in 25(EA)"
+          else
+            "sha256-6gZ1BEzMe96qIlGvRBgQVRJsrr1txXciwLk952PRYEs=";
+      };
+
+      aarch64-darwin = {
+        inherit zuluVersion;
+        jdkVersion = "25.0.0-beta.34";
+        hash =
+          if enableJavaFX then
+            throw "JavaFX not currently available in 25(EA)"
+          else
+            "sha256-7XjZfOsa50dPHFEXu4Dfr2r6M1YaCU3ffNR3NscpEnk=";
+      };
+    };
+  }
+  // builtins.removeAttrs args [ "callPackage" ]
+)

--- a/pkgs/development/compilers/zulu/common.nix
+++ b/pkgs/development/compilers/zulu/common.nix
@@ -5,6 +5,7 @@
   setJavaClassPath,
   testers,
   enableJavaFX ? false,
+  earlyAccess ? false,
   dists,
   # minimum dependencies
   unzip,
@@ -68,7 +69,13 @@ let
     hash = "sha256-gCGii4ysQbRPFCH9IQoKCCL8r4jWLS5wo1sv9iioZ1o=";
   };
 
-  javaPackage = if enableJavaFX then "ca-fx-jdk" else "ca-jdk";
+  javaPackage =
+    if enableJavaFX then
+      "ca-fx-jdk"
+    else if earlyAccess then
+      "beta-jdk"
+    else
+      "ca-jdk";
 
   isJdk8 = lib.versions.major dist.jdkVersion == "8";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5812,6 +5812,7 @@ with pkgs;
   zulu21 = callPackage ../development/compilers/zulu/21.nix { };
   zulu23 = callPackage ../development/compilers/zulu/23.nix { };
   zulu24 = callPackage ../development/compilers/zulu/24.nix { };
+  zulu25 = callPackage ../development/compilers/zulu/25.nix { earlyAccess = true; };
   zulu = zulu21;
 
   ### DEVELOPMENT / INTERPRETERS


### PR DESCRIPTION
Add zulu25, currently the latest EA version seen using the API at: https://api.azul.com/metadata/v1/zulu/packages

Builds with JavaFX  are not available yet.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
