### PR TITLE
treewide: Correctly force Java font anti-aliasing to gasp mode

### DIFF
--- a/pkgs/applications/editors/greenfoot/default.nix
+++ b/pkgs/applications/editors/greenfoot/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${openjdk}/bin/java $out/bin/greenfoot \
       "''${gappsWrapperArgs[@]}" \
-      --add-flags "-Dawt.useSystemAAFontSettings=on -Xmx512M \
+      --add-flags "-Dawt.useSystemAAFontSettings=gasp -Xmx512M \
                    --add-opens javafx.graphics/com.sun.glass.ui=ALL-UNNAMED \
                    -cp $out/share/greenfoot/boot.jar bluej.Boot \
                    -greenfoot=true -bluej.compiler.showunchecked=false \

--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -131,11 +131,11 @@ stdenv.mkDerivation rec {
     makeWrapper $out/share/${pname}/processing $out/bin/processing \
       ''${gappsWrapperArgs[@]} \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
-      --prefix _JAVA_OPTIONS " " -Dawt.useSystemAAFontSettings=lcd
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp"
     makeWrapper $out/share/${pname}/processing-java $out/bin/processing-java \
       ''${gappsWrapperArgs[@]} \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
-      --prefix _JAVA_OPTIONS " " -Dawt.useSystemAAFontSettings=lcd
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp"
 
     runHook postInstall
   '';

--- a/pkgs/applications/misc/ganttproject-bin/default.nix
+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
       };
 
       javaOptions = [
-        "-Dawt.useSystemAAFontSettings=on"
+        "-Dawt.useSystemAAFontSettings=gasp"
       ];
 
     in
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       mkdir -pv "$out/bin"
       wrapProgram "$out/share/ganttproject/ganttproject" \
         --set JAVA_HOME "${jre}" \
-        --set _JAVA_OPTIONS "${builtins.toString javaOptions}"
+        --prefix _JAVA_OPTIONS " " "${builtins.toString javaOptions}"
 
       mv -v "$out/share/ganttproject/ganttproject" "$out/bin"
 

--- a/pkgs/by-name/bl/bluej/package.nix
+++ b/pkgs/by-name/bl/bluej/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${openjdk}/bin/java $out/bin/bluej \
       "''${gappsWrapperArgs[@]}" \
-      --add-flags "-Dawt.useSystemAAFontSettings=on -Xmx512M \
+      --add-flags "-Dawt.useSystemAAFontSettings=gasp -Xmx512M \
                    --add-opens javafx.graphics/com.sun.glass.ui=ALL-UNNAMED \
                    -cp $out/share/bluej/boot.jar bluej.Boot"
 

--- a/pkgs/by-name/br/brmodelo/package.nix
+++ b/pkgs/by-name/br/brmodelo/package.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     # _JAVA_AWT_WM_NONREPARENTING=1.
     makeWrapper ${jdk8}/bin/java $out/bin/brmodelo \
        --prefix _JAVA_AWT_WM_NONREPARENTING : 1 \
-       --prefix _JAVA_OPTIONS : "-Dawt.useSystemAAFontSettings=on" \
+       --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp" \
        --add-flags "-jar $out/share/java/brModelo.jar"
 
     for size in 16 24 32 48 64 128 256; do

--- a/pkgs/by-name/ci/cie-middleware-linux/package.nix
+++ b/pkgs/by-name/ci/cie-middleware-linux/package.nix
@@ -120,7 +120,7 @@ stdenv.mkDerivation {
     mkdir -p "$out/bin"
     makeWrapper "${jre}/bin/java" "$out/bin/cieid" \
       --add-flags "-Djna.library.path='$out/lib:${libraries}'" \
-      --add-flags '-Dawt.useSystemAAFontSettings=on' \
+      --add-flags "-Dawt.useSystemAAFontSettings=gasp" \
       --add-flags "-cp $out/share/cieid/cieid.jar" \
       --add-flags "app.m0rf30.cieid.MainApplication"
 

--- a/pkgs/by-name/cr/crossfire-gridarta/package.nix
+++ b/pkgs/by-name/cr/crossfire-gridarta/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${jre}/bin/java $out/bin/crossfire-gridarta \
       --add-flags "-jar $out/share/java/CrossfireEditor.jar" \
-      --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=on' \
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp" \
       --set _JAVA_AWT_WM_NONREPARENTING 1
 
     runHook postInstall

--- a/pkgs/by-name/cr/crossfire-jxclient/package.nix
+++ b/pkgs/by-name/cr/crossfire-jxclient/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
     makeWrapper ${jre}/bin/java $out/bin/crossfire-jxclient \
       --add-flags "-jar $out/share/java/jxclient.jar" \
-      --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=on' \
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp" \
       --set _JAVA_AWT_WM_NONREPARENTING 1
 
     runHook postInstall

--- a/pkgs/by-name/fr/freeplane/package.nix
+++ b/pkgs/by-name/fr/freeplane/package.nix
@@ -102,7 +102,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         ]
       } \
       --prefix _JAVA_AWT_WM_NONREPARENTING : 1 \
-      --prefix _JAVA_OPTIONS : "-Dawt.useSystemAAFontSettings=on"
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -65,7 +65,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     # make xdg-open overrideable at runtime
     makeWrapper ${jdk11}/bin/java $out/bin/irpf \
