### PR TITLE
Midisnoop

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8966,6 +8966,7 @@
     github = "gavinrogers";
     githubId = 2430469;
     name = "Gavin Rogers";
+  };
   gax = {
     email = "mail@maxgenson.de";
     github = "backtail";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8966,6 +8966,11 @@
     github = "gavinrogers";
     githubId = 2430469;
     name = "Gavin Rogers";
+  gax = {
+    email = "mail@maxgenson.de";
+    github = "backtail";
+    githubId = 95583524;
+    name = "Max Genson";
   };
   gaykitty = {
     email = "sasha@noraa.gay";

--- a/pkgs/applications/audio/midisnoop/default.nix
+++ b/pkgs/applications/audio/midisnoop/default.nix
@@ -1,0 +1,68 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "midisnoop";
+  version = "master";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "surfacepatterns";
+    repo = "midisnoop";
+    rev = "master"; # This 'master' branch has not been updated in a long time (latest commit bc30f60 from 11 years ago).
+    sha256 = "sha256-XDpDfTq5sAHqeYk3j+HA9H0SGq5sawrLzdK2rqN9fv4="; # Will notify us if there is ever a change
+  };
+
+  # This ensures the compiler finds RtMidi.h
+  NIX_CFLAGS_COMPILE = "-I${pkgs.rtmidi}/include/rtmidi/";
+
+  postPatch = ''
+    echo "Applying sed patches to engine.cpp and engine.h..."
+    # Remove the WINDOWS_KS case
+    sed -i '/case RtMidi::WINDOWS_KS:/,+2d' src/engine.cpp
+
+    # Replace all instances of RtError with RtMidiError
+    sed -i 's/RtError/RtMidiError/g' src/engine.cpp
+
+    # Replace all instances of e.what() with e.getMessage()
+    # Convert the std::string result to QString for Qt compatibility.
+    sed -i 's/\.what()/\.getMessage()/g' src/engine.cpp
+    sed -i 's/\(e\.getMessage()\)/QString::fromStdString(\1)/g' src/engine.cpp
+
+    # Add #include <QObject> to engine.h at the very beginning of the file.
+    # This is critical for Q_OBJECT and other Qt macros to be defined correctly.
+    sed -i '1i#include <QObject>' src/engine.h
+
+    # Fix the shebang of the Python script to use the Nix-provided python3
+    echo "Fixing shebang for install/build-desktop-file..."
+    sed -i "1s|.*|#!${pkgs.python3}/bin/python3|" install/build-desktop-file
+  '';
+
+  buildInputs = with pkgs; [
+    libsForQt5.full
+    rtmidi
+    python313
+  ];
+
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    libsForQt5.qt5.wrapQtAppsHook
+  ];
+
+  configurePhase = ''
+    python3 configure --prefix=$out
+  '';
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    make install
+  '';
+
+  meta = with pkgs.lib; {
+    description = "A simple MIDI monitor and prober";
+    homepage = "https://github.com/surfacepatterns/midisnoop"; # Corrected homepage to the GitHub repository
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/midisnoop/default.nix
+++ b/pkgs/applications/audio/midisnoop/default.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 pkgs.stdenv.mkDerivation {
   pname = "midisnoop";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13091,7 +13091,7 @@ with pkgs;
 
   mixxx = qt6Packages.callPackage ../applications/audio/mixxx { };
 
-  midisnoop = callPackage ../applications/audio/midisnoop {};
+  midisnoop = callPackage ../applications/audio/midisnoop { };
 
   mldonkey = callPackage ../applications/networking/p2p/mldonkey {
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13091,6 +13091,8 @@ with pkgs;
 
   mixxx = qt6Packages.callPackage ../applications/audio/mixxx { };
 
+  midisnoop = callPackage ../applications/audio/midisnoop {};
+
   mldonkey = callPackage ../applications/networking/p2p/mldonkey {
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;
   };


### PR DESCRIPTION
Initial import of midisnoop, a simple MIDI monitor and prober. It has been patched to work with modern RtMidi and Qt5.

The last change of this software is 11 years old and I wanted to ressurect it, because I use it at work and I want to migrate to NixOS. I did some patching to accont for the oudated qt and rtmidi libraries.

homepage: https://github.com/surfacepatterns/midisnoop

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
