### PR TITLE
nvidia_x11.mkDriver: use finalAttrs; use fabricmanagerVersion

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -12,7 +12,7 @@ nvidia_x11: sha256:
 let
   sys = lib.concatStringsSep "-" (lib.reverseList (lib.splitString "-" stdenv.system));
   bsys = builtins.replaceStrings [ "_" ] [ "-" ] sys;
-  fmver = nvidia_x11.version;
+  fmver = nvidia_x11.fabricmanagerVersion;
   ldd = (lib.getBin glibc) + "/bin/ldd";
 in
 

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -10,7 +10,7 @@
   persistencedSha256 ? null,
   persistencedVersion ? null,
   fabricmanagerSha256 ? null,
-  fabricmanagerVersion ? version,
+  fabricmanagerVersion ? null,
   useGLVND ? true,
   useProfiles ? true,
   preferGtk2 ? false,
@@ -313,6 +313,8 @@ stdenv.mkDerivation (finalAttrs: {
       settingsVersion = if settingsVersion != null then settingsVersion else finalAttrs.version;
       persistencedVersion =
         if persistencedVersion != null then persistencedVersion else finalAttrs.version;
+      fabricmanagerVersion =
+        if fabricmanagerVersion != null then fabricmanagerVersion else finalAttrs.version;
       compressFirmware = false;
       ibtSupport = ibtSupport || (lib.versionAtLeast version "530");
     }

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -6,9 +6,9 @@
   sha256_aarch64 ? null,
   openSha256 ? null,
   settingsSha256 ? null,
-  settingsVersion ? version,
+  settingsVersion ? null,
   persistencedSha256 ? null,
-  persistencedVersion ? version,
+  persistencedVersion ? null,
   fabricmanagerSha256 ? null,
   fabricmanagerVersion ? version,
   useGLVND ? true,
@@ -140,199 +140,201 @@ let
 
     [1]: https://www.nvidia.com/content/DriverDownloads/licence.php?lang=us
   '';
-
-  self = stdenv.mkDerivation {
-    name = "nvidia-${if useFabricmanager then "dc" else "x11"}-${version}${nameSuffix}";
-
-    builder = ./builder.sh;
-
-    src =
-      if !acceptLicense && (openSha256 == null) then
-        throwLicense
-      else if stdenv.hostPlatform.system == "x86_64-linux" then
-        fetchurl {
-          urls =
-            if args ? url then
-              [ args.url ]
-            else
-              [
-                "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
-                "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
-              ];
-          sha256 = sha256_64bit;
-        }
-      else if stdenv.hostPlatform.system == "i686-linux" then
-        fetchurl {
-          urls =
-            if args ? url then
-              [ args.url ]
-            else
-              [
-                "https://us.download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
-                "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
-              ];
-          sha256 = sha256_32bit;
-        }
-      else if stdenv.hostPlatform.system == "aarch64-linux" && sha256_aarch64 != null then
-        fetchurl {
-          urls =
-            if args ? url then
-              [ args.url ]
-            else
-              [
-                "https://us.download.nvidia.com/XFree86/aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
-                "https://download.nvidia.com/XFree86/Linux-aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
-              ];
-          sha256 = sha256_aarch64;
-        }
-      else
-        throw "nvidia-x11 does not support platform ${stdenv.hostPlatform.system}";
-
-    patches = if libsOnly then null else patches;
-    inherit prePatch postPatch patchFlags;
-    inherit preInstall postInstall;
-    inherit version useGLVND useProfiles;
-    inherit (stdenv.hostPlatform) system;
-    inherit i686bundled;
-
-    outputs =
-      [ "out" ]
-      ++ lib.optional i686bundled "lib32"
-      ++ lib.optional (!libsOnly) "bin"
-      ++ lib.optional (!libsOnly && firmware) "firmware";
-    outputDev = if libsOnly then null else "bin";
-
-    kernel = if libsOnly then null else kernel.dev;
-    kernelVersion = if libsOnly then null else kernel.modDirVersion;
-
-    makeFlags = lib.optionals (!libsOnly) (
-      kernelModuleMakeFlags
-      ++ [
-        "IGNORE_PREEMPT_RT_PRESENCE=1"
-        "NV_BUILD_SUPPORTS_HMM=1"
-        "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
-        "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-      ]
-    );
-
-    hardeningDisable = [
-      "pic"
-      "format"
-    ];
-
-    dontStrip = true;
-    dontPatchELF = true;
-
-    libPath = libPathFor pkgs;
-    libPath32 = lib.optionalString i686bundled (libPathFor pkgsi686Linux);
-
-    nativeBuildInputs = [
-      perl
-      nukeReferences
-      which
-      libarchive
-      jq
-    ] ++ lib.optionals (!libsOnly) kernel.moduleBuildDependencies;
-
-    disallowedReferences = lib.optionals (!libsOnly) [ kernel.dev ];
-
-    passthru =
-      let
-        fetchFromGithubOrNvidia =
-          {
-            owner,
-            repo,
-            rev,
-            ...
-          }@args:
-          let
-            args' = builtins.removeAttrs args [
-              "owner"
-              "repo"
-              "rev"
-            ];
-            baseUrl = "https://github.com/${owner}/${repo}";
-          in
-          fetchzip (
-            args'
-            // {
-              urls = [
-                "${baseUrl}/archive/${rev}.tar.gz"
-                "https://download.nvidia.com/XFree86/${repo}/${repo}-${rev}.tar.bz2"
-              ];
-              # github and nvidia use different compression algorithms,
-              #  use an invalid file extension to force detection.
-              extension = "tar.??";
-            }
-          );
-      in
-      {
-        open = lib.mapNullable (
-          hash:
-          callPackage ./open.nix {
-            inherit hash;
-            nvidia_x11 = self;
-            patches =
-              (builtins.map (rewritePatch {
-                from = "kernel";
-                to = "kernel-open";
-              }) patches)
-              ++ patchesOpen;
-            broken = brokenOpen;
-          }
-        ) openSha256;
-        settings =
-          if useSettings then
-            (if settings32Bit then pkgsi686Linux.callPackage else callPackage)
-              (import ./settings.nix self settingsSha256)
-              {
-                withGtk2 = preferGtk2;
-                withGtk3 = !preferGtk2;
-                fetchFromGitHub = fetchFromGithubOrNvidia;
-              }
-          else
-            { };
-        persistenced =
-          if usePersistenced then
-            lib.mapNullable (
-              hash:
-              callPackage (import ./persistenced.nix self hash) {
-                fetchFromGitHub = fetchFromGithubOrNvidia;
-              }
-            ) persistencedSha256
-          else
-            { };
-        fabricmanager =
-          if useFabricmanager then
-            lib.mapNullable (hash: callPackage (import ./fabricmanager.nix self hash) { }) fabricmanagerSha256
-          else
-            { };
-        inherit persistencedVersion settingsVersion;
-        compressFirmware = false;
-        ibtSupport = ibtSupport || (lib.versionAtLeast version "530");
-      }
-      // lib.optionalAttrs (!i686bundled) {
-        inherit lib32;
-      };
-
-    meta = with lib; {
-      homepage = "https://www.nvidia.com/object/unix.html";
-      description = "${
-        if useFabricmanager then "Data Center" else "X.org"
-      } driver and kernel module for NVIDIA cards";
-      license = licenses.unfreeRedistributable;
-      platforms =
-        [ "x86_64-linux" ]
-        ++ lib.optionals (sha256_32bit != null) [ "i686-linux" ]
-        ++ lib.optionals (sha256_aarch64 != null) [ "aarch64-linux" ];
-      maintainers = with maintainers; [
-        kiskae
-        edwtjo
-      ];
-      priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
-      inherit broken;
-    };
-  };
-
 in
