### PR TITLE
kexec-tools: Only force ELFv2 on ppc64 when the platform settings aggree

### DIFF
--- a/pkgs/by-name/ke/kexec-tools/package.nix
+++ b/pkgs/by-name/ke/kexec-tools/package.nix
@@ -23,15 +23,17 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Use ELFv2 ABI on ppc64be
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/void-linux/void-packages/6c1192cbf166698932030c2e3de71db1885a572d/srcpkgs/kexec-tools/patches/ppc64-elfv2.patch";
-      sha256 = "19wzfwb0azm932v0vhywv4221818qmlmvdfwpvvpfyw4hjsc2s1l";
-    })
     # Fix for static builds, will likely be removable on the next release
     (fetchpatch {
       url = "https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git/patch/?id=daa29443819d3045338792b5ba950ed90e79d7a5";
       hash = "sha256-Nq5HIcLY6KSvvrs2sbfE/vovMbleJYElHW9AVRU5rSA=";
+    })
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isAbiElfv2) [
+    # Use ELFv2 ABI on ppc64be
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/void-linux/void-packages/6c1192cbf166698932030c2e3de71db1885a572d/srcpkgs/kexec-tools/patches/ppc64-elfv2.patch";
+      sha256 = "19wzfwb0azm932v0vhywv4221818qmlmvdfwpvvpfyw4hjsc2s1l";
     })
   ]
   ++ lib.optional (stdenv.hostPlatform.useLLVM or false) ./fix-purgatory-llvm-libunwind.patch;


### PR DESCRIPTION
Fixes building for ELFv1.

```
gcc -fno-zero-initialized-in-bss -m64 -msoft-float -fno-exceptions -mabi=elfv2 -Os -fno-builtin -ffreestanding -fno-zero-initialized-in-bss -fno-PIC -fno-PIE -fno-stack-protector -fno-tree-vectorize -m64 -msoft-float -fno-exceptions -mabi=elfv2 -I./purgatory/include -I./purgatory/arch/ppc64/include -I./util_lib/include -I./include -Iinclude -I/nix/store/4x3b5aqamqsjm7z43z4ri6cajdban5dw-gcc-14.3.0/lib/gcc/powerpc64-unknown-linux-gnuabielfv1/14.3.0/include  -c -MD -o purgatory/purgatory.o purgatory/purgatory.c
In file included from /nix/store/zdsdr1j59by3ab1ryvqkx5kpdz30g7k2-glibc-2.40-66-dev/include/features.h:535,
                 from /nix/store/zdsdr1j59by3ab1ryvqkx5kpdz30g7k2-glibc-2.40-66-dev/include/bits/libc-header-start.h:33,
                 from /nix/store/zdsdr1j59by3ab1ryvqkx5kpdz30g7k2-glibc-2.40-66-dev/include/limits.h:26,
                 from /nix/store/4x3b5aqamqsjm7z43z4ri6cajdban5dw-gcc-14.3.0/lib/gcc/powerpc64-unknown-linux-gnuabielfv1/14.3.0/include/limits.h:210,
                 from /nix/store/4x3b5aqamqsjm7z43z4ri6cajdban5dw-gcc-14.3.0/lib/gcc/powerpc64-unknown-linux-gnuabielfv1/14.3.0/include/syslimits.h:7,
                 from /nix/store/4x3b5aqamqsjm7z43z4ri6cajdban5dw-gcc-14.3.0/lib/gcc/powerpc64-unknown-linux-gnuabielfv1/14.3.0/include/limits.h:34,
                 from purgatory/purgatory.c:2:
/nix/store/zdsdr1j59by3ab1ryvqkx5kpdz30g7k2-glibc-2.40-66-dev/include/gnu/stubs.h:14:11: fatal error: gnu/stubs-64-v2.h: No such file or directory
   14 | # include <gnu/stubs-64-v2.h>
      |           ^~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:123: purgatory/purgatory.o] Error 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] powerpc64-linux (ELFv1)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
