### PR TITLE
[Backport release-25.05] signalbackup-tools: 20250511-1 -> 20250630-2

### DIFF
--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20250606";
+  version = "20250617";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = "signalbackup-tools";
     rev = version;
-    hash = "sha256-UGSto0RbC+ZTXgcT+F5UEmRYg79jGyYJaWA4m5ulB+Y=";
+    hash = "sha256-sX/JM8d0kex09OT8n4IF26+bSPwvTjarqoiRTknA2Og=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20250511-1";
+  version = "20250513-1";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = "signalbackup-tools";
     rev = version;
-    hash = "sha256-9JrSXfq6GF4fa7r15OY2M3aqXrvuUQ3UzVbuiViQZsI=";
+    hash = "sha256-JUMAA7B+2yJlkAd3JoJgEk8N73FzmbJFeMbrEx/BiVg=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20250622-1";
+  version = "20250626";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = "signalbackup-tools";
     rev = version;
-    hash = "sha256-QLlnIrlWGbPPD2ZgmvzX28UkVSQHcEUoL/XmajgFs6o=";
+    hash = "sha256-RZLe0d/zpWu8x/4qVZBY3zatb9bc5kfKy7L0EdK02uw=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20250617";
+  version = "20250622-1";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = "signalbackup-tools";
     rev = version;
-    hash = "sha256-sX/JM8d0kex09OT8n4IF26+bSPwvTjarqoiRTknA2Og=";
+    hash = "sha256-QLlnIrlWGbPPD2ZgmvzX28UkVSQHcEUoL/XmajgFs6o=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20250626";
+  version = "20250630-2";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = "signalbackup-tools";
     rev = version;
-    hash = "sha256-RZLe0d/zpWu8x/4qVZBY3zatb9bc5kfKy7L0EdK02uw=";
+    hash = "sha256-/zbBiVWqHoKG2h6ExIDIP6ZQH1F8LByZYWbx8wysGDw=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20250529";
+  version = "20250606";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = "signalbackup-tools";
     rev = version;
-    hash = "sha256-7TUyH2J4DFOAM1HWjWK4l4Dta0/aANhVUBNEbNF1G14=";
+    hash = "sha256-UGSto0RbC+ZTXgcT+F5UEmRYg79jGyYJaWA4m5ulB+Y=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20250522";
+  version = "20250529";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = "signalbackup-tools";
     rev = version;
-    hash = "sha256-gfwlFvLoOPqL4GfV+Xv2m+afsfXjWR1gumn9VHp3etU=";
+    hash = "sha256-7TUyH2J4DFOAM1HWjWK4l4Dta0/aANhVUBNEbNF1G14=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20250513-1";
+  version = "20250519";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = "signalbackup-tools";
     rev = version;
-    hash = "sha256-JUMAA7B+2yJlkAd3JoJgEk8N73FzmbJFeMbrEx/BiVg=";
+    hash = "sha256-4h6eYP7Lvagm0GmkwtK1CNa/FaaWj0A78Ralevjmj5I=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/si/signalbackup-tools/package.nix
+++ b/pkgs/by-name/si/signalbackup-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20250519";
+  version = "20250522";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = "signalbackup-tools";
     rev = version;
-    hash = "sha256-4h6eYP7Lvagm0GmkwtK1CNa/FaaWj0A78Ralevjmj5I=";
+    hash = "sha256-gfwlFvLoOPqL4GfV+Xv2m+afsfXjWR1gumn9VHp3etU=";
   };
 
   nativeBuildInputs =


### PR DESCRIPTION
Manual backport of #406859 #408819 #409932 #412077 #415183 #418062 #419101 #420316 #421311 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.