### PR TITLE
buildstream: 2.4.1 -> 2.5.0

### DIFF
--- a/pkgs/by-name/bu/buildstream/package.nix
+++ b/pkgs/by-name/bu/buildstream/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  fetchpatch,
 
   # buildInputs
   buildbox,
@@ -20,15 +21,27 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "buildstream";
-  version = "2.4.1";
+  version = "2.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "buildstream";
     tag = version;
-    hash = "sha256-6a0VzYO5yj7EHvAb0xa4xZ0dgBKjFcwKv2F4o93oahY=";
+    hash = "sha256-/kGmAHx10//iVeqLXwcIWNI9FGIi0LlNJW+s6v0yU3Q=";
   };
+
+  # FIXME: To be removed in v2.6.0 of Buildstream.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/apache/buildstream/commit/9c4378ab2ec71b6b79ef90ee4bd950dd709a0310.patch?full_index=1";
+      hash = "sha256-po3Dn7gCv7o7h3k8qhmoH/b6Vv6ikKO/pkA20RvdU1g=";
+    })
+    (fetchpatch {
+      url = "https://github.com/apache/buildstream/commit/456a464b2581c52cad2b0b48596f5c19ad1db23f.patch?full_index=1";
+      hash = "sha256-0oFENx4AUhd1uJxRzbKzO5acGDosCc4vFJaSJ6urvhk=";
+    })
+  ];
 
   build-system = with python3Packages; [
     cython
@@ -104,6 +117,7 @@ python3Packages.buildPythonApplication rec {
     "test_source_pull_partial_fallback_fetch"
 
     # FAILED tests/sources/tar.py::test_out_of_basedir_hardlinks - AssertionError
+    # FIXME: To be removed in v2.6.0 of Buildstream.
     "test_out_of_basedir_hardlinks"
   ];
 


### PR DESCRIPTION
buildstream: 2.4.1 -> 2.5.0

Applied two patches from upstream repository for Buildstrream, to fix
the Protobuf runtime warnings, and dependency constraints.

These patches can be removed once Buildstream v2.6.0 is released.

For now, it is important to get 2.5.0 landed, as it includes a new API
which is necessary for new releases of Buildstream plugins.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
