### PR TITLE
[Backport release-25.05] bitwarden-desktop: 2025.4.2 -> 2025.6.0

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/dont-use-platform-triple.patch
+++ b/pkgs/by-name/bi/bitwarden-desktop/dont-use-platform-triple.patch
@@ -45,10 +45,10 @@ index 2922035..6497a38 100644
    ],
    "electronVersion": "34.0.0",
    "generateUpdatesFilesForAllChannels": true,
-@@ -67,7 +67,6 @@
-       ],
+@@ -68,7 +68,6 @@
        "CFBundleDevelopmentRegion": "en"
      },
+     "provisioningProfile": "bitwarden_desktop_developer_id.provisionprofile",
 -    "singleArchFiles": "node_modules/@bitwarden/desktop-napi/desktop_napi.darwin-*.node",
      "extraFiles": [
        {

--- a/pkgs/by-name/bi/bitwarden-desktop/fix-lock-files.diff
+++ b/pkgs/by-name/bi/bitwarden-desktop/fix-lock-files.diff
@@ -1,0 +1,282 @@
+diff --git a/apps/cli/package.json b/apps/cli/package.json
+index 2ec4e6f697..db5981b5ec 100644
+--- a/apps/cli/package.json
++++ b/apps/cli/package.json
+@@ -85,7 +85,7 @@
+     "multer": "1.4.5-lts.2",
+     "node-fetch": "2.6.12",
+     "node-forge": "1.3.1",
+-    "open": "10.1.2",
++    "open": "8.4.2",
+     "papaparse": "5.5.3",
+     "proper-lockfile": "4.1.2",
+     "rxjs": "7.8.1",
+diff --git a/apps/desktop/desktop_native/Cargo.lock b/apps/desktop/desktop_native/Cargo.lock
+index 05663ea7e0..eadd75e598 100644
+--- a/apps/desktop/desktop_native/Cargo.lock
++++ b/apps/desktop/desktop_native/Cargo.lock
+@@ -162,7 +162,7 @@ dependencies = [
+  "serde_repr",
+  "tokio",
+  "url",
+- "zbus 5.6.0",
++ "zbus",
+ ]
+ 
+ [[package]]
+@@ -900,7 +900,7 @@ dependencies = [
+  "widestring",
+  "windows 0.61.1",
+  "windows-future",
+- "zbus 4.4.0",
++ "zbus",
+  "zbus_polkit",
+  "zeroizing-alloc",
+ ]
+@@ -2063,10 +2063,10 @@ dependencies = [
+  "sha2",
+  "subtle",
+  "tokio",
+- "zbus 5.6.0",
+- "zbus_macros 5.6.0",
++ "zbus",
++ "zbus_macros",
+  "zeroize",
+- "zvariant 5.5.1",
++ "zvariant",
+ ]
+ 
+ [[package]]
+@@ -2715,17 +2715,6 @@ dependencies = [
+  "syn",
+ ]
+ 
+-[[package]]
+-name = "sha1"
+-version = "0.10.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+-dependencies = [
+- "cfg-if",
+- "cpufeatures",
+- "digest",
+-]
+-
+ [[package]]
+ name = "sha2"
+ version = "0.10.8"
+@@ -3921,9 +3910,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "zbus"
+-version = "4.4.0"
++version = "5.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
++checksum = "59c333f648ea1b647bc95dc1d34807c8e25ed7a6feff3394034dc4776054b236"
+ dependencies = [
+  "async-broadcast",
+  "async-executor",
+@@ -3938,90 +3927,37 @@ dependencies = [
+  "enumflags2",
+  "event-listener",
+  "futures-core",
+- "futures-sink",
+- "futures-util",
+- "hex",
+- "nix",
+- "ordered-stream",
+- "rand 0.8.5",
+- "serde",
+- "serde_repr",
+- "sha1",
+- "static_assertions",
+- "tracing",
+- "uds_windows",
+- "windows-sys 0.52.0",
+- "xdg-home",
+- "zbus_macros 4.4.0",
+- "zbus_names 3.0.0",
+- "zvariant 4.2.0",
+-]
+-
+-[[package]]
+-name = "zbus"
+-version = "5.6.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2522b82023923eecb0b366da727ec883ace092e7887b61d3da5139f26b44da58"
+-dependencies = [
+- "async-broadcast",
+- "async-recursion",
+- "async-trait",
+- "enumflags2",
+- "event-listener",
+- "futures-core",
+  "futures-lite",
+  "hex",
+  "nix",
+  "ordered-stream",
+  "serde",
+  "serde_repr",
++ "static_assertions",
+  "tokio",
+  "tracing",
+  "uds_windows",
+  "windows-sys 0.59.0",
+  "winnow",
+- "zbus_macros 5.6.0",
+- "zbus_names 4.2.0",
+- "zvariant 5.5.1",
++ "xdg-home",
++ "zbus_macros",
++ "zbus_names",
++ "zvariant",
+ ]
+ 
+ [[package]]
+ name = "zbus_macros"
+-version = "4.4.0"
++version = "5.5.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
++checksum = "f325ad10eb0d0a3eb060203494c3b7ec3162a01a59db75d2deee100339709fc0"
+ dependencies = [
+  "proc-macro-crate",
+  "proc-macro2",
+  "quote",
+  "syn",
+- "zvariant_utils 2.1.0",
+-]
+-
+-[[package]]
+-name = "zbus_macros"
+-version = "5.6.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "05d2e12843c75108c00c618c2e8ef9675b50b6ec095b36dc965f2e5aed463c15"
+-dependencies = [
+- "proc-macro-crate",
+- "proc-macro2",
+- "quote",
+- "syn",
+- "zbus_names 4.2.0",
+- "zvariant 5.5.1",
+- "zvariant_utils 3.2.0",
+-]
+-
+-[[package]]
+-name = "zbus_names"
+-version = "3.0.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+-dependencies = [
+- "serde",
+- "static_assertions",
+- "zvariant 4.2.0",
++ "zbus_names",
++ "zvariant",
++ "zvariant_utils",
+ ]
+ 
+ [[package]]
+@@ -4033,20 +3969,20 @@ dependencies = [
+  "serde",
+  "static_assertions",
+  "winnow",
+- "zvariant 5.5.1",
++ "zvariant",
+ ]
+ 
+ [[package]]
+ name = "zbus_polkit"
+-version = "4.0.0"
++version = "5.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "00a29bfa927b29f91b7feb4e1990f2dd1b4604072f493dc2f074cf59e4e0ba90"
++checksum = "ad23d5c4d198c7e2641b33e6e0d1f866f117408ba66fe80bbe52e289eeb77c52"
+ dependencies = [
+  "enumflags2",
+  "serde",
+  "serde_repr",
+  "static_assertions",
+- "zbus 4.4.0",
++ "zbus",
+ ]
+ 
+ [[package]]
+@@ -4149,19 +4085,6 @@ dependencies = [
+  "syn",
+ ]
+ 
+-[[package]]
+-name = "zvariant"
+-version = "4.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+-dependencies = [
+- "endi",
+- "enumflags2",
+- "serde",
+- "static_assertions",
+- "zvariant_derive 4.2.0",
+-]
+-
+ [[package]]
+ name = "zvariant"
+ version = "5.5.1"
+@@ -4173,21 +4096,8 @@ dependencies = [
+  "serde",
+  "url",
+  "winnow",
+- "zvariant_derive 5.5.1",
+- "zvariant_utils 3.2.0",
+-]
+-
+-[[package]]
+-name = "zvariant_derive"
+-version = "4.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+-dependencies = [
+- "proc-macro-crate",
+- "proc-macro2",
+- "quote",
+- "syn",
+- "zvariant_utils 2.1.0",
++ "zvariant_derive",
++ "zvariant_utils",
+ ]
+ 
+ [[package]]
+@@ -4200,18 +4110,7 @@ dependencies = [
+  "proc-macro2",
+  "quote",
+  "syn",
+- "zvariant_utils 3.2.0",
+-]
+-
+-[[package]]
+-name = "zvariant_utils"
+-version = "2.1.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn",
++ "zvariant_utils",
+ ]
+ 
+ [[package]]
+diff --git a/package-lock.json b/package-lock.json
+index 5df63a79dd..702b6d1c81 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -225,7 +225,7 @@
+         "multer": "1.4.5-lts.2",
+         "node-fetch": "2.6.12",
+         "node-forge": "1.3.1",
+-        "open": "10.1.2",
++        "open": "8.4.2",
+         "papaparse": "5.5.3",
+         "proper-lockfile": "4.1.2",
+         "rxjs": "7.8.1",

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -34,13 +34,13 @@ let
 in
 buildNpmPackage' rec {
   pname = "bitwarden-desktop";
