### PR TITLE
python3Packages.{pyobjc-core,pyobjc-framework-Cocoa}: 11.0 -> 11.1

### DIFF
--- a/pkgs/development/python-modules/pyobjc-core/default.nix
+++ b/pkgs/development/python-modules/pyobjc-core/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pyobjc-core";
-  version = "11.0";
+  version = "11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ronaldoussoren";
     repo = "pyobjc";
     tag = "v${version}";
-    hash = "sha256-RhB0Ht6vyDxYwDGS+A9HZL9ySIjWlhdB4S+gHxvQQBg=";
+    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
   };
 
   sourceRoot = "${src.name}/pyobjc-core";
@@ -30,18 +30,6 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     darwin.DarwinTools # sw_vers
   ];
-
-  # See https://github.com/ronaldoussoren/pyobjc/pull/641. Unfortunately, we
-  # cannot just pull that diff with fetchpatch due to https://discourse.nixos.org/t/how-to-apply-patches-with-sourceroot/59727.
-  postPatch = ''
-    for file in Modules/objc/test/*.m; do
-      substituteInPlace "$file" --replace "[[clang::suppress]]" ""
-    done
-
-    substituteInPlace setup.py \
-      --replace-fail "-buildversion" "-buildVersion" \
-      --replace-fail "-productversion" "-productVersion"
-  '';
 
   env.NIX_CFLAGS_COMPILE = toString [
     "-I${darwin.libffi.dev}/include"

--- a/pkgs/development/python-modules/pyobjc-framework-Cocoa/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-Cocoa/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "pyobjc-framework-Cocoa";
-  version = "11.0";
+  version = "11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ronaldoussoren";
     repo = "pyobjc";
     tag = "v${version}";
-    hash = "sha256-RhB0Ht6vyDxYwDGS+A9HZL9ySIjWlhdB4S+gHxvQQBg=";
+    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
   };
 
   sourceRoot = "${src.name}/pyobjc-framework-Cocoa";
@@ -25,7 +25,6 @@ buildPythonPackage rec {
 
   buildInputs = [
     darwin.libffi
-    darwin.DarwinTools
   ];
 
   nativeBuildInputs = [
@@ -37,7 +36,9 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyobjc_setup.py \
       --replace-fail "-buildversion" "-buildVersion" \
-      --replace-fail "-productversion" "-productVersion"
+      --replace-fail "-productversion" "-productVersion" \
+      --replace-fail "/usr/bin/sw_vers" "sw_vers" \
+      --replace-fail "/usr/bin/xcrun" "xcrun"
   '';
 
   dependencies = [ pyobjc-core ];
@@ -47,7 +48,13 @@ buildPythonPackage rec {
     "-Wno-error=unused-command-line-argument"
   ];
 
-  pythonImportsCheck = [ "Cocoa" ];
+  pythonImportsCheck = [
+    "Cocoa"
+    "CoreFoundation"
+    "Foundation"
+    "AppKit"
+    "PyObjCTools"
+  ];
 
   meta = with lib; {
     description = "PyObjC wrappers for the Cocoa frameworks on macOS";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates [pyobjc](https://github.com/ronaldoussoren/pyobjc) packages on nixpkgs from `v11.0` to [`v11.1`](https://github.com/ronaldoussoren/pyobjc/releases/tag/v11.1). Notes:

- I did NOT test it with applications that depend on it.
- In `postPatch`, `substituteInPlace "$file" --replace "[[clang::suppress]]" ""` actually created unnecessary logs, so I deleted it.
- In `pyobjc-framework-Cocoa`, it still needed `buildversion` and `productversion` subsitution in `postPatch`.
- In `pyobjc-framework-Cocoa`, `sw_vers` and `xcrun` need to be tweaked this time, but I don't know why.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
