### PR TITLE
[release-25.05]: nixos/systemd-stage-1: follow systemd /run propagation

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -642,7 +642,7 @@ in
         {
           where = "/sysroot/run";
           what = "/run";
-          options = "bind";
+          options = "rbind";
           unitConfig = {
             # See the comment on the mount unit for /run/etc-metadata
             DefaultDependencies = false;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1304,6 +1304,7 @@ in
   systemd-escaping = handleTest ./systemd-escaping.nix { };
   systemd-initrd-bridge = handleTest ./systemd-initrd-bridge.nix { };
   systemd-initrd-btrfs-raid = handleTest ./systemd-initrd-btrfs-raid.nix { };
+  systemd-initrd-credentials = handleTest ./systemd-initrd-credentials.nix { };
   systemd-initrd-luks-fido2 = handleTest ./systemd-initrd-luks-fido2.nix { };
   systemd-initrd-luks-keyfile = handleTest ./systemd-initrd-luks-keyfile.nix { };
   systemd-initrd-luks-empty-passphrase = handleTest ./initrd-luks-empty-passphrase.nix {

--- a/nixos/tests/systemd-initrd-credentials.nix
+++ b/nixos/tests/systemd-initrd-credentials.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix (
+
+  { lib, pkgs, ... }:
+  {
+    name = "systemd-initrd-credentials";
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        virtualisation = {
+          qemu.options = [
+            "-smbios type=11,value=io.systemd.credential:cred-smbios=secret-smbios"
+          ];
+        };
+
+        boot.initrd.availableKernelModules = [ "dmi_sysfs" ];
+
+        boot.kernelParams = [ "systemd.set_credential=cred-cmdline:secret-cmdline" ];
+
+        boot.initrd.systemd = {
+          enable = true;
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      # Check credential passed via kernel command line
+      assert "secret-cmdline" in machine.succeed("systemd-creds --system cat cred-cmdline")
+
+      # Check credential passed via SMBIOS
+      assert "secret-smbios" in machine.succeed("systemd-creds --system cat cred-smbios")
+    '';
+  }
+)


### PR DESCRIPTION
This is required for creds at /run/credentials to survive the transition from initrd -> host.

Manual backport of https://github.com/NixOS/nixpkgs/pull/405687 for 25.05.

Fixes #421388

cc @petm5 @xeniarose 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
