### PR TITLE
telegram-desktop: 5.15.4 -> 5.16.4, update forks

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -5,6 +5,10 @@
   fetchpatch,
   libsForQt5,
   yasm,
+  alsa-lib,
+  jemalloc,
+  libopus,
+  libpulseaudio,
   withWebkit ? true,
 }:
 
@@ -38,7 +42,7 @@ in
 telegram-desktop.override {
   pname = "kotatogram-desktop";
   inherit withWebkit;
-  unwrapped = (telegram-desktop.unwrapped.override { inherit tg_owt; }).overrideAttrs {
+  unwrapped = (telegram-desktop.unwrapped.override { inherit tg_owt; }).overrideAttrs (old: {
     pname = "kotatogram-desktop-unwrapped";
     version = "${version}-unstable-2024-09-27";
 
@@ -60,6 +64,13 @@ telegram-desktop.override {
       })
     ];
 
+    buildInputs = (old.buildInputs or [ ]) ++ [
+      alsa-lib
+      jemalloc
+      libopus
+      libpulseaudio
+    ];
+
     meta = {
       description = "Kotatogram – experimental Telegram Desktop fork";
       longDescription = ''
@@ -74,5 +85,5 @@ telegram-desktop.override {
       maintainers = with lib.maintainers; [ ilya-fedin ];
       mainProgram = if stdenv.hostPlatform.isLinux then "kotatogram-desktop" else "Kotatogram";
     };
-  };
+  });
 }

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
@@ -20,14 +20,10 @@
   protobuf,
   openalSoft,
   minizip,
-  libopus,
-  alsa-lib,
-  libpulseaudio,
   range-v3,
   tl-expected,
   hunspell,
   gobject-introspection,
-  jemalloc,
   rnnoise,
   microsoft-gsl,
   boost,
@@ -46,24 +42,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "telegram-desktop-unwrapped";
-  version = "5.15.4";
+  version = "5.16.4";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "tdesktop";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-C7mUV/Jc0OJnVXxRGVx/l2T7APOsY05t5MLW8laIwnA=";
+    hash = "sha256-yU2Ai2JgxDlaTK5GsL+yWkwtFbk14tPRAj1Rdt+gmmQ=";
   };
-
-  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
-    substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioInputALSA.cpp \
-      --replace-fail '"libasound.so.2"' '"${lib.getLib alsa-lib}/lib/libasound.so.2"'
-    substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioOutputALSA.cpp \
-      --replace-fail '"libasound.so.2"' '"${lib.getLib alsa-lib}/lib/libasound.so.2"'
-    substituteInPlace Telegram/ThirdParty/libtgvoip/os/linux/AudioPulse.cpp \
-      --replace-fail '"libpulse.so.0"' '"${lib.getLib libpulseaudio}/lib/libpulse.so.0"'
-  '';
 
   nativeBuildInputs =
     [
@@ -87,7 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
       ffmpeg_6
       openalSoft
       minizip
-      libopus
       range-v3
       tl-expected
       rnnoise
@@ -101,10 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
       protobuf
       qtwayland
       kcoreaddons
-      alsa-lib
-      libpulseaudio
       hunspell
-      jemalloc
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_15

--- a/pkgs/by-name/_6/_64gram/package.nix
+++ b/pkgs/by-name/_6/_64gram/package.nix
@@ -4,6 +4,10 @@
   fetchFromGitHub,
   fetchpatch,
   telegram-desktop,
+  alsa-lib,
+  jemalloc,
+  libopus,
+  libpulseaudio,
   withWebkit ? true,
 }:
 
@@ -30,6 +34,13 @@ telegram-desktop.override {
         stripLen = 1;
         hash = "sha256-xiq8WLAiSZwpvdyK5JbRAdQ9us93+9oMmeMBqVb1TbI=";
       })
+    ];
+
+    buildInputs = (old.buildInputs or [ ]) ++ [
+      alsa-lib
+      jemalloc
+      libopus
+      libpulseaudio
     ];
 
     cmakeFlags = (old.cmakeFlags or [ ]) ++ [

--- a/pkgs/by-name/ay/ayugram-desktop/package.nix
+++ b/pkgs/by-name/ay/ayugram-desktop/package.nix
@@ -13,13 +13,13 @@ telegram-desktop.override {
   unwrapped = telegram-desktop.unwrapped.overrideAttrs (
     finalAttrs: previousAttrs: {
       pname = "ayugram-desktop-unwrapped";
-      version = "5.14.3";
+      version = "5.16.3";
 
       src = fetchFromGitHub {
         owner = "AyuGram";
         repo = "AyuGramDesktop";
-        tag = "v${finalAttrs.version}";
-        hash = "sha256-cirUnGtjEc8aQzXH0r5kVhobEqf63eoZ17Gg99e+FCQ=";
+        rev = "aafdac6da465e6498e39e1b55566fc8fe2402843";
+        hash = "sha256-GNFkGw/CxtbeoEMBjExNudBcKFwlfXee5VVnXa4wGko=";
         fetchSubmodules = true;
       };
 

--- a/pkgs/by-name/ma/materialgram/package.nix
+++ b/pkgs/by-name/ma/materialgram/package.nix
@@ -11,13 +11,13 @@ telegram-desktop.override {
   unwrapped = telegram-desktop.unwrapped.overrideAttrs (
     finalAttrs: previousAttrs: {
       pname = "materialgram-unwrapped";
-      version = "5.14.3.1";
+      version = "5.16.4.1";
 
       src = fetchFromGitHub {
         owner = "kukuruzka165";
         repo = "materialgram";
         rev = "refs/tags/v${finalAttrs.version}";
-        hash = "sha256-wnhEnhNeuY7eRvmsDnpZ2CiKHXFvgIYpZp2ftjq54/Q=";
+        hash = "sha256-sN+Asoy9oZ08wZv9y454HqBxkEK7Zt0ynmfyuzk/SBc=";
         fetchSubmodules = true;
       };
 


### PR DESCRIPTION
Release: https://github.com/telegramdesktop/tdesktop/releases/tag/v5.16.3

Diff: https://github.com/telegramdesktop/tdesktop/compare/v5.15.4...v5.16.0, https://github.com/telegramdesktop/tdesktop/compare/v5.16.0...v5.16.1, https://github.com/telegramdesktop/tdesktop/compare/v5.16.1...v5.16.2, https://github.com/telegramdesktop/tdesktop/compare/v5.16.2...v5.16.3

Works like a charm. ~~They haven't switched off of jemalloc yet, so nothing special to do for this PR.~~ Nevermind. They just did in 5.16.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
