### PR TITLE
cerberus: init at 0-unstable-2025-06-29

### DIFF
--- a/pkgs/by-name/ce/cerberus/package.nix
+++ b/pkgs/by-name/ce/cerberus/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  unstableGitUpdater,
+  ocamlPackages,
+  opam,
+}:
+ocamlPackages.buildDunePackage {
+  pname = "cerberus";
+  version = "0-unstable-2025-06-29";
+
+  src = fetchFromGitHub {
+    owner = "rems-project";
+    repo = "cerberus";
+    rev = "61700b301f0f1fbc1940db51c50240c397759057";
+    hash = "sha256-QpgHOQqiJMlMf2RH5/TI3AirdqYPS7HwE9YIlxgorqg=";
+  };
+
+  minimalOCamlVersion = "4.12";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    opam
+    writableTmpDirAsHomeHook
+    ocamlPackages.lem
+    ocamlPackages.menhir
+  ];
+
+  buildInputs = with ocamlPackages; [
+    sha
+    pprint
+    cmdliner
+    yojson
+    lem
+    result
+    ppx_deriving
+    zarith
+    sexplib
+    menhirLib
+    janeStreet.ppx_sexp_conv
+  ];
+
+  env.OPAM_SWITCH_PREFIX = placeholder "out";
+  buildPhase = ''
+    runHook preBuild
+
+    make Q= cerberus
+
+    runHook postBuild
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    PATH="$out/bin":$PATH
+
+    patchShebangs --build tests
+
+    tests/run-ci.sh
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = unstableGitUpdater { branch = "master"; };
+
+  meta = {
+    homepage = "https://www.cl.cam.ac.uk/~pes20/cerberus/";
+    license = with lib.licenses; [
+      # Most of Cerberus
+      bsd2
+      # https://github.com/rems-project/cerberus/blob/master/THIRD_PARTY_FILES.md
+      # Files from Linux kernel
+      gpl2Only
+      # Files from cppmem
+      bsd3
+      # Files from musl
+      mit
+      # Files from BSD
+      bsdOriginal
+      # Slightly modified vendored SibylFS
+      isc
+    ];
+    mainProgram = "cerberus";
+    maintainers = with lib.maintainers; [
+      RossSmyth
+    ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
With the publication of https://www.iso.org/standard/81899.html
It would probably be a good idea to have Cerberus available on nixpkgs.

## Things done

1. Add Cerberus package

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
