### PR TITLE
nixos/varnish: turn listen addresses into structured config

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -103,4 +103,7 @@
 - `amdgpu` kernel driver overdrive mode can now be enabled by setting [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable) and customized through [hardware.amdgpu.overdrive.ppfeaturemask](#opt-hardware.amdgpu.overdrive.ppfeaturemask).
   This allows for fine-grained control over the GPU's performance and maybe required by overclocking softwares like Corectrl and Lact. These new options replace old options such as {option}`programs.corectrl.gpuOverclock.enable` and {option}`programs.tuxclocker.enableAMD`.
 
+- `services.varnish.http_address` has been superseeded by `services.varnish.listen` which is now
+  structured config for all of varnish's `-a` variations.
+
 - [](#opt-services.gnome.gnome-keyring.enable) does not ship with an SSH agent anymore, as this is now handled by the `gcr_4` package instead of `gnome-keyring`. A new module has been added to support this, under [](#opt-services.gnome.gcr-ssh-agent.enable) (its default value has been set to [](#opt-services.gnome.gnome-keyring.enable) to ensure a smooth transition). See the [relevant upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67) for more details.

--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -6,6 +6,16 @@
 }:
 
 let
+  inherit (lib)
+    types
+    mkOption
+    hasPrefix
+    concatMapStringsSep
+    optionalString
+    concatMap
+    ;
+  inherit (builtins) isNull;
+
   cfg = config.services.varnish;
 
   # Varnish has very strong opinions and very complicated code around handling
@@ -26,6 +36,91 @@ let
     else
       "/var/run/varnishd";
 
+  # from --help:
+  #   -a [<name>=]address[:port][,proto] # HTTP listen address and port
+  #      [,user=<u>][,group=<g>]   # Can be specified multiple times.
+  #      [,mode=<m>]               #   default: ":80,HTTP"
+  #                                # Proto can be "PROXY" or "HTTP" (default)
+  #                                # user, group and mode set permissions for
+  #                                #   a Unix domain socket.
+  commandLineAddresses =
+    (concatMapStringsSep " " (
+      a:
+      "-a "
+      + optionalString (!isNull a.name) "${a.name}="
+      + a.address
+      + optionalString (!isNull a.port) ":${toString a.port}"
+      + optionalString (!isNull a.proto) ",${a.proto}"
+      + optionalString (!isNull a.user) ",user=${a.user}"
+      + optionalString (!isNull a.group) ",group=${a.group}"
+      + optionalString (!isNull a.mode) ",mode=${a.mode}"
+    ) cfg.listen)
+    + lib.optionalString (!isNull cfg.http_address) " -a ${cfg.http_address}";
+  addressSubmodule = types.submodule {
+    options = {
+      name = mkOption {
+        description = "Name is referenced in logs. If name is not specified, 'a0', 'a1', etc. is used.";
+        default = null;
+        type = with types; nullOr str;
+      };
+      address = mkOption {
+        description = ''
+          If given an IP address, it can be a host name ("localhost"), an IPv4 dotted-quad
+          ("127.0.0.1") or an IPv6  address enclosed in square brackets ("[::1]").
+
+          (VCL4.1 and higher) If given an absolute Path ("/path/to/listen.sock") or "@"
+          followed by the name of an abstract socket ("@myvarnishd") accept connections
+          on a Unix domain socket.
+
+          The user, group and mode sub-arguments may be used to specify the permissions
+          of the socket file. These sub-arguments do not apply to  abstract sockets.
+        '';
+        type = types.str;
+      };
+      port = mkOption {
+        description = "The port to use for IP sockets. If port is not specified, port 80 (http) is used.";
+        default = null;
+        type = with types; nullOr int;
+      };
+      proto = mkOption {
+        description = "PROTO can be 'HTTP' (the default) or 'PROXY'.  Both version 1 and 2 of the proxy protocol can be used.";
+        type = types.enum [
+          "HTTP"
+          "PROXY"
+        ];
+        default = "HTTP";
+      };
+      user = mkOption {
+        description = "User name who owns the socket file.";
+        default = null;
+        type = with lib.types; nullOr str;
+      };
+      group = mkOption {
+        description = "Group name who owns the socket file.";
+        default = null;
+        type = with lib.types; nullOr str;
+      };
+      mode = mkOption {
+        description = "Permission of the socket file (3-digit octal value).";
+        default = null;
+        type = with types; nullOr str;
+      };
+    };
+  };
+  checkedAddressModule = types.addCheck addressSubmodule (
+    m:
+    (
+      if ((hasPrefix "@" m.address) || (hasPrefix "/" m.address)) then
+        # this is a unix socket
+        (m.port != null)
+      else
+      # this is not a path-based unix socket
+      if !(hasPrefix "/" m.address) && (m.group != null) || (m.user != null) || (m.mode != null) then
+        false
+      else
+        true
+    )
+  );
   commandLine =
     "-f ${pkgs.writeText "default.vcl" cfg.config}"
     +
@@ -54,11 +149,21 @@ in
       package = lib.mkPackageOption pkgs "varnish" { };
 
       http_address = lib.mkOption {
-        type = lib.types.str;
-        default = "*:6081";
+        type = with lib.types; nullOr str;
+        default = null;
         description = ''
           HTTP listen address and port.
         '';
+      };
+
+      listen = lib.mkOption {
+        description = "Accept for client requests on the specified listen addresses.";
+        type = lib.types.listOf checkedAddressModule;
+        defaultText = lib.literalExpression ''[ { address="*"; port=6081; } ]'';
+        default = lib.optional (isNull cfg.http_address) {
+          address = "*";
+          port = 6081;
+        };
       };
 
       config = lib.mkOption {
@@ -97,7 +202,7 @@ in
       serviceConfig = {
         Type = "simple";
         PermissionsStartOnly = true;
-        ExecStart = "${cfg.package}/sbin/varnishd -a ${cfg.http_address} -n ${stateDir} -F ${cfg.extraCommandLine} ${commandLine}";
+        ExecStart = "${cfg.package}/sbin/varnishd ${commandLineAddresses} -n ${stateDir} -F ${cfg.extraCommandLine} ${commandLine}";
         Restart = "always";
         RestartSec = "5s";
         User = "varnish";
@@ -117,6 +222,21 @@ in
         ${cfg.package}/bin/varnishd -C ${commandLine} 2> $out || (cat $out; exit 1)
       '')
     ];
+
+    assertions = concatMap (m: [
+      {
+        assertion = (hasPrefix "/" m.address) || (hasPrefix "@" m.address) -> m.port == null;
+        message = "Listen ports must not be specified with UNIX sockets: ${builtins.toJSON m}";
+      }
+      {
+        assertion = !(hasPrefix "/" m.address) -> m.user == null && m.group == null && m.mode == null;
+        message = "Abstract UNIX sockets or IP sockets can not be used with user, group, and mode settings: ${builtins.toJSON m}";
+      }
+    ]) cfg.listen;
+
+    warnings =
+      lib.optional (!isNull cfg.http_address)
+        "The option `services.varnish.http_address` is deprecated. Use `services.varnish.listen` instead.";
 
     users.users.varnish = {
       group = "varnish";


### PR DESCRIPTION
Introduces `services.varnish.listen` as a list of structured listen addresses with all allowed variations of arguments documented in the man page.

Deprecates `services.varnish.http_address`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
