### PR TITLE
python3Packages.{pyhdfe,linearmodels}: init at {0.2.0,6.1}

### DIFF
--- a/pkgs/development/python-modules/linearmodels/default.nix
+++ b/pkgs/development/python-modules/linearmodels/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cython,
+  formulaic,
+  mypy-extensions,
+  numpy,
+  pandas,
+  pyhdfe,
+  pytestCheckHook,
+  scipy,
+  setuptools,
+  setuptools-scm,
+  statsmodels,
+}:
+
+buildPythonPackage rec {
+  pname = "linearmodels";
+  version = "6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bashtage";
+    repo = "linearmodels";
+    tag = "v${version}";
+    hash = "sha256-oWVBsFSKnv/8AHYP5sxO6+u5+hsOw/uQlOetse5ue88=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+    cython
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  dependencies = [
+    formulaic
+    mypy-extensions
+    numpy
+    pandas
+    pyhdfe
+    scipy
+    statsmodels
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "linearmodels" ];
+
+  meta = {
+    description = "Models for panel data, system regression, instrumental variables and asset pricing";
+    homepage = "https://bashtage.github.io/linearmodels/";
+    changelog = "https://github.com/bashtage/linearmodels/releases/tag/v${version}";
+    license = lib.licenses.ncsa;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+}

--- a/pkgs/development/python-modules/pyhdfe/default.nix
+++ b/pkgs/development/python-modules/pyhdfe/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  numpy,
+  pytestCheckHook,
+  scipy,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pyhdfe";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jeffgortmaker";
+    repo = "pyhdfe";
+    tag = "v${version}";
+    hash = "sha256-UXVQHf4Nmq/zQZtPaLba4TShhpgPUBwPM+zCEa8qaKs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    scipy
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pyhdfe" ];
+
+  meta = {
+    description = "Python 3 implementation of algorithms for absorbing high dimensional fixed effects";
+    homepage = "https://github.com/jeffgortmaker/pyhdfe";
+    changelog = "https://github.com/jeffgortmaker/pyhdfe/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12783,6 +12783,8 @@ self: super: with self; {
 
   pyhcl = callPackage ../development/python-modules/pyhcl { };
 
+  pyhdfe = callPackage ../development/python-modules/pyhdfe { };
+
   pyheck = callPackage ../development/python-modules/pyheck { };
 
   pyheif = callPackage ../development/python-modules/pyheif { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8219,6 +8219,8 @@ self: super: with self; {
 
   linear-operator = callPackage ../development/python-modules/linear-operator { };
 
+  linearmodels = callPackage ../development/python-modules/linearmodels { };
+
   lineax = callPackage ../development/python-modules/lineax { };
 
   linecache2 = callPackage ../development/python-modules/linecache2 { };


### PR DESCRIPTION
linearmodels depends on pyhdfe, thus I've put both in this PR. Happy to split into 2 PRs, although I'm not sure how to set up PR dependencies properly.

Commits:
- `python3Packages.pyhdfe`: init at 0.2.0
- `python3Packages.linearmodels`: init at 6.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
