### PR TITLE
python3Packages.slycot: init at 0.7.0

### DIFF
--- a/pkgs/development/python-modules/control/default.nix
+++ b/pkgs/development/python-modules/control/default.nix
@@ -11,6 +11,7 @@
   scipy,
   setuptools-scm,
   setuptools,
+  slycot,
 }:
 
 buildPythonPackage rec {
@@ -37,9 +38,8 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
-    # slycot is not in nixpkgs
-    # slycot = [ slycot ];
     cvxopt = [ cvxopt ];
+    slycot = [ slycot ];
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/slycot/default.nix
+++ b/pkgs/development/python-modules/slycot/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  blas,
+  buildPythonPackage,
+  cmake,
+  fetchFromGitHub,
+  gfortran,
+  lapack,
+  ninja,
+  numpy,
+  pytestCheckHook,
+  pytest-timeout,
+  python,
+  scikit-build-core,
+  scipy,
+  setuptools-scm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "slycot";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "python-control";
+    repo = "slycot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NOoxgOCng6fTaRP+oTS4aoQlHES8ZwD8iKYJ3CS1waQ=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [
+    ninja
+    scikit-build-core
+    setuptools-scm
+  ];
+  pyproject = true;
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  buildInputs = [
+    blas
+    lapack
+  ];
+
+  dependencies = [ numpy ];
+
+  nativeCheckInputs = [
+    pytest-timeout
+    pytestCheckHook
+    scipy
+  ];
+
+  postInstall = ''
+    pythonRemoveTestsDir
+  '';
+
+  preCheck = ''
+    rm -rf slycot
+  '';
+
+  pytestFlags = [
+    "--pyargs"
+    "slycot"
+  ];
+
+  pythonImportsCheck = [ "slycot" ];
+
+  meta = {
+    description = "Python wrapper for included SLICOT Fortran library";
+    changelog = "https://github.com/python-control/slycot/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/python-control/slycot";
+    license = with lib.licenses; [
+      gpl2Only # slycot wrapper
+      bsd3 # Fortran SLICOT library
+      gpl3Plus # GPL-3.0 for the GCC-exception runtime parts
+      bsd2 # BSD-2-Clause for specific build utilities
+    ];
+    maintainers = with lib.maintainers; [ Peter3579 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18872,6 +18872,8 @@ self: super: with self; {
 
   sly = callPackage ../development/python-modules/sly { };
 
+  slycot = callPackage ../development/python-modules/slycot { };
+
   smart-meter-texas = callPackage ../development/python-modules/smart-meter-texas { };
 
   smart-open = callPackage ../development/python-modules/smart-open { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Python wrapper for included SLICOT Fortran library. The slycot library is needed for full functionality of the Python Control package.
homepage: https://github.com/python-control/slycot

Finally resolves: https://github.com/NixOS/nixpkgs/issues/416787

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