-  version = "2025.4.2";
+  version = "2025.5.0";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    hash = "sha256-sWphSdxh07GS7GPlNVxK7zoXMTGLjT7qTLfH1nsIiQQ=";
+    hash = "sha256-8jVKwqKhTfhur226SER4sb1i4dY+TjJRYmOY8YtO6CY=";
   };
 
   patches = [
@@ -76,7 +76,7 @@ buildNpmPackage' rec {
     "--ignore-scripts"
   ];
   npmWorkspace = "apps/desktop";
-  npmDepsHash = "sha256-/BOzDt+wgnWedWfShPkAhaeujBBQTDlZdtiKl3wrOqE=";
+  npmDepsHash = "sha256-0IoBPRGdtkMeTrT5cqZLHB/WrUCONtsJ6YHh0y4K5Ls=";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit
@@ -86,7 +86,7 @@ buildNpmPackage' rec {
       cargoRoot
       patches
       ;
-    hash = "sha256-EONHK33RuVy2ZlUzwdvdBX+6/jiCsrNo9ueZYQtWSkA=";
+    hash = "sha256-ZD/UPYRa+HR7hyWDP6S/BKvQpYRDwWQJV6iGF9LT2uY=";
   };
   cargoRoot = "apps/desktop/desktop_native";
 

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -34,13 +34,13 @@ let
 in
 buildNpmPackage' rec {
   pname = "bitwarden-desktop";
