### PR TITLE
[Backport release-25.05] vintagestory: 1.20.9 -> 1.20.12, improve perf, add dtomvan as maintainer

### DIFF
--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "vintagestory";
-  version = "1.20.9";
+  version = "1.20.11";
 
   src = fetchurl {
     url = "https://cdn.vintagestory.at/gamefiles/stable/vs_client_linux-x64_${version}.tar.gz";
-    hash = "sha256-pia2Dv0FY28nkATOk60GqiAEnZmxgZvZfvkM8U/bZzU=";
+    hash = "sha256-IOreg6j/jLhOK8jm2AgSnYQrql5R6QxsshvPs8OUcQA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -77,21 +77,22 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  preFixup =
-    ''
-      makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory \
-        --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
-        --add-flags $out/share/vintagestory/Vintagestory.dll
+  preFixup = ''
+    makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --set-default mesa_glthread true \
+      --add-flags $out/share/vintagestory/Vintagestory.dll
 
-      makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory-server \
-        --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
-        --add-flags $out/share/vintagestory/VintagestoryServer.dll
+    makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory-server \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --set-default mesa_glthread true \
+      --add-flags $out/share/vintagestory/VintagestoryServer.dll
 
-      find "$out/share/vintagestory/assets/" -not -path "*/fonts/*" -regex ".*/.*[A-Z].*" | while read -r file; do
-        local filename="$(basename -- "$file")"
-        ln -sf "$filename" "''${file%/*}"/"''${filename,,}"
-      done
-    '';
+    find "$out/share/vintagestory/assets/" -not -path "*/fonts/*" -regex ".*/.*[A-Z].*" | while read -r file; do
+      local filename="$(basename -- "$file")"
+      ln -sf "$filename" "''${file%/*}"/"''${filename,,}"
+    done
+  '';
 
   meta = {
     description = "In-development indie sandbox game about innovation and exploration";

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -82,11 +82,11 @@ stdenv.mkDerivation rec {
       makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory \
         --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
         --add-flags $out/share/vintagestory/Vintagestory.dll
+
       makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory-server \
         --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
         --add-flags $out/share/vintagestory/VintagestoryServer.dll
-    ''
-    + ''
+
       find "$out/share/vintagestory/assets/" -not -path "*/fonts/*" -regex ".*/.*[A-Z].*" | while read -r file; do
         local filename="$(basename -- "$file")"
         ln -sf "$filename" "''${file%/*}"/"''${filename,,}"

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -97,6 +97,7 @@ stdenv.mkDerivation rec {
     description = "In-development indie sandbox game about innovation and exploration";
     homepage = "https://www.vintagestory.at/";
     license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
     maintainers = with lib.maintainers; [
       artturin
       gigglesquid

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -103,5 +103,6 @@ stdenv.mkDerivation rec {
       gigglesquid
       niraethm
     ];
+    mainProgram = "vintagestory";
   };
 }

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -33,8 +33,6 @@ stdenv.mkDerivation rec {
     copyDesktopItems
   ];
 
-  buildInputs = [ dotnet-runtime_7 ];
-
   runtimeLibs = lib.makeLibraryPath (
     [
       gtk2

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -21,11 +21,11 @@
 
 stdenv.mkDerivation rec {
   pname = "vintagestory";
-  version = "1.20.11";
+  version = "1.20.12";
 
   src = fetchurl {
     url = "https://cdn.vintagestory.at/gamefiles/stable/vs_client_linux-x64_${version}.tar.gz";
-    hash = "sha256-IOreg6j/jLhOK8jm2AgSnYQrql5R6QxsshvPs8OUcQA=";
+    hash = "sha256-h6YXEZoVVV9IuKkgtK9Z3NTvJogVNHmXdAcKxwfvqcE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -98,6 +98,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.vintagestory.at/";
     license = lib.licenses.unfree;
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       artturin
       gigglesquid

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -93,11 +93,11 @@ stdenv.mkDerivation rec {
       done
     '';
 
-  meta = with lib; {
+  meta = {
     description = "In-development indie sandbox game about innovation and exploration";
     homepage = "https://www.vintagestory.at/";
-    license = licenses.unfree;
-    maintainers = with maintainers; [
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
       artturin
       gigglesquid
       niraethm

--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -104,6 +104,7 @@ stdenv.mkDerivation rec {
       artturin
       gigglesquid
       niraethm
+      dtomvan
     ];
     mainProgram = "vintagestory";
   };


### PR DESCRIPTION
Manual backport of #410712 #414847 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.