### PR TITLE
tenacity: add darwin support

### DIFF
--- a/pkgs/by-name/te/tenacity/package.nix
+++ b/pkgs/by-name/te/tenacity/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitea,
   cmake,
+  ninja,
   wxGTK32,
   gtk3,
   pkg-config,
@@ -60,16 +61,42 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-2gndOwgEJK2zDSbjcZigbhEpGv301/ygrf+EQhKp8PI=";
   };
 
-  postPatch = ''
-    mkdir -p build/src/private
-    touch build/src/private/RevisionIdent.h
+  postPatch =
+    ''
+      # GIT_DESCRIBE is used for the version string and can't be passed in
+      # as an option, so we substitute it instead.
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'set( GIT_DESCRIBE "unknown" )' 'set( GIT_DESCRIBE "${finalAttrs.version}" )'
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      substituteInPlace libraries/lib-files/FileNames.cpp \
+        --replace-fail /usr/include/linux/magic.h ${linuxHeaders}/include/linux/magic.h
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # Tenacity has special handling for ffmpeg library search on darwin,
+      # looking only in a few specific directories.
+      # Make sure it searches for our version of ffmpeg in the nix store.
+      substituteInPlace libraries/lib-ffmpeg-support/FFmpegFunctions.cpp \
+        --replace-fail /usr/local/lib/tenacity ${lib.getLib ffmpeg}/lib
+    '';
 
-    substituteInPlace libraries/lib-files/FileNames.cpp \
-         --replace /usr/include/linux/magic.h \
-                   ${linuxHeaders}/include/linux/magic.h
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir $out/{bin,Applications}
+    mv $out/{,Applications/}Tenacity.app
+
+    # Symlinking the binary is insufficient as it would be unable to
+    # find the bundle resources
+    cat << EOF > "$out/bin/tenacity"
+    #!${stdenv.shell}
+    open -na "$out/Applications/Tenacity.app" --args "\$@"
+    EOF
+    chmod +x "$out/bin/tenacity"
+
+    # Only contains a static library that is already linked into the tenacity binary
+    rm -r $out/lib
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     wrapProgram "$out/bin/tenacity" \
       --suffix AUDACITY_PATH : "$out/share/tenacity" \
       --suffix AUDACITY_MODULES_PATH : "$out/lib/tenacity/modules" \
@@ -77,10 +104,9 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH"
   '';
 
-  env.NIX_CFLAGS_COMPILE = "-D GIT_DESCRIBE=\"\"";
-
-  # tenacity only looks for ffmpeg at runtime, so we need to link it in manually
-  NIX_LDFLAGS = toString [
+  # Tenacity only looks for ffmpeg at runtime, so we need to link it in manually.
+  # On darwin, these are ignored by the ffmpeg search even when linked.
+  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux (toString [
     "-lavcodec"
     "-lavdevice"
     "-lavfilter"
@@ -89,23 +115,23 @@ stdenv.mkDerivation (finalAttrs: {
     "-lpostproc"
     "-lswresample"
     "-lswscale"
-  ];
+  ]);
 
   nativeBuildInputs =
     [
       cmake
+      ninja
       gettext
-      makeWrapper
       pkg-config
       python3
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
+      makeWrapper
       linuxHeaders
     ];
 
   buildInputs =
     [
-      alsa-lib
       expat
       ffmpeg
       file
@@ -134,6 +160,7 @@ stdenv.mkDerivation (finalAttrs: {
       gtk3
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
+      alsa-lib
       at-spi2-core
       dbus
       libepoxy
@@ -149,6 +176,9 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     # RPATH of binary /nix/store/.../bin/... contains a forbidden reference to /build/
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    # Disabled by default on Linux but enabled on Darwin, so we disable it explicitly for all platforms,
+    # as we provide dependencies from nixpkgs regardless of the target platform.
+    "-DVCPKG=OFF"
   ];
 
   meta = {
@@ -157,6 +187,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://tenacityaudio.org/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ irenes ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/te/tenacity/package.nix
+++ b/pkgs/by-name/te/tenacity/package.nix
@@ -47,7 +47,7 @@
   util-linux,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tenacity";
   version = "1.3.4";
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     owner = "tenacityteam";
     repo = "tenacity";
     fetchSubmodules = true;
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-2gndOwgEJK2zDSbjcZigbhEpGv301/ygrf+EQhKp8PI=";
   };
 
@@ -151,12 +151,12 @@ stdenv.mkDerivation rec {
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Sound editor with graphical UI";
     mainProgram = "tenacity";
     homepage = "https://tenacityaudio.org/";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ irenes ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ irenes ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/te/tenacity/package.nix
+++ b/pkgs/by-name/te/tenacity/package.nix
@@ -186,7 +186,10 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "tenacity";
     homepage = "https://tenacityaudio.org/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ irenes ];
+    maintainers = with lib.maintainers; [
+      irenes
+      niklaskorz
+    ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Darwin build for tenacity, which works with very few changes thanks to MacPorts upstreaming their own patches.

Also added me as maintainer to not leave you alone with the darwin parts of the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
