### PR TITLE
amp-cli: fix entry point

### DIFF
--- a/pkgs/by-name/am/amp-cli/package-lock.json
+++ b/pkgs/by-name/am/amp-cli/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@sourcegraph/amp": "^0.0.1750924878-gfee7d7"
+        "@sourcegraph/amp": "^0.0.1751544357-g213afc"
       }
     },
     "node_modules/@colors/colors": {
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@sourcegraph/amp": {
-      "version": "0.0.1750924878-gfee7d7",
-      "resolved": "https://registry.npmjs.org/@sourcegraph/amp/-/amp-0.0.1750924878-gfee7d7.tgz",
-      "integrity": "sha512-3TZRSPaQY1eSIyAy4m/wSmW8CUq33r1oZfxguq2IWBLYdud90vPoLgOf6Hl9ZX3bkiLVRiU34oXXMmhb2Z5nzA==",
+      "version": "0.0.1751544357-g213afc",
+      "resolved": "https://registry.npmjs.org/@sourcegraph/amp/-/amp-0.0.1751544357-g213afc.tgz",
+      "integrity": "sha512-EBoakK3uItuzrhRlE1qHPuZB5N3ifHawEjpegVcZY3LUmi3oZxAtgSgjQujWqGJlZSLup9Vja0hubJzdZqA23w==",
       "dependencies": {
         "@vscode/ripgrep": "1.15.11",
         "commander": "^11.1.0",
@@ -43,7 +43,7 @@
         "xdg-basedir": "^5.1.0"
       },
       "bin": {
-        "amp": "dist/amp.js"
+        "amp": "dist/main.js"
       },
       "engines": {
         "node": ">=18"

--- a/pkgs/by-name/am/amp-cli/package.nix
+++ b/pkgs/by-name/am/amp-cli/package.nix
@@ -9,11 +9,11 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "amp-cli";
-  version = "0.0.1750924878-gfee7d7";
+  version = "0.0.1751544357-g213afc";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@sourcegraph/amp/-/amp-${finalAttrs.version}.tgz";
-    hash = "sha256-scp4Nw6fwn8uB5oLPg6eWkT7+YGFV/B5VlQbbFimsLg=";
+    hash = "sha256-7Nn0Y3ksI69G6PA6KUFLVMA49+NK6Y9rCj2N2oLvFz8=";
   };
 
   postPatch = ''
@@ -40,12 +40,12 @@ buildNpmPackage (finalAttrs: {
     # Create a wrapper script that will be installed by npm
     cat > bin/amp-wrapper.js << EOF
     #!/usr/bin/env node
-    require('@sourcegraph/amp/dist/amp.js')
+    import('@sourcegraph/amp/dist/main.js')
     EOF
     chmod +x bin/amp-wrapper.js
   '';
 
-  npmDepsHash = "sha256-INH8Pulds05pZm6DeaFYfZR+1derav2ZjQC6aPx+8qA=";
+  npmDepsHash = "sha256-EsaAXo54CuQnPVJJsjuph1htciWdxXvGAK2R4a0nOow=";
 
   propagatedBuildInputs = [
     ripgrep


### PR DESCRIPTION
Fixing the entry point (main.js instead of amp.js) after the change in the recent update.
+ version bump

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
