### PR TITLE
zulu: add version check in passthru.tests

### DIFF
--- a/pkgs/development/compilers/zulu/common.nix
+++ b/pkgs/development/compilers/zulu/common.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   setJavaClassPath,
+  testers,
   enableJavaFX ? false,
   dists,
   # minimum dependencies
@@ -141,11 +142,6 @@ let
         fi
       '';
 
-  passthru.tests.version = testers.testVersion {
-    package = jdk;
-    command = "java -version";
-    version = ''openjdk version "${if lib.versions.major version == "23" then "23" else version}"'';
-  };
     preFixup =
       ''
         # Propagate the setJavaClassPath setup hook from the ${if isJdk8 then "JRE" else "JDK"} so that
@@ -188,6 +184,13 @@ let
       })
       // {
         home = jdk;
+        tests.version = testers.testVersion {
+          package = jdk;
+          command = "java -version";
+          version = ''openjdk version \""${
+            if lib.versions.major version == "8" then "1.8" else lib.versions.major version
+          }"'';
+        };
       }
       // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
         bundle = "${jdk}/Library/Java/JavaVirtualMachines/zulu-${lib.versions.major version}.jdk";

--- a/pkgs/development/compilers/zulu/common.nix
+++ b/pkgs/development/compilers/zulu/common.nix
@@ -141,18 +141,11 @@ let
         fi
       '';
 
-    doInstallCheck = true;
-    installCheckPhase = ''
-      echo "Checking 'java -version' output contains ${dist.jdkVersion}, 'OpenJDK', and 'Zulu'"
-      output=`$out/bin/java -version 2>&1`
-      # Our Zulu 23 package is a special case (and should be deleted as it is End-of-Life)
-      expected_version=$(if [[ "${dist.jdkVersion}" == 23* ]]; then echo 23; else echo "${dist.jdkVersion}"; fi)
-      echo "Output is: $output"
-      echo "$output" | grep -q "$expected_version"
-      echo "$output" | grep -q "OpenJDK"
-      echo "$output" | grep -q "Zulu"
-    '';
-
+  passthru.tests.version = testers.testVersion {
+    package = jdk;
+    command = "java -version";
+    version = ''openjdk version "${if lib.versions.major version == "23" then "23" else version}"'';
+  };
     preFixup =
       ''
         # Propagate the setJavaClassPath setup hook from the ${if isJdk8 then "JRE" else "JDK"} so that

--- a/pkgs/development/compilers/zulu/common.nix
+++ b/pkgs/development/compilers/zulu/common.nix
@@ -141,6 +141,18 @@ let
         fi
       '';
 
+    doInstallCheck = true;
+    installCheckPhase = ''
+      echo "Checking 'java -version' output contains ${dist.jdkVersion}, 'OpenJDK', and 'Zulu'"
+      output=`$out/bin/java -version 2>&1`
+      # Our Zulu 23 package is a special case (and should be deleted as it is End-of-Life)
+      expected_version=$(if [[ "${dist.jdkVersion}" == 23* ]]; then echo 23; else echo "${dist.jdkVersion}"; fi)
+      echo "Output is: $output"
+      echo "$output" | grep -q "$expected_version"
+      echo "$output" | grep -q "OpenJDK"
+      echo "$output" | grep -q "Zulu"
+    '';
+
     preFixup =
       ''
         # Propagate the setJavaClassPath setup hook from the ${if isJdk8 then "JRE" else "JDK"} so that


### PR DESCRIPTION
This basic check just launches `java -version` and makes sure it returns some expected output.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