-  version = "2025.5.0";
+  version = "2025.5.1";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    hash = "sha256-8jVKwqKhTfhur226SER4sb1i4dY+TjJRYmOY8YtO6CY=";
+    hash = "sha256-1gxd73E7Y7e1A6yU+J3XYQ4QzXZTxuKd+AE+t8HD478=";
   };
 
   patches = [

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -5,7 +5,7 @@
   cargo,
   copyDesktopItems,
   darwin,
-  electron_34,
+  electron_36,
   fetchFromGitHub,
   gnome-keyring,
   jq,
@@ -25,7 +25,7 @@
 let
   description = "Secure and free password manager for all of your devices";
   icon = "bitwarden";
-  electron = electron_34;
+  electron = electron_36;
 
   # argon2 npm dependency is using `std::basic_string<uint8_t>`, which is no longer allowed in LLVM 19
   buildNpmPackage' = buildNpmPackage.override {
@@ -34,21 +34,26 @@ let
 in
 buildNpmPackage' rec {
   pname = "bitwarden-desktop";
-  version = "2025.5.1";
+  version = "2025.6.0";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     rev = "desktop-v${version}";
-    hash = "sha256-1gxd73E7Y7e1A6yU+J3XYQ4QzXZTxuKd+AE+t8HD478=";
+    hash = "sha256-KI6oIMNtqfywVqeTdzthSHBnAlF55cINTr04LNSq0AM=";
   };
 
   patches = [
     ./electron-builder-package-lock.patch
     ./dont-auto-setup-biometrics.patch
-    ./set-exe-path.patch # ensures `app.getPath("exe")` returns our wrapper, not ${electron}/bin/electron
-    ./skip-afterpack-and-aftersign.patch # on linux: don't flip fuses, don't create wrapper script, on darwin: don't try copying safari extensions, don't try re-signing app
-    ./dont-use-platform-triple.patch # since out arch doesn't match upstream, we'll generate and use desktop_napi.node instead of desktop_napi.${platform}-${arch}.node
+    ./fix-lock-files.diff
+
+    # ensures `app.getPath("exe")` returns our wrapper, not ${electron}/bin/electron
+    ./set-exe-path.patch
+    # on linux: don't flip fuses, don't create wrapper script, on darwin: don't try copying safari extensions, don't try re-signing app
+    ./skip-afterpack-and-aftersign.patch
+    # since out arch doesn't match upstream, we'll generate and use desktop_napi.node instead of desktop_napi.${platform}-${arch}.node
+    ./dont-use-platform-triple.patch
   ];
 
   postPatch = ''
@@ -76,7 +81,7 @@ buildNpmPackage' rec {
     "--ignore-scripts"
   ];
   npmWorkspace = "apps/desktop";
-  npmDepsHash = "sha256-0IoBPRGdtkMeTrT5cqZLHB/WrUCONtsJ6YHh0y4K5Ls=";
+  npmDepsHash = "sha256-52cLVrfbeNeRH7OKN5QZdGD5VkUVliN0Rn/cbdohsG0=";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit
@@ -86,7 +91,7 @@ buildNpmPackage' rec {
       cargoRoot
       patches
       ;
-    hash = "sha256-ZD/UPYRa+HR7hyWDP6S/BKvQpYRDwWQJV6iGF9LT2uY=";
+    hash = "sha256-mt7zWKgH21khAIrfpBFzb+aS2V2mV56zMqCSLzDhGfQ=";
   };
   cargoRoot = "apps/desktop/desktop_native";
 

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -46,6 +46,7 @@ buildNpmPackage' rec {
   patches = [
     ./electron-builder-package-lock.patch
     ./dont-auto-setup-biometrics.patch
+    # The nixpkgs tooling trips over upstreams inconsistent lock files, so we fixed them by running npm install open@10.2.1 and cargo b
     ./fix-lock-files.diff
 
     # ensures `app.getPath("exe")` returns our wrapper, not ${electron}/bin/electron


### PR DESCRIPTION
Manual backport of #413104 #416906 #420516 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.