### PR TITLE
jq: backport patch for GHSA-f946-j5j2-4w5m

### DIFF
--- a/pkgs/by-name/jq/jq/0006-Fix-GHSA-f946-j5j2-4w5m-stack-overflow-by-limit-regex-parse-depth.patch
+++ b/pkgs/by-name/jq/jq/0006-Fix-GHSA-f946-j5j2-4w5m-stack-overflow-by-limit-regex-parse-depth.patch
@@ -1,0 +1,45 @@
+From 5e159b34b179417e3e0404108190a2ac7d65611c Mon Sep 17 00:00:00 2001
+From: Mattias Wadman <mattias.wadman@gmail.com>
+Date: Tue, 24 Jun 2025 15:39:40 +0200
+Subject: [PATCH] Fix GHSA-f946-j5j2-4w5m stack-overflow by limit regex parse
+ depth
+
+Was detect by AFL build but it's unsure if possible to trigger in non-fuzz build.
+
+Oniguruma has a default limit of 4096 but this is not be low enough to
+protect from stack-overflows in some builds like with AFL where it seems
+to use more stack space. A limit of 1024 should be enough usage-wise
+and also give more margin.
+---
+ src/main.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/main.c b/src/main.c
+index a316f63c0c..90f5f2afdb 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -21,6 +21,10 @@
+ extern void jv_tsd_dtoa_ctx_init();
+ #endif
+ 
++#ifdef HAVE_LIBONIG
++#include <oniguruma.h>
++#endif
++
+ #if !defined(HAVE_ISATTY) && defined(HAVE__ISATTY)
+ #undef isatty
+ #define isatty _isatty
+@@ -298,6 +302,13 @@ int main(int argc, char* argv[]) {
+   (void) setlocale(LC_ALL, "");
+ #endif
+ 
++#ifdef HAVE_LIBONIG
++  // use a lower regex parse depth limit than the default (4096) to protect
++  // from stack-overflows
++  // https://github.com/jqlang/jq/security/advisories/GHSA-f946-j5j2-4w5m
++  onig_set_parse_depth_limit(1024);
++#endif
++
+ #ifdef __OpenBSD__
+   if (pledge("stdio rpath", NULL) == -1) {
+     perror("pledge");

--- a/pkgs/by-name/jq/jq/package.nix
+++ b/pkgs/by-name/jq/jq/package.nix
@@ -49,6 +49,13 @@ stdenv.mkDerivation rec {
     # Improve-performance-of-repeating-strings is only a partial fix
     # https://github.com/jqlang/jq/commit/c6e041699d8cd31b97375a2596217aff2cfca85b
     ./0005-Fix-heap-buffer-overflow-when-formatting-an-empty-st.patch
+
+    # CVE-2025-49014 only relevant to 1.8.0, added for posterity
+    # https://github.com/jqlang/jq/commit/499c91bca9d4d027833bc62787d1bb075c03680e
+
+    # GHSA-f946-j5j2-4w5m (no CVE identifier)
+    # https://github.com/jqlang/jq/commit/5e159b34b179417e3e0404108190a2ac7d65611c
+    ./0006-Fix-GHSA-f946-j5j2-4w5m-stack-overflow-by-limit-regex-parse-depth.patch
   ];
 
   # https://github.com/jqlang/jq/issues/2871


### PR DESCRIPTION


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


related #421497 

GHSA-f946-j5j2-4w5m (no CVE identifier)
https://github.com/jqlang/jq/commit/5e159b34b179417e3e0404108190a2ac7d65611c

CVE-2025-49014 only relevant to 1.8.0 so not included but mentioned for posterity
I double checked [`if ((n == 0 && *fmt)`](https://github.com/jqlang/jq/pull/3271/commits/cfa4976e4b95d102c74bbe8a842fc12b822b70f0) doesn't appear in s`rc/builtin.c` after patching and it looks like we're good to skip that one. I've not double checked what versions of jq are affected by that segfault issue but I think we can leave that one.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
