### PR TITLE
percona-server_8_0: fix mysqld_safe.sh FIND_PROC resolution

### DIFF
--- a/pkgs/servers/sql/percona-server/8_0.nix
+++ b/pkgs/servers/sql/percona-server/8_0.nix
@@ -121,6 +121,15 @@ stdenv.mkDerivation (finalAttrs: {
     "static"
   ];
 
+  # Due to sandbox restriction, ps command detection fails on darwin in mysqld_safe.sh.
+  # As a workaround we set FIND_PROC here.
+  # Due to complicated escaping, it cannot be done in cmakeFlags.
+  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    cmakeFlagsArray+=(
+      "-DFIND_PROC=ps -ef | grep -v mysqld_safe | grep -- \$MYSQLD | grep \$PID > /dev/null"
+    )
+  '';
+
   cmakeFlags = [
     # Percona-specific flags.
     "-DPORTABLE=1"


### PR DESCRIPTION
`mysqld_safe` is produced out of `scripts/mysqld_safe.sh`, which tries to detect available `ps` command. Under sandbox restrictions it fails the detection, which result into an invalid `.mysqld_safe-wrapped`:

```
 869     if
 870     then    # The pid contains a mysqld process
 871       log_error "A mysqld process already exists"
 872       exit 1
 873     fi
```

Which fails with:
```
/nix/store/ljfwp8c3a980hb4fbdjri7gmsvmhfaj7-percona-server-8.0.42-33/bin/.mysqld_safe-wrapped: line 870: syntax error near unexpected token `then'
/nix/store/ljfwp8c3a980hb4fbdjri7gmsvmhfaj7-percona-server-8.0.42-33/bin/.mysqld_safe-wrapped: line 870: `    then    # The pid contains a mysqld process'

```

To avoid `ps` resolution, we can set [FIND_PROC](https://github.com/percona/percona-server/blob/release-8.0.42-33/scripts/mysqld_safe.sh#L869) CMake flag with already resolved command.

I didn’t find a way how to handle escaping with `cmakeFlags`, so added via flag directly via `preConfigure`. This is Macos specific, it seems to resolve FIND_PROC correctly on Linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
