### PR TITLE
noseyparker: add shell completions and manpages

### DIFF
--- a/pkgs/by-name/no/noseyparker/package.nix
+++ b/pkgs/by-name/no/noseyparker/package.nix
@@ -57,6 +57,10 @@ rustPlatform.buildRustPackage rec {
   OPENSSL_NO_VENDOR = 1;
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    mkdir -p manpages
+    "$out/bin/noseyparker-cli" generate manpages
+    installManPage manpages/*
+
     installShellCompletion --cmd noseyparker-cli \
       --bash <("$out/bin/noseyparker-cli" generate shell-completions --shell bash) \
       --zsh <("$out/bin/noseyparker-cli" generate shell-completions --shell zsh) \

--- a/pkgs/by-name/no/noseyparker/package.nix
+++ b/pkgs/by-name/no/noseyparker/package.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   boost,
   cmake,
-  git,
   vectorscan,
   openssl,
   pkg-config,
@@ -27,10 +26,6 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-hVBHIm/12WU6g45QMxxuGk41B0kwThk7A84fOxArvno=";
 
-  nativeCheckInputs = [
-    git
-  ];
-
   checkFlags = [
     # These tests expect access to network to clone and use GitHub API
     "--skip=github::github_repos_list_multiple_user_dedupe_jsonl_format"
@@ -44,6 +39,11 @@ rustPlatform.buildRustPackage rec {
 
     # This caused a flaky result. See https://github.com/NixOS/nixpkgs/pull/422012#issuecomment-3031728181
     "--skip=scan::git_url::git_binary_missing"
+
+    # Also skips all tests which depend on external git command to prevent unstable tests similar to git_binary_missing
+    # See https://github.com/NixOS/nixpkgs/pull/422012#discussion_r2182551619
+    "--skip=scan::git_url::https_nonexistent"
+    "--skip=scan::basic::scan_git_emptyrepo"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noseyparker/package.nix
+++ b/pkgs/by-name/no/noseyparker/package.nix
@@ -41,6 +41,9 @@ rustPlatform.buildRustPackage rec {
     "--skip=github::github_repos_list_user_jsonl_format"
     "--skip=github::github_repos_list_user_repo_filter"
     "--skip=scan::appmaker::scan_workflow_from_git_url"
+
+    # This caused a flaky result. See https://github.com/NixOS/nixpkgs/pull/422012#issuecomment-3031728181
+    "--skip=scan::git_url::git_binary_missing"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noseyparker/package.nix
+++ b/pkgs/by-name/no/noseyparker/package.nix
@@ -8,6 +8,7 @@
   vectorscan,
   openssl,
   pkg-config,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -51,6 +52,13 @@ rustPlatform.buildRustPackage rec {
   ];
 
   OPENSSL_NO_VENDOR = 1;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/noseyparker-cli";
+  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Find secrets and sensitive information in textual data";

--- a/pkgs/by-name/no/noseyparker/package.nix
+++ b/pkgs/by-name/no/noseyparker/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   boost,
@@ -8,6 +9,7 @@
   vectorscan,
   openssl,
   pkg-config,
+  installShellFiles,
   versionCheckHook,
 }:
 
@@ -44,6 +46,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    installShellFiles
   ];
   buildInputs = [
     boost
@@ -52,6 +55,13 @@ rustPlatform.buildRustPackage rec {
   ];
 
   OPENSSL_NO_VENDOR = 1;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd noseyparker-cli \
+      --bash <("$out/bin/noseyparker-cli" generate shell-completions --shell bash) \
+      --zsh <("$out/bin/noseyparker-cli" generate shell-completions --shell zsh) \
+      --fish <("$out/bin/noseyparker-cli" generate shell-completions --shell fish)
+  '';
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upstream introduced these assets in 0.17.0 https://github.com/praetorian-inc/noseyparker/blob/1e9e4141c01a27850f203ab4b9457ab7415d7872/CHANGELOG.md?plain=1#L402-L406

Follow https://github.com/NixOS/nixpkgs/pull/329719

<details>

<summary>tree</summary>

```console
> tree
.
├── bin
│   └── noseyparker-cli
└── share
    ├── bash-completion
    │   └── completions
    │       └── noseyparker-cli.bash
    ├── fish
    │   └── vendor_completions.d
    │       └── noseyparker-cli.fish
    ├── man
    │   └── man1
    │       ├── noseyparker-annotations-export.1.gz
    │       ├── noseyparker-annotations-import.1.gz
    │       ├── noseyparker-annotations.1.gz
    │       ├── noseyparker-datastore-export.1.gz
    │       ├── noseyparker-datastore-init.1.gz
    │       ├── noseyparker-datastore.1.gz
    │       ├── noseyparker-generate-json-schema.1.gz
    │       ├── noseyparker-generate-manpages.1.gz
    │       ├── noseyparker-generate-shell-completions.1.gz
    │       ├── noseyparker-generate.1.gz
    │       ├── noseyparker-github-repos-list.1.gz
    │       ├── noseyparker-github-repos.1.gz
    │       ├── noseyparker-github.1.gz
    │       ├── noseyparker-report.1.gz
    │       ├── noseyparker-rules-check.1.gz
    │       ├── noseyparker-rules-list.1.gz
    │       ├── noseyparker-rules.1.gz
    │       ├── noseyparker-scan.1.gz
    │       ├── noseyparker-summarize.1.gz
    │       └── noseyparker.1.gz
    └── zsh
        └── site-functions
            └── _noseyparker-cli

11 directories, 24 files
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
