### PR TITLE
python3Packages.viser: init at 1.0.0, python3Packages.yourdfpy: init at 0.0.58, python3Packages.plyfile: 1.0.2 -> 1.1.2, python3Packages.robot-descriptions: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/plyfile/default.nix
+++ b/pkgs/development/python-modules/plyfile/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
 
   # build-system
-  pdm-pep517,
+  pdm-backend,
 
   # dependencies
   numpy,
@@ -15,25 +15,27 @@
 
 buildPythonPackage rec {
   pname = "plyfile";
-  version = "1.0.2";
+  version = "1.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dranjan";
     repo = "python-plyfile";
     tag = "v${version}";
-    hash = "sha256-HlyqljfjuaZoG5f2cfDQj+7KS0en7pW2PPEnpvH8U+E=";
+    hash = "sha256-J72aoXEMcuHtYaLtzWJ5UGN9HdJTnQ1/8KgdMLtwyr0=";
   };
 
-  nativeBuildInputs = [ pdm-pep517 ];
+  build-system = [ pdm-backend ];
 
-  propagatedBuildInputs = [ numpy ];
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  meta = with lib; {
+  pythonImportsCheck = [ "plyfile" ];
+
+  meta = {
     description = "NumPy-based text/binary PLY file reader/writer for Python";
     homepage = "https://github.com/dranjan/python-plyfile";
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with lib.maintainers; [ abbradar ];
   };
 }

