### PR TITLE
shotcut: 25.01 -> 25.08, mlt: 7.30 -> 7.32, fix mlt-qt6 in shotcut

### DIFF
--- a/pkgs/by-name/ml/mlt/package.nix
+++ b/pkgs/by-name/ml/mlt/package.nix
@@ -40,13 +40,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mlt";
-  version = "7.30.0";
+  version = "7.32.0";
 
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "mlt";
     tag = "v${version}";
-    hash = "sha256-z1bW+hcVeMeibC1PUS5XNpbkNB+75YLoOWZC2zuDol4=";
+    hash = "sha256-8T5FXXGs7SxL6nD+R1Q/0Forsdp5Xux4S3VLvgqXzw8=";
     # The submodule contains glaxnimate code, since MLT uses internally some functions defined in glaxnimate.
     # Since glaxnimate is not available as a library upstream, we cannot remove for now this dependency on
     # submodules until upstream exports glaxnimate as a library: https://gitlab.com/mattbas/glaxnimate/-/issues/545

--- a/pkgs/by-name/mo/movit/package.nix
+++ b/pkgs/by-name/mo/movit/package.nix
@@ -45,12 +45,13 @@ stdenv.mkDerivation rec {
     libepoxy
   ];
 
-  env = {
-    NIX_CFLAGS_COMPILE = "-std=c++17"; # needed for latest gtest
-  }
-  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    NIX_LDFLAGS = "-framework OpenGL";
-  };
+  env =
+    lib.optionalAttrs stdenv.cc.isGNU {
+      NIX_CFLAGS_COMPILE = "-std=c++17"; # needed for latest gtest
+    }
+    // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+      NIX_LDFLAGS = "-framework OpenGL";
+    };
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/sh/shotcut/package.nix
+++ b/pkgs/by-name/sh/shotcut/package.nix
@@ -7,11 +7,11 @@
   frei0r,
   ladspaPlugins,
   gettext,
-  mlt,
   jack1,
   pkg-config,
   fftw,
   qt6,
+  qt6Packages,
   cmake,
   gitUpdater,
   ffmpeg,
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     frei0r
     ladspaPlugins
     gettext
-    mlt
+    qt6Packages.mlt
     fftw
     qt6.qtbase
     qt6.qttools
@@ -54,7 +54,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (replaceVars ./fix-mlt-ffmpeg-path.patch {
-      inherit mlt ffmpeg;
+      inherit ffmpeg;
+      mlt = qt6Packages.mlt;
     })
   ];
 

--- a/pkgs/by-name/sh/shotcut/package.nix
+++ b/pkgs/by-name/sh/shotcut/package.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shotcut";
-  version = "25.01.25";
+  version = "25.08.16";
 
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "shotcut";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YrnmhxD7Yf2LgdEaBU4mmRdvZdO6VQ6IAb4s+V9QvLM=";
+    hash = "sha256-PpMfiqUwG11H+7sLkp3sLzDWjco1OxYqGyfMAFojSPU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- mlt: 7.30 -> 7.32
see https://github.com/mltframework/mlt/releases/tag/v7.32.0
required by shotcut upgrade
- shotcut: 25.01 -> 25.08
see https://github.com/mltframework/shotcut/releases/
- shotcut: mlt with qt
see #377764
replace mlt with qt6Packages.mlt as it was before moving to by-name hierarchy
fixes: #420054 #429039

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
