### PR TITLE
python3Packages.django-cte: 1.3.3 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/django-cte/default.nix
+++ b/pkgs/development/python-modules/django-cte/default.nix
@@ -3,53 +3,32 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
-  unittestCheckHook,
-  setuptools,
+  flit-core,
   django,
+  pytest-unmagic,
 }:
 
 buildPythonPackage rec {
   pname = "django-cte";
-  version = "1.3.3";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dimagi";
     repo = "django-cte";
     tag = "v${version}";
-    hash = "sha256-OCENg94xHBeeE4A2838Cu3q2am2im2X4SkFSjc6DuhE=";
+    hash = "sha256-DPbvmxTh24gTGvqzBg1VVN1LHxhGc+r81RITCuyccfw=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    flit-core
+  ];
 
   dependencies = [ django ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTests = [
-    # Require Database connection
-    "test_cte_queryset"
-    "test_experimental_left_outer_join"
-    "test_explain"
-    "test_left_outer_join_on_empty_result_set_cte"
-    "test_named_ctes"
-    "test_named_simple_ctes"
-    "test_non_cte_subquery"
-    "test_outerref_in_cte_query"
-    "test_simple_cte_query"
-    "test_update_cte_query"
-    "test_update_with_subquery"
-    "test_heterogeneous_filter_in_cte"
-    "test_raw_cte_sql"
-    "test_alias_as_subquery"
-    "test_alias_change_in_annotation"
-    "test_attname_should_not_mask_col_name"
-    "test_pickle_recursive_cte_queryset"
-    "test_recursive_cte_query"
-    "test_recursive_cte_reference_in_condition"
-    "test_union_with_first"
-    "test_union_with_select_related_and_first"
-    "test_union_with_select_related_and_order"
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-unmagic
   ];
 
   pythonImportsCheck = [ "django_cte" ];

--- a/pkgs/development/python-modules/pytest-unmagic/default.nix
+++ b/pkgs/development/python-modules/pytest-unmagic/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  flit-core,
+  pytest,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-unmagic";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "dimagi";
+    repo = "pytest-unmagic";
+    tag = "v${version}";
+    hash = "sha256-5WnLjQ0RuwLBIZAbOJoQ0KBEnb7yUWTUFBKy+WgNctQ=";
+  };
+
+  build-system = [
+    flit-core
+  ];
+
+  dependencies = [ pytest ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "unmagic" ];
+
+  meta = {
+    description = "Pytest fixtures with conventional import semantics";
+    homepage = "https://github.com/dimagi/pytest-unmagic";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ jopejoe1 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14231,6 +14231,8 @@ self: super: with self; {
 
   pytest-twisted = callPackage ../development/python-modules/pytest-twisted { };
 
+  pytest-unmagic = callPackage ../development/python-modules/pytest-unmagic { };
+
   pytest-unordered = callPackage ../development/python-modules/pytest-unordered { };
 
   pytest-variables = callPackage ../development/python-modules/pytest-variables { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
