### PR TITLE
nixos/acme: improve scalability - reduce superfluous unit activations

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1468,6 +1468,9 @@
   "module-security-acme-fix-jws": [
     "index.html#module-security-acme-fix-jws"
   ],
+  "module-security-acme-reload-dependencies": [
+    "index.html#module-security-acme-reload-dependencies"
+  ],
   "module-programs-zsh-ohmyzsh": [
     "index.html#module-programs-zsh-ohmyzsh"
   ],

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -165,6 +165,21 @@
 
 - `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.
 
+- Revamp of the ACME certificate acquisication and renewal process to help scale systems with lots (100+) of certificates.
+
+  Units and targets have been reshaped to better support more specific dependency propagation and avoid
+  superfluously triggering unchanged units:
+
+  If a service requires a syntactically valid certificate to start it should now depend on the `acme-{certname}.service` unit.
+
+  We now always generate initial self-signed certificates as this drastically simplifies the dependency structure. As a result, the option `security.acme.preliminarySelfsigned` has been removed.
+
+  Instead of the previous `acme-finished-{certname}.target`s there are now `acme-order-renew-{certname}.service`s that will be activated
+  in a delayed fashion to ensure that bootstrapping with servers like nginx that take part in the acquisition/renewal process works
+  smoothly. Dependencies on `acme-finished` units should move to `acme-order-renew`.
+
+  Note that system activation will complete before all certificates may have been renewed or acquired.
+
 - `libvirt` now supports using `nftables` backend.
 
 - `systemd.extraConfig` and `boot.initrd.systemd.extraConfig` was converted to RFC42-style `systemd.settings.Manager` and `boot.initrd.systemd.settings.Manager` respectively.

--- a/nixos/modules/security/acme/default.md
+++ b/nixos/modules/security/acme/default.md
@@ -318,7 +318,7 @@ can be applied to any service.
 
   # Now you must augment OpenSMTPD's systemd service to load
   # the certificate files.
-  systemd.services.opensmtpd.requires = [ "acme-finished-mail.example.com.target" ];
+  systemd.services.opensmtpd.requires = [ "acme-mail.example.com.service" ];
   systemd.services.opensmtpd.serviceConfig.LoadCredential =
     let
       certDir = config.security.acme.certs."mail.example.com".directory;

--- a/nixos/modules/security/acme/default.md
+++ b/nixos/modules/security/acme/default.md
@@ -376,3 +376,11 @@ systemd-tmpfiles --create
 # Note: Do this for all certs that share the same account email address
 systemctl start acme-example.com.service
 ```
+
+## Ensuring dependencies for services that need to be reloaded when a certificate challenges {#module-security-acme-reload-dependencies}
+
+Services that depend on ACME certificates and need to be reloaded can use one of two approaches to reload upon successfull certificate acquisition or renewal:
+
+1. **Using the `security.acme.certs.<name>.reloadServices` option**: This will cause `systemctl try-reload-or-restart` to be run for the listed services.
+
+2. **Using a separate reload unit**: if you need perform more complex actions you can implement a separate reload unit but need to ensure that it lists the `acme-renew-<name>.service` unit both as `wantedBy` AND `after`. See the nginx module implementation with its `nginx-config-reload` service.

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -160,58 +160,49 @@ let
   );
 
   # This is defined with lib.mkMerge so that we can separate the config per function.
