### PR TITLE
python3Packages.django-pghistory: init at 3.7.0

### DIFF
--- a/pkgs/development/python-modules/django-pghistory/default.nix
+++ b/pkgs/development/python-modules/django-pghistory/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  django,
+  django-pgtrigger,
+  poetry-core,
+}:
+
+buildPythonPackage rec {
+  pname = "django-pghistory";
+  version = "3.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Opus10";
+    repo = "django-pghistory";
+    tag = "${version}";
+    hash = "sha256-HXnljqbLNnKqueDNDTEhKHNkm5FcQGsA54mdnk3rYNI=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    django
+    django-pgtrigger
+  ];
+
+  pythonImportsCheck = [ "pghistory" ];
+
+  meta = {
+    changelog = "https://github.com/Opus10/django-pghistory/releases/tag/${version}";
+    description = "History tracking for Django and Postgres";
+    homepage = "https://django-pghistory.readthedocs.io";
+    maintainers = with lib.maintainers; [ pyrox0 ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/django-pgtrigger/default.nix
+++ b/pkgs/development/python-modules/django-pgtrigger/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  django,
+  psycopg2,
+}:
+
+buildPythonPackage rec {
+  pname = "django-pgtrigger";
+  version = "4.15.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "AmbitionEng";
+    repo = "django-pgtrigger";
+    tag = version;
+    hash = "sha256-aFjg4rCWM1F2O1zDBVo2zN1LhOPN+UyIZphuTHMAjhQ=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    django
+    psycopg2
+  ];
+
+  pythonImportsCheck = [ "pgtrigger" ];
+
+  meta = {
+    description = "Write Postgres triggers for your Django models";
+    homepage = "https://github.com/Opus10/django-pgtrigger";
+    changelog = "https://github.com/Opus10/django-pgtrigger/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      raitobezarius
+      pyrox0
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3923,6 +3923,8 @@ self: super: with self; {
 
   django-pgactivity = callPackage ../development/python-modules/django-pgactivity { };
 
+  django-pghistory = callPackage ../development/python-modules/django-pghistory { };
+
   django-pglock = callPackage ../development/python-modules/django-pglock { };
 
   django-pglocks = callPackage ../development/python-modules/django-pglocks { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3927,6 +3927,8 @@ self: super: with self; {
 
   django-pglocks = callPackage ../development/python-modules/django-pglocks { };
 
+  django-pgtrigger = callPackage ../development/python-modules/django-pgtrigger { };
+
   django-phonenumber-field = callPackage ../development/python-modules/django-phonenumber-field { };
 
   django-picklefield = callPackage ../development/python-modules/django-picklefield { };


### PR DESCRIPTION
Adds django-pghistory and the django-pgtrigger package that it relies on. 

Initial code is from https://github.com/Nix-Security-WG/nix-security-tracker, motivated by https://github.com/Nix-Security-WG/nix-security-tracker/issues/563.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
