### PR TITLE
[Backport release-25.05] python3Packages.mitmproxy: Fix broken build 

### DIFF
--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -15,7 +15,6 @@
   hypothesis,
   kaitaistruct,
   ldap3,
-  mitmproxy-linux,
   mitmproxy-rs,
   msgpack,
   passlib,
@@ -31,7 +30,6 @@
   ruamel-yaml,
   setuptools,
   sortedcontainers,
-  stdenv,
   tornado,
   urwid,
   wsproto,
@@ -40,14 +38,14 @@
 
 buildPythonPackage rec {
   pname = "mitmproxy";
-  version = "12.0.1";
+  version = "12.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mitmproxy";
     repo = "mitmproxy";
     tag = "v${version}";
-    hash = "sha256-BKT/qBWlfShAveL1KY5XXgQjhxR3Vr4zoJwiRxtBJkE=";
+    hash = "sha256-RTHL5+lbR+AbkiE4+z4ZbxZSV2E4NGTmShbMIMRKJPA=";
   };
 
   pythonRelaxDeps = [
@@ -55,6 +53,7 @@ buildPythonPackage rec {
     "h2"
     "passlib"
     "typing-extensions" # https://github.com/NixOS/nixpkgs/pull/397082
+    "tornado"
   ];
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -49,10 +49,11 @@ buildPythonPackage rec {
   };
 
   pythonRelaxDeps = [
-    "h11" # https://github.com/NixOS/nixpkgs/pull/399393
+    "cryptography"
+    "flask"
     "h2"
     "passlib"
-    "typing-extensions" # https://github.com/NixOS/nixpkgs/pull/397082
+    "pyopenssl"
     "tornado"
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes: https://github.com/NixOS/nixpkgs/pull/418038#issuecomment-3031236694
broken build in hydra
https://hydra.nixos.org/build/301490445

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
