### PR TITLE
writeShellApplication: add `shell` parameter

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -315,6 +315,21 @@ rec {
         "nounset"
         "pipefail"
       ],
+
+      /*
+        The path to a custom shell binary.
+
+        :::{.note}
+        You probably need to unset `bashOptions`.
+        :::
+        :::{.note}
+        Shellcheck only supports some shell types.
+        :::
+
+        Type: Path
+      */
+      shell ? runtimeShell,
+
       /*
         Extra arguments to pass to `stdenv.mkDerivation`.
 
@@ -346,7 +361,7 @@ rec {
       preferLocalBuild = false;
       text =
         ''
-          #!${runtimeShell}
+          #!${shell}
           ${lib.concatMapStringsSep "\n" (option: "set -o ${option}") bashOptions}
         ''
         + lib.optionalString (runtimeEnv != null) (

--- a/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
+++ b/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
@@ -8,6 +8,7 @@
   linkFarm,
   diffutils,
   hello,
+  ksh,
 }:
 let
   checkShellApplication =
@@ -143,4 +144,15 @@ linkFarm "writeShellApplication-tests" {
     expected = "";
   };
 
+  test-shell-ksh = checkShellApplication rec {
+    name = "test-bash-options-nounset";
+    text = ''
+      head -n1 "$0"
+    '';
+    shell = lib.getExe' ksh "ksh";
+    bashOptions = [ ];
+    expected = ''
+      #!${shell}
+    '';
+  };
 }


### PR DESCRIPTION
I need to use a shell other than bash because bash drops privileges gained via SUID but I'd also rather not have to re-implement all the functionality of writeShellApplication. This makes it possible to simply use any shell you want.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
