### PR TITLE
sparrow: add arch64-linux support

### DIFF
--- a/pkgs/by-name/sp/sparrow/package.nix
+++ b/pkgs/by-name/sp/sparrow/package.nix
@@ -29,9 +29,22 @@ let
 
   openjdk = jdk23.override { enableJavaFX = true; };
 
+  sparrowArch =
+    {
+      x86_64-linux = "x86_64";
+      aarch64-linux = "aarch64";
+    }
+    ."${stdenvNoCC.hostPlatform.system}";
+
+  # nixpkgs-update: no auto update
   src = fetchurl {
-    url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/sparrowwallet-${version}-x86_64.tar.gz";
-    hash = "sha256-MsERgfJGpxRkQm4Ww30Tc95kThjlgI+nO4bq2zNGdeU=";
+    url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/sparrowwallet-${version}-${sparrowArch}.tar.gz";
+    hash =
+      {
+        x86_64-linux = "sha256-MsERgfJGpxRkQm4Ww30Tc95kThjlgI+nO4bq2zNGdeU=";
+        aarch64-linux = "sha256-31x4Ck/+Fa6CvBb6o9ncVH99Zeh0DUVv/hqVN31ysHk=";
+      }
+      ."${stdenvNoCC.hostPlatform.system}";
 
     # nativeBuildInputs, downloadToTemp, and postFetch are used to verify the signed upstream package.
     # The signature is not a self-contained file. Instead the SHA256 of the package is added to a manifest file.
@@ -49,7 +62,7 @@ let
       mkdir -m 700 -p $GNUPGHOME
       ln -s ${manifest} ./manifest.txt
       ln -s ${manifestSignature} ./manifest.txt.asc
-      ln -s $downloadedFile ./sparrowwallet-${version}-x86_64.tar.gz
+      ln -s $downloadedFile ./sparrowwallet-${version}-${sparrowArch}.tar.gz
       gpg --import ${publicKey}
       gpg --verify manifest.txt.asc manifest.txt
       sha256sum -c --ignore-missing manifest.txt
@@ -165,7 +178,6 @@ let
 
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86-64
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86
-      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-aarch64
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-arm
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-armel
       rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-mips64el
@@ -184,7 +196,6 @@ let
       rm -fR com.github.sarxos.webcam.capture/com/github/sarxos/webcam/ds/buildin/lib/linux_x86
       rm -fR openpnp.capture.java/darwin-aarch64
       rm -fR openpnp.capture.java/darwin-x86-64
-      rm -fR openpnp.capture.java/linux-aarch64
       rm -fR openpnp.capture.java/win32-x86-64
       rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_arm32_armel
       rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_armel
@@ -192,9 +203,9 @@ let
       rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_x86
       rm -fR com.nativelibs4java.bridj/org/bridj/lib/sunos_x64
       rm -fR com.nativelibs4java.bridj/org/bridj/lib/sunos_x86
-      rm -fR com.sparrowwallet.merged.module/linux-aarch64
       rm -fR com.sparrowwallet.merged.module/linux-arm
       rm -fR com.sparrowwallet.merged.module/linux-x86
+      rm -fR com.fazecast.jSerialComm/FreeBSD
       rm -fR com.fazecast.jSerialComm/OpenBSD
       rm -fR com.fazecast.jSerialComm/Android
       rm -fR com.fazecast.jSerialComm/Solaris
@@ -206,7 +217,7 @@ let
       # Replace the embedded Tor binary (which is in a Tar archive)
       # with one from Nixpkgs.
       gzip -c ${torWrapper}  > tor.gz
-      cp tor.gz modules/io.matthewnelson.kmp.tor.resource.exec.tor/io/matthewnelson/kmp/tor/resource/exec/tor/native/linux-libc/x86_64/tor.gz
+      cp tor.gz modules/io.matthewnelson.kmp.tor.resource.exec.tor/io/matthewnelson/kmp/tor/resource/exec/tor/native/linux-libc/${sparrowArch}/tor.gz
     '';
 
     installPhase = ''
@@ -294,7 +305,10 @@ stdenvNoCC.mkDerivation rec {
       msgilligan
       _1000101
     ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     mainProgram = "sparrow-desktop";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR updates the sparrow package to support aarch64-linux. Closes #362516

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all x86_64 binary files (usually in `./result/bin/`)
- [X] Tested basic functionality of all aarch64 binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
