### PR TITLE
cloud-init: 24.2 -> 25.1.3

### DIFF
--- a/pkgs/tools/virtualization/cloud-init/0002-fix-test-logs-on-nixos.patch
+++ b/pkgs/tools/virtualization/cloud-init/0002-fix-test-logs-on-nixos.patch
@@ -1,0 +1,22 @@
+diff --git a/tests/unittests/cmd/devel/test_logs.py b/tests/unittests/cmd/devel/test_logs.py
+index 78466e8d0..cc2b7246d 100644
+--- a/tests/unittests/cmd/devel/test_logs.py
++++ b/tests/unittests/cmd/devel/test_logs.py
+@@ -179,7 +179,7 @@ class TestCollectLogs:
+ 
+         for to_write in to_collect:
+             write_file(
+-                tmp_path / to_write, pathlib.Path(to_write).name, mode=0x700
++                tmp_path / to_write, pathlib.Path(to_write).name
+             )
+ 
+         collect_dir = tmp_path / "collect"
+@@ -225,7 +225,7 @@ class TestCollectLogs:
+ 
+         for to_write in to_collect:
+             write_file(
+-                tmp_path / to_write, pathlib.Path(to_write).name, mode=0x700
++                tmp_path / to_write, pathlib.Path(to_write).name
+             )
+ 
+         collect_dir = tmp_path / "collect"

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -17,7 +17,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "cloud-init";
-  version = "24.2";
+  version = "25.1.4";
   pyproject = true;
 
   namePrefix = "";
@@ -26,11 +26,12 @@ python3.pkgs.buildPythonApplication rec {
     owner = "canonical";
     repo = "cloud-init";
     tag = version;
-    hash = "sha256-BhTcOeSKZ1XRIx+xJQkqkSw9M8ilr+BRKXDy5MUXB6E=";
+    hash = "sha256-Ubu0uhpRrr4eV4ztOq/l004/+B2kjBWjRNwYcuHCfbU=";
   };
 
   patches = [
     ./0001-add-nixos-support.patch
+    ./0002-fix-test-logs-on-nixos.patch
   ];
 
   prePatch = ''


### PR DESCRIPTION
Auto update broke with version 24.3, caused by the following commit: canonical/cloud-init@c28092f.

The above commit changed some tests to write temporary files with specific permissions, which seems to be causing trouble for us. I've included a patch which removes these permissions, and the build is working fine now.

Changelogs:
- [24.3](https://github.com/canonical/cloud-init/releases/tag/24.3)
- [24.3.1](https://github.com/canonical/cloud-init/releases/tag/24.3.1)
- [24.4](https://github.com/canonical/cloud-init/releases/tag/24.4)
- [24.4.1](https://github.com/canonical/cloud-init/releases/tag/24.4.1)
- [25.1](https://github.com/canonical/cloud-init/releases/tag/25.1)
- [25.1.1](https://github.com/canonical/cloud-init/releases/tag/25.1.1)
- [25.1.2](https://github.com/canonical/cloud-init/releases/tag/25.1.2)
- [25.1.3](https://github.com/canonical/cloud-init/releases/tag/25.1.3)

It seems the only breaking changes are in version 24.3. I've tested this on a VPS I use cloud-init on, and it's working correctly. This PR supercedes #357780.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