-  setupService = lib.mkMerge [
-    {
-      description = "Set up the ACME certificate renewal infrastructure";
-      script = lib.mkBefore ''
-        ${lib.optionalString cfg.defaults.enableDebugLogs "set -x"}
-        set -euo pipefail
-      '';
-      serviceConfig = commonServiceConfig // {
-        # This script runs with elevated privileges, denoted by the +
-        # ExecStartPre is used instead of ExecStart so that the `script` continues to work.
-        ExecStartPre = "+${lib.getExe privilegedSetupScript}";
+  setupService = {
+    description = "Set up the ACME certificate renewal infrastructure";
+    path = [ pkgs.minica ];
 
-        # We don't want this to run every time a renewal happens
-        RemainAfterExit = true;
+    script = lib.mkBefore ''
+      ${lib.optionalString cfg.defaults.enableDebugLogs "set -x"}
+      set -euo pipefail
+      test -e ca/key.pem || minica \
+        --ca-key ca/key.pem \
+        --ca-cert ca/cert.pem \
+        --domains selfsigned.local
+    '';
 
-        # StateDirectory entries are a cleaner, service-level mechanism
-        # for dealing with persistent service data
-        StateDirectory = [
-          "acme"
-          "acme/.lego"
-          "acme/.lego/accounts"
-        ];
-        StateDirectoryMode = "0755";
+    serviceConfig = commonServiceConfig // {
+      # This script runs with elevated privileges, denoted by the +
+      # ExecStartPre is used instead of ExecStart so that the `script` continues to work.
+      ExecStartPre = "+${lib.getExe privilegedSetupScript}";
 
-        # Creates ${lockdir}. Earlier RemainAfterExit=true means
-        # it does not get deleted immediately.
-        RuntimeDirectory = "acme";
-        RuntimeDirectoryMode = "0700";
+      # We don't want this to run every time a renewal happens
+      RemainAfterExit = true;
 
-        # Generally, we don't write anything that should be group accessible.
-        # Group varies for most ACME units, and setup files are only used
-        # under the acme user.
-        UMask = "0077";
-      };
-    }
+      # StateDirectory entries are a cleaner, service-level mechanism
+      # for dealing with persistent service data
+      StateDirectory = [
+        "acme"
+        "acme/.lego"
+        "acme/.lego/accounts"
+        "acme/.minica"
+      ];
+      BindPaths = "/var/lib/acme/.minica:/tmp/ca";
+      StateDirectoryMode = "0755";
 
-    # Avoid race conditions creating the CA for selfsigned certs
-    (lib.mkIf cfg.preliminarySelfsigned {
-      path = [ pkgs.minica ];
-      # Working directory will be /tmp
-      script = ''
-        test -e ca/key.pem || minica \
-          --ca-key ca/key.pem \
-          --ca-cert ca/cert.pem \
-          --domains selfsigned.local
-      '';
-      serviceConfig = {
-        StateDirectory = [ "acme/.minica" ];
-        BindPaths = "/var/lib/acme/.minica:/tmp/ca";
-      };
-    })
-  ];
+      # Creates ${lockdir}. Earlier RemainAfterExit=true means
+      # it does not get deleted immediately.
+      RuntimeDirectory = "acme";
+      RuntimeDirectoryMode = "0700";
+
+      # Generally, we don't write anything that should be group accessible.
+      # Group varies for most ACME units, and setup files are only used
+      # under the acme user.
+      UMask = "0077";
+    };
+  };
 
   certToConfig =
     cert: data:
@@ -219,7 +210,6 @@ let
       acmeServer = data.server;
       useDns = data.dnsProvider != null;
       destPath = "/var/lib/acme/${cert}";
-      selfsignedDeps = lib.optionals (cfg.preliminarySelfsigned) [ "acme-selfsigned-${cert}.service" ];
 
       # Minica and lego have a "feature" which replaces * with _. We need
       # to make this substitution to reference the output files from both programs.
