### PR TITLE
pgsql-tools: init at 2.0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21991,6 +21991,11 @@
     githubId = 2660;
     name = "Russell Sim";
   };
+  rutgerdj = {
+    github = "rutgerdj";
+    githubId = 35080130;
+    name = "Rutger";
+  };
   rutherther = {
     name = "Rutherther";
     email = "rutherther@proton.me";

--- a/pkgs/by-name/pg/pgsql-tools/fetch_hashes.sh
+++ b/pkgs/by-name/pg/pgsql-tools/fetch_hashes.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION="2.0.6"
+BASE_URL="https://github.com/microsoft/pgsql-tools/releases/download/v${VERSION}"
+
+declare -A ARCHES=(
+  ["x86_64-linux"]="linux-x64"
+  ["aarch64-linux"]="linux-arm64"
+  ["x86_64-darwin"]="osx-x86"
+  ["aarch64-darwin"]="osx-arm64"
+)
+
+declare -A HASHES
+
+for SYSTEM in "${!ARCHES[@]}"; do
+  ARCH="${ARCHES[$SYSTEM]}"
+  URL="${BASE_URL}/pgsqltoolsservice-${ARCH}.tar.gz"
+
+  echo "Fetching for ${SYSTEM}..."
+  HASH=$(nix-prefetch-url "$URL")
+  echo "  hash = '$HASH'"
+  HASHES["$SYSTEM"]="$HASH"
+done
+
+echo
+echo "sha256 = selectSystem {"
+for SYSTEM in "${!ARCHES[@]}"; do
+  echo "  ${SYSTEM} = \"${HASHES[$SYSTEM]}\";"
+done
+echo "};"

--- a/pkgs/by-name/pg/pgsql-tools/fetch_hashes.sh
+++ b/pkgs/by-name/pg/pgsql-tools/fetch_hashes.sh
@@ -8,8 +8,6 @@ BASE_URL="https://github.com/microsoft/pgsql-tools/releases/download/v${VERSION}
 declare -A ARCHES=(
   ["x86_64-linux"]="linux-x64"
   ["aarch64-linux"]="linux-arm64"
-  ["x86_64-darwin"]="osx-x86"
-  ["aarch64-darwin"]="osx-arm64"
 )
 
 declare -A HASHES

--- a/pkgs/by-name/pg/pgsql-tools/package.nix
+++ b/pkgs/by-name/pg/pgsql-tools/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchurl,
   autoPatchelfHook,
+  libxcrypt,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,6 +31,7 @@ stdenv.mkDerivation rec {
     };
 
   nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ libxcrypt ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/pg/pgsql-tools/package.nix
+++ b/pkgs/by-name/pg/pgsql-tools/package.nix
@@ -11,12 +11,12 @@ stdenv.mkDerivation rec {
 
   src =
     let
-      selectSystem = attrs: attrs.${stdenv.hostPlatform.system};
+      selectSystem =
+        attrs:
+        attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
       arch = selectSystem {
         x86_64-linux = "linux-x64";
         aarch64-linux = "linux-arm64";
-        x86_64-darwin = "osx-x86";
-        aarch64-darwin = "osx-arm64";
       };
     in
     fetchurl {
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
       sha256 = selectSystem {
         aarch64-linux = "1vai84yqk34rkbddczvfr3m1g8d7hhcdigm4rk6zff4zhq133k4r";
         x86_64-linux = "101504x7lc98kfmzfp7mna48qcsf5df77f5y28asgnwysb1jjvq1";
-        x86_64-darwin = "1340ni7c7gd7vix3s7pwv6spggvj603alqi3zsm5r97qb32qk41i";
-        aarch64-darwin = "1c6pnbxvgn84i724c4812rfqsnk0skmn0v395mmbz5w8qlixll8s";
       };
     };
 
@@ -44,7 +42,7 @@ stdenv.mkDerivation rec {
     description = "PostgreSQL tools service is a backend service for PostgreSQL server tools, offering features such as connection management, query execution with result set handling, and language service support via the VS Code protocol.";
     changelog = "https://github.com/microsoft/pgsql-tools/releases";
     license = with licenses; [ mit ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = lib.platforms.linux;
     maintainers = with maintainers; [ rutgerdj ];
     mainProgram = "ossdbtoolsservice_main";
   };

--- a/pkgs/by-name/pg/pgsql-tools/package.nix
+++ b/pkgs/by-name/pg/pgsql-tools/package.nix
@@ -1,0 +1,51 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  autoPatchelfHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pgsql-tools";
+  version = "2.0.6";
+
+  src =
+    let
+      selectSystem = attrs: attrs.${stdenv.hostPlatform.system};
+      arch = selectSystem {
+        x86_64-linux = "linux-x64";
+        aarch64-linux = "linux-arm64";
+        x86_64-darwin = "osx-x86";
+        aarch64-darwin = "osx-arm64";
+      };
+    in
+    fetchurl {
+      url = "https://github.com/microsoft/pgsql-tools/releases/download/v${version}/pgsqltoolsservice-${arch}.tar.gz";
+
+      # When updating to a new version, use the ./fetch_hashes.sh script to calculate the hash for each architecture
+      sha256 = selectSystem {
+        aarch64-linux = "1vai84yqk34rkbddczvfr3m1g8d7hhcdigm4rk6zff4zhq133k4r";
+        x86_64-linux = "101504x7lc98kfmzfp7mna48qcsf5df77f5y28asgnwysb1jjvq1";
+        x86_64-darwin = "1340ni7c7gd7vix3s7pwv6spggvj603alqi3zsm5r97qb32qk41i";
+        aarch64-darwin = "1c6pnbxvgn84i724c4812rfqsnk0skmn0v395mmbz5w8qlixll8s";
+      };
+    };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ossdbtoolsservice_main $out/bin/
+    cp -r _internal $out/bin/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/microsoft/pgsql-tools";
+    description = "PostgreSQL tools service is a backend service for PostgreSQL server tools, offering features such as connection management, query execution with result set handling, and language service support via the VS Code protocol.";
+    changelog = "https://github.com/microsoft/pgsql-tools/releases";
+    license = with licenses; [ mit ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with maintainers; [ rutgerdj ];
+    mainProgram = "ossdbtoolsservice_main";
+  };
+}


### PR DESCRIPTION
This PR adds [pgsql-tools](https://github.com/microsoft/pgsql-tools) to nixpkgs.
pgsql-tools is used by Microsofts Postgres extension for vscode.

I'ts my first package addition to Nixpkgs, I've tried to follow all guidelines but I could have missed something. Please let me know!

The release comes with its own libs, so instead of trying to find the specific versions they are using I just copy them over to the output. 
I guess it's not very Nixy but in this case I would argue its the best approach to prevent having to manually pick the correct versions every time the package is updated.  

I have included a script to calculate the checksums for each architecture, I'm not sure if its good practice to include that here so just let me know. I can also put a link to a gist or something.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
