### PR TITLE
pgadmin: 9.4 -> 9.5

### DIFF
--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -6,7 +6,7 @@
   nixosTests,
   postgresqlTestHook,
   postgresql,
-  yarn-berry_3,
+  yarn-berry_4,
   nodejs,
   autoconf,
   automake,
@@ -22,14 +22,14 @@
 
 let
   pname = "pgadmin";
-  version = "9.4";
-  yarnHash = "sha256-AlAyHtadjmKZb0rHNIlaPtEcGFQ15Fc6rExMsNFGwDc=";
+  version = "9.5";
+  yarnHash = "sha256-i3WCEpcZepB7K0A4QgjoLfkO7icew/8usJCo4DkWT6I=";
 
   src = fetchFromGitHub {
     owner = "pgadmin-org";
     repo = "pgadmin4";
     rev = "REL-${lib.versions.major version}_${lib.versions.minor version}";
-    hash = "sha256-oslp9g63mYeP9CmpCzF80nlyqF1ftGbMRIsp6goJOx4=";
+    hash = "sha256-5FwYkdhpg/2Cidi2qiFhhsQYbIwsp80K3MNxw5rp4ww=";
   };
 
   mozjpeg-bin = fetchFromGitHub {
@@ -59,7 +59,7 @@ in
 pythonPackages.buildPythonApplication rec {
   inherit pname version src;
 
-  offlineCache = yarn-berry_3.fetchYarnBerryDeps {
+  offlineCache = yarn-berry_4.fetchYarnBerryDeps {
     # mozjpeg fails to build on darwin due to a hardocded path
     # this has been fixed upstream on master but no new version
     # has been released. We therefore point yarn to upstream
@@ -154,11 +154,11 @@ pythonPackages.buildPythonApplication rec {
     export LD=$CC
     export HOME=$(mktemp -d)
     export YARN_ENABLE_SCRIPTS=1
-    YARN_IGNORE_PATH=1 ${yarn-berry_3.yarn-berry-offline}/bin/yarn config set enableTelemetry false
-    YARN_IGNORE_PATH=1 ${yarn-berry_3.yarn-berry-offline}/bin/yarn config set enableGlobalCache false
+    YARN_IGNORE_PATH=1 ${yarn-berry_4.yarn-berry-offline}/bin/yarn config set enableTelemetry false
+    YARN_IGNORE_PATH=1 ${yarn-berry_4.yarn-berry-offline}/bin/yarn config set enableGlobalCache false
     export npm_config_nodedir="${srcOnly nodejs}"
     export npm_config_node_gyp="${nodejs}/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js"
-    YARN_IGNORE_PATH=1 ${yarn-berry_3.yarn-berry-offline}/bin/yarn install --inline-builds
+    YARN_IGNORE_PATH=1 ${yarn-berry_4.yarn-berry-offline}/bin/yarn install --inline-builds
     )
     yarn webpacker
     cp -r * ../pip-build/pgadmin4
@@ -185,8 +185,8 @@ pythonPackages.buildPythonApplication rec {
     cython
     pip
     sphinx
-    yarn-berry_3
-    yarn-berry_3.yarnBerryConfigHook
+    yarn-berry_4
+    yarn-berry_4.yarnBerryConfigHook
     nodejs
 
     # for building mozjpeg2

--- a/pkgs/tools/admin/pgadmin/mozjpeg.patch
+++ b/pkgs/tools/admin/pgadmin/mozjpeg.patch
@@ -1,45 +1,44 @@
 diff --git a/yarn.lock b/yarn.lock
-index fa189ef..54066a6 100644
+index 8bfff31..0f12f87 100644
 --- a/yarn.lock
 +++ b/yarn.lock
-@@ -7299,6 +7299,23 @@ __metadata:
+@@ -7347,6 +7347,23 @@ __metadata:
    languageName: node
    linkType: hard
- 
+
 +"execa@npm:^7.1.1":
 +  version: 7.1.1
 +  resolution: "execa@npm:7.1.1"
 +  dependencies:
-+    cross-spawn: ^7.0.3
-+    get-stream: ^6.0.1
-+    human-signals: ^3.0.1
-+    is-stream: ^3.0.0
-+    merge-stream: ^2.0.0
-+    npm-run-path: ^5.1.0
-+    onetime: ^6.0.0
-+    signal-exit: ^3.0.7
-+    strip-final-newline: ^3.0.0
-+  checksum: 21fa46fc69314ace4068cf820142bdde5b643a5d89831c2c9349479c1555bff137a291b8e749e7efca36535e4e0a8c772c11008ca2e84d2cbd6ca141a3c8f937
++    cross-spawn: "npm:^7.0.3"
++    get-stream: "npm:^6.0.1"
++    human-signals: "npm:^3.0.1"
++    is-stream: "npm:^3.0.0"
++    merge-stream: "npm:^2.0.0"
++    npm-run-path: "npm:^5.1.0"
++    onetime: "npm:^6.0.0"
++    signal-exit: "npm:^3.0.7"
++    strip-final-newline: "npm:^3.0.0"
++  checksum: 0da5ee1c895b62142bc3d1567d1974711c28c2cfa6bae96e1923379bd597e476d762a13f282f92815d8ebfa33407949634fa32a0d6db8334a20e625fe11d4351
 +  languageName: node
 +  linkType: hard
 +
  "executable@npm:^4.1.0":
    version: 4.1.1
    resolution: "executable@npm:4.1.1"
-@@ -11027,13 +11044,14 @@ __metadata:
- 
+@@ -11120,13 +11137,14 @@ __metadata:
+
  "mozjpeg@npm:^8.0.0":
    version: 8.0.0
 -  resolution: "mozjpeg@npm:8.0.0"
 +  resolution: "mozjpeg@https://github.com/imagemin/mozjpeg-bin.git#commit=c0587fbc00b21ed8cad8bae499a0827baeaf7ffa"
    dependencies:
-     bin-build: ^3.0.0
-     bin-wrapper: ^4.0.0
-+    execa: ^7.1.1
+     bin-build: "npm:^3.0.0"
+     bin-wrapper: "npm:^4.0.0"
++    execa: "npm:^7.1.1"
    bin:
      mozjpeg: cli.js
--  checksum: cba27c2efbc21a48434da1c6c8d6886988432430f958315fc59ef9b52bc2d6ee597e19f1cf6aae0fd611d5b2a113561fe2e85ec30a1ccd55c007340c638eb557
+-  checksum: 10c0/e91294c15bb31dcaa5eb0780e772214052aa8cb1efc35f74a5c4fe85c9af9d3d6e2f3dc64d3379a86a63b5cbc86a2618c23e350c9131e55ac76726647537b7e8
 +  checksum: cba27c2efbc21a48434da1c6c8d6886988432430f958315fc59ef9b52bc2d6ee597e19f1cf6aae0fd611d5b2a113561fe2e85ec30a1ccd55c007340c638eb556
    languageName: node
    linkType: hard
- 

--- a/pkgs/tools/admin/pgadmin/update.sh
+++ b/pkgs/tools/admin/pgadmin/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl wget jq common-updater-scripts yarn-berry_3 yarn-berry_3.yarn-berry-fetcher
+#!nix-shell -i bash -p curl wget jq common-updater-scripts yarn-berry_4 yarn-berry_4.yarn-berry-fetcher
 
 set -eu -o pipefail
 


### PR DESCRIPTION
fixes #421277
Release notes: https://www.pgadmin.org/docs/pgadmin4/9.5/release_notes_9_5.html

Major changes: Yarn has been upgraded to v4.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
