### PR TITLE
octoprint: pin tornado to 6.4.2, fix header issue with tornado

### DIFF
--- a/pkgs/by-name/oc/octoprint/package.nix
+++ b/pkgs/by-name/oc/octoprint/package.nix
@@ -16,6 +16,23 @@ let
   py = python3.override {
     self = py;
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
+      (
+
+        self: super: {
+          # fix tornado.httputil.HTTPInputError: Multiple host headers not allowed
+          tornado = super.tornado.overridePythonAttrs (oldAttrs: {
+            version = "6.4.2";
+            format = "setuptools";
+            pyproject = null;
+            src = fetchFromGitHub {
+              owner = "tornadoweb";
+              repo = "tornado";
+              tag = "v6.4.2";
+              hash = "sha256-qgJh8pnC1ALF8KxhAYkZFAc0DE6jHVB8R/ERJFL4OFc=";
+            };
+            doCheck = false;
+          });
+        })
       # Built-in dependency
       (self: super: {
         octoprint-filecheck = self.buildPythonPackage rec {


### PR DESCRIPTION
Due to the recent update of `tornado` to versions above 6.4 (9eee3b6cf287d6141ceb219eba86be12fcfb8af4) octoprint has issues working with reverse proxies, probably due to type annotation changes (https://www.tornadoweb.org/en/stable/releases/v6.5.0.html#type-annotation-changes) 
Since upstream explicitly pins tornado to <6.5 (https://github.com/OctoPrint/OctoPrint/blob/96e48c5662274a1941486d3e0853141661fc0455/setup.py#L72) this is not an upstream issue

This commit pins the tornado version to 6.4.2 which resolves the issue.

Note for testing: Normal nixosTests do not catch the error, since we don't test reverse proxies. I deployed this on my raspberry and it started working again. for reference, this is the error message:

```
6	File "/nix/store/ifyn643ydf565j3imkvwba04pqzkxn9f-python3-3.13.4-env/lib/python3.13/site-packages/tornado/http1connection.py", line 222, in _read_message
header_recv_future = delegate.headers_received(start_line, headers)
octoprint	6	File "/nix/store/ifyn643ydf565j3imkvwba04pqzkxn9f-python3-3.13.4-env/lib/python3.13/site-packages/tornado/httpserver.py", line 393, in headers_received
octoprint	6	return self.delegate.headers_received(start_line, headers)
octoprint	6	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
octoprint	6	File "/nix/store/ifyn643ydf565j3imkvwba04pqzkxn9f-python3-3.13.4-env/lib/python3.13/site-packages/tornado/routing.py", line 255, in headers_received
octoprint	6	request = httputil.HTTPServerRequest(
octoprint	6	connection=self.request_conn,
octoprint	6	...<2 lines>...
octoprint	6	headers=headers,
octoprint	6	)
octoprint	6	File "/nix/store/ifyn643ydf565j3imkvwba04pqzkxn9f-python3-3.13.4-env/lib/python3.13/site-packages/tornado/httputil.py", line 524, in __init__
octoprint	6	raise HTTPInputError("Multiple host headers not allowed: %r" % self.host)
octoprint	6	tornado.httputil.HTTPInputError: Multiple host headers not allowed: 'octoprint.myserver.lan,octoprint.myserver.lan'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
