### PR TITLE
cudaPackages.nsight_compute: fix

### DIFF
--- a/pkgs/development/cuda-modules/_cuda/fixups/nsight_compute.nix
+++ b/pkgs/development/cuda-modules/_cuda/fixups/nsight_compute.nix
@@ -40,17 +40,19 @@ in
   postInstall =
     prevAttrs.postInstall or ""
     + ''
-      moveToOutput 'ncu' "''${!outputBin}/bin"
-      moveToOutput 'ncu-ui' "''${!outputBin}/bin"
-      moveToOutput 'host/${archDir}' "''${!outputBin}/bin"
-      moveToOutput 'target/${archDir}' "''${!outputBin}/bin"
-      wrapQtApp "''${!outputBin}/bin/host/${archDir}/ncu-ui.bin"
+      mkdir -p "$out/bin"
+      moveToOutput 'host/${archDir}' "$out"
+      moveToOutput 'target/${archDir}' "$out"
+      wrapQtApp "$out/host/${archDir}/ncu-ui.bin"
+      ln -snf "$out/target/linux-desktop-glibc_2_11_3-x64/ncu" "$out/bin/"
+      ln -snf "$out/host/linux-desktop-glibc_2_11_3-x64/ncu-ui" "$out/bin/"
+      rm "$out/ncu" "$out/ncu-ui"
     '';
   preFixup =
     prevAttrs.preFixup or ""
     + ''
       # lib needs libtiff.so.5, but nixpkgs provides libtiff.so.6
-      patchelf --replace-needed libtiff.so.5 libtiff.so "''${!outputBin}/bin/host/${archDir}/Plugins/imageformats/libqtiff.so"
+      patchelf --replace-needed libtiff.so.5 libtiff.so "$out/host/${archDir}/Plugins/imageformats/libqtiff.so"
     '';
   autoPatchelfIgnoreMissingDeps = prevAttrs.autoPatchelfIgnoreMissingDeps or [ ] ++ [
     "libnvidia-ml.so.1"


### PR DESCRIPTION
Cuda packages binaries relying on a specific relative folder structure. Current derivation invalidates some of the assumptions.
Binaries ncu,ncu-ui could not find required target platform directory 'bin/target/linux-desktop...' leading to missing profiler metadata.

![image](https://github.com/user-attachments/assets/0b921af0-1496-4517-a840-f522e38821d0)


## Things done
Changed the final derivation directory structure to accomodate that.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
