### PR TITLE
linux: Enable Virtualbox guest modules

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -975,12 +975,6 @@ let
 
       UDMABUF = yes;
 
-      # VirtualBox guest drivers in the kernel conflict with the ones in the
-      # official additions package and prevent the vboxsf module from loading,
-      # so disable them for now.
-      VBOXGUEST = option no;
-      DRM_VBOXVIDEO = option no;
-
       XEN = option yes;
       XEN_DOM0 = option yes;
       PCI_XEN = option yes;


### PR DESCRIPTION
The mainline Linux kernel modules for VirtualBox guests are enabled by many other distros. It seems reasonable to assume that they are stable and functional enough at this point. The modules include vboxguest, vboxvideo and vboxsf. So enable them for NixOS too.

This provides an overview about what other Linux distros do:

* [Arch](https://archlinux.org/packages/?sort=&q=virtualbox&maintainer=&flagged=)
  * [Enabled mainline](https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/commit/4ce5aa26d45f2ec30ffb926f3450ae225226dc41) Virtualbox guest kernel modules
  * No guest modules package, only guest utils

* [Alpine](https://pkgs.alpinelinux.org/packages?name=*virtualbox*&branch=edge&repo=&arch=x86_64&origin=&flagged=&maintainer=)
  * [Enabled mainline](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/linux-lts/lts.x86_64.config?__goaway_challenge=cookie&__goaway_id=6d9c6ce73df12ad9d4edd231da8d2b12&__goaway_referer=https%3A%2F%2Fgithub.com%2F#L2750) Virtualbox guest kernel modules
  * no guest modules package, only guest utils

* [openSUSE](https://software.opensuse.org/search?q=virtualbox&baseproject=openSUSE%3AFactory)
  * [Enabled mainline](https://software.opensuse.org/package/kernel-default) Virtualbox guest kernel modules
  * 3rd-party modules are shipped with host modules in one package
    * [Stable](https://software.opensuse.org/package/virtualbox-kmp-default)
    * [LTS](https://software.opensuse.org/package/virtualbox-kmp-longterm)

* [Debian](https://packages.debian.org/search?suite=sid&searchon=names&keywords=virtualbox)
  * [Enabled mainline](https://salsa.debian.org/search?search=vbox&nav_source=navbar&project_id=18670&group_id=2107&search_code=true&repository_ref=debian%2Flatest) Virtualbox guest kernel modules
  * No guest modules package, only guest utils
  * [File search for vboxguest.ko](https://packages.debian.org/search?suite=bookworm&arch=any&mode=exactfilename&searchon=contents&keywords=vboxguest.ko), only shipped by the kernel package

* [Gentoo](https://packages.gentoo.org/packages/search?q=virtualbox)
  * [Enabled mainline](https://github.com/projg2/fedora-kernel-config-for-gentoo/blob/6.12.8-gentoo/kernel-x86_64-fedora.config#L8486) Virtualbox guest kernel modules
  * [Packaged 3rd-party](https://packages.gentoo.org/packages/app-emulation/virtualbox-guest-modules) kernel modules for guests

* [Fedora](https://packages.fedoraproject.org/search?query=virtualbox)
  * [Enabled mainline](https://src.fedoraproject.org/rpms/kernel/c/5d7cf4582847852950c9650e68943241cf68468a) Virtualbox guest kernel modules
  * No guest modules package, only guest utils

Follow-up PR on #421602.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
