### PR TITLE
[Backport release-25.05] atlas: 0.33.0 -> 0.35.0

### DIFF
--- a/pkgs/by-name/at/atlas/package.nix
+++ b/pkgs/by-name/at/atlas/package.nix
@@ -8,19 +8,19 @@
 
 buildGoModule (finalAttrs: {
   pname = "atlas";
-  version = "0.34.0";
+  version = "0.35.0";
 
   src = fetchFromGitHub {
     owner = "ariga";
     repo = "atlas";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-7s03YrZw7J2LRCHibMqzBBtVUBSPVEf+TMqtKoWSkkM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-USA3PiZcOF39LK45Xu0Oq/GJi3URMxJpBrUXxIsEkCY=";
   };
 
   modRoot = "cmd/atlas";
 
   proxyVendor = true;
-  vendorHash = "sha256-K94zOisolCplE/cFrWmv4/MWl5DD27lRekPTl+o4Jwk=";
+  vendorHash = "sha256-G78KpERRAP4lVsy3ur2ejT6jA6K5T257FHLb7afC/7c=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -46,7 +46,7 @@ buildGoModule (finalAttrs: {
   };
 
   meta = {
-    description = "Modern tool for managing database schemas";
+    description = "Manage your database schema as code";
     homepage = "https://atlasgo.io/";
     changelog = "https://github.com/ariga/atlas/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;

--- a/pkgs/by-name/at/atlas/package.nix
+++ b/pkgs/by-name/at/atlas/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "atlas";
-  version = "0.33.1";
+  version = "0.34.0";
 
   src = fetchFromGitHub {
     owner = "ariga";
     repo = "atlas";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Io7FnPxvr3XIj+Tbf1yVxjTnqoRzQZnaVlImcwBjwXE=";
+    hash = "sha256-7s03YrZw7J2LRCHibMqzBBtVUBSPVEf+TMqtKoWSkkM=";
   };
 
   modRoot = "cmd/atlas";

--- a/pkgs/by-name/at/atlas/package.nix
+++ b/pkgs/by-name/at/atlas/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "atlas";
-  version = "0.33.0";
+  version = "0.33.1";
 
   src = fetchFromGitHub {
     owner = "ariga";
     repo = "atlas";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-uMINAdoHYRVaZ7QdxZ0G03cOTRe6ObnIuxo3ic+tMnE=";
+    hash = "sha256-Io7FnPxvr3XIj+Tbf1yVxjTnqoRzQZnaVlImcwBjwXE=";
   };
 
   modRoot = "cmd/atlas";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1898,10 +1898,6 @@ with pkgs;
 
   asmrepl = callPackage ../development/interpreters/asmrepl { };
 
-  atlas = callPackage ../by-name/at/atlas/package.nix {
-    buildGoModule = buildGo123Module;
-  };
-
   avahi = callPackage ../development/libraries/avahi { };
 
   avahi-compat = callPackage ../development/libraries/avahi {


### PR DESCRIPTION
Manual backport of #410393 #413522 #420882 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.