### PR TITLE
nixos/hddfancontrol: loosen pwmPaths and disks types to str, nixos/hddtemp: allow command substitution for drives

### DIFF
--- a/nixos/modules/services/hardware/hddfancontrol.nix
+++ b/nixos/modules/services/hardware/hddfancontrol.nix
@@ -52,21 +52,30 @@ in
             {
               options = {
                 disks = lib.mkOption {
-                  type = lib.types.listOf lib.types.path;
+                  type = lib.types.listOf lib.types.str;
                   default = [ ];
                   description = ''
                     Drive(s) to get temperature from
+
+                    Can also use command substitution to automatically grab all matching drives; such as all scsi (sas) drives
                   '';
-                  example = [ "/dev/sda" ];
+                  example = [
+                    "/dev/sda"
+                    "`find /dev/disk/by-id -name \"scsi*\" -and -not -name \"*-part*\" -printf \"%p \"`"
+                  ];
                 };
 
                 pwmPaths = lib.mkOption {
-                  type = lib.types.listOf lib.types.path;
+                  type = lib.types.listOf lib.types.str;
                   default = [ ];
                   description = ''
                     PWM filepath(s) to control fan speed (under /sys), followed by initial and fan-stop PWM values
+                    Can also use command substitution to ensure the correct hwmonX is selected on every boot
                   '';
-                  example = [ "/sys/class/hwmon/hwmon2/pwm1:30:10" ];
+                  example = [
+                    "/sys/class/hwmon/hwmon2/pwm1:30:10"
+                    "`echo /sys/devices/platform/nct6775.656/hwmon/hwmon[[:print:]]`/pwm4:80:20"
+                  ];
                 };
 
                 logVerbosity = lib.mkOption {
@@ -151,9 +160,12 @@ in
         documentation = [ "man:hddfancontrol(1)" ];
         after = [ "hddtemp.service" ];
         wants = [ "hddtemp.service" ];
+        script =
+          let
+            argString = lib.strings.concatStringsSep " " (args cnf);
+          in
+          "${lib.getExe pkgs.hddfancontrol} -v ${cnf.logVerbosity} daemon ${argString}";
         serviceConfig = {
-          ExecStart = "${lib.getExe pkgs.hddfancontrol} -v ${cnf.logVerbosity} daemon ${lib.escapeShellArgs (args cnf)}";
-
           CPUSchedulingPolicy = "rr";
           CPUSchedulingPriority = 49;
 


### PR DESCRIPTION
nixos/hddfancontrol: loosen pwmPaths and disks types to str and use script instead of ExecStart in the service.

Lets you use command substitutions in your config to automatically select the correct disks and fan controllers. Useful as hwmonX can change value frequently and spontaneously, and replaced disks may have different drive paths.

Using this right now for the fans because my nas keeps switching the number of hwmon from 1 to 4 randomly, and the current option and service config don't let you use the widely suggest command substitution of:
```
`/sys/devices/platform/asus-nb-wmi/hwmon/hwmon[[:print:]]`(/pwm1)
```
I have included an example in the relevant option.

If you choose to keep using the direct fan controller hwmon path or disk paths, it also still works.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@benley