### PR TITLE
sideband: init at 1.6.1

### DIFF
--- a/pkgs/by-name/si/sideband/fix-kv-packaging.patch
+++ b/pkgs/by-name/si/sideband/fix-kv-packaging.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 022ba5e..e3e9e60 100644
+--- a/setup.py
++++ b/setup.py
+@@ -37,7 +37,7 @@ __variant__ = get_variant()
+ 
+ def glob_paths(pattern):
+     out_files = []
+-    src_path = os.path.join(os.path.dirname(__file__), "kivymd")
++    src_path = os.path.join(os.path.dirname(__file__), "sbapp/kivymd")
+ 
+     for root, dirs, files in os.walk(src_path):
+         for file in files:

--- a/pkgs/by-name/si/sideband/package.nix
+++ b/pkgs/by-name/si/sideband/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  python312Packages,
+  fetchFromGitHub,
+  xclip,
+  xsel,
+}:
+
+python312Packages.buildPythonApplication rec {
+  pname = "sideband";
+  version = "1.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "markqvist";
+    repo = "Sideband";
+    tag = "${version}";
+    hash = "sha256-whrmeIcS4+KkDR0j2Cp1F2EkimSl4djSRrPHVQwiK2A=";
+  };
+
+  patches = [ ./fix-kv-packaging.patch ]; # https://github.com/markqvist/Sideband/pull/72
+
+  build-system = with python312Packages; [
+    setuptools
+  ];
+
+  dependencies = with python312Packages; [
+    pyaudio
+    pycodec2
+    audioop-lts
+    mistune
+    beautifulsoup4
+    sh
+    materialyoucolor
+    qrcode
+    pillow
+    kivy
+    lxmf
+    rns
+    numpy_1
+    ffpyplayer
+    lxst
+  ];
+
+  propagatedBuildInputs = [
+    xclip
+    xsel
+  ];
+
+  meta = {
+    description = "Extensible Reticulum LXMF messaging and LXST telephony client";
+    homepage = "https://github.com/markqvist/Sideband";
+    license = lib.licenses.cc-by-nc-sa-40;
+    mainProgram = "sideband";
+  };
+}

--- a/pkgs/development/python-modules/ffpyplayer/default.nix
+++ b/pkgs/development/python-modules/ffpyplayer/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  cython,
+  SDL2,
+  pkg-config,
+  ffmpeg_6,
+}:
+
+buildPythonPackage rec {
+  pname = "ffpyplayer";
+  version = "4.5.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-i5Yj4EmXunu/VHYxOqjZ6uJmXGX0A7Xe/0rFHxYVXn4=";
+  };
+
+  patches = [ ./sws_scale_ptr.patch ]; # https://github.com/matham/ffpyplayer/pull/182
+  patchFlags = [
+    "-p1"
+    "--binary"
+  ]; # CRLFs in pypi src dist
+
+  build-system = [
+    setuptools
+    cython
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  dependencies = [
+    SDL2
+    # https://github.com/matham/ffpyplayer/issues/166 blocks updating to 7
+    ffmpeg_6
+  ];
+
+  meta = {
+    description = "Python binding for the FFmpeg library for playing and writing media files";
+    homepage = "https://matham.github.io/ffpyplayer/index.html";
+    license = lib.licenses.lgpl3Only;
+  };
+}

--- a/pkgs/development/python-modules/ffpyplayer/sws_scale_ptr.patch
+++ b/pkgs/development/python-modules/ffpyplayer/sws_scale_ptr.patch
@@ -1,0 +1,13 @@
+diff --git a/ffpyplayer/player/frame_queue.pyx b/ffpyplayer/player/frame_queue.pyx
+index 3c506ca..60ebedb 100644
+--- a/ffpyplayer/player/frame_queue.pyx
++++ b/ffpyplayer/player/frame_queue.pyx
+@@ -162,7 +162,7 @@ cdef class FrameQueue(object):
+             if player.img_convert_ctx == NULL:
+                 av_log(NULL, AV_LOG_FATAL, b"Cannot initialize the conversion context\n")
+                 raise_py_exception(b'Cannot initialize the conversion context.')
+-            sws_scale(player.img_convert_ctx, src_frame.data, src_frame.linesize,
++            sws_scale(player.img_convert_ctx, <const unsigned char* const*>src_frame.data, src_frame.linesize,
+                       0, vp.height, vp.frame.data, vp.frame.linesize)
+             av_frame_unref(src_frame)
+         return 0

--- a/pkgs/development/python-modules/lxst/default.nix
+++ b/pkgs/development/python-modules/lxst/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  lxmf,
+  numpy_1,
+  pycodec2,
+  rns,
+  soundcard,
+}:
+
+buildPythonPackage rec {
+  pname = "lxst";
+  version = "0.3.0-unstable-2025-05-12";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "markqvist";
+    repo = "lxst";
+    rev = "a0098cf74fb68d615c14951ccebae75d7797e374";
+    hash = "sha256-Lb13M1Au+DOK7Uxcieo+57r6pnNtJdtESPUXVAoODO8=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pycodec2
+    numpy_1
+    rns
+    lxmf
+    (soundcard.override { numpy = numpy_1; })
+  ];
+
+  meta = {
+    description = "Simple and flexible real-time streaming format and delivery protocol for Reticulum";
+    homepage = "https://github.com/markqvist/LXST";
+    license = lib.licenses.cc-by-nc-nd-40;
+    mainProgram = "rnphone";
+  };
+}

--- a/pkgs/development/python-modules/pycodec2/default.nix
+++ b/pkgs/development/python-modules/pycodec2/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  codec2,
+  cython,
+  numpy_1,
+}:
+
+buildPythonPackage rec {
+  pname = "pycodec2";
+  version = "3.1.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-eDvz1EkdEaYily25MX2xyUCPrUjT1dtHrRROVaVkkHA=";
+  };
+
+  build-system = [
+    setuptools
+    cython
+    numpy_1
+  ];
+
+  dependencies = [
+    codec2
+    numpy_1
+  ];
+
+  meta = {
+    description = "Cython wrapper for Codec 2";
+    homepage = "https://github.com/gregorias/pycodec2";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8616,6 +8616,8 @@ self: super: with self; {
 
   lxml-stubs = callPackage ../development/python-modules/lxml-stubs { };
 
+  lxst = callPackage ../development/python-modules/lxst { };
+
   lyricwikia = callPackage ../development/python-modules/lyricwikia { };
 
   lz4 = callPackage ../development/python-modules/lz4 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12368,6 +12368,8 @@ self: super: with self; {
 
   pycocotools = callPackage ../development/python-modules/pycocotools { };
 
+  pycodec2 = callPackage ../development/python-modules/pycodec2 { };
+
   pycodestyle = callPackage ../development/python-modules/pycodestyle { };
 
   pycognito = callPackage ../development/python-modules/pycognito { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5006,6 +5006,8 @@ self: super: with self; {
 
   ffmpy = callPackage ../development/python-modules/ffmpy { };
 
+  ffpyplayer = callPackage ../development/python-modules/ffpyplayer { };
+
   fhir-py = callPackage ../development/python-modules/fhir-py { };
 
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };


### PR DESCRIPTION
[Sideband](https://github.com/markqvist/Sideband) is an application for performing diverse communication tasks on the [Reticulum](https://github.com/markqvist/Reticulum) secure mesh network. PR also includes a few new required libraries.

Fixes https://github.com/NixOS/nixpkgs/issues/370970.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
