### PR TITLE
Update pyvisa to 1.15.0 and pyvisa-py to 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27367,6 +27367,12 @@
     githubId = 21125058;
     name = "xeals";
   };
+  xeniagda = {
+    name = "Xenia Agda";
+    email = "xenia.agda@gmail.com";
+    github = "xeniagda";
+    githubId = 8290983;
+  };
   xeji = {
     email = "xeji@cat3.de";
     github = "xeji";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27367,12 +27367,6 @@
     githubId = 21125058;
     name = "xeals";
   };
-  xeniagda = {
-    name = "Xenia Agda";
-    email = "xenia.agda@gmail.com";
-    github = "xeniagda";
-    githubId = 8290983;
-  };
   xeji = {
     email = "xeji@cat3.de";
     github = "xeji";
@@ -27384,6 +27378,12 @@
     github = "Xelden";
     githubId = 117323435;
     name = "Andrés Pico";
+  };
+  xeniagda = {
+    name = "Xenia Agda";
+    email = "xenia.agda@gmail.com";
+    github = "xeniagda";
+    githubId = 8290983;
   };
   xfnw = {
     email = "xfnw+nixos@riseup.net";

--- a/pkgs/development/python-modules/pyvisa-py/default.nix
+++ b/pkgs/development/python-modules/pyvisa-py/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "pyvisa-py";
-  version = "0.7.2";
+  version = "0.8.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "pyvisa";
     repo = "pyvisa-py";
     tag = version;
-    hash = "sha256-UFAKLrZ1ZrTmFXwVuyTCPVo3Y1YIDOvkx5krpsz71BM=";
+    hash = "sha256-bYxl7zJ36uorEasAKvPiVWLaG2ISQGBHrQZJcnkbfzU=";
   };
 
   nativeBuildInputs = [
@@ -55,6 +55,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pyvisa/pyvisa-py";
     changelog = "https://github.com/pyvisa/pyvisa-py/blob/${version}/CHANGES";
     license = licenses.mit;
-    maintainers = with maintainers; [ mvnetbiz ];
+    maintainers = with maintainers; [ mvnetbiz xeniagda ];
   };
 }

--- a/pkgs/development/python-modules/pyvisa-py/default.nix
+++ b/pkgs/development/python-modules/pyvisa-py/default.nix
@@ -55,6 +55,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/pyvisa/pyvisa-py";
     changelog = "https://github.com/pyvisa/pyvisa-py/blob/${version}/CHANGES";
     license = licenses.mit;
-    maintainers = with maintainers; [ mvnetbiz xeniagda ];
+    maintainers = with maintainers; [
+      mvnetbiz
+      xeniagda
+    ];
   };
 }

--- a/pkgs/development/python-modules/pyvisa/default.nix
+++ b/pkgs/development/python-modules/pyvisa/default.nix
@@ -39,6 +39,9 @@ buildPythonPackage rec {
     description = "Python package for support of the Virtual Instrument Software Architecture (VISA)";
     homepage = "https://github.com/pyvisa/pyvisa";
     license = licenses.mit;
-    maintainers = with maintainers; [ mvnetbiz xeniagda ];
+    maintainers = with maintainers; [
+      mvnetbiz
+      xeniagda
+    ];
   };
 }

--- a/pkgs/development/python-modules/pyvisa/default.nix
+++ b/pkgs/development/python-modules/pyvisa/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "pyvisa";
-  version = "1.14.1";
+  version = "1.15.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "pyvisa";
     repo = "pyvisa";
     tag = version;
-    hash = "sha256-GKrgUK2nSZi+8oJoS45MjpU9+INEgcla9Kaw6ceNVp0=";
+    hash = "sha256-cjKOyBn5O7ThZI7pi6JXeLhe47xGbhQaSRcAqXb3lV8=";
   };
 
   nativeBuildInputs = [
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     description = "Python package for support of the Virtual Instrument Software Architecture (VISA)";
     homepage = "https://github.com/pyvisa/pyvisa";
     license = licenses.mit;
-    maintainers = with maintainers; [ mvnetbiz ];
+    maintainers = with maintainers; [ mvnetbiz xeniagda ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

`PyVISA-py` 0.8.0 added support for the PROLOGIX GPIB-to-ETHERNET adapter among other things and was released back in early April. `PyVISA-py` 0.8.0 depends on `PyVISA` (a different package) version 1.15.0, which is also updated.

This is my first contribution to nixpkgs, so do tell me if I missed anything. The package has been tested for functionality and seems to be working well. Added myself as a maintainer for the package because I foresee myself using the package a lot and wouldn't mind keeping it in working condition :)


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
