### PR TITLE
nixosTests.mitmproxy: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -845,6 +845,7 @@ in
   miriway = runTest ./miriway.nix;
   misc = runTest ./misc.nix;
   misskey = runTest ./misskey.nix;
+  mitmproxy = runTest ./mitmproxy.nix;
   mjolnir = runTest ./matrix/mjolnir.nix;
   mobilizon = runTest ./mobilizon.nix;
   mod_perl = runTest ./mod_perl.nix;

--- a/nixos/tests/mitmproxy.nix
+++ b/nixos/tests/mitmproxy.nix
@@ -1,0 +1,134 @@
+{ lib, pkgs, ... }:
+let
+  # https://docs.mitmproxy.org/stable/concepts/certificates/#using-a-custom-certificate-authority
+  caCert = pkgs.runCommand "ca-cert" { } ''
+    touch $out
+    cat ${./common/acme/server/ca.key.pem} >> $out
+    cat ${./common/acme/server/ca.cert.pem} >> $out
+  '';
+in
+{
+  name = "mitmproxy";
+  meta.maintainers = [ lib.teams.ngi.members ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      security.pki.certificateFiles = [ caCert ];
+
+      services.getty.autologinUser = "root";
+
+      environment.systemPackages =
+        let
+          # A counter.  It has 2 functions:
+          # 1. GET /old and GET /new, to demostrate rewriting requests.
+          # 2. GET /counter and POST /counter, to demonstrate replaying requests.
+          counter = pkgs.writers.writePython3Bin "counter" { } ''
+            from http.server import BaseHTTPRequestHandler, HTTPServer
+
+            counter = 0
+
+
+            class HTTPRequestHandler(BaseHTTPRequestHandler):
+                def do_POST(self):
+                    match self.path:
+                        case "/counter":
+                            global counter
+                            counter += 1
+                            self.send_response(204)
+                            self.end_headers()
+                        case _:
+                            self.send_response(404)
+                            self.end_headers()
+
+                def do_GET(self):
+                    match self.path:
+                        case "/counter":
+                            self.send_response(200)
+                            self.send_header("Content-type", "text/plain")
+                            self.end_headers()
+                            _ = self.wfile.write(str(counter).encode())
+                        case "/old":
+                            self.send_response(200)
+                            self.send_header("Content-type", "text/plain")
+                            self.end_headers()
+                            _ = self.wfile.write("fail".encode())
+                        case "/new":
+                            self.send_response(200)
+                            self.send_header("Content-type", "text/plain")
+                            self.end_headers()
+                            _ = self.wfile.write("success".encode())
+                        case _:
+                            self.send_response(404)
+                            self.end_headers()
+
+
+            server_address = ("", 8000)
+            server = HTTPServer(server_address, HTTPRequestHandler)
+            server.serve_forever()
+          '';
+        in
+        [
+          counter
+          pkgs.mitmproxy
+        ];
+    };
+
+  testScript =
+    let
+      addonScript = pkgs.writeText "addon-script" ''
+        def request(flow):
+            # https://docs.mitmproxy.org/stable/api/mitmproxy/http.html#Request
+            flow.request.path = "/new"
+      '';
+    in
+    ''
+      def curl(command: str, proxy: bool = False):
+          if proxy:
+              command = "curl --proxy 127.0.0.1:8080 --cacert ~/.mitmproxy/mitmproxy-ca-cert.pem " + command
+          else:
+              command = "curl " + command
+          return machine.succeed(command)
+
+      start_all()
+      machine.wait_for_unit("default.target")
+
+      # https://docs.mitmproxy.org/stable/concepts/certificates/#using-a-custom-certificate-authority
+      machine.succeed("mkdir -p ~/.mitmproxy")
+      machine.succeed("ln -s ${caCert} ~/.mitmproxy/mitmproxy-ca.pem")
+
+      machine.succeed("counter >/dev/null &")
+      machine.wait_for_open_port(8000)
+
+      # rewrite
+      # https://docs.mitmproxy.org/stable/mitmproxytutorial-modifyrequests/
+
+      t.assertEqual("fail", curl("http://localhost:8000/old"))
+
+      machine.send_chars("mitmdump -s ${addonScript}\n")
+      machine.wait_for_open_port(8080)
+
+      t.assertEqual("success", curl("http://localhost:8000/old", proxy=True))
+
+      machine.send_key("ctrl-c")
+
+      # replay
+      # https://docs.mitmproxy.org/stable/mitmproxytutorial-replayrequests/
+      # https://docs.mitmproxy.org/stable/tutorials/client-replay/
+
+      t.assertEqual("0", curl("http://localhost:8000/counter"))
+
+      machine.send_chars("mitmdump -w replay\n")
+      machine.wait_for_open_port(8080)
+
+      curl("-X POST http://localhost:8000/counter", proxy=True)
+
+      machine.send_key("ctrl-c")
+
+      t.assertEqual("1", curl("http://localhost:8000/counter"))
+
+      machine.succeed("mitmdump -C /root/replay")
+
+      t.assertEqual("2", curl("http://localhost:8000/counter"))
+    '';
+}


### PR DESCRIPTION
Test that we can override request path.

Related-to: https://github.com/ngi-nix/projects/issues/1835

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
