### PR TITLE
claudia: init at unstable-2025-07-02

### DIFF
--- a/pkgs/by-name/cl/claudia/package.nix
+++ b/pkgs/by-name/cl/claudia/package.nix
@@ -1,0 +1,126 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  bun,
+  pkg-config,
+  webkitgtk_4_1,
+  gtk3,
+  libayatana-appindicator,
+  librsvg,
+  openssl,
+  xdotool,
+  libsoup_2_4,
+  dbus,
+  cargo,
+  rustc,
+  nodejs,
+  jq,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "claudia";
+  version = "0-unstable-2025-07-02";
+
+  src = fetchFromGitHub {
+    owner = "getAsterisk";
+    repo = "claudia";
+    rev = "f1377833b36ffde6fde49bf0d78a73e2c9972e4b";
+    hash = "sha256-Gms+sQwQBy4LcHv/KprXN2borhei/sI3FLdzARJYIYs=";
+  };
+
+  cargoRoot = "src-tauri";
+
+  cargoHash = "sha256-J4MFgXay8xUaAv0AXk+JhMwNZIYCUchJqWOSQ8Jw41s=";
+
+  bunDeps = stdenv.mkDerivation {
+    pname = "${pname}-bun-deps";
+    inherit src version;
+    nativeBuildInputs = [
+      bun
+      nodejs
+    ];
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-ciY5hWt2H8eVvlvbERuTTKodXsB4LoTkzZpl0I7dmsc=";
+
+    installPhase = ''
+      cp ${src}/bun.lock .
+      cp ${src}/package.json .
+      mkdir -p src-tauri
+      cp -r ${src}/src-tauri/* src-tauri/
+
+      bun install --frozen-lockfile
+      patchShebangs node_modules/.bin
+
+      mkdir -p $out
+      mv node_modules $out/
+    '';
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    bun
+    pkg-config
+    cargo
+    rustc
+    nodejs
+    jq
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    gtk3
+    libayatana-appindicator
+    librsvg
+    openssl
+    xdotool
+    libsoup_2_4
+    dbus
+  ];
+
+  preBuild = ''
+    ln -s ${bunDeps}/node_modules ./node_modules
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # this prevents the tauri cli from running beforeBuildCommand
+    jq '.build.beforeBuildCommand = ""' src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.tmp
+    mv src-tauri/tauri.conf.json.tmp src-tauri/tauri.conf.json
+
+    node ./node_modules/.bin/tsc
+    node ./node_modules/.bin/vite build
+
+    node ./node_modules/.bin/tauri build --no-bundle
+
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    cd src-tauri
+    cargo test $cargoCheckFlags
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -Dm755 target/release/claudia $out/bin/claudia
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Powerful GUI app and Toolkit for Claude Code";
+    homepage = "https://github.com/getAsterisk/claudia";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.codebam ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
- Added [claudia](https://github.com/getAsterisk/claudia) package

Claudia is "A powerful GUI app and Toolkit for Claude Code". It's a graphical frontend for claude-code

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