@@ -339,16 +329,18 @@ let
       certificateKey = if data.csrKey != null then "${data.csrKey}" else "certificates/${keyName}.key";
     in
     {
-      inherit accountHash cert selfsignedDeps;
+      inherit accountHash cert;
 
       group = data.group;
 
       renewTimer = {
         description = "Renew ACME Certificate for ${cert}";
         wantedBy = [ "timers.target" ];
+        # Avoid triggering certificate renewals accidentally when running s-t-c.
+        unitConfig."X-OnlyManualStart" = true;
         timerConfig = {
           OnCalendar = data.renewInterval;
-          Unit = "acme-${cert}.service";
+          Unit = "acme-order-renew-${cert}.service";
           Persistent = "yes";
 
           # Allow systemd to pick a convenient time within the day
@@ -364,15 +356,29 @@ let
         };
       };
 
-      selfsignService = lockfileName: {
-        description = "Generate self-signed certificate for ${cert}";
+      baseService = lockfileName: {
+        description = "Ensure certificate for ${cert}";
+
+        wantedBy = [ "multi-user.target" ];
+
         after = [ "acme-setup.service" ];
-        requires = [ "acme-setup.service" ];
+
+        # Whenever this service starts (on boot, through dependencies, through
+        # changes) we trigger the acme-order-renew service to give it a chance
+        # to catch up with the potentially changed config.
+        wants = [
+          "acme-setup.service"
+          "acme-order-renew-${cert}.service"
+        ];
+        before = [ "acme-order-renew-${cert}.service" ];
+
+        restartTriggers = [
+          config.systemd.services."acme-order-renew-${cert}".script
+        ];
 
         path = [ pkgs.minica ];
 
         unitConfig = {
-          ConditionPathExists = "!/var/lib/acme/${cert}/key.pem";
           StartLimitIntervalSec = 0;
         };
 
@@ -380,11 +386,13 @@ let
           Group = data.group;
           UMask = "0027";
 
+          RemainAfterExit = true;
+
           StateDirectory = "acme/${cert}";
 
           BindPaths = [
             "/var/lib/acme/.minica:/tmp/ca"
-            "/var/lib/acme/${cert}:/tmp/${keyName}"
+            "/var/lib/acme/${cert}:/tmp/out"
           ];
         };
 
@@ -392,40 +400,69 @@ let
         # minica will output to a folder sharing the name of the first domain
         # in the list, which will be ${data.domain}
         script = (if (lockfileName == null) then lib.id else wrapInFlock "${lockdir}${lockfileName}") ''
+          set -ex
+
+          # Regenerate self-signed certificates (in case the SANs change) until we
+          # have seen a succesfull ACME certificate at least once.
+          if [ -e out/acme-success ]; then
+            exit 0
+          fi
+
           minica \
             --ca-key ca/key.pem \
             --ca-cert ca/cert.pem \
             --domains ${lib.escapeShellArg (builtins.concatStringsSep "," ([ data.domain ] ++ extraDomains))}
 
           # Create files to match directory layout for real certificates
-          cd '${keyName}'
-          cp ../ca/cert.pem chain.pem
-          cat cert.pem chain.pem > fullchain.pem
-          cat key.pem fullchain.pem > full.pem
+          (
+            cd '${keyName}'
+            cp -vp cert.pem ../out/cert.pem
+            cp -vp key.pem ../out/key.pem
+          )
+          cat out/cert.pem ca/cert.pem > out/fullchain.pem
+          cp ca/cert.pem out/chain.pem
+          cat out/key.pem out/fullchain.pem > out/full.pem
 
-          # Group might change between runs, re-apply it
-          chown '${user}:${data.group}' -- *
+          # Fix up the output files to adhere to the group and
+          # have consistent permissions. This needs to be kept
+          # consistent with the acme-setup script above.
+          for fixpath in out certificates; do
+            if [ -d "$fixpath" ]; then
+              chmod -R u=rwX,g=rX,o= "$fixpath"
+              chown -R ${user}:${data.group} "$fixpath"
+            fi
+          done
 
-          # Default permissions make the files unreadable by group + anon
-          # Need to be readable by group
-          chmod 640 -- *
+          ${lib.optionalString (data.webroot != null) ''
+            # Ensure the webroot exists. Fixing group is required in case configuration was changed between runs.
+            # Lego will fail if the webroot does not exist at all.
+            (
+              mkdir -p '${data.webroot}/.well-known/acme-challenge' \
+              && chgrp '${data.group}' ${data.webroot}/.well-known/acme-challenge
+            ) || (
+              echo 'Please ensure ${data.webroot}/.well-known/acme-challenge exists and is writable by acme:${data.group}' \
+              && exit 1
+            )
+          ''}
         '';
       };
 
-      renewService = lockfileName: {
-        description = "Renew ACME certificate for ${cert}";
+      orderRenewService = lockfileName: {
+        description = "Order (and renew) ACME certificate for ${cert}";
         after = [
           "network.target"
           "network-online.target"
           "acme-setup.service"
           "nss-lookup.target"
-        ]
-        ++ selfsignedDeps;
-        wants = [ "network-online.target" ] ++ selfsignedDeps;
-        requires = [ "acme-setup.service" ];
-
-        # https://github.com/NixOS/nixpkgs/pull/81371#issuecomment-605526099
-        wantedBy = lib.optionals (!config.boot.isContainer) [ "multi-user.target" ];
+          "acme-${cert}.service"
+        ];
+        wants = [
+          "network-online.target"
+          "acme-setup.service"
+          "acme-${cert}.service"
+        ];
+        # Ensure that certificates are generated if people use `security.acme.certs`
+        # without having/declaring other systemd units that depend on the cert.
 
         path = with pkgs; [
           lego
@@ -523,25 +560,12 @@ let
             [[ $expiration_days -gt ${toString data.validMinDays} ]]
           }
 
-          ${lib.optionalString (data.webroot != null) ''
-            # Ensure the webroot exists. Fixing group is required in case configuration was changed between runs.
-            # Lego will fail if the webroot does not exist at all.
-            (
-              mkdir -p '${data.webroot}/.well-known/acme-challenge' \
-              && chgrp '${data.group}' ${data.webroot}/.well-known/acme-challenge
-            ) || (
-              echo 'Please ensure ${data.webroot}/.well-known/acme-challenge exists and is writable by acme:${data.group}' \
-              && exit 1
-            )
-          ''}
-
           echo '${domainHash}' > domainhash.txt
 
-          # Check if we can renew.
+          # Check if a new order is needed
           # We can only renew if the list of domains has not changed.
           # We also need an account key. Avoids #190493
           if cmp -s domainhash.txt certificates/domainhash.txt && [ -e '${certificateKey}' ] && [ -e 'certificates/${keyName}.crt' ] && [ -n "$(find accounts -name '${data.email}.key')" ]; then
-
             # Even if a cert is not expired, it may be revoked by the CA.
             # Try to renew, and silently fail if the cert is not expired.
             # Avoids #85794 and resolves #129838
@@ -553,13 +577,12 @@ let
                 exit 11
               fi
             fi
-
-          # Otherwise do a full run
+          # Do a full run
           elif ! lego ${runOpts}; then
             # Produce a nice error for those doing their first nixos-rebuild with these certs
             echo Failed to fetch certificates. \
               This may mean your DNS records are set up incorrectly. \
-              ${lib.optionalString (cfg.preliminarySelfsigned) "Selfsigned certs are in place and dependant services will still start."}
+              Self-signed certs are in place and dependant services will still start.
             # Exit 10 so that users can potentially amend SuccessExitStatus to ignore this error.
             # High number to avoid Systemd reserved codes.
             exit 10
@@ -567,10 +590,12 @@ let
 
           mv domainhash.txt certificates/
 
-          # Group might change between runs, re-apply it
-          chown '${user}:${data.group}' certificates/*
+          touch out/acme-success
 
           # Copy all certs to the "real" certs directory
+          # lego has only an interesting subset of files available,
+          # construct reasonably compatible files that clients can consume
+          # as expected.
           if ! cmp -s 'certificates/${keyName}.crt' out/fullchain.pem; then
             touch out/renewed
             echo Installing new certificate
@@ -581,10 +606,13 @@ let
             cat out/key.pem out/fullchain.pem > out/full.pem
           fi
 
-          # By default group will have no access to the cert files.
-          # This chmod will fix that.
-          chmod 640 out/*
-
+          # Keep permissions consistent. Needs to be in sync with the other scripts.
+          for fixpath in out certificates; do
+            if [ -d "$fixpath" ]; then
+              chmod -R u=rwX,g=rX,o= "$fixpath"
+              chown -R ${user}:${data.group} "$fixpath"
+            fi
+          done
           # Also ensure safer permissions on the account directory.
           chmod -R u=rwX,g=,o= accounts/.
         '';
@@ -905,19 +933,6 @@ in
 
   options = {
     security.acme = {
-      preliminarySelfsigned = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = ''
-          Whether a preliminary self-signed certificate should be generated before
-          doing ACME requests. This can be useful when certificates are required in
-          a webserver, but ACME needs the webserver to make its requests.
-
-          With preliminary self-signed certificate the webserver can be started and
-          can later reload the correct ACME certificates.
-        '';
-      };
-
       acceptTerms = lib.mkOption {
         type = lib.types.bool;
         default = false;
@@ -1003,10 +1018,13 @@ in
       "ACME Directory is now hardcoded to /var/lib/acme and its permissions are managed by systemd. See https://github.com/NixOS/nixpkgs/issues/53852 for more info."
     )
     (lib.mkRemovedOptionModule [ "security" "acme" "preDelay" ]
-      "This option has been removed. If you want to make sure that something executes before certificates are provisioned, add a RequiredBy=acme-\${cert}.service to the service you want to execute before the cert renewal"
+      "This option has been removed. If you want to make sure that something executes before certificates are provisioned, add a RequiredBy=acme-\${cert}.service and Before=acme-\${cert}.service to the service you want to execute before the cert renewal"
     )
     (lib.mkRemovedOptionModule [ "security" "acme" "activationDelay" ]
-      "This option has been removed. If you want to make sure that something executes before certificates are provisioned, add a RequiredBy=acme-\${cert}.service to the service you want to execute before the cert renewal"
+      "This option has been removed. If you want to make sure that something executes before certificates are provisioned, add a RequiredBy=acme-\${cert}.service and Before=acme-\${cert}.service to the service you want to execute before the cert renewal"
+    )
+    (lib.mkRemovedOptionModule [ "security" "acme" "preliminarySelfsigned" ]
+      "This option has been removed. Preliminary self-signed certificates are now always generated to simplify the dependency structure."
     )
     (lib.mkChangedOptionModule
       [ "security" "acme" "validMin" ]
@@ -1161,45 +1179,35 @@ in
 
       systemd.services =
         let
-          renewServiceFunctions = lib.mapAttrs' (
-            cert: conf: lib.nameValuePair "acme-${cert}" conf.renewService
+          orderRenewServiceFunctions = lib.mapAttrs' (
+            cert: conf: lib.nameValuePair "acme-order-renew-${cert}" conf.orderRenewService
           ) certConfigs;
-          renewServices =
+          orderRenewServices =
             if cfg.maxConcurrentRenewals > 0 then
-              roundRobinApplyAttrs renewServiceFunctions concurrencyLockfiles
+              roundRobinApplyAttrs orderRenewServiceFunctions concurrencyLockfiles
             else
-              lib.mapAttrs (_: f: f null) renewServiceFunctions;
-          selfsignServiceFunctions = lib.mapAttrs' (
-            cert: conf: lib.nameValuePair "acme-selfsigned-${cert}" conf.selfsignService
+              lib.mapAttrs (_: f: f null) orderRenewServiceFunctions;
+          baseServiceFunctions = lib.mapAttrs' (
+            cert: conf: lib.nameValuePair "acme-${cert}" conf.baseService
           ) certConfigs;
-          selfsignServices =
+          baseServices =
             if cfg.maxConcurrentRenewals > 0 then
-              roundRobinApplyAttrs selfsignServiceFunctions concurrencyLockfiles
+              roundRobinApplyAttrs baseServiceFunctions concurrencyLockfiles
             else
-              lib.mapAttrs (_: f: f null) selfsignServiceFunctions;
+              lib.mapAttrs (_: f: f null) baseServiceFunctions;
         in
         {
           acme-setup = setupService;
         }
-        // renewServices
-        // lib.optionalAttrs cfg.preliminarySelfsigned selfsignServices;
+        // baseServices
+        // orderRenewServices;
 
       systemd.timers = lib.mapAttrs' (
-        cert: conf: lib.nameValuePair "acme-${cert}" conf.renewTimer
+        cert: conf: lib.nameValuePair "acme-renew-${cert}" conf.renewTimer
       ) certConfigs;
 
       systemd.targets =
         let
-          # Create some targets which can be depended on to be "active" after cert renewals
-          finishedTargets = lib.mapAttrs' (
-            cert: conf:
-            lib.nameValuePair "acme-finished-${cert}" {
-              wantedBy = [ "default.target" ];
-              requires = [ "acme-${cert}.service" ];
-              after = [ "acme-${cert}.service" ];
-            }
-          ) certConfigs;
-
           # Create targets to limit the number of simultaneous account creations
           # How it works:
           # - Pick a "leader" cert service, which will be in charge of creating the account,
@@ -1214,8 +1222,8 @@ in
             let
               dnsConfs = builtins.filter (conf: cfg.certs.${conf.cert}.dnsProvider != null) confs;
               leaderConf = if dnsConfs != [ ] then builtins.head dnsConfs else builtins.head confs;
-              leader = "acme-${leaderConf.cert}.service";
-              followers = map (conf: "acme-${conf.cert}.service") (
+              leader = "acme-order-renew-${leaderConf.cert}.service";
+              followers = map (conf: "acme-order-renew-${conf.cert}.service") (
                 builtins.filter (conf: conf != leaderConf) confs
               );
             in
@@ -1224,10 +1232,11 @@ in
               before = followers;
               requires = [ leader ];
               after = [ leader ];
+              unitConfig.RefuseManualStart = true;
             }
           ) (lib.groupBy (conf: conf.accountHash) (lib.attrValues certConfigs));
         in
-        finishedTargets // accountTargets;
+        accountTargets;
     })
   ];
 

--- a/nixos/modules/services/networking/doh-server.nix
+++ b/nixos/modules/services/networking/doh-server.nix
@@ -156,7 +156,7 @@ in
         "network.target"
       ]
       ++ lib.optional (cfg.useACMEHost != null) "acme-${cfg.useACMEHost}.service";
-      wants = lib.optional (cfg.useACMEHost != null) "acme-finished-${cfg.useACMEHost}.target";
+      wants = lib.optional (cfg.useACMEHost != null) "acme-${cfg.useACMEHost}.service";
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         AmbientCapabilities = "CAP_NET_BIND_SERVICE";

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -15,8 +15,6 @@ let
     vhostConfig: vhostConfig.enableACME || vhostConfig.useACMEHost != null
   ) vhostsConfigs;
   vhostCertNames = unique (map (hostOpts: hostOpts.certName) acmeEnabledVhosts);
-  dependentCertNames = filter (cert: certs.${cert}.dnsProvider == null) vhostCertNames; # those that might depend on the HTTP server
-  independentCertNames = filter (cert: certs.${cert}.dnsProvider != null) vhostCertNames; # those that don't depend on the HTTP server
   virtualHosts = mapAttrs (
     vhostName: vhostConfig:
     let
@@ -442,6 +440,7 @@ let
                   auth_basic off;
                   auth_request off;
                   proxy_pass http://${vhost.acmeFallbackHost};
+                  proxy_set_header Host $host;
                 }
               ''}
             '';
@@ -1481,16 +1480,14 @@ in
     systemd.services.nginx = {
       description = "Nginx Web Server";
       wantedBy = [ "multi-user.target" ];
-      wants = concatLists (map (certName: [ "acme-finished-${certName}.target" ]) vhostCertNames);
+      wants = concatLists (map (certName: [ "acme-${certName}.service" ]) vhostCertNames);
       after = [
         "network.target"
       ]
-      ++ map (certName: "acme-selfsigned-${certName}.service") vhostCertNames
-      ++ map (certName: "acme-${certName}.service") independentCertNames; # avoid loading self-signed key w/ real cert, or vice-versa
-      # Nginx needs to be started in order to be able to request certificates
-      # (it's hosting the acme challenge after all)
-      # This fixes https://github.com/NixOS/nixpkgs/issues/81842
-      before = map (certName: "acme-${certName}.service") dependentCertNames;
+      # Ensure nginx runs with baseline certificates in place.
+      ++ map (certName: "acme-${certName}.service") vhostCertNames;
+      # Ensure nginx runs (with current config) before the actual ACME jobs run
+      before = map (certName: "acme-order-renew-${certName}.service") vhostCertNames;
       stopIfChanged = false;
       preStart = ''
         ${cfg.preStart}
@@ -1585,26 +1582,24 @@ in
     # This service waits for all certificates to be available
     # before reloading nginx configuration.
     # sslTargets are added to wantedBy + before
-    # which allows the acme-finished-$cert.target to signify the successful updating
+    # which allows the acme-order-renew-$cert.service to signify the successful updating
     # of certs end-to-end.
     systemd.services.nginx-config-reload =
       let
-        sslServices = map (certName: "acme-${certName}.service") vhostCertNames;
-        sslTargets = map (certName: "acme-finished-${certName}.target") vhostCertNames;
+        sslOrderRenewServices = map (certName: "acme-order-renew-${certName}.service") vhostCertNames;
       in
       mkIf (cfg.enableReload || vhostCertNames != [ ]) {
         wants = optionals cfg.enableReload [ "nginx.service" ];
-        wantedBy = sslServices ++ [ "multi-user.target" ];
-        # Before the finished targets, after the renew services.
+        wantedBy = sslOrderRenewServices ++ [ "multi-user.target" ];
+        # XXX Before the finished targets, after the renew services.
         # This service might be needed for HTTP-01 challenges, but we only want to confirm
         # certs are updated _after_ config has been reloaded.
-        before = sslTargets;
-        after = sslServices;
+        after = sslOrderRenewServices;
         restartTriggers = optionals cfg.enableReload [ configFile ];
         # Block reloading if not all certs exist yet.
         # Happens when config changes add new vhosts/certs.
         unitConfig = {
-          ConditionPathExists = optionals (sslServices != [ ]) (
+          ConditionPathExists = optionals (vhostCertNames != [ ]) (
             map (certName: certs.${certName}.directory + "/fullchain.pem") vhostCertNames
           );
           # Disable rate limiting for this, because it may be triggered quickly a bunch of times

--- a/nixos/tests/acme/webserver.nix
+++ b/nixos/tests/acme/webserver.nix
@@ -2,7 +2,7 @@
   serverName,
   group,
   baseModule,
-  domain ? "example.test",
+  domain,
 }:
 {
   config,
@@ -17,6 +17,8 @@
     # Hard timeout in seconds. Average run time is about 100 seconds.
     timeout = 300;
   };
+
+  interactive.sshBackdoor.enable = true;
 
   nodes = {
     # The fake ACME server which will respond to client requests
@@ -45,6 +47,7 @@
           "certchange.${domain}"
           "zeroconf.${domain}"
           "zeroconf2.${domain}"
+          "zeroconf3.${domain}"
           "nullroot.${domain}"
         ];
 
@@ -57,6 +60,7 @@
         systemd.targets."renew-triggered" = {
           wantedBy = [ "${serverName}-config-reload.service" ];
           after = [ "${serverName}-config-reload.service" ];
+          unitConfig.RefuseManualStart = true;
         };
 
         security.acme.certs."proxied.${domain}" = {
@@ -101,11 +105,40 @@
           # Test that "acmeRoot = null" still results in
           # valid cert generation by inheriting defaults.
           nullroot.configuration = {
-            security.acme.defaults.listenHTTP = ":8080";
+            # The default.nix has the server-type dependent config statements
+            # to properly set up the proxying. We need a separate port here to
+            # avoid hostname issues with the proxy already running on :8080
+            security.acme.defaults.listenHTTP = ":8081";
             services.${serverName}.virtualHosts."nullroot.${domain}" = {
-              onlySSL = true;
+              addSSL = true;
               enableACME = true;
               acmeRoot = null;
+            };
+          };
+
+          # Test that a adding a second virtual host will not trigger
+          # other units (account and renewal service for first)
+          zeroconf3.configuration = {
+            services.${serverName}.virtualHosts = {
+              "zeroconf.${domain}" = {
+                addSSL = true;
+                enableACME = true;
+                serverAliases = [ "zeroconf2.${domain}" ];
+              };
+              "zeroconf3.${domain}" = {
+                addSSL = true;
+                enableACME = true;
+              };
+            };
+            # We're doing something risky with the combination of the service unit being persistent
+            # that could end up that the timers do not trigger properly. Show that timers have the
+            # desired effect.
+            systemd.timers."acme-renew-zeroconf3.${domain}".timerConfig = {
+              OnCalendar = lib.mkForce "*-*-* *:*:0/5";
+              AccuracySec = lib.mkForce 0;
+              # Skew randomly within the day, per https://letsencrypt.org/docs/integration-guide/.
+              RandomizedDelaySec = lib.mkForce 0;
+              FixedRandomDelay = lib.mkForce 0;
             };
           };
         };
@@ -121,30 +154,24 @@
       ca_domain = "${nodes.acme.test-support.acme.caDomain}"
       fqdn = f"proxied.{domain}"
 
+      webserver.start()
+      webserver.wait_for_unit("${serverName}.service")
+
+      with subtest("Can run on self-signed certificates"):
+          check_issuer(webserver, fqdn, "minica")
+          # Check that the web server has picked up the selfsigned cert
+          check_connection(webserver, fqdn, minica=True)
+
       acme.start()
       wait_for_running(acme)
       acme.wait_for_open_port(443)
 
       with subtest("Acquire a cert through a proxied lego"):
-          webserver.start()
-          webserver.succeed("systemctl is-system-running --wait")
-          wait_for_running(webserver)
-          download_ca_certs(webserver, ca_domain)
-          check_connection(webserver, fqdn)
-
-      with subtest("Can run on selfsigned certificates"):
-          # Switch to selfsigned first
-          webserver.succeed(f"systemctl clean acme-{fqdn}.service --what=state")
-          webserver.succeed(f"systemctl start acme-selfsigned-{fqdn}.service")
-          check_issuer(webserver, fqdn, "minica")
-          webserver.succeed("systemctl restart ${serverName}-config-reload.service")
-          # Check that the web server has picked up the selfsigned cert
-          check_connection(webserver, fqdn, minica=True)
-          webserver.succeed("systemctl stop renew-triggered.target")
-          webserver.succeed(f"systemctl start acme-{fqdn}.service")
-          webserver.wait_for_unit("renew-triggered.target")
-          check_issuer(webserver, fqdn, "pebble")
-          check_connection(webserver, fqdn)
+        webserver.succeed(f"systemctl start acme-order-renew-{fqdn}.service")
+        webserver.wait_for_unit("renew-triggered.target")
+        download_ca_certs(webserver, ca_domain)
+        check_issuer(webserver, fqdn, "pebble")
+        check_connection(webserver, fqdn)
 
       with subtest("security.acme changes reflect on web server part 1"):
           check_connection(webserver, f"certchange.{domain}", fail=True)
@@ -181,5 +208,23 @@
           switch_to(webserver, "nullroot")
           webserver.wait_for_unit("renew-triggered.target")
           check_connection(webserver, f"nullroot.{domain}")
+
+      with subtest("Ensure that adding a second vhost does not trigger first vhost acme units"):
+          switch_to(webserver, "zeroconf")
+          webserver.wait_for_unit("renew-triggered.target")
+          webserver.succeed("journalctl --cursor-file=/tmp/cursor | grep acme")
+          switch_to(webserver, "zeroconf3")
+          webserver.wait_for_unit("renew-triggered.target")
+          output = webserver.succeed("journalctl --cursor-file=/tmp/cursor | grep acme")
+          # The new certificate unit gets triggered:
+          t.assertIn(f"acme-zeroconf3.{domain}-start", output)
+          # The account generation should not be triggered again:
+          t.assertNotIn("acme-account-d590213ed52603e9128d.target", output)
+          # The other certificates should also not be triggered:
+          t.assertNotIn(f"acme-zeroconf.{domain}-start", output)
+          t.assertNotIn(f"acme-proxied.{domain}-start", output)
+          # Ensure the timer works, due to our shenanigans with
+          # RemainAfterExit=true
+          webserver.wait_until_succeeds(f"journalctl --cursor-file=/tmp/cursor | grep 'Starting Order (and renew) ACME certificate for zeroconf3.{domain}...'")
     '';
 }

--- a/nixos/tests/step-ca.nix
+++ b/nixos/tests/step-ca.nix
@@ -137,17 +137,18 @@ import ./make-test-python.nix (
         caserver.wait_for_unit("step-ca.service")
         caserver.wait_until_succeeds("journalctl -o cat -u step-ca.service | grep '${pkgs.step-ca.version}'")
 
-        caclient.wait_for_unit("acme-finished-caclient.target")
-        catester.succeed("curl https://caclient/ | grep \"Welcome to nginx!\"")
+        caclient.wait_for_unit("acme-caclient.service")
+        # The order is run asynchonously, keep trying.
+        catester.wait_until_succeeds("curl https://caclient/ | grep \"Welcome to nginx!\"")
 
         caclientcaddy.wait_for_unit("caddy.service")
         # It’s hard to know when Caddy has finished the ACME dance with
         # step-ca, so we keep trying cURL until success.
         catester.wait_until_succeeds("curl https://caclientcaddy/ | grep \"Welcome to Caddy!\"")
 
-        caclienth2o.wait_for_unit("acme-finished-caclienth2o.target")
+        caclienth2o.wait_for_unit("acme-caclienth2o.service")
         caclienth2o.wait_for_unit("h2o.service")
-        catester.succeed("curl https://caclienth2o/ | grep \"Welcome to H2O!\"")
+        catester.wait_until_succeeds("curl https://caclienth2o/ | grep \"Welcome to H2O!\"")
       '';
   }
 )


### PR DESCRIPTION
##  acme: improve scalability - reduce superfluous unit activations

The previous setup caused all renewal units to be triggered upon
ever so slight changes in config. In larger setups (100+ certificates)
adding a new certificate caused high system load and/or large memory
consumption issues. The memory issues are already a alleviated with
the locking mechanism. However, this then causes long delays upwards
of multiple minutes depending on individual runs and also caused
superfluous activations.

In this change we streamline the overall setup of units:

1. The unit that other services can depend upon is 'acme-{cert}.service'.
We call this the 'base unit'. As this one as `RemainAfterExit` set
the `acme-finished-{cert}` targets are not required any longer.

2. We now always generate initial self-signed certificates to simplify
the dependency structure. This deprecates the `preliminarySelfsigned`
option.

3. The `acme-order-renew-{cert}` service gets activated after the base
unit and services using certificates have started and performs all acme
interactions. When it finishes others services (like web servers) will
be notified through the `reloadServices` option or they can use
`wantedBy` and `after` dependencies if they implement their own reload
units.

The renewal timer also triggers this unit.

4. The timer unit is explicitly blocked from being started by s-t-c.

5. Permission management has been cleaned up a bit: there was an
   inconsistency between having the .lego files set to 600 vs 640
   on the exposed side. This is unified to 640 now.

6. Exempt the account target from being restarted by s-t-c. This will
   happen automatically if something relevant to the account changes.

##  acme: switch concurrency limit to a runtime-based implementation

The previous implementation caused triggers on many units when adding
or removing certificates because the baked-in lock file assignments
changed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
