### PR TITLE
python3Packages.tt-flash: init at 3.3.3

### DIFF
--- a/pkgs/development/python-modules/pyluwen/default.nix
+++ b/pkgs/development/python-modules/pyluwen/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  runCommand,
+  fetchFromGitHub,
+  rustPlatform,
+  maturin,
+  protobuf_30,
+}:
+buildPythonPackage rec {
+  pname = "pyluwen";
+  version = "0.7.11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tenstorrent";
+    repo = "luwen";
+    tag = "v${version}";
+    hash = "sha256-eQpKEeuy0mVrmu8ssAOWBcXi7zutStu+RbZOEF/IJ98=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    hash = "sha256-INzF8ORkrmPQMJbGSNm5QkfMOgE+HJ3taU1EZ9i+HJg=";
+  };
+
+  sourceRoot = "${src.name}/crates/${pname}";
+
+  prePatch = ''
+    chmod -R u+w ../../
+    cd ../../
+  '';
+
+  postPatch = ''
+    cd ../$sourceRoot
+    cp --no-preserve=ownership,mode ../../Cargo.lock .
+  '';
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+    protobuf_30
+  ];
+
+  build-system = [ maturin ];
+
+  meta = {
+    description = "Tenstorrent system interface library";
+    homepage = "https://github.com/tenstorrent/luwen";
+    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/pkgs/development/python-modules/tt-flash/default.nix
+++ b/pkgs/development/python-modules/tt-flash/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  setuptools,
+  pyyaml,
+  tabulate,
+  pyluwen,
+  tt-tools-common,
+}:
+buildPythonPackage rec {
+  pname = "tt-flash";
+  version = "3.3.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tenstorrent";
+    repo = "tt-flash";
+    tag = "v${version}";
+    hash = "sha256-edWogH/HZZlGwyiqGbj6vunNxhsCr/+3LzmFgFGzjck=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    tabulate
+    pyyaml
+    pyluwen
+    tt-tools-common
+  ];
+
+  pythonImportsCheck = [ "tt_flash" ];
+  pythonRelaxDeps = [ "pyyaml" ];
+
+  meta = {
+    description = "Tenstorrent Firmware Update Utility";
+    homepage = "https://tenstorrent.com";
+    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/pkgs/development/python-modules/tt-tools-common/default.nix
+++ b/pkgs/development/python-modules/tt-tools-common/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchpatch,
+  fetchFromGitHub,
+  setuptools,
+  distro,
+  elasticsearch,
+  psutil,
+  pyyaml,
+  rich,
+  textual,
+  requests,
+  tqdm,
+  pydantic,
+}:
+buildPythonPackage rec {
+  pname = "tt-tools-common";
+  version = "1.4.25";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tenstorrent";
+    repo = "tt-tools-common";
+    tag = "v${version}";
+    hash = "sha256-phal8KxfQqsGAIcKQTlSPZB04J158jZYlyamZr45vdU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    distro
+    elasticsearch
+    psutil
+    pyyaml
+    rich
+    textual
+    requests
+    tqdm
+    pydantic
+  ];
+
+  meta = {
+    description = "Helper library for common utilities shared across Tentorrent tools";
+    homepage = "https://github.com/tenstorrent/tt-tools-common";
+    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18499,6 +18499,8 @@ self: super: with self; {
 
   tsplib95 = callPackage ../development/python-modules/tsplib95 { };
 
+  tt-tools-common = callPackage ../development/python-modules/tt-tools-common { };
+
   ttach = callPackage ../development/python-modules/ttach { };
 
   ttfautohint-py = callPackage ../development/python-modules/ttfautohint-py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18499,6 +18499,8 @@ self: super: with self; {
 
   tsplib95 = callPackage ../development/python-modules/tsplib95 { };
 
+  tt-flash = callPackage ../development/python-modules/tt-flash { };
+
   tt-tools-common = callPackage ../development/python-modules/tt-tools-common { };
 
   ttach = callPackage ../development/python-modules/ttach { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13240,6 +13240,8 @@ self: super: with self; {
 
   pylutron-caseta = callPackage ../development/python-modules/pylutron-caseta { };
 
+  pyluwen = callPackage ../development/python-modules/pyluwen { };
+
   pylxd = callPackage ../development/python-modules/pylxd { };
 
   pylyrics = callPackage ../development/python-modules/pylyrics { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Adds the flash tool for Tenstorrent cards.

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
