### PR TITLE
test-driver: Implement debugging breakpoint hooks

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -340,3 +340,54 @@ id-prefix: test-opt-
 list-id: test-options-list
 source: @NIXOS_TEST_OPTIONS_JSON@
 ```
+
+## Accessing VMs in the sandbox with SSH {#sec-test-sandbox-breakpoint}
+
+As explained in [](#sec-nixos-test-ssh-access), it's possible to configure an
+SSH backdoor based on AF_VSOCK. This can be used to SSH into a VM of a running
+build in a sandbox.
+
+This can be done when something in the test fails, e.g.
+
+```nix
+{
+  nodes.machine = {};
+
+  sshBackdoor.enable = true;
+  enableDebugHook = true;
+
+  testScript = ''
+    start_all()
+    machine.succeed("false") # this will fail
+  '';
+}
+```
+
+For the AF_VSOCK feature to work, `/dev/vhost-vsock` is needed in the sandbox
+which can be done with e.g.
+
+```
+nix-build -A nixosTests.foo --option sandbox-paths /dev/vhost-vsock
+```
+
+This will halt the test execution on a test-failure and print instructions
+on how to enter the sandbox shell of the VM test. Inside, one can log into
+e.g. `machine` with
+
+```
+ssh -F ./ssh_config vsock/3
+```
+
+As described in [](#sec-nixos-test-ssh-access), the numbers for vsock start at
+`3` instead of `1`. So the first VM in the network (sorted alphabetically) can
+be accessed with `vsock/3`.
+
+Alternatively, it's possible to explicitly set a breakpoint with
+`debug.breakpoint()`. This also has the benefit, that one can step through
+`testScript` with `pdb` like this:
+
+```
+$ sudo /nix/store/eeeee-attach <id>
+bash# telnet 127.0.0.1 4444
+pdb$ …
+```

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1902,6 +1902,9 @@
   "test-opt-sshBackdoor.vsockOffset": [
     "index.html#test-opt-sshBackdoor.vsockOffset"
   ],
+  "test-opt-enableDebugHook": [
+    "index.html#test-opt-enableDebugHook"
+  ],
   "test-opt-defaults": [
     "index.html#test-opt-defaults"
   ],
@@ -2009,6 +2012,9 @@
   ],
   "sec-nixos-test-testing-hardware-features": [
     "index.html#sec-nixos-test-testing-hardware-features"
+  ],
+  "sec-test-sandbox-breakpoint": [
+    "index.html#sec-test-sandbox-breakpoint"
   ],
   "chap-developing-the-test-driver": [
     "index.html#chap-developing-the-test-driver"

--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -14,6 +14,7 @@
   extraPythonPackages ? (_: [ ]),
   nixosTests,
 }:
+
 python3Packages.buildPythonApplication {
   pname = "nixos-test-driver";
   version = "1.1";
@@ -32,6 +33,7 @@ python3Packages.buildPythonApplication {
       junit-xml
       ptpython
       ipython
+      remote-pdb
     ]
     ++ extraPythonPackages python3Packages;
 

--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import ptpython.ipython
 
+from test_driver.debug import Debug, DebugAbstract, DebugNop
 from test_driver.driver import Driver
 from test_driver.logger import (
     CompositeLogger,
@@ -64,6 +65,10 @@ def main() -> None:
         "--interactive",
         help="drop into a python repl and run the tests interactively",
         action=argparse.BooleanOptionalAction,
+    )
+    arg_parser.add_argument(
+        "--debug-hook-attach",
+        help="Enable interactive debugging breakpoints for sandboxed runs",
     )
     arg_parser.add_argument(
         "--start-scripts",
@@ -129,6 +134,10 @@ def main() -> None:
     if not args.keep_vm_state:
         logger.info("Machine state will be reset. To keep it, pass --keep-vm-state")
 
+    debugger: DebugAbstract = DebugNop()
+    if args.debug_hook_attach is not None:
+        debugger = Debug(logger, args.debug_hook_attach)
+
     with Driver(
         args.start_scripts,
         args.vlans,
@@ -137,6 +146,7 @@ def main() -> None:
         logger,
         args.keep_vm_state,
         args.global_timeout,
+        debug=debugger,
     ) as driver:
         if args.interactive:
             history_dir = os.getcwd()

--- a/nixos/lib/test-driver/src/test_driver/debug.py
+++ b/nixos/lib/test-driver/src/test_driver/debug.py
@@ -1,0 +1,53 @@
+import logging
+import os
+import random
+import shutil
+import subprocess
+import sys
+from abc import ABC, abstractmethod
+
+from remote_pdb import RemotePdb  # type:ignore
+
+from test_driver.logger import AbstractLogger
+
+
+class DebugAbstract(ABC):
+    @abstractmethod
+    def breakpoint(self, host: str = "127.0.0.1", port: int = 4444) -> None:
+        pass
+
+
+class DebugNop(DebugAbstract):
+    def __init__(self) -> None:
+        pass
+
+    def breakpoint(self, host: str = "127.0.0.1", port: int = 4444) -> None:
+        pass
+
+
+class Debug(DebugAbstract):
+    def __init__(self, logger: AbstractLogger, attach_command: str) -> None:
+        self.breakpoint_on_failure = False
+        self.logger = logger
+        self.attach = attach_command
+
+    def breakpoint(self, host: str = "127.0.0.1", port: int = 4444) -> None:
+        """
+        Call this function to stop execution and put the process on sleep while
+        at the same time have the test driver provide a debug shell on TCP port
+        `port`. This is meant to be used for sandboxed tests that have the test
+        driver feature `enableDebugHook` enabled.
+        """
+        pattern = str(random.randrange(999999, 9999999))
+        self.logger.log_test_error(
+            f"Breakpoint reached, run 'sudo {self.attach} {pattern}'"
+        )
+        os.environ["bashInteractive"] = shutil.which("bash")  # type:ignore
+        if os.fork() == 0:
+            subprocess.run(["sleep", pattern])
+        else:
+            # RemotePdb writes log messages to both stderr AND the logger,
+            # which is the same here. Hence, disabling the remote_pdb logger
+            # to avoid duplicate messages in the build log.
+            logging.root.manager.loggerDict["remote_pdb"].disabled = True  # type:ignore
+            RemotePdb(host=host, port=port).set_trace(sys._getframe().f_back)

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -13,6 +13,7 @@ from unittest import TestCase
 
 from colorama import Style
 
+from test_driver.debug import DebugAbstract, DebugNop
 from test_driver.errors import MachineError, RequestedAssertionFailed
 from test_driver.logger import AbstractLogger
 from test_driver.machine import Machine, NixStartScript, retry
@@ -67,6 +68,7 @@ class Driver:
     global_timeout: int
     race_timer: threading.Timer
     logger: AbstractLogger
+    debug: DebugAbstract
 
     def __init__(
         self,
@@ -77,12 +79,14 @@ class Driver:
         logger: AbstractLogger,
         keep_vm_state: bool = False,
         global_timeout: int = 24 * 60 * 60 * 7,
+        debug: DebugAbstract = DebugNop(),
     ):
         self.tests = tests
         self.out_dir = out_dir
         self.global_timeout = global_timeout
         self.race_timer = threading.Timer(global_timeout, self.terminate_test)
         self.logger = logger
+        self.debug = debug
 
         tmp_dir = get_tmp_dir()
 
@@ -159,6 +163,7 @@ class Driver:
             polling_condition=self.polling_condition,
             Machine=Machine,  # for typing
             t=AssertionTester(),
+            debug=self.debug,
         )
         machine_symbols = {pythonize_name(m.name): m for m in self.machines}
         # If there's exactly one machine, make it available under the name
@@ -224,7 +229,13 @@ class Driver:
                 for line in f"{exc_prefix}: {exc}".splitlines():
                     self.logger.log_test_error(line)
 
+                self.debug.breakpoint()
+
                 sys.exit(1)
+
+            except Exception:
+                self.debug.breakpoint()
+                raise
 
     def run_tests(self) -> None:
         """Run the test script (for non-interactive test runs)"""

--- a/nixos/lib/test-script-prepend.py
+++ b/nixos/lib/test-script-prepend.py
@@ -1,6 +1,7 @@
 # This file contains type hints that can be prepended to Nix test scripts so they can be type
 # checked.
 
+from test_driver.debug import DebugAbstract
 from test_driver.driver import Driver
 from test_driver.vlan import VLan
 from test_driver.machine import Machine
@@ -52,4 +53,5 @@ join_all: Callable[[], None]
 serial_stdout_off: Callable[[], None]
 serial_stdout_on: Callable[[], None]
 polling_condition: PollingConditionProtocol
+debug: DebugAbstract
 t: TestCase

--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -84,7 +84,8 @@ in
   options = {
     sshBackdoor = {
       enable = mkOption {
-        default = false;
+        default = config.enableDebugHook;
+        defaultText = lib.literalExpression "config.enableDebugHook";
         type = types.bool;
         description = "Whether to turn on the VSOCK-based access to all VMs. This provides an unauthenticated access intended for debugging.";
       };


### PR DESCRIPTION
This work picks up the core parts of https://github.com/NixOS/nixpkgs/pull/392117 (@Ma27)

I suppose that the review discussion might change some design aspects, so i would only document this at the end.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
