### PR TITLE
nixos/tests/vaultwarden-litestream: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -947,6 +947,11 @@
     githubId = 339369;
     name = "Alexander Kjeldaas";
   };
+  ak2k = {
+    github = "ak2k";
+    githubId = 19240940;
+    name = "Adam";
+  };
   akamaus = {
     email = "dmitryvyal@gmail.com";
     github = "akamaus";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1722,6 +1722,7 @@ in
   vault-dev = runTest ./vault-dev.nix;
   vault-postgresql = runTest ./vault-postgresql.nix;
   vaultwarden = discoverTests (import ./vaultwarden.nix);
+  vaultwarden-litestream = runTest ./vaultwarden-litestream.nix;
   vdirsyncer = runTest ./vdirsyncer.nix;
   vector = import ./vector { inherit runTest; };
   velocity = runTest ./velocity.nix;

--- a/nixos/tests/vaultwarden-litestream.nix
+++ b/nixos/tests/vaultwarden-litestream.nix
@@ -1,0 +1,130 @@
+# Integration test: Vaultwarden with Litestream continuous replication.
+# Validates cross-service file access and disaster recovery.
+{ pkgs, lib, ... }:
+let
+  dbPath = "/var/lib/vaultwarden/db.sqlite3";
+  backupPath = "/var/backup/litestream";
+  socketPath = "/run/litestream/litestream.sock";
+  server = "http://localhost:8000";
+  testUser = builtins.toJSON {
+    email = "test@example.com";
+    name = "Test User";
+    masterPasswordHash = "pbkdf2$100000$J0+G2hx3fwLJivASjZNn5g==$VHB/rfRjawuwyHdznIqBxZf+UxzjxpKY3exnDYwO70g=";
+    key = "2.ftF0K4LPgR1vFPl7gLJI6A==|W2c0OIvS4BsFLIrqiGlbVxbnJLWJPMQaLF2kb+E3u1M=";
+    kdf = 0;
+    kdfIterations = 100000;
+  };
+in
+{
+  name = "vaultwarden-litestream";
+  meta = {
+    maintainers = with lib.maintainers; [ ak2k ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services = {
+        vaultwarden = {
+          enable = true;
+          config = {
+            DOMAIN = server;
+            SIGNUPS_ALLOWED = true;
+            DATABASE_URL = dbPath;
+            ROCKET_ADDRESS = "0.0.0.0";
+            ROCKET_PORT = 8000;
+          };
+        };
+
+        litestream = {
+          enable = true;
+          settings = {
+            socket = {
+              enabled = true;
+              path = socketPath;
+            };
+            dbs = [
+              {
+                path = dbPath;
+                replicas = [
+                  {
+                    type = "file";
+                    path = backupPath;
+                  }
+                ];
+              }
+            ];
+          };
+        };
+      };
+
+      users.users.litestream.extraGroups = [ "vaultwarden" ];
+
+      systemd = {
+        services = {
+          vaultwarden.serviceConfig = {
+            # Pre-create the database to ensure WAL mode (idempotent)
+            ExecStartPre = lib.mkAfter "${pkgs.sqlite}/bin/sqlite3 ${dbPath} 'PRAGMA journal_mode=WAL;'";
+          };
+
+          litestream = {
+            after = [ "vaultwarden.service" ];
+            requires = [ "vaultwarden.service" ];
+            serviceConfig = {
+              RuntimeDirectory = "litestream";
+              ExecStartPre = "+/bin/sh -c 'chmod 660 ${dbPath}; chmod 770 /var/lib/vaultwarden'";
+            };
+          };
+        };
+
+        tmpfiles.rules = [
+          "d /var/backup 0755 root root -"
+          "d ${backupPath} 0755 litestream litestream -"
+        ];
+      };
+
+      environment.systemPackages = with pkgs; [
+        curl
+        sqlite
+      ];
+
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("vaultwarden.service")
+    machine.wait_for_open_port(8000)
+    machine.wait_for_unit("litestream.service")
+
+    with subtest("Verify litestream is creating backups on changes"):
+        assert machine.succeed("stat -c '%a %U:%G' ${dbPath}").strip() == "660 vaultwarden:vaultwarden"
+
+        machine.succeed(register_cmd := r"""curl -sf ${server}/identity/accounts/register --json '${testUser}'""")
+        machine.succeed("litestream sync -wait -socket ${socketPath} ${dbPath}")
+        machine.succeed(
+            "litestream restore -o /tmp/restored.db ${dbPath} && "
+            "sqlite3 /tmp/restored.db '.dump' | grep -q test@example.com"
+        )
+
+    with subtest("Simulate disaster recovery"):
+        machine.systemctl("stop vaultwarden.service litestream.service")
+
+        original_checksum = machine.succeed("sqlite3 ${dbPath} '.dump' | cksum").split()[0]
+
+        machine.succeed("rm -f ${dbPath}*")
+
+        machine.succeed("litestream restore ${dbPath}")
+        machine.succeed("chown vaultwarden:vaultwarden ${dbPath} && chmod 660 ${dbPath}")
+        restored_checksum = machine.succeed("sqlite3 ${dbPath} '.dump' | cksum").split()[0]
+
+        assert original_checksum == restored_checksum
+
+    with subtest("Verify service recovery"):
+        machine.systemctl("start litestream.service vaultwarden.service")
+        machine.wait_for_open_port(8000)
+
+        # Vaultwarden returns HTTP 400 when trying to register an existing user
+        assert machine.succeed(register_cmd.replace("-sf", "-s -o /dev/null -w '%{http_code}'")).strip() == "400"
+
+  '';
+}

--- a/nixos/tests/vaultwarden-litestream.nix
+++ b/nixos/tests/vaultwarden-litestream.nix
@@ -77,10 +77,18 @@ in
           };
         };
 
-        tmpfiles.rules = [
-          "d /var/backup 0755 root root -"
-          "d ${backupPath} 0755 litestream litestream -"
-        ];
+        tmpfiles.settings."10-vaultwarden-litestream" = {
+          "/var/backup".d = {
+            mode = "0755";
+            user = "root";
+            group = "root";
+          };
+          ${backupPath}.d = {
+            mode = "0755";
+            user = "litestream";
+            group = "litestream";
+          };
+        };
       };
 
       environment.systemPackages = with pkgs; [


### PR DESCRIPTION
## Description

Integration test for Vaultwarden with Litestream continuous replication.
Validates cross-service file access and disaster recovery.

> **Note:** This PR depends on #500605 (litestream 0.3.13 → 0.5.10). The first 3 commits are from that PR — **only the last commit is for review here.** Once #500605 merges, this can be rebased to a single commit.

## Test coverage

- **Permission setup**: litestream user in vaultwarden group, chmod via ExecStartPre
- **Backup verification**: `sync -wait` via IPC socket for deterministic replication, then restore and verify test data
- **Disaster recovery**: stop services, delete DB, restore from backup, verify checksum match
- **Service recovery**: restart both services, confirm data persists (duplicate registration returns 400)

## Things done

- [x] Uses `runTest` module style (#386873)
- [x] Added myself to maintainer-list.nix
- [x] Test passes (NixOS VM test, aarch64-linux) — verified on nixos host
- [x] Uses litestream 0.5.x IPC socket (`sync -wait`) for deterministic sync verification
- [x] `nix build .#nixosTests.vaultwarden-litestream` — pass
- [x] `nix build .#nixosTests.litestream` — pass (no regression)

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review rev 68f8d064842d`

<details>
<summary>Results for <code>aarch64-linux</code></summary>

```
1 package updated:
litestream (0.3.13 → 0.5.10)

1 package built:
litestream
```

</details>

<details>
<summary>NixOS VM test results</summary>

```
$ nix build .#nixosTests.vaultwarden-litestream  # pass (298s)
$ nix build .#nixosTests.litestream               # pass (no regression)
```

</details>

---

cc @dotlambda @SuperSandro2000 (vaultwarden maintainers)
cc @fbrs (litestream maintainer)