### PR TITLE
treewide: move StartLimitIntervalSec/StartLimitBurst to unitConfig

### DIFF
--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -295,6 +295,8 @@ in
       '';
       Restart = "on-failure";
       RestartSec = 5;
+    };
+    unitConfig = {
       StartLimitBurst = 3;
       StartLimitInterval = 10;
     };

--- a/nixos/modules/services/cluster/spark/default.nix
+++ b/nixos/modules/services/cluster/spark/default.nix
@@ -123,8 +123,10 @@ in
             ExecStart = "${cfg.package}/sbin/start-master.sh";
             ExecStop = "${cfg.package}/sbin/stop-master.sh";
             TimeoutSec = 300;
-            StartLimitBurst = 10;
             Restart = "always";
+          };
+          unitConfig = {
+            StartLimitBurst = 10;
           };
         };
         spark-worker = lib.mkIf cfg.worker.enable {
@@ -151,8 +153,10 @@ in
             ExecStart = "${cfg.package}/sbin/start-worker.sh spark://${cfg.worker.master}";
             ExecStop = "${cfg.package}/sbin/stop-worker.sh";
             TimeoutSec = 300;
-            StartLimitBurst = 10;
             Restart = "always";
+          };
+          unitConfig = {
+            StartLimitBurst = 10;
           };
         };
       };

--- a/nixos/modules/services/games/xonotic.nix
+++ b/nixos/modules/services/games/xonotic.nix
@@ -195,6 +195,8 @@ in
 
         Restart = "on-failure";
         RestartSec = 10;
+      };
+      unitConfig = {
         StartLimitBurst = 5;
       };
     };

--- a/nixos/modules/services/matrix/conduit.nix
+++ b/nixos/modules/services/matrix/conduit.nix
@@ -157,8 +157,10 @@ in
         ExecStart = "${cfg.package}/bin/conduit";
         Restart = "on-failure";
         RestartSec = 10;
-        StartLimitBurst = 5;
         UMask = "077";
+      };
+      unitConfig = {
+        StartLimitBurst = 5;
       };
     };
   };

--- a/nixos/modules/services/networking/fedimintd.nix
+++ b/nixos/modules/services/networking/fedimintd.nix
@@ -310,7 +310,6 @@ in
 
               Restart = "always";
               RestartSec = 10;
-              StartLimitBurst = 5;
               UMask = "007";
               LimitNOFILE = "100000";
 
@@ -340,6 +339,9 @@ in
                 "@system-service"
                 "~@privileged"
               ];
+            };
+            unitConfig = {
+              StartLimitBurst = 5;
             };
           }
         ))

--- a/nixos/modules/services/networking/frr.nix
+++ b/nixos/modules/services/networking/frr.nix
@@ -298,7 +298,6 @@ in
           Nice = -5;
           Type = "forking";
           NotifyAccess = "all";
-          StartLimitBurst = "3";
           TimeoutSec = 120;
           WatchdogSec = 60;
           RestartSec = 5;
@@ -308,6 +307,9 @@ in
           ExecStart = "${pkgs.frr}/libexec/frr/frrinit.sh start";
           ExecStop = "${pkgs.frr}/libexec/frr/frrinit.sh stop";
           ExecReload = "${pkgs.frr}/libexec/frr/frrinit.sh reload";
+        };
+        unitConfig = {
+          StartLimitBurst = "3";
         };
       };
     };

--- a/nixos/modules/virtualisation/docker-rootless.nix
+++ b/nixos/modules/virtualisation/docker-rootless.nix
@@ -82,13 +82,15 @@ in
         TimeoutSec = 0;
         RestartSec = 2;
         Restart = "always";
-        StartLimitBurst = 3;
         LimitNOFILE = "infinity";
         LimitNPROC = "infinity";
         LimitCORE = "infinity";
         Delegate = true;
         NotifyAccess = "all";
         KillMode = "mixed";
+      };
+      unitConfig = {
+        StartLimitBurst = 3;
       };
     };
   };

--- a/nixos/tests/vault-postgresql.nix
+++ b/nixos/tests/vault-postgresql.nix
@@ -29,7 +29,7 @@
         ];
         # Try for about 10 minutes rather than the default of 5 attempts.
         serviceConfig.RestartSec = 1;
-        serviceConfig.StartLimitBurst = 600;
+        unitConfig.StartLimitBurst = 600;
       };
       # systemd.services.vault.unitConfig.RequiresMountsFor = "/run/keys/";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
