### PR TITLE
nixos/kanidm: move provisioning to separate systemd service

### DIFF
--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -146,7 +146,7 @@ let
   maybeRecoverAdmin = optionalString (cfg.provision.adminPasswordFile != null) ''
     KANIDM_ADMIN_PASSWORD=$(< ${cfg.provision.adminPasswordFile})
     # We always reset the admin account password if a desired password was specified.
-    if ! KANIDM_RECOVER_ACCOUNT_PASSWORD=$KANIDM_ADMIN_PASSWORD ${cfg.package}/bin/kanidmd recover-account -c ${serverConfigFile} admin --from-environment >/dev/null; then
+    if ! KANIDM_RECOVER_ACCOUNT_PASSWORD=$KANIDM_ADMIN_PASSWORD ${lib.getExe' cfg.package "kanidmd"} recover-account -c ${serverConfigFile} admin --from-environment >/dev/null; then
       echo "Failed to recover admin account" >&2
       exit 1
     fi
@@ -160,7 +160,7 @@ let
       ''
         KANIDM_IDM_ADMIN_PASSWORD=$(< ${cfg.provision.idmAdminPasswordFile})
         # We always reset the idm_admin account password if a desired password was specified.
-        if ! KANIDM_RECOVER_ACCOUNT_PASSWORD=$KANIDM_IDM_ADMIN_PASSWORD ${cfg.package}/bin/kanidmd recover-account -c ${serverConfigFile} idm_admin --from-environment >/dev/null; then
+        if ! KANIDM_RECOVER_ACCOUNT_PASSWORD=$KANIDM_IDM_ADMIN_PASSWORD ${lib.getExe' cfg.package "kanidmd"} recover-account -c ${serverConfigFile} idm_admin --from-environment >/dev/null; then
           echo "Failed to recover idm_admin account" >&2
           exit 1
         fi
@@ -168,7 +168,7 @@ let
     else
       ''
         # Recover idm_admin account
-        if ! recover_out=$(${cfg.package}/bin/kanidmd recover-account -c ${serverConfigFile} idm_admin -o json); then
+        if ! recover_out=$(${lib.getExe' cfg.package "kanidmd"} recover-account -c ${serverConfigFile} idm_admin -o json); then
           echo "$recover_out" >&2
           echo "kanidm provision: Failed to recover admin account" >&2
           exit 1
@@ -188,7 +188,7 @@ let
     else
       provisionStateJson;
 
-  postStartScript = pkgs.writeShellScript "post-start" ''
+  provisionScript = pkgs.writeShellScriptBin "kanidm-provision" ''
     set -euo pipefail
 
     # Wait for the kanidm server to come online
@@ -199,7 +199,7 @@ let
     do
       sleep 1
       if [[ "$count" -eq 30 ]]; then
-        echo "Tried for at least 30 seconds, giving up..."
+        echo "Tried for at least 30 seconds, giving up..." >&2
         exit 1
       fi
       count=$((++count))
@@ -895,7 +895,7 @@ in
     };
 
     systemd.services.kanidm = mkIf cfg.enableServer {
-      description = "kanidm identity management daemon";
+      description = "Kanidm identity management daemon";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       serviceConfig = mkMerge [
@@ -917,8 +917,7 @@ in
           StateDirectory = "kanidm";
           StateDirectoryMode = "0700";
           RuntimeDirectory = "kanidmd";
-          ExecStart = "${cfg.package}/bin/kanidmd server -c ${serverConfigFile}";
-          ExecStartPost = mkIf cfg.provision.enable postStartScript;
+          ExecStart = "${lib.getExe' cfg.package "kanidmd"} server -c ${serverConfigFile}";
           User = "kanidm";
           Group = "kanidm";
 
@@ -946,6 +945,24 @@ in
       ];
     };
 
+    systemd.services.kanidm-provision = mkIf cfg.provision.enable {
+      description = "Kanidm provisioning";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "kanidm.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = lib.getExe provisionScript;
+        inherit (config.systemd.services.kanidm.serviceConfig)
+          User
+          Group
+          BindPaths
+          BindReadOnlyPaths
+          ;
+      };
+      environment.RUST_LOG = "info";
+    };
+
     systemd.services.kanidm-unixd = mkIf cfg.enablePam {
       description = "Kanidm PAM daemon";
       wantedBy = [ "multi-user.target" ];
@@ -960,7 +977,7 @@ in
           CacheDirectory = "kanidm-unixd";
           CacheDirectoryMode = "0700";
           RuntimeDirectory = "kanidm-unixd";
-          ExecStart = "${cfg.package}/bin/kanidm_unixd";
+          ExecStart = lib.getExe' cfg.package "kanidm_unixd";
           User = "kanidm-unixd";
           Group = "kanidm-unixd";
 
@@ -1002,7 +1019,7 @@ in
         clientConfigFile
       ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/kanidm_unixd_tasks";
+        ExecStart = lib.getExe' cfg.package "kanidm_unixd_tasks";
 
         BindReadOnlyPaths = [
           "/nix/store"

--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -328,6 +328,8 @@ in
           provision.wait_until_succeeds("curl -Lsf https://${serverDomain} | grep Kanidm")
           if pw is None:
               pw = provision.succeed("su - kanidm -c 'kanidmd recover-account -c ${serverConfigFile} idm_admin 2>&1 | rg -o \'[A-Za-z0-9]{48}\' '").strip().removeprefix("'").removesuffix("'")
+          else:
+            provision.wait_for_unit("kanidm-provision.service")
           out = provision.succeed(f"KANIDM_PASSWORD={pw} kanidm login -D idm_admin")
           assert_contains(out, "Login Success for idm_admin")
 
@@ -337,6 +339,7 @@ in
 
       with subtest("Test Provisioning - credentialProvision"):
           provision.succeed('${specialisations}/credentialProvision/bin/switch-to-configuration test')
+          provision.succeed("systemctl restart kanidm-provision.service")
           provision_login("${provisionIdmAdminPassword}")
 
           # Make sure neither password is logged


### PR DESCRIPTION
Currently, a failure during provisioning causes the kanidm service to fail. With this change the provisioning is a separate service that can be inspected and restarted on demand.

> [!WARNING]  
> The test suite uncovers an interesting edge case for the switch-to-configuration script: the first time when switching from a configuration that did not have a oneshot service, to one that has it, does not start that oneshot service. This is reflected in the manual `systemctl restart kanidm-provision` line in the test.
>
> I don't think this should be merged until that behaviour is investigated.

The motivation for this change is that I'm getting the following errors when testing out kanidm with provisioning in a VM. The errors go away when using the updated module.

<details>
<summary>Error log</summary>
<pre>
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Starting the web server...
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: ready to rock! 🪨  UI available at: https://idm.server.test | event_tag_id: 3
kanidmd[1055]: 918660d3-52d2-4e2e-9b2b-b420f7ccda19 INFO     request [ 964µs | 100.00% ] method: GET | uri: / | version: HTTP/1.1
kanidmd[1055]: 918660d3-52d2-4e2e-9b2b-b420f7ccda19 INFO     ┕━ ｉ [info]:  | latency: 1.379505ms | status_code: 303 | kopid: "918660d3-52d2-4e2e-9b2b-b420f7ccda19" | msg: "client redirection sent"
kanidmd[1055]: b0d76763-a0ee-43ae-8e32-d544bd72eb20 INFO     request [ 2.01ms | 100.00% ] method: GET | uri: /ui | version: HTTP/1.1
kanidmd[1055]: b0d76763-a0ee-43ae-8e32-d544bd72eb20 INFO     ┕━ ｉ [info]:  | latency: 2.058083ms | status_code: 308 | kopid: "b0d76763-a0ee-43ae-8e32-d544bd72eb20" | msg: "client redirection sent"
kanidmd[1055]: 00a338ba-e4bd-4a75-a1bb-8d201f142575 INFO     request [ 10.2ms | 83.87% / 100.00% ] method: GET | uri: /ui/login | version: HTTP/1.1
kanidmd[1055]: 00a338ba-e4bd-4a75-a1bb-8d201f142575 INFO     ┕━ handle_auth_valid [ 1.64ms | 14.61% / 16.13% ]
kanidmd[1055]: 00a338ba-e4bd-4a75-a1bb-8d201f142575 INFO        ┝━ validate_client_auth_info_to_ident [ 154µs | 1.51% ]
kanidmd[1055]: 00a338ba-e4bd-4a75-a1bb-8d201f142575 ERROR       ┕━ 🚨 [error]: Invalid identity: NotAuthenticated
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1110]: 📜 Using config file: "/nix/store/mp2h85am9zk0ifm0sva8rrj5r2mhjh2l-server.toml"
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1110]: Ignoring env var KANIDM_RECOVER_ACCOUNT_PASSWORD
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Allowing admin socket access | pid: Some(1110)
kanidmd[1055]: 00411efa-8818-4477-a314-3f44712bc427 INFO     handle_admin_client_request [ 71.3ms | 0.71% / 100.00% ]
kanidmd[1055]: 00411efa-8818-4477-a314-3f44712bc427 INFO     ┕━ handle_admin_recover_account [ 70.8ms | 18.53% / 99.29% ] name: "idm_admin"
kanidmd[1055]: 00411efa-8818-4477-a314-3f44712bc427 INFO        ┕━ qswt_commit [ 57.6ms | 80.76% ]
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1110]: Logging pipeline completed shutdown
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1119]: 📜 Using config file: "/nix/store/mp2h85am9zk0ifm0sva8rrj5r2mhjh2l-server.toml"
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1119]: Ignoring env var KANIDM_RECOVER_ACCOUNT_PASSWORD
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Allowing admin socket access | pid: Some(1119)
kanidmd[1055]: 5d265439-c4f1-4913-9208-a4d74684cb16 INFO     handle_admin_client_request [ 28.3ms | 0.34% / 100.00% ]
kanidmd[1055]: 5d265439-c4f1-4913-9208-a4d74684cb16 INFO     ┕━ handle_admin_recover_account [ 28.2ms | 45.38% / 99.66% ] name: "admin"
kanidmd[1055]: 5d265439-c4f1-4913-9208-a4d74684cb16 INFO        ┕━ qswt_commit [ 15.4ms | 54.28% ]
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1119]: Logging pipeline completed shutdown
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1128]: Error:
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1128]:    0: error sending request for url (https://localhost:3013/v1/auth)
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1128]:    1: client error (Connect)
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1128]:    2: tcp connect error
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1128]:    3: Connection refused (os error 111)
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1128]: Location:
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1128]:    src/client.rs:99
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1128]: Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
5lyp46y54738inmi7iq7xwqlnirg2l04-post-start[1128]: Run with RUST_BACKTRACE=full to include source snippets.
systemd[1]: kanidm.service: Control process exited, code=exited, status=1/FAILURE
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Signal received, shutting down
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Stopped Delayed Action Actor
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Stopped Auditd Actor
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Stopped TlsAcceptor Reload Monitor
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Stopped Backup Actor
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Stopped LDAP Acceptor Actor
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Stopped Interval Actor
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Stopped HTTPS Server
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Stopped Admin Socket
kanidmd[1055]: 00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Stopped 🛑
kanidmd[1055]: Logging pipeline completed shutdown
systemd[1]: kanidm.service: Failed with result 'exit-code'.
systemd[1]: Failed to start kanidm identity management daemon.
systemd[1]: kanidm.service: Consumed 316ms CPU time, 111.9M memory peak, 1.8M written to disk, 10.3K incoming IP traffic, 10.4K outgoing IP traffic.
</pre>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
