### PR TITLE
nixos/backrest: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -32,6 +32,8 @@
 
 - [tlsrpt-reporter], an application suite to generate and deliver TLSRPT reports. Available as [services.tlsrpt](#opt-services.tlsrpt.enable).
 
+- [Backrest](https://github.com/garethgeorge/backrest), a web UI and orchestrator for restic backup. Available as [services.backrest](#opt-services.backrest.enable).
+
 - [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).
 
 - Docker now defaults to 28.x, because version 27.x stopped receiving security updates and bug fixes after [May 2, 2025](https://github.com/moby/moby/pull/49910).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -437,6 +437,7 @@
   ./services/audio/ympd.nix
   ./services/autotierfs.nix
   ./services/backup/automysqlbackup.nix
+  ./services/backup/backrest.nix
   ./services/backup/bacula.nix
   ./services/backup/borgbackup.nix
   ./services/backup/borgmatic.nix

--- a/nixos/modules/services/backup/backrest.nix
+++ b/nixos/modules/services/backup/backrest.nix
@@ -1,0 +1,178 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.backrest;
+in
+{
+  options.services.backrest = with lib; {
+    enable = mkEnableOption "Backrest Web UI";
+    package = mkPackageOption pkgs "backrest" { };
+    openFirewall = mkEnableOption "opening the ports in the firewall";
+    user = mkOption {
+      type = types.str;
+      description = "The user to run Backrest as";
+      default = "backrest";
+    };
+    group = mkOption {
+      type = types.str;
+      description = "The group to run Backrest as";
+      default = "backrest";
+    };
+    listen = mkOption {
+      type = types.submodule {
+        options = {
+          host = mkOption {
+            type = types.str;
+            description = "The host to listen to";
+            default = "127.0.0.1";
+          };
+          port = mkOption {
+            type = types.port;
+            description = "The port to listen to";
+            default = 9898;
+          };
+        };
+      };
+      description = "Listen options";
+      default = { };
+    };
+    resticBinary = mkPackageOption pkgs "restic" { };
+    rootDirectory = mkOption {
+      type = types.str;
+      description = "The main Backrest root directory";
+      default = "/var/lib/backrest";
+    };
+    configPath = mkOption {
+      type = types.oneOf [
+        types.str
+        types.path
+      ];
+      description = "The path of the Backrest config file";
+      default = "${cfg.rootDirectory}/config.json";
+    };
+    dataDirectory = mkOption {
+      type = types.str;
+      description = "The path of the Backrest data directory. This is not to be confused with the target repository location.";
+      default = "${cfg.rootDirectory}/data";
+    };
+    cacheDirectory = mkOption {
+      type = types.str;
+      description = "The path of the Backrest cache directory";
+      default = "${cfg.rootDirectory}/cache";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+      cfg.resticBinary
+    ];
+
+    users.users.${cfg.user} = {
+      description = lib.mkDefault "Backrest service user";
+      isSystemUser = true;
+      group = cfg.group;
+    };
+
+    users.groups.${cfg.group} = { };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
+      cfg.listen.port
+    ];
+
+    systemd.tmpfiles.settings = {
+      "10-backrest" = {
+        "${cfg.rootDirectory}" = {
+          d = {
+            user = cfg.user;
+            group = cfg.group;
+            mode = "0750";
+            age = "-";
+          };
+        };
+        "${cfg.cacheDirectory}" = {
+          d = {
+            user = cfg.user;
+            group = cfg.group;
+            mode = "0750";
+            age = "-";
+          };
+        };
+        "${cfg.dataDirectory}" = {
+          d = {
+            user = cfg.user;
+            group = cfg.group;
+            mode = "0750";
+            age = "-";
+          };
+        };
+      };
+    };
+
+    systemd.services.backrest = {
+      description = "Web-accessible backup solution built on top of restic.";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      path = [ pkgs.bash ]; # Needed for the hooks to work
+      environment = {
+        BACKREST_PORT = "${cfg.listen.host}:${toString cfg.listen.port}";
+        BACKREST_CONFIG = cfg.configPath;
+        BACKREST_DATA = cfg.dataDirectory;
+        BACKREST_RESTIC_COMMAND = lib.getExe' cfg.resticBinary "restic";
+        XDG_CACHE_HOME = cfg.cacheDirectory;
+      };
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Type = "simple";
+        RestartSec = 60;
+        NoNewPrivileges = true;
+        LockPersonality = true;
+        UMask = "0077";
+        SystemCallFilter = [
+          " " # This is needed to clear the SystemCallFilter existing definitions
+          "~@reboot"
+          "~@swap"
+          "~@obsolete"
+          "~@mount"
+          "~@module"
+          "~@debug"
+          "~@cpu-emulation"
+          "~@clock"
+          "~@raw-io"
+          "~@privileged"
+          "~@resources"
+        ];
+        AmbientCapabilities = [
+          "CAP_DAC_READ_SEARCH"
+        ];
+        CapabilityBoundingSet = [
+          "CAP_DAC_READ_SEARCH"
+        ];
+        RestrictAddressFamilies = [
+          " " # This is needed to clear the RestrictAddressFamilies existing definitions
+          "none" # Remove all addresses families
+          "AF_INET"
+          "AF_INET6"
+        ];
+        DevicePolicy = "closed";
+        ProtectKernelLogs = true;
+        SystemCallArchitectures = "native";
+        RestrictSUIDSGID = true;
+        ExecStart = [
+          "${lib.getExe' cfg.package "backrest"}"
+        ];
+      };
+    };
+  };
+  meta = {
+    maintainers = with lib.maintainers; [
+      m0ustach3
+    ];
+  };
+}

--- a/nixos/modules/services/backup/backrest.nix
+++ b/nixos/modules/services/backup/backrest.nix
@@ -53,16 +53,19 @@ in
       ];
       description = "The path of the Backrest config file";
       default = "${cfg.rootDirectory}/config.json";
+      defaultText = "\"\${cfg.rootDirectory}/config.json\"";
     };
     dataDirectory = mkOption {
       type = types.str;
       description = "The path of the Backrest data directory. This is not to be confused with the target repository location.";
       default = "${cfg.rootDirectory}/data";
+      defaultText = "\"\${cfg.rootDirectory}/data\"";
     };
     cacheDirectory = mkOption {
       type = types.str;
       description = "The path of the Backrest cache directory";
       default = "${cfg.rootDirectory}/cache";
+      defaultText = "\"\${cfg.rootDirectory}/cache\"";
     };
   };
 

--- a/nixos/modules/services/backup/backrest.nix
+++ b/nixos/modules/services/backup/backrest.nix
@@ -41,6 +41,11 @@ in
       default = { };
     };
     resticBinary = mkPackageOption pkgs "restic" { };
+    additionalPaths = mkOption {
+      type = types.listOf types.path;
+      description = "Packages to add to the PATH of the unit file. Useful to make packages available to hooks. See https://garethgeorge.github.io/backrest/cookbooks/command-hook-examples for examples";
+      default = [ ];
+    };
     rootDirectory = mkOption {
       type = types.str;
       description = "The main Backrest root directory";
@@ -121,7 +126,7 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
-      path = [ pkgs.bash ]; # Needed for the hooks to work
+      path = cfg.additionalPaths;
       environment = {
         BACKREST_PORT = "${cfg.listen.host}:${toString cfg.listen.port}";
         BACKREST_CONFIG = cfg.configPath;


### PR DESCRIPTION
Backrest NixOS module

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
