### PR TITLE
omnom: fix & refactor

### DIFF
--- a/pkgs/by-name/om/omnom/package.nix
+++ b/pkgs/by-name/om/omnom/package.nix
@@ -70,6 +70,7 @@ buildGoModule (finalAttrs: {
 
         pushd build
           zip "$out/omnom_ext_chrome.zip" ./* icons/* -x manifest_ff.json
+          cp manifest_ff.json manifest.json
           zip "$out/omnom_ext_firefox.zip" ./* icons/* -x manifest_ff.json
         popd
       '';

--- a/pkgs/by-name/om/omnom/package.nix
+++ b/pkgs/by-name/om/omnom/package.nix
@@ -34,14 +34,12 @@ buildGoModule (finalAttrs: {
     "-w"
   ];
 
-  postBuild = ''
+  postInstall = ''
     mkdir -p $out/share/addons
 
     # Copy Firefox and Chrome addons
     cp -r ${finalAttrs.passthru.omnom-addons}/*.zip $out/share/addons
-  '';
 
-  postInstall = ''
     mkdir -p $out/share/examples
 
     cp -r static templates $out/share

--- a/pkgs/by-name/om/omnom/package.nix
+++ b/pkgs/by-name/om/omnom/package.nix
@@ -34,46 +34,12 @@ buildGoModule (finalAttrs: {
     "-w"
   ];
 
-  postBuild =
-    let
-      omnom-addons = buildNpmPackage {
-        pname = "omnom-addons";
-        inherit (finalAttrs) version src;
+  postBuild = ''
+    mkdir -p $out/share/addons
 
-        npmDepsHash = "sha256-sUn5IvcHWJ/yaqeGz9SGvGx9HHAlrcnS0lJxIxUVS6M=";
-        sourceRoot = "${finalAttrs.src.name}/ext";
-        npmPackFlags = [ "--ignore-scripts" ];
-
-        nativeBuildInputs = [ zip ];
-
-        # Fix path for the `static` directory
-        postConfigure = ''
-          substituteInPlace webpack.config.js \
-          --replace-fail '"..", ".."' '".."'
-        '';
-
-        postBuild = ''
-          mkdir -p $out
-
-          zip -r "$out/omnom_ext_src.zip" README.md src utils package* webpack.config.js
-
-          pushd build
-            zip "$out/omnom_ext_chrome.zip" ./* icons/* -x manifest_ff.json
-            zip "$out/omnom_ext_firefox.zip" ./* icons/* -x manifest_ff.json
-          popd
-        '';
-
-        postCheck = ''
-          npm run build-test
-        '';
-      };
-    in
-    ''
-      mkdir -p $out/share/addons
-
-      # Copy Firefox and Chrome addons
-      cp -r ${omnom-addons}/*.zip $out/share/addons
-    '';
+    # Copy Firefox and Chrome addons
+    cp -r ${finalAttrs.passthru.omnom-addons}/*.zip $out/share/addons
+  '';
 
   postInstall = ''
     mkdir -p $out/share/examples
@@ -82,7 +48,41 @@ buildGoModule (finalAttrs: {
     cp config.yml_sample $out/share/examples/config.yml
   '';
 
-  passthru.tests = nixosTests.omnom;
+  passthru = {
+    omnom-addons = buildNpmPackage (finalAttrs': {
+      pname = "omnom-addons";
+      inherit (finalAttrs) version src;
+
+      npmDepsHash = "sha256-sUn5IvcHWJ/yaqeGz9SGvGx9HHAlrcnS0lJxIxUVS6M=";
+      sourceRoot = "${finalAttrs'.src.name}/ext";
+      npmPackFlags = [ "--ignore-scripts" ];
+
+      nativeBuildInputs = [ zip ];
+
+      # Fix path for the `static` directory
+      postConfigure = ''
+        substituteInPlace webpack.config.js \
+        --replace-fail '"..", ".."' '".."'
+      '';
+
+      postBuild = ''
+        mkdir -p $out
+
+        zip -r "$out/omnom_ext_src.zip" README.md src utils package* webpack.config.js
+
+        pushd build
+          zip "$out/omnom_ext_chrome.zip" ./* icons/* -x manifest_ff.json
+          zip "$out/omnom_ext_firefox.zip" ./* icons/* -x manifest_ff.json
+        popd
+      '';
+
+      postCheck = ''
+        npm run build-test
+      '';
+    });
+
+    tests = nixosTests.omnom;
+  };
 
   meta = {
     description = "Webpage bookmarking and snapshotting service";


### PR DESCRIPTION
The addons package is moved to passthru to allow for easy overriding.

Also, the Firefox extension is fixed by using the correct manifest.json.

Related:
- https://github.com/asciimoo/omnom/blob/ca9fe75f6dad7c0449741bbc7224d45600a9a802/ext/webpack.config.js#L109-L133

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
