### PR TITLE
haskell.compiler.ghc902Binary: fix (system) libffi header discovery 

### DIFF
--- a/pkgs/development/compilers/ghc/9.0.2-binary.nix
+++ b/pkgs/development/compilers/ghc/9.0.2-binary.nix
@@ -136,6 +136,7 @@ let
             fileToCheckFor = null;
           }
         ];
+        isHadrian = true;
       };
       aarch64-darwin = {
         variantSuffix = "";
@@ -158,6 +159,7 @@ let
             fileToCheckFor = null;
           }
         ];
+        isHadrian = true;
       };
     };
     # Binary distributions for the musl libc for the respective system.
@@ -179,6 +181,7 @@ let
             fileToCheckFor = "libncursesw.so.6";
           }
         ];
+        isHadrian = true;
       };
     };
   };

--- a/pkgs/development/compilers/ghc/9.0.2-binary.nix
+++ b/pkgs/development/compilers/ghc/9.0.2-binary.nix
@@ -313,7 +313,7 @@ stdenv.mkDerivation {
       # To link RTS in the end we also need libffi now
       find . -name 'rts*.conf' \
           -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib libffi}/lib' \
-                    -e 's@/Library/Developer/.*/usr/include/ffi@${lib.getDev libffi}/include@' \
+                    -e 's@/.*/Developer/.*/usr/include/ffi@${lib.getDev libffi}/include@' \
                     -i {} \;
     ''
     +
@@ -363,13 +363,23 @@ stdenv.mkDerivation {
   makeFlags = lib.optionals stdenv.buildPlatform.isDarwin [ "XATTR=/does-not-exist" ];
 
   # Patch scripts to include runtime dependencies in $PATH.
-  postInstall = ''
-    for i in "$out/bin/"*; do
-      test ! -h "$i" || continue
-      isScript "$i" || continue
-      sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
-    done
-  '';
+  postInstall =
+    ''
+      for i in "$out/bin/"*; do
+        test ! -h "$i" || continue
+        isScript "$i" || continue
+        sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
+      done
+    ''
+    # On Darwin, GHC doesn't install a bundled libffi.so, but instead uses the
+    # system one (see postUnpack). Due to a bug in Hadrian, the (bundled) libffi
+    # headers are installed anyways. This problem has been fixed in GHC 9.2:
+    # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8189. While the system
+    # header should shadow the GHC installed ones, remove them to be safe.
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && binDistUsed.isHadrian or false) ''
+      echo Deleting redundant libffi headers:
+      find "$out" '(' -name ffi.h -or -name ffitarget.h ')' -print -delete
+    '';
 
   # Apparently necessary for the ghc Alpine (musl) bindist:
   # When we strip, and then run the


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

(GHC 9.4 test build is still running)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
