### PR TITLE
mcsmanager: init at 10.7.1; mcsmanager-zip-tools: init at 1.0; mcsmanager-pty: init at 1.5.1

### DIFF
--- a/pkgs/by-name/mc/mcsmanager-pty/package.nix
+++ b/pkgs/by-name/mc/mcsmanager-pty/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mcsmanager-pty";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "MCSManager";
+    repo = "PTY";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mmHnJ+sdLqFmXv5jIeokkYZFbOSPoZEqlYeBRSVVDN4=";
+  };
+
+  vendorHash = "sha256-WfTp8Nsz9N5PYWDJF3EI6pqC+T3vnAW/kdevY7Bw4Rg=";
+
+  ldflags = [ "-s" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cross-platform pseudo-teletype application";
+    homepage = "https://github.com/MCSManager/PTY";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "pty";
+  };
+})

--- a/pkgs/by-name/mc/mcsmanager-zip-tools/package.nix
+++ b/pkgs/by-name/mc/mcsmanager-zip-tools/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mcsmanager-zip-tools";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "MCSManager";
+    repo = "Zip-Tools";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6WiflLqAlERcCXXx0laxmsRdFGwiWKPU8Rk7E2szAPU=";
+  };
+
+  vendorHash = "sha256-otiqMUwNoZ7jTPNpAT2go8vJ5RDRPZ4At9yZYSgL74k=";
+
+  ldflags = [ "-s" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Lightweight compression and decompression tool";
+    homepage = "https://github.com/MCSManager/Zip-Tools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "file-zip";
+  };
+})