-      --add-flags "-Dawt.useSystemAAFontSettings=on" \
+      --add-flags "-Dawt.useSystemAAFontSettings=gasp" \
       --add-flags "-Dswing.aatext=true" \
       --add-flags "-jar $BASEDIR/irpf.jar" \
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \

--- a/pkgs/by-name/jf/jflap/package.nix
+++ b/pkgs/by-name/jf/jflap/package.nix
@@ -55,7 +55,7 @@ stdenvNoCC.mkDerivation rec {
     mkdir -p $out/share/java
     cp -s $src $out/share/java/jflap.jar
     makeWrapper ${jre8}/bin/java $out/bin/jflap \
-      --prefix _JAVA_OPTIONS : "-Dawt.useSystemAAFontSettings=on" \
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp" \
       --add-flags "-jar $out/share/java/jflap.jar"
     runHook postInstall
   '';

--- a/pkgs/by-name/jo/josm/package.nix
+++ b/pkgs/by-name/jo/josm/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
           --add-flags "${baseJavaOpts} ${extraJavaOpts} -jar $out/share/josm/josm.jar" \
           --prefix LD_LIBRARY_PATH ":" '${libXxf86vm}/lib' \
           --prefix _JAVA_AWT_WM_NONREPARENTING : 1 \
-          --prefix _JAVA_OPTIONS : "-Dawt.useSystemAAFontSettings=on"
+          --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp"
       '';
 
   meta = {

--- a/pkgs/by-name/ka/kamilalisp/package.nix
+++ b/pkgs/by-name/ka/kamilalisp/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     cp ${src} $out/share/java/kamilalisp-${version}.jar
     makeWrapper ${jre}/bin/java $out/bin/kamilalisp \
       --add-flags "-jar $out/share/java/kamilalisp-${version}.jar" \
-      --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=on' \
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp" \
       --set _JAVA_AWT_WM_NONREPARENTING 1
   '';
 

--- a/pkgs/by-name/ne/netbeans/package.nix
+++ b/pkgs/by-name/ne/netbeans/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
       } \
       --prefix JAVA_HOME : ${jdk21.home} \
       --add-flags "--jdkhome ${jdk21.home} \
-      -J-Dawt.useSystemAAFontSettings=on -J-Dswing.aatext=true"
+      -J-Dawt.useSystemAAFontSettings=gasp -J-Dswing.aatext=true"
 
     # Extract pngs from the Apple icon image and create
     # the missing ones from the 1024x1024 image.

--- a/pkgs/by-name/st/structorizer/package.nix
+++ b/pkgs/by-name/st/structorizer/package.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
     install -D ${pname}.jar -t $out/share/java/
       makeWrapper ${jdk11}/bin/java $out/bin/${pname} \
       --add-flags "-jar $out/share/java/${pname}.jar" \
-      --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=lcd'
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp"
 
     cat << EOF > $out/share/mime/packages/structorizer.xml
     <?xml version="1.0" encoding="UTF-8"?>

--- a/pkgs/by-name/ti/tigerjython/package.nix
+++ b/pkgs/by-name/ti/tigerjython/package.nix
@@ -87,7 +87,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --add-flags "-Duser.dir=$CUSTOM_LIBS/" \
       --add-flags "-Xmx512M" \
       --add-flags "-jar $JAR" \
-      --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=lcd'
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/up/uppaal/package.nix
+++ b/pkgs/by-name/up/uppaal/package.nix
@@ -64,7 +64,7 @@ stdenvNoCC.mkDerivation rec {
     makeWrapper $out/lib/uppaal/uppaal $out/bin/uppaal \
       --set JAVA_HOME ${jdk17} \
       --set PATH $out/lib/uppaal:$PATH \
-      --prefix _JAVA_OPTIONS " " -Dawt.useSystemAAFontSettings=lcd
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/wo/workcraft/package.nix
+++ b/pkgs/by-name/wo/workcraft/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     mkdir $out/bin
     makeWrapper $out/share/workcraft $out/bin/workcraft \
       --set JAVA_HOME "${jre}" \
-      --set _JAVA_OPTIONS '-Dawt.useSystemAAFontSettings=gasp';
+      --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp";
   '';
 
   meta = {

--- a/pkgs/by-name/wp/wpcleaner/package.nix
+++ b/pkgs/by-name/wp/wpcleaner/package.nix
@@ -17,7 +17,7 @@ let
   botScript = "$out/bin/wpcleaner-bot";
   runTaskScript = "$out/bin/wpcleaner-run-task";
   extraJavaArgs = [
-    "-Dawt.useSystemAAFontSettings=lcd"
+    "-Dawt.useSystemAAFontSettings=gasp"
     "-Xms1g"
     "-Xmx8g"
   ];


### PR DESCRIPTION
Fixes instances of the `awt.useSystemAAFontSettings` property in `_JAVA_OPTIONS` being impossible to override due to incorrect separators and due to replacing the value from the shell.

Changes the font anti-aliasing mode to `gasp`. `led` is not suitable for users with subpixel arrangements other than horizontal RGB, while `on` doesn't respect the hints encoded in fonts.

See https://github.com/NixOS/nixpkgs/issues/422043 for more discussion.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
