### PR TITLE
nixos/libvirtd: Make all OVMF images from QEMU package available

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -144,6 +144,22 @@
 
 - `virtualisation.lxd` has been removed due to lack of Nixpkgs maintenance. Users can migrate to `virtualisation.incus`, a fork of LXD, as a replacement. See [Incus migration documentation](https://linuxcontainers.org/incus/docs/main/howto/server_migrate_lxd/) for migration information.
 
+- `virtualisation.libvirtd` now uses OVMF images shipped with QEMU for UEFI machines. `virtualisation.libvirtd.qemu.ovmf` has been removed.
+  - OVMF images from underlying QEMU package are now made available under '/run/libvirt/nix-ovmf', fixing prior issues when using QEMU's automatic EFI firmware and feature handling, relied upon by GNOME Boxes, virsh, virt-manager, etc.
+  - Domains that rely on automatic firmware and feature handling, i.e. `<os firmware='efi'>` need to trigger an update to `<loader>` and `<nvram>` entries.
+    Using `virsh edit <domain>` and deleting aforementioned tags will cause libvirt to replace them with the new paths.
+  - Configurations that relied on `virtualisation.libvirtd.qemu.ovmf` and had domains that did not use automatic firmware and feature handling, require a manual change to their domain configuration, updating `<loader>` and `<nvram>` entries from old path to the new path.
+    | Old Path                               | New Path                                         |
+    |----------------------------------------|--------------------------------------------------|
+    | /run/libvirt/nix-ovmf/OVMF_CODE.fd     | /run/libvirt/nix-ovmf/edk2-x86_64-code.fd        |
+    | /run/libvirt/nix-ovmf/OVMF_VARS.fd     | /run/libvirt/nix-ovmf/edk2-i386-vars.fd          |
+    | /run/libvirt/nix-ovmf/OVMF_CODE.ms.fd  | /run/libvirt/nix-ovmf/edk2-x86_64-secure-code.fd |
+    | /run/libvirt/nix-ovmf/OVMF_VARS.ms.fd  | /run/libvirt/nix-ovmf/edk2-i386-vars.fd          |
+    | /run/libvirt/nix-ovmf/AAVMF_CODE.fd    | /run/libvirt/nix-ovmf/edk2-aarch64-code.fd       |
+    | /run/libvirt/nix-ovmf/AAVMF_VARS.fd    | /run/libvirt/nix-ovmf/edk2-arm-vars.fd           |
+    | /run/libvirt/nix-ovmf/AAVMF_CODE.ms.fd | /run/libvirt/nix-ovmf/edk2-aarch64-code.fd       |
+    | /run/libvirt/nix-ovmf/AAVMF_VARS.ms.fd | /run/libvirt/nix-ovmf/edk2-arm-vars.fd           |
+
 - The non-LTS Forgejo package (`forgejo`) has been updated to 12.0.0. This release contains breaking changes, see the [release blog post](https://forgejo.org/2025-07-release-v12-0/)
   for all the details and how to ensure smooth upgrades.
 

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -17,14 +17,6 @@ let
     ${cfg.extraConfig}
   '';
   qemuConfigFile = pkgs.writeText "qemu.conf" ''
-    ${optionalString cfg.qemu.ovmf.enable ''
-      nvram = [
-        "/run/libvirt/nix-ovmf/AAVMF_CODE.fd:/run/libvirt/nix-ovmf/AAVMF_VARS.fd",
-        "/run/libvirt/nix-ovmf/AAVMF_CODE.ms.fd:/run/libvirt/nix-ovmf/AAVMF_VARS.ms.fd",
-        "/run/libvirt/nix-ovmf/OVMF_CODE.fd:/run/libvirt/nix-ovmf/OVMF_VARS.fd",
-        "/run/libvirt/nix-ovmf/OVMF_CODE.ms.fd:/run/libvirt/nix-ovmf/OVMF_VARS.ms.fd"
-      ]
-    ''}
     ${optionalString (!cfg.qemu.runAsRoot) ''
       user = "qemu-libvirtd"
       group = "qemu-libvirtd"
@@ -37,36 +29,6 @@ let
 
   dirName = "libvirt";
   subDirs = list: [ dirName ] ++ map (e: "${dirName}/${e}") list;
-
-  ovmfModule = types.submodule {
-    options = {
-      enable = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Allows libvirtd to take advantage of OVMF when creating new
-          QEMU VMs with UEFI boot.
-        '';
-      };
-
-      # mkRemovedOptionModule does not work in submodules, do it manually
-      package = mkOption {
-        type = types.nullOr types.package;
-        default = null;
-        internal = true;
-      };
-
-      packages = mkOption {
-        type = types.listOf types.package;
-        default = [ pkgs.OVMF.fd ];
-        defaultText = literalExpression "[ pkgs.OVMF.fd ]";
-        example = literalExpression "[ pkgs.OVMFFull.fd pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd ]";
-        description = ''
-          List of OVMF packages to use. Each listed package must contain files names FV/OVMF_CODE.fd and FV/OVMF_VARS.fd or FV/AAVMF_CODE.fd and FV/AAVMF_VARS.fd
-        '';
-      };
-    };
-  };
 
   swtpmModule = types.submodule {
     options = {
@@ -116,11 +78,28 @@ let
       };
 
       ovmf = mkOption {
-        type = ovmfModule;
+        type = types.submodule {
+          options = {
+            enable = mkOption {
+              type = types.nullOr types.bool;
+              default = null;
+              internal = true;
+            };
+            package = mkOption {
+              type = types.nullOr types.package;
+              default = null;
+              internal = true;
+            };
+            packages = mkOption {
+              type = types.nullOr (types.listOf types.package);
+              default = null;
+              internal = true;
+            };
+          };
+        };
         default = { };
-        description = ''
-          QEMU's OVMF options.
-        '';
+        internal = true;
+        description = "This submodule is deprecated and has been removed";
       };
 
       swtpm = mkOption {
@@ -220,6 +199,21 @@ let
       };
     };
   };
+
+  qemuOvmfMetadata = pkgs.stdenv.mkDerivation {
+    name = "qemu-ovmf-metadata";
+    version = cfg.qemu.package.version;
+    nativeBuildInputs = [ cfg.qemu.package ];
+    dontBuild = true;
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p $out
+      cp ${cfg.qemu.package}/share/qemu/firmware/*.json $out
+      substituteInPlace $out/*.json \
+        --replace-fail "${cfg.qemu.package}/share/qemu/" "/run/${dirName}/nix-ovmf/"
+    '';
+  };
+
 in
 {
 
@@ -242,15 +236,14 @@ in
       [ "virtualisation" "libvirtd" "qemu" "verbatimConfig" ]
     )
     (mkRenamedOptionModule
-      [ "virtualisation" "libvirtd" "qemuOvmf" ]
-      [ "virtualisation" "libvirtd" "qemu" "ovmf" "enable" ]
-    )
-    (mkRemovedOptionModule [ "virtualisation" "libvirtd" "qemuOvmfPackage" ]
-      "If this option was set to `foo`, set the option `virtualisation.libvirtd.qemu.ovmf.packages' to `[foo.fd]` instead."
-    )
-    (mkRenamedOptionModule
       [ "virtualisation" "libvirtd" "qemuSwtpm" ]
       [ "virtualisation" "libvirtd" "qemu" "swtpm" "enable" ]
+    )
+    (mkRemovedOptionModule [ "virtualisation" "libvirtd" "qemuOvmf" ]
+      "The 'virtualisation.libvirtd.qemuOvmf' option has been removed. All OVMF images distributed with QEMU are now available by default."
+    )
+    (mkRemovedOptionModule [ "virtualisation" "libvirtd" "qemuOvmfPackage" ]
+      "The 'virtualisation.libvirtd.qemuOvmfPackage' option has been removed. All OVMF images distributed with QEMU are now available by default."
     )
   ];
 
@@ -409,15 +402,13 @@ in
 
     assertions = [
       {
-        assertion = config.virtualisation.libvirtd.qemu.ovmf.package == null;
-        message = ''
-          The option virtualisation.libvirtd.qemu.ovmf.package is superseded by virtualisation.libvirtd.qemu.ovmf.packages.
-          If this option was set to `foo`, set the option `virtualisation.libvirtd.qemu.ovmf.packages' to `[foo.fd]` instead.
-        '';
-      }
-      {
         assertion = config.security.polkit.enable;
         message = "The libvirtd module currently requires Polkit to be enabled ('security.polkit.enable = true').";
+      }
+
+      {
+        assertion = ((lib.filterAttrs (n: v: v != null) cfg.qemu.ovmf) == { });
+        message = "The 'virtualisation.libvirtd.qemu.ovmf' submodule has been removed. All OVMF images distributed with QEMU are now available by default.";
       }
     ];
 
@@ -488,20 +479,12 @@ in
 
         ln -s --force ${cfg.qemu.package}/bin/qemu-pr-helper /run/${dirName}/nix-helpers/
 
-        ${optionalString cfg.qemu.ovmf.enable (
-          let
-            ovmfpackage = pkgs.buildEnv {
-              name = "qemu-ovmf";
-              paths = cfg.qemu.ovmf.packages;
-            };
-          in
-          ''
-            ln -s --force ${ovmfpackage}/FV/AAVMF_CODE{,.ms}.fd /run/${dirName}/nix-ovmf/
-            ln -s --force ${ovmfpackage}/FV/OVMF_CODE{,.ms}.fd /run/${dirName}/nix-ovmf/
-            ln -s --force ${ovmfpackage}/FV/AAVMF_VARS{,.ms}.fd /run/${dirName}/nix-ovmf/
-            ln -s --force ${ovmfpackage}/FV/OVMF_VARS{,.ms}.fd /run/${dirName}/nix-ovmf/
-          ''
-        )}
+        # Symlink to OVMF firmware code and variable template images distributed with QEMU
+        cp -sfv $(
+          ${pkgs.jq}/bin/jq -rs \
+            '[.[] | .mapping.executable.filename, .mapping."nvram-template".filename] | unique | .[]' \
+          ${cfg.qemu.package}/share/qemu/firmware/* \
+        ) /run/${dirName}/nix-ovmf
 
         # Symlink hooks to /var/lib/libvirt
         ${concatStringsSep "\n" (
@@ -620,7 +603,7 @@ in
       in
       [
         "L+ /var/lib/qemu/vhost-user - - - - ${vhostUserCollection}/share/qemu/vhost-user"
-        "L+ /var/lib/qemu/firmware - - - - ${cfg.qemu.package}/share/qemu/firmware"
+        "L+ /var/lib/qemu/firmware - - - - ${qemuOvmfMetadata}"
       ];
 
     security.polkit = {


### PR DESCRIPTION
This PR primarily addresses the broken libvirtd QEMU VMs after configuration switches.
Domains, essentially VMs in libvirt parlance, have `loader` and `nvram` defined for their firmware. Loader being the firmware image, and NVRAM being the variable values, accompanied with an NVRAM template. The image and template entries in the configuration point to the canonical paths in QEMU package. Once the hash for QEMU package used by the module changes, the domains cannot be edited anymore without manually changing these canonical paths to point to the current QEMU package path. Eventually when the old path gets garbage collected, domains break.

A prior remedy to firmware image and variable template stability was landed in 84a6a3683b7e10122d7a2c00a150cc1b1c02c4bb (albeit without a commit message) in 2017, relying on now obsolete `nvram` option in `qemu.conf`. This option was [removed from libvirt in 2019](https://github.com/libvirt/libvirt/commit/75597f022a69bc8000ddcdea857b77fe45f0d874) and was being ignored since then, with an warning logged.

```
% journalctl -u libvirtd -p warning -g nvram -o cat | uniq
Obsolete nvram variable is set while firmware metadata files found. Note that the nvram config file variable is going to be ignored.
```

Since [Apr 2019](https://github.com/qemu/qemu/commit/536d2173b2b35fef6be0d4fa2645bf812ef8ba3d), QEMU has been shipping with EDK II ROMs; along with a then-new way of mapping these images to machine types with [descriptor JSON files](https://github.com/qemu/qemu/commit/13814db0408a87ab198e5c4e742def1c56662df7). QEMU looks up for these descriptors under `/var/lib/firmware/qemu`. These descriptors are the reason `nvram` configurable was retired in libvirt.  In the module we create a package of these descriptor files but replaceInPlace image and template paths to point the symlinks under /run/libvirt/nix-ovmf.

Given now the module always have access to OVMF images and templates for i386 (+secure boot), x86_64 (+secure boot), arm, aarch64, loongarch64, and riscv64 architectures; it removes the the `virtualisation.libvirtd.qemu.ovmf` submodule entirely. To the best of my understanding pkgs.OVMF doesn't offer that isn't already shipped with QEMU, and given QEMU package by default brings these blobs, there's also a no storage saving optimization.

 
### TODO:
- [x] Add an entry to NixOS 25.11 Release Notes


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
