### PR TITLE
python312Packages.schedula: init at 1.5.62

### DIFF
--- a/pkgs/development/python-modules/schedula/default.nix
+++ b/pkgs/development/python-modules/schedula/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # optional-dependencies
+  dill,
+  flask,
+  graphviz,
+  multiprocess,
+  regex,
+  requests,
+  sphinx,
+  sphinx-click,
+
+  # tests
+  pytestCheckHook,
+  ddt,
+  cryptography,
+  schedula,
+}:
+
+buildPythonPackage rec {
+  pname = "schedula";
+  version = "1.5.62";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "vinci1it2000";
+    repo = "schedula";
+    tag = "v${version}";
+    hash = "sha256-erEUdiKV1MRwjVy3SKFneJVHp6gWEok7EWdv6v6HFGM=";
+  };
+
+  build-system = [ setuptools ];
+
+  optional-dependencies = rec {
+    # dev omitted, we have nativeCheckInputs for this
+    # form omitted, as it pulls in a kitchensink of deps, some not even packaged in nixpkgs
+    io = [ dill ];
+    parallel = [ multiprocess ];
+    plot = [
+      requests
+      graphviz
+      regex
+      flask
+    ];
+    sphinx = [
+      sphinx
+      sphinx-click
+    ] ++ plot;
+    web = [
+      requests
+      regex
+      flask
+    ];
+  };
+
+  nativeCheckInputs =
+    [
+      cryptography # doctests
+      ddt
+      sphinx
+      pytestCheckHook
+    ]
+    ++ schedula.optional-dependencies.io
+    ++ schedula.optional-dependencies.parallel
+    ++ schedula.optional-dependencies.plot;
+
+  disabledTests = [
+    # FAILED tests/test_setup.py::TestSetup::test_long_description - ModuleNotFoundError: No module named 'sphinxcontrib.writers'
+    "test_long_description"
+  ];
+
+  disabledTestPaths = [
+    # ERROR tests/utils/test_form.py::TestDispatcherForm::test_form1 - ModuleNotFoundError: No module named 'chromedriver_autoinstaller'
+    # ERROR tests/utils/test_form.py::TestDispatcherForm::test_form_stripe - ModuleNotFoundError: No module named 'chromedriver_autoinstaller'
+    "tests/utils/test_form.py"
+  ];
+
+  pythonImportsCheck = [ "schedula" ];
+
+  meta = {
+    description = "Smart function scheduler for dynamic flow-based programming";
+    homepage = "https://github.com/vinci1it2000/schedula";
+    changelog = "https://github.com/vinci1it2000/schedula/blob/v${version}/CHANGELOG.rst";
+    license = lib.licenses.eupl11;
+    maintainers = with lib.maintainers; [ flokli ];
+    # at least some tests fail on Darwin
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15851,6 +15851,8 @@ self: super: with self; {
 
   scenedetect = callPackage ../development/python-modules/scenedetect { };
 
+  schedula = callPackage ../development/python-modules/schedula { };
+
   schedule = callPackage ../development/python-modules/schedule { };
 
   scheduler = callPackage ../development/python-modules/scheduler { };


### PR DESCRIPTION
This adds [schedula](https://github.com/vinci1it2000/schedula), a smart function scheduler for dynamic flow-based programming to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
