### PR TITLE
typst-full: Typst environment with a full set of Typst packages

### DIFF
--- a/pkgs/by-name/ty/typst-full/package.nix
+++ b/pkgs/by-name/ty/typst-full/package.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  stdenv,
+  writeShellScript,
+  typst,
+}:
+
+let
+  typstFull = typst.withPackages (
+    tpkgs:
+    builtins.attrValues (
+      lib.filterAttrs (
+        _: maybe_p: builtins.isAttrs maybe_p && lib.hasAttrByPath [ "typstDeps" ] maybe_p
+      ) tpkgs
+    )
+  );
+in
+typstFull.overrideAttrs (
+  finalAttrs: _: {
+    name = "typst-full-${finalAttrs.version}";
+    version = "0-unstable-2025-09-22";
+    passthru.updateScript = ./update.sh;
+  }
+)

--- a/pkgs/by-name/ty/typst-full/update.sh
+++ b/pkgs/by-name/ty/typst-full/update.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash nix
+
+set -euxo pipefail
+
+maintainers/scripts/update-typst-packages.py --output "pkgs/by-name/ty/typst/typst-packages-from-universe.toml" > /dev/null
+
+sed -i -E "s|(version = \")[^\"]*(\";)|\10-unstable-$(date -u +%F)\2|" pkgs/by-name/ty/typst-full/package.nix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR adds a new package `typst-full` to instantiate a typst environment with a full set of Typst packages from Typst Universe.

The main reason here to make it a separate package is to integrate typst packages update into nixpkgs CI and have a more or less meaningful version number to represent changes of the typst package set.

This PR is tested with `nix-shell maintainers/scripts/update.nix --argstr package typst-full --argstr commit true`, and the update can be correctly committed on the current branch. However, based on the past experience, it doesn't necessarily imply `r-ryantm` would correctly commit the update. Also please let me know if there's a better way to approach this.

@emaryn @drupol 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
