### PR TITLE
[Backport release-25.05] k9s: 0.50.5 -> 0.50.6

### DIFF
--- a/pkgs/by-name/k9/k9s/package.nix
+++ b/pkgs/by-name/k9/k9s/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule rec {
   pname = "k9s";
-  version = "0.50.5";
+  version = "0.50.6";
 
   src = fetchFromGitHub {
     owner = "derailed";
     repo = "k9s";
     rev = "v${version}";
-    hash = "sha256-hh00R0PCqhAUlwFps40CQ+hc6p2634WEGqNjX1mi/J8=";
+    hash = "sha256-cL7OD9OtkVx325KcANU8FudcOk6HMct6ve2p0qSkEoc=";
   };
 
   ldflags = [
@@ -33,7 +33,7 @@ buildGoModule rec {
 
   proxyVendor = true;
 
-  vendorHash = "sha256-g2tS1EpmG+Wba3kF9cH83JAG6EhKK4LrASGUSFtYYY8=";
+  vendorHash = "sha256-dATWFH5XKicdP8sftGGm2zopTef189MJWd9AM/Gxsjw=";
 
   # TODO investigate why some config tests are failing
   doCheck = !(stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64);

--- a/pkgs/by-name/k9/k9s/package.nix
+++ b/pkgs/by-name/k9/k9s/package.nix
@@ -75,6 +75,7 @@ buildGoModule rec {
       markus1189
       bryanasdev000
       qjoly
+      devusb
       ryan4yin
     ];
   };


### PR DESCRIPTION
Manual backport of #408543 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.