-self
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "nvidia-${if useFabricmanager then "dc" else "x11"}-${version}${nameSuffix}";
+
+  builder = ./builder.sh;
+
+  src =
+    if !acceptLicense && (openSha256 == null) then
+      throwLicense
+    else if stdenv.hostPlatform.system == "x86_64-linux" then
+      fetchurl {
+        urls =
+          if args ? url then
+            [ args.url ]
+          else
+            [
+              "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+              "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+            ];
+        sha256 = sha256_64bit;
+      }
+    else if stdenv.hostPlatform.system == "i686-linux" then
+      fetchurl {
+        urls =
+          if args ? url then
+            [ args.url ]
+          else
+            [
+              "https://us.download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+              "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+            ];
+        sha256 = sha256_32bit;
+      }
+    else if stdenv.hostPlatform.system == "aarch64-linux" && sha256_aarch64 != null then
+      fetchurl {
+        urls =
+          if args ? url then
+            [ args.url ]
+          else
+            [
+              "https://us.download.nvidia.com/XFree86/aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+              "https://download.nvidia.com/XFree86/Linux-aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+            ];
+        sha256 = sha256_aarch64;
+      }
+    else
+      throw "nvidia-x11 does not support platform ${stdenv.hostPlatform.system}";
+
+  patches = if libsOnly then null else patches;
+  inherit prePatch postPatch patchFlags;
+  inherit preInstall postInstall;
+  inherit version useGLVND useProfiles;
+  inherit (stdenv.hostPlatform) system;
+  inherit i686bundled;
+
+  outputs =
+    [ "out" ]
+    ++ lib.optional i686bundled "lib32"
+    ++ lib.optional (!libsOnly) "bin"
+    ++ lib.optional (!libsOnly && firmware) "firmware";
+  outputDev = if libsOnly then null else "bin";
+
+  kernel = if libsOnly then null else kernel.dev;
+  kernelVersion = if libsOnly then null else kernel.modDirVersion;
+
+  makeFlags = lib.optionals (!libsOnly) (
+    kernelModuleMakeFlags
+    ++ [
+      "IGNORE_PREEMPT_RT_PRESENCE=1"
+      "NV_BUILD_SUPPORTS_HMM=1"
+      "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
+      "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    ]
+  );
+
+  hardeningDisable = [
+    "pic"
+    "format"
+  ];
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  libPath = libPathFor pkgs;
+  libPath32 = lib.optionalString i686bundled (libPathFor pkgsi686Linux);
+
+  nativeBuildInputs = [
+    perl
+    nukeReferences
+    which
+    libarchive
+    jq
+  ] ++ lib.optionals (!libsOnly) kernel.moduleBuildDependencies;
+
+  disallowedReferences = lib.optionals (!libsOnly) [ kernel.dev ];
+
+  passthru =
+    let
+      fetchFromGithubOrNvidia =
+        {
+          owner,
+          repo,
+          rev,
+          ...
+        }@args:
+        let
+          args' = builtins.removeAttrs args [
+            "owner"
+            "repo"
+            "rev"
+          ];
+          baseUrl = "https://github.com/${owner}/${repo}";
+        in
+        fetchzip (
+          args'
+          // {
+            urls = [
+              "${baseUrl}/archive/${rev}.tar.gz"
+              "https://download.nvidia.com/XFree86/${repo}/${repo}-${rev}.tar.bz2"
+            ];
+            # github and nvidia use different compression algorithms,
+            #  use an invalid file extension to force detection.
+            extension = "tar.??";
+          }
+        );
+    in
+    {
+      open = lib.mapNullable (
+        hash:
+        callPackage ./open.nix {
+          inherit hash;
+          nvidia_x11 = finalAttrs.finalPackage;
+          patches =
+            (builtins.map (rewritePatch {
+              from = "kernel";
+              to = "kernel-open";
+            }) patches)
+            ++ patchesOpen;
+          broken = brokenOpen;
+        }
+      ) openSha256;
+      settings =
+        if useSettings then
+          (if settings32Bit then pkgsi686Linux.callPackage else callPackage)
+            (import ./settings.nix finalAttrs.finalPackage settingsSha256)
+            {
+              withGtk2 = preferGtk2;
+              withGtk3 = !preferGtk2;
+              fetchFromGitHub = fetchFromGithubOrNvidia;
+            }
+        else
+          { };
+      persistenced =
+        if usePersistenced then
+          lib.mapNullable (
+            hash:
+            callPackage (import ./persistenced.nix finalAttrs.finalPackage hash) {
+              fetchFromGitHub = fetchFromGithubOrNvidia;
+            }
+          ) persistencedSha256
+        else
+          { };
+      fabricmanager =
+        if useFabricmanager then
+          lib.mapNullable (
+            hash: callPackage (import ./fabricmanager.nix finalAttrs.finalPackage hash) { }
+          ) fabricmanagerSha256
+        else
+          { };
+      settingsVersion = if settingsVersion != null then settingsVersion else finalAttrs.version;
+      persistencedVersion =
+        if persistencedVersion != null then persistencedVersion else finalAttrs.version;
+      compressFirmware = false;
+      ibtSupport = ibtSupport || (lib.versionAtLeast version "530");
+    }
+    // lib.optionalAttrs (!i686bundled) {
+      inherit lib32;
+    };
+
+  meta = with lib; {
+    homepage = "https://www.nvidia.com/object/unix.html";
+    description = "${
+      if useFabricmanager then "Data Center" else "X.org"
+    } driver and kernel module for NVIDIA cards";
+    license = licenses.unfreeRedistributable;
+    platforms =
+      [ "x86_64-linux" ]
+      ++ lib.optionals (sha256_32bit != null) [ "i686-linux" ]
+      ++ lib.optionals (sha256_aarch64 != null) [ "aarch64-linux" ];
+    maintainers = with maintainers; [
+      kiskae
+      edwtjo
+    ];
+    priority = 4; # resolves collision with xorg-server's "lib/xorg/modules/extensions/libglx.so"
+    inherit broken;
+  };
+})


### PR DESCRIPTION
This allows correct usage of overrideAttrs and also ensures
overrides are properly propagated to the packages in passthru.

Looks like fabricmanagerVersion was unused since introduction.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
