### PR TITLE
virtualbox-guest-modules-mainline: init

### DIFF
--- a/pkgs/os-specific/linux/virtualbox-guest-modules-mainline/default.nix
+++ b/pkgs/os-specific/linux/virtualbox-guest-modules-mainline/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  kernel,
+  kernelModuleMakeFlags,
+}:
+
+stdenv.mkDerivation {
+  pname = "virtualbox-guest-modules-mainline";
+  inherit (kernel) src version postPatch nativeBuildInputs;
+
+  kernel_dev = kernel.dev;
+  kernelVersion = kernel.modDirVersion;
+
+  modulePath = "drivers/virt/vboxguest";
+
+  buildPhase = ''
+    BUILT_KERNEL=$kernel_dev/lib/modules/$kernelVersion/build
+
+    cp $BUILT_KERNEL/Module.symvers .
+    cp $BUILT_KERNEL/.config .
+    cp $kernel_dev/vmlinux .
+
+    sed -i '/# CONFIG_VBOXGUEST is not set/c\CONFIG_VBOXGUEST=m' .config
+
+    make "-j$NIX_BUILD_CORES" modules_prepare
+    make "-j$NIX_BUILD_CORES" M=$modulePath modules
+  '';
+
+  installPhase = ''
+    make \
+      INSTALL_MOD_PATH="$out" \
+      XZ="xz -T$NIX_BUILD_CORES" \
+      M="$modulePath" \
+      modules_install
+  '';
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -657,6 +657,8 @@ in
 
         vmware = callPackage ../os-specific/linux/vmware { };
 
+        virtualbox-guest-modules-mainline = callPackage ../os-specific/linux/virtualbox-guest-modules-mainline { };
+
         wireguard =
           if lib.versionOlder kernel.version "5.6" then
             callPackage ../os-specific/linux/wireguard { }


### PR DESCRIPTION
The Virtualbox guest modules in mainline Linux have the same names as the 3rd party ones and thus they conflict. So create a dedicated package for the mainline modules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
