### PR TITLE
mame: use absolute path to bgfx data directory

### DIFF
--- a/pkgs/applications/emulators/mame/001-use-absolute-paths.diff
+++ b/pkgs/applications/emulators/mame/001-use-absolute-paths.diff
@@ -1,8 +1,8 @@
 diff --git a/src/emu/emuopts.cpp b/src/emu/emuopts.cpp
-index 3defd33d0bb..33daacc4fc8 100644
+index 834710c9eb0..6394ad8a7bc 100644
 --- a/src/emu/emuopts.cpp
 +++ b/src/emu/emuopts.cpp
-@@ -39,16 +39,16 @@ const options_entry emu_options::s_option_entries[] =
+@@ -42,16 +42,16 @@ const options_entry emu_options::s_option_entries[] =
  	{ nullptr,                                           nullptr,     core_options::option_type::HEADER,     "CORE SEARCH PATH OPTIONS" },
  	{ OPTION_PLUGINDATAPATH,                             ".",         core_options::option_type::PATH,       "path to base folder for plugin data (read/write)" },
  	{ OPTION_MEDIAPATH ";rp;biospath;bp",                "roms",      core_options::option_type::MULTIPATH,  "path to ROM sets and hard disk images" },
@@ -27,3 +27,16 @@ index 3defd33d0bb..33daacc4fc8 100644
  	{ OPTION_SWPATH,                                     "software",  core_options::option_type::MULTIPATH,  "path to loose software" },
  
  	// output directory options
+diff --git a/src/osd/modules/lib/osdobj_common.cpp b/src/osd/modules/lib/osdobj_common.cpp
+index 82fabfdc0ba..eefdaba7fbe 100644
+--- a/src/osd/modules/lib/osdobj_common.cpp
++++ b/src/osd/modules/lib/osdobj_common.cpp
+@@ -158,7 +158,7 @@ const options_entry osd_options::s_option_entries[] =
+ 	{ OSDOPTION_NETWORK_PROVIDER,                OSDOPTVAL_AUTO,   core_options::option_type::STRING,    "Emulated networking provider: " },
+ 
+ 	{ nullptr,                                   nullptr,           core_options::option_type::HEADER,   "BGFX POST-PROCESSING OPTIONS" },
+-	{ OSDOPTION_BGFX_PATH,                       "bgfx",            core_options::option_type::PATH,     "path to BGFX-related files" },
++	{ OSDOPTION_BGFX_PATH,                       "@mamePath@/bgfx",            core_options::option_type::PATH,     "path to BGFX-related files" },
+ 	{ OSDOPTION_BGFX_BACKEND,                    "auto",            core_options::option_type::STRING,   "BGFX backend to use (d3d9, d3d11, d3d12, metal, opengl, gles, vulkan)" },
+ 	{ OSDOPTION_BGFX_DEBUG,                      "0",               core_options::option_type::BOOLEAN,  "enable BGFX debugging statistics" },
+ 	{ OSDOPTION_BGFX_SCREEN_CHAINS,              "",                core_options::option_type::STRING,   "comma-delimited list of screen chain JSON names, colon-delimited per-window" },

--- a/pkgs/applications/emulators/mame/default.nix
+++ b/pkgs/applications/emulators/mame/default.nix
@@ -123,8 +123,10 @@ stdenv.mkDerivation rec {
   # it is not possible to use substituteAll
   postPatch =
     ''
-      substituteInPlace src/emu/emuopts.cpp \
-        --subst-var-by mamePath "$out/opt/mame"
+      for file in src/emu/emuopts.cpp src/osd/modules/lib/osdobj_common.cpp; do
+        substituteInPlace "$file" \
+          --subst-var-by mamePath "$out/opt/mame"
+      done
     ''
     # MAME's build system uses `sw_vers` to test whether it needs to link with
     # the Metal framework or not. However:


### PR DESCRIPTION
Currently if you try to use the `bgfx` renderer, MAME outputs an error:

```
Unable to find the BGFX path bgfx, please install it or fix the bgfx_path setting to use the BGFX renderer.
Initializing video module bgfx failed, falling back to opengl
```

because it's looking for the `bgfx` directory inside the working directory. To fix this, you have to explicitly set `bgfx_path` to `/nix/store/whatever1234hash567890-mame-0.277/opt/mame/bgfx`.

This commit changes the default `bgfx_path` to be an absolute path to the right place, similarly to what's already being done for `artpath`, `ctrlrpath`, etc. However, unlike those options, `bgfx_path` can only take a single directory - so this is technically a breaking change if you actually _wanted_ MAME to use `./bgfx`.

This will be more important if MAME ever [switches back to using BGFX as the default renderer](https://github.com/mamedev/mame/issues/10859).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
    - **Note**: I can run `mame -video bgfx` and not get the error/warning, and video works. I can also set `-bgfx_screen_chains` to `crt-geom`, `crt-geom-deluxe`, or `lcd-grid`, and they all seem to work. However, I'm new to setting up BGFX in MAME[^hbmame], so it's possible I've missed things.
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

[^hbmame]: I hadn't even heard of BGFX before getting the warning from [my build](https://github.com/Rhys-T/nur-packages/blob/master/pkgs/mame/hbmame.nix) of [HBMAME](https://hbmame.1emulation.com/), which apparently still defaults to `bgfx`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