--- a/pkgs/development/python-modules/robot-descriptions/default.nix
+++ b/pkgs/development/python-modules/robot-descriptions/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  gitpython,
+  tqdm,
+  # idyntree,
+  mujoco,
+  pinocchio,
+  pybullet,
+  pycollada,
+  # robomeshcat,
+  yourdfpy,
+}:
+
+buildPythonPackage rec {
+  pname = "robot-descriptions";
+  version = "1.20.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "robot-descriptions";
+    repo = "robot_descriptions.py";
+    tag = "v${version}";
+    hash = "sha256-8SBzhkENpUodnfObekkMPUsTQr/8mz27v3PK0S3IKO0=";
+  };
+
+  build-system = [
+    flit-core
+  ];
+
+  dependencies = [
+    gitpython
+    tqdm
+    pycollada
+  ];
+
+  optional-dependencies = {
+    opts = [
+      # idyntree
+      mujoco
+      pinocchio
+      pybullet
+      # robomeshcat
+      yourdfpy
+    ];
+  };
+
+  pythonImportsCheck = [
+    "robot_descriptions"
+  ];
+
+  # This package needs to download a lot of data at runtime
+  doCheck = false;
+
+  meta = {
+    description = "Access 125+ robot descriptions from the main Python robotics frameworks";
+    homepage = "https://github.com/robot-descriptions/robot_descriptions.py";
+    changelog = "https://github.com/robot-descriptions/robot_descriptions.py/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -1,0 +1,152 @@
+{
+  lib,
+
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  nodejs,
+  fetchYarnDeps,
+  yarnConfigHook,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  imageio,
+  msgspec,
+  nodeenv,
+  numpy,
+  opencv-python,
+  plyfile,
+  psutil,
+  requests,
+  rich,
+  scikit-image,
+  scipy,
+  tqdm,
+  trimesh,
+  tyro,
+  websockets,
+  yourdfpy,
+
+  # optional-dependencies
+  hypothesis,
+  pre-commit,
+  pandas,
+  pyright,
+  pytest,
+  ruff,
+  gdown,
+  matplotlib,
+  plotly,
+  # pyliblzfse,
+  robot-descriptions,
+  torch,
+
+  # nativeCheckInputs
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "viser";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nerfstudio-project";
+    repo = "viser";
+    tag = "v${version}";
+    hash = "sha256-itFJ9mlN2VaWbLzQp1ERMxBvXg0O7SMWzEWDdxoTA/0=";
+  };
+
+  postPatch = ''
+    # prepare yarn offline cache
+    mkdir -p node_modules
+    cd src/viser/client
+    cp package.json yarn.lock ../../..
+    ln -s ../../../node_modules
+
+    # fix: [vite-plugin-eslint] Failed to load config "react-app" to extend from.
+    substituteInPlace vite.config.mts --replace-fail \
+      "eslint({ failOnError: false, failOnWarning: false })," ""
+
+    cd ../../..
+  '';
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    nodejs
+  ];
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = src + "/src/viser/client/yarn.lock";
+    hash = "sha256-4x+zJIqjVoKmEdOUPGpCuMmlRBfF++3oWtbNYAvd2ko=";
+  };
+
+  preBuild = ''
+    cd src/viser/client
+    yarn --offline build
+    cd ../../..
+  '';
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    imageio
+    msgspec
+    nodeenv
+    numpy
+    opencv-python
+    plyfile
+    psutil
+    requests
+    rich
+    scikit-image
+    scipy
+    tqdm
+    trimesh
+    tyro
+    websockets
+    yourdfpy
+  ];
+
+  optional-dependencies = {
+    dev = [
+      hypothesis
+      pre-commit
+      pyright
+      pytest
+      ruff
+    ];
+    examples = [
+      gdown
+      matplotlib
+      pandas
+      plotly
+      plyfile
+      # pyliblzfse
+      robot-descriptions
+      torch
+    ];
+  };
+
+  nativeCheckInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "viser"
+  ];
+
+  meta = {
+    changelog = "https://github.com/nerfstudio-project/viser/releases/tag/${src.tag}";
+    description = "Web-based 3D visualization + Python";
+    homepage = "https://github.com/nerfstudio-project/viser";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/yourdfpy/default.nix
+++ b/pkgs/development/python-modules/yourdfpy/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  lxml,
+  trimesh,
+  numpy,
+  six,
+
+  # nativeCheckInputs
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "yourdfpy";
+  version = "0.0.58";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "clemense";
+    repo = "yourdfpy";
+    tag = "v${version}";
+    hash = "sha256-Wi4QcgTOf/1nXWssFtlyRxql8Jg1nNKjEGkWuP+w73g=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    lxml
+    trimesh
+    numpy
+    six
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  pythonImportsCheck = [
+    "yourdfpy"
+  ];
+
+  meta = {
+    description = "Python parser for URDFs";
+    homepage = "https://github.com/clemense/yourdfpy/";
+    changelog = "https://github.com/clemense/yourdfpy/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "yourdfpy";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19976,6 +19976,8 @@ self: super: with self; {
 
   youless-api = callPackage ../development/python-modules/youless-api { };
 
+  yourdfpy = callPackage ../development/python-modules/yourdfpy { };
+
   youseedee = callPackage ../development/python-modules/youseedee { };
 
   youtokentome = callPackage ../development/python-modules/youtokentome { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19344,6 +19344,8 @@ self: super: with self; {
 
   virtualenvwrapper = callPackage ../development/python-modules/virtualenvwrapper { };
 
+  viser = callPackage ../development/python-modules/viser { };
+
   visions = callPackage ../development/python-modules/visions { };
 
   visitor = callPackage ../development/python-modules/visitor { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15754,6 +15754,8 @@ self: super: with self; {
 
   robomachine = callPackage ../development/python-modules/robomachine { };
 
+  robot-descriptions = callPackage ../development/python-modules/robot-descriptions { };
+
   robot-detection = callPackage ../development/python-modules/robot-detection { };
 
   robotframework = callPackage ../development/python-modules/robotframework { };


### PR DESCRIPTION
Fix #266695 

This PR:
- add https://viser.studio/main/, 
- add yourdfpy (a required dependency)
- add robot-descriptions (a dependency to check the examples)
- update & fix plyfile (another required dependency)

NB: viser somehow depend on tensorflow which does not work with python 3.13 yet

Tested by opening a few things in the examples directory on x86_64-linux with eg
```
nix build .#python312Packages.viser.src
nix-shell -I nixpkgs=. \
                 -p "python312.withPackages (p: with p; [ viser ] ++ viser.optional-dependencies.examples)" \
                 --command "python result/examples/04_demos/02_urdf_visualizer.py"
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