--- a/pkgs/by-name/mc/mcsmanager/Replace-hardcoded-PTY-and-zip-tools-paths-with-placeholders.patch
+++ b/pkgs/by-name/mc/mcsmanager/Replace-hardcoded-PTY-and-zip-tools-paths-with-placeholders.patch
@@ -1,0 +1,61 @@
+From b1c502726f304eb01ec38db56d6f78d64dae984d Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Tue, 1 Jul 2025 22:58:29 +0800
+Subject: [PATCH] Replace hardcoded PTY and zip-tools paths with placeholders;
+ Remove runtime chmod
+
+---
+ src/app.ts   | 10 ----------
+ src/const.ts |  9 ++-------
+ 2 files changed, 2 insertions(+), 17 deletions(-)
+
+diff --git a/src/app.ts b/src/app.ts
+index 46af2d65..06c1feb3 100755
+--- a/src/app.ts
++++ b/src/app.ts
+@@ -99,16 +99,6 @@ try {
+   process.exit(-1);
+ }
+ 
+-(function initCompressModule() {
+-  try {
+-    fs.chmodSync(GOLANG_ZIP_PATH, 0o755);
+-    fs.chmodSync(PTY_PATH, 0o755);
+-  } catch (error: any) {
+-    logger.error(error?.message);
+-    logger.error($t("TXT_CODE_a8b245fa"));
+-  }
+-})();
+-
+ // Initialize Websocket server
+ io.on("connection", (socket: Socket) => {
+   protocol.addGlobalSocket(socket);
+diff --git a/src/const.ts b/src/const.ts
+index 98226dd3..90e7c03d 100755
+--- a/src/const.ts
++++ b/src/const.ts
+@@ -2,19 +2,14 @@ import os from "os";
+ import path from "path";
+ 
+ const SYS_INFO = `${os.platform()}_${os.arch()}${os.platform() === "win32" ? ".exe" : ""}`;
+-const ptyName = `pty_${SYS_INFO}`;
+ const frpcName = `frpc_${SYS_INFO}`;
+-const PTY_PATH = path.normalize(path.join(process.cwd(), "lib", ptyName));
++const PTY_PATH = "@ptyPath@";
+ const FRPC_PATH = path.normalize(path.join(process.cwd(), "lib", frpcName));
+ const FILENAME_BLACKLIST = ["\\", "/", ".", "'", '"', "?", "*", "<", ">"];
+ const LOCAL_PRESET_LANG_PATH = path.normalize(path.join(process.cwd(), "language"));
+ const IGNORE = "[IGNORE_LOG]";
+-const SYSTEM_TYPE = os.platform();
+ const ZIP_TIMEOUT_SECONDS = 60 * 40;
+-const GOLANG_ZIP_NAME = `file_zip_${SYSTEM_TYPE}_${os.arch()}${
+-  SYSTEM_TYPE === "win32" ? ".exe" : ""
+-}`;
+-const GOLANG_ZIP_PATH = path.normalize(path.join(process.cwd(), "lib", GOLANG_ZIP_NAME));
++const GOLANG_ZIP_PATH = "@zipToolsPath@";
+ 
+ export {
+   GOLANG_ZIP_PATH,
+-- 
+2.50.1
+

--- a/pkgs/by-name/mc/mcsmanager/Replace-static-path-with-placeholder-in-panel.patch
+++ b/pkgs/by-name/mc/mcsmanager/Replace-static-path-with-placeholder-in-panel.patch
@@ -1,0 +1,25 @@
+From 5aaec7dc27f948aced29536716e24c065912c3cc Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Wed, 2 Jul 2025 01:00:14 +0800
+Subject: [PATCH] Replace static path with placeholder in panel
+
+---
+ src/app.ts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/app.ts b/src/app.ts
+index 724d7ebc..da012465 100755
+--- a/src/app.ts
++++ b/src/app.ts
+@@ -176,7 +176,7 @@ _  /  / / / /___  ____/ /_  /  / / / /_/ /_  / / / /_/ /_  /_/ //  __/  /
+   }
+   app.use(protocolMiddleware);
+   app.use(
+-    koaStatic(path.join(process.cwd(), "public"), {
++    koaStatic("@frontendDist@", {
+       maxAge: 10 * 24 * 60 * 60
+     })
+   );
+-- 
+2.50.1
+

--- a/pkgs/by-name/mc/mcsmanager/Replace-version-with-placeholder-in-daemon.patch
+++ b/pkgs/by-name/mc/mcsmanager/Replace-version-with-placeholder-in-daemon.patch
@@ -1,0 +1,40 @@
+From 5954950b64b6424d8ab63cfe51210e72dfb3bb02 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Wed, 2 Jul 2025 01:07:07 +0800
+Subject: [PATCH] Replace version with placeholder in daemon
+
+---
+ src/service/version.ts | 17 +----------------
+ 1 file changed, 1 insertion(+), 16 deletions(-)
+
+diff --git a/src/service/version.ts b/src/service/version.ts
+index 7da8b633..150feb06 100755
+--- a/src/service/version.ts
++++ b/src/service/version.ts
+@@ -1,22 +1,7 @@
+-import { $t } from "../i18n";
+-import * as fs from "fs-extra";
+ import { GlobalVariable } from "mcsmanager-common";
+-import logger from "./log";
+-
+-const PACKAGE_JSON = "package.json";
+ 
+ export function initVersionManager() {
+-  try {
+-    GlobalVariable.set("version", "Unknown");
+-    if (fs.existsSync(PACKAGE_JSON)) {
+-      const data: any = JSON.parse(fs.readFileSync(PACKAGE_JSON, { encoding: "utf-8" }));
+-      if (data.version) {
+-        GlobalVariable.set("version", data.version);
+-      }
+-    }
+-  } catch (error: any) {
+-    logger.error($t("TXT_CODE_version.versionDetectErr"), error);
+-  }
++  GlobalVariable.set("version", "@daemonVersion@");
+ }
+ 
+ export function getVersion() {
+-- 
+2.50.1
+

--- a/pkgs/by-name/mc/mcsmanager/Replace-versions-with-placeholders-in-panel.patch
+++ b/pkgs/by-name/mc/mcsmanager/Replace-versions-with-placeholders-in-panel.patch
@@ -1,0 +1,62 @@
+From 336d5e3a7669c092452dfa77db4de46e9eb82c41 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Wed, 2 Jul 2025 00:31:31 +0800
+Subject: [PATCH] Replace versions with placeholders in panel
+
+---
+ src/app/version.ts | 29 ++---------------------------
+ 1 file changed, 2 insertions(+), 27 deletions(-)
+
+diff --git a/src/app/version.ts b/src/app/version.ts
+index 493b5baa..632c3349 100755
+--- a/src/app/version.ts
++++ b/src/app/version.ts
+@@ -1,32 +1,12 @@
+-import * as fs from "fs-extra";
+ import { GlobalVariable } from "mcsmanager-common";
+ import { logger } from "./service/log";
+ import storage from "./common/system_storage";
+ 
+-interface IPackageInfo {
+-  name: string;
+-  version: string;
+-  daemonVersion: string;
+-  description: string;
+-}
+-
+-const PACKAGE_JSON = "package.json";
+ const VERSION_LOG_TEXT_NAME = "current-version.txt";
+ let currentVersion = "";
+ 
+ export function initVersionManager() {
+-  try {
+-    GlobalVariable.set("version", "Unknown");
+-    if (fs.existsSync(PACKAGE_JSON)) {
+-      const data: IPackageInfo = JSON.parse(fs.readFileSync(PACKAGE_JSON, { encoding: "utf-8" }));
+-      if (data.version) {
+-        GlobalVariable.set("version", data.version);
+-        currentVersion = String(data.version);
+-      }
+-    }
+-  } catch (error: any) {
+-    logger.error("Version Check failure:", error);
+-  }
++  GlobalVariable.set("version", "@panelVersion@");
+ 
+   if (currentVersion && storage.fileExists(VERSION_LOG_TEXT_NAME)) {
+     const LastLaunchedVersion = storage.readFile(VERSION_LOG_TEXT_NAME);
+@@ -43,10 +23,5 @@ export function getVersion(): string {
+ }
+ 
+ export function specifiedDaemonVersion() {
+-  try {
+-    const data: any = JSON.parse(fs.readFileSync(PACKAGE_JSON, { encoding: "utf-8" }));
+-    return data.daemonVersion ?? "1.0.0";
+-  } catch (error: any) {
+-    return "1.0.0";
+-  }
++  return "@daemonVersion@";
+ }
+-- 
+2.50.1
+

--- a/pkgs/by-name/mc/mcsmanager/package.nix
+++ b/pkgs/by-name/mc/mcsmanager/package.nix
@@ -1,0 +1,197 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+  jq,
+  mcsmanager-zip-tools,
+  mcsmanager-pty,
+  makeBinaryWrapper,
+  removeReferencesTo,
+  srcOnly,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mcsmanager";
+  version = "10.7.1";
+
+  src = fetchFromGitHub {
+    owner = "MCSManager";
+    repo = "MCSManager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-R3OCQSmM7+AmTKccdgp6GrikMBA2uXv7fYusk//IhFU=";
+  };
+
+  common = buildNpmPackage (subFinalAttrs: {
+    pname = "${finalAttrs.pname}-common";
+    inherit (finalAttrs) version src;
+    inherit nodejs;
+
+    sourceRoot = "${subFinalAttrs.src.name}/common";
+
+    npmDepsHash = "sha256-WRgnY0kSd+g+0LpEvBJsN3j1T6zgMq4sQCKMiIbAGOA=";
+  });
+
+  frontend = buildNpmPackage (subFinalAttrs: {
+    pname = "${finalAttrs.pname}-frontend";
+    inherit (finalAttrs) version src;
+    inherit nodejs;
+
+    sourceRoot = "${subFinalAttrs.src.name}/frontend";
+
+    npmDepsHash = "sha256-ViCJ7kwBxuWJiZB4690i/9kJUBhx/TrYkA+ap5MigSg=";
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r dist $out
+
+      runHook postInstall
+    '';
+  });
+
+  daemon = buildNpmPackage (subFinalAttrs: {
+    pname = "${finalAttrs.pname}-daemon";
+    inherit (finalAttrs) version src;
+    inherit nodejs;
+
+    sourceRoot = "${subFinalAttrs.src.name}/daemon";
+
+    patches = [
+      # Remove runtime chmod for modules like mcsmanager-pty and mcsmanager-zip-tools
+      ./Replace-hardcoded-PTY-and-zip-tools-paths-with-placeholders.patch
+      # Use a placeholder for the version to read it from package.json later
+      ./Replace-version-with-placeholder-in-daemon.patch
+    ];
+
+    postPatch = ''
+      chmod -R u+w ..
+      rm -rf ../common
+      cp -r ${finalAttrs.common}/lib/node_modules/mcsmanager-common ../common
+
+      substituteInPlace src/const.ts \
+        --replace-fail "@ptyPath@" "${lib.getExe mcsmanager-pty}" \
+        --replace-fail "@zipToolsPath@" "${lib.getExe mcsmanager-zip-tools}"
+
+      substituteInPlace src/service/version.ts \
+        --replace-fail "@daemonVersion@" "$(${lib.getExe jq} -r .version < package.json)"
+    '';
+
+    npmDepsHash = "sha256-i7s+3ceo683rftrI3TPso5rh8xqmfx8Wq+e3JffYN+U=";
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r . $out
+
+      runHook postInstall
+    '';
+  });
+
+  panel = buildNpmPackage (subFinalAttrs: {
+    pname = "${finalAttrs.pname}-panel";
+    inherit (finalAttrs) version src;
+    inherit nodejs;
+
+    sourceRoot = "${subFinalAttrs.src.name}/panel";
+
+    # These patches are required because mcsm-web assumes it runs under the same directory as app.js
+    patches = [
+      # Use placeholders for the daemon and panel versions to read them from package.json later
+      ./Replace-versions-with-placeholders-in-panel.patch
+      # Allow panel to correctly find the the path of frontend
+      ./Replace-static-path-with-placeholder-in-panel.patch
+    ];
+
+    postPatch = ''
+      chmod -R u+w ..
+      rm -rf ../{common,daemon}
+      cp -r ${finalAttrs.daemon} ../daemon
+      cp -r ${finalAttrs.common}/lib/node_modules/mcsmanager-common ../common
+
+      substituteInPlace src/app/version.ts \
+        --replace-fail "@panelVersion@" "$(${lib.getExe jq} -r .version < package.json)" \
+        --replace-fail "@daemonVersion@" "$(${lib.getExe jq} -r .daemonVersion < package.json)"
+
+      substituteInPlace src/app.ts \
+        --replace-fail "@frontendDist@" "${finalAttrs.frontend}"
+    '';
+
+    npmDepsHash = "sha256-zdryoufbxt8r0L0nFG5Y3NG1AzOjf16/4KDDv5R+y1U=";
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r . $out
+
+      runHook postInstall
+    '';
+  });
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    nodejs
+    removeReferencesTo
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Glob will match all subdirs.
+    shopt -s globstar
+
+    mkdir -p $out/share/{daemon,web}
+
+    cp -r ${finalAttrs.daemon}/{production/app.js{,.map},node_modules,package{,-lock}.json} $out/share/daemon
+    cp -r ${finalAttrs.panel}/{production/app.js{,.map},node_modules,package{,-lock}.json} $out/share/web
+
+    for p in daemon web; do
+      # Prune
+      pushd $out/share/$p
+        chmod -R +w node_modules
+        npm prune --omit=dev --no-save
+        # Remove build artifacts that bloat the closure
+        rm -rf \
+          package{,-lock}.json \
+          node_modules/**/{*.target.mk,binding.Makefile,config.gypi,Makefile,Release/.deps}
+        find node_modules -type f -exec remove-references-to -t "${srcOnly nodejs}" {} \;
+      popd
+
+      makeWrapper ${lib.getExe nodejs} $out/bin/mcsm-$p \
+        --set NODE_PATH "$out/share/$p/node_modules" \
+        --add-flags $out/share/$p/app.js
+    done
+
+    shopt -u globstar
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    # The order of frontend, common, daemon, and panel must be preserved here.
+    extraArgs = [
+      "-s"
+      "frontend"
+      "-s"
+      "common"
+      "-s"
+      "daemon"
+      "-s"
+      "panel"
+    ];
+  };
+
+  meta = {
+    description = "Free, Secure, Distributed, Modern Control Panel for Minecraft and most Steam Game Servers";
+    homepage = "https://mcsmanager.com";
+    changelog = "https://github.com/MCSManager/MCSManager/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ moraxyc ];
+    mainProgram = "mcsm-daemon";
+  };
+})


### PR DESCRIPTION
https://github.com/MCSManager/MCSManager


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
