### PR TITLE
postgresqlPackages: fix update scripts with PG versioning scheme

### DIFF
--- a/pkgs/by-name/ps/psqlodbc/package.nix
+++ b/pkgs/by-name/ps/psqlodbc/package.nix
@@ -1,13 +1,15 @@
 {
-  lib,
-  stdenv,
-  fetchFromGitHub,
-  nix-update-script,
   autoreconfHook,
+  fetchFromGitHub,
+  lib,
   libpq,
+  nix-update-script,
   openssl,
+  stdenv,
+
   withLibiodbc ? false,
   libiodbc,
+
   withUnixODBC ? true,
   unixODBC,
 }:
@@ -38,6 +40,13 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
+  configureFlags = [
+    "CPPFLAGS=-DSQLCOLATTRIBUTE_SQLLEN" # needed for cross
+    "--with-libpq=${lib.getDev libpq}"
+  ]
+  ++ lib.optional withLibiodbc "--with-iodbc=${libiodbc}"
+  ++ lib.optional withUnixODBC "--with-unixodbc=${unixODBC}";
+
   passthru = {
     updateScript = nix-update-script { };
   }
@@ -46,18 +55,11 @@ stdenv.mkDerivation rec {
     driver = "lib/psqlodbcw.so";
   };
 
-  configureFlags = [
-    "CPPFLAGS=-DSQLCOLATTRIBUTE_SQLLEN" # needed for cross
-    "--with-libpq=${lib.getDev libpq}"
-  ]
-  ++ lib.optional withLibiodbc "--with-iodbc=${libiodbc}"
-  ++ lib.optional withUnixODBC "--with-unixodbc=${unixODBC}";
-
-  meta = with lib; {
+  meta = {
     homepage = "https://odbc.postgresql.org/";
     description = "ODBC driver for PostgreSQL";
-    license = licenses.lgpl2;
-    platforms = platforms.unix;
+    license = lib.licenses.lgpl2;
+    platforms = lib.platforms.unix;
     teams = libpq.meta.teams;
   };
 }

--- a/pkgs/by-name/ps/psqlodbc/package.nix
+++ b/pkgs/by-name/ps/psqlodbc/package.nix
@@ -16,14 +16,14 @@
 
 assert lib.xor withLibiodbc withUnixODBC;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "psqlodbc";
-  version = "${builtins.replaceStrings [ "_" ] [ "." ] (lib.strings.removePrefix "REL-" src.tag)}";
+  version = "17.00.0006";
 
   src = fetchFromGitHub {
     owner = "postgresql-interfaces";
     repo = "psqlodbc";
-    tag = "REL-17_00_0006";
+    tag = "REL-${lib.replaceString "." "_" finalAttrs.version}";
     hash = "sha256-iu1PWkfOyWtMmy7/8W+acu8v+e8nUPkCIHtVNZ8HzRg=";
   };
 
@@ -48,7 +48,9 @@ stdenv.mkDerivation rec {
   ++ lib.optional withUnixODBC "--with-unixodbc=${unixODBC}";
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex=^REL-(\\d+)_(\\d+)_(\\d+)$" ];
+    };
   }
   // lib.optionalAttrs withUnixODBC {
     fancyName = "PostgreSQL";
@@ -62,4 +64,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     teams = libpq.meta.teams;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
@@ -9,13 +9,13 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "pg_squeeze";
-  version = "1.7.0";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "cybertec-postgresql";
     repo = "pg_squeeze";
     tag = "REL${lib.replaceString "." "_" finalAttrs.version}";
-    hash = "sha256-Kh1wSOvV5Rd1CG/na3yzbWzvaR8SJ6wmTZOnM+lbgik=";
+    hash = "sha256-RrG7qeX0NQ4cq6N+9uVfalNW+HfiSt4wcjeZjInnfgE=";
   };
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
@@ -9,18 +9,18 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "pg_squeeze";
-  version = "${builtins.replaceStrings [ "_" ] [ "." ] (
-    lib.strings.removePrefix "REL" finalAttrs.src.rev
-  )}";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "cybertec-postgresql";
     repo = "pg_squeeze";
-    tag = "REL1_7_0";
+    tag = "REL${lib.replaceString "." "_" finalAttrs.version}";
     hash = "sha256-Kh1wSOvV5Rd1CG/na3yzbWzvaR8SJ6wmTZOnM+lbgik=";
   };
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=REL(.*)" ]; };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^REL(\\d+)_(\\d+)_(\\d+)$" ];
+  };
   passthru.tests.extension = postgresqlTestExtension {
     inherit (finalAttrs) finalPackage;
     postgresqlExtraSettings = ''

--- a/pkgs/servers/sql/postgresql/ext/plr.nix
+++ b/pkgs/servers/sql/postgresql/ext/plr.nix
@@ -2,6 +2,7 @@
   buildEnv,
   fetchFromGitHub,
   lib,
+  nix-update-script,
   pkg-config,
   postgresql,
   postgresqlBuildExtension,
@@ -12,14 +13,12 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "plr";
-  version = "${builtins.replaceStrings [ "_" ] [ "." ] (
-    lib.strings.removePrefix "REL" finalAttrs.src.rev
-  )}";
+  version = "8.4.7";
 
   src = fetchFromGitHub {
     owner = "postgres-plr";
     repo = "plr";
-    tag = "REL8_4_7";
+    tag = "REL${lib.replaceString "." "_" finalAttrs.version}";
     hash = "sha256-PdvFEmtKfLT/xfaf6obomPR5hKC9F+wqpfi1heBphRk=";
   };
 
@@ -29,6 +28,9 @@ postgresqlBuildExtension (finalAttrs: {
   makeFlags = [ "USE_PGXS=1" ];
 
   passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex=^REL(\\d+)_(\\d+)_(\\d+)$" ];
+    };
     withPackages =
       f:
       let

--- a/pkgs/servers/sql/postgresql/ext/plr.nix
+++ b/pkgs/servers/sql/postgresql/ext/plr.nix
@@ -13,13 +13,13 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "plr";
-  version = "8.4.7";
+  version = "8.4.8";
 
   src = fetchFromGitHub {
     owner = "postgres-plr";
     repo = "plr";
     tag = "REL${lib.replaceString "." "_" finalAttrs.version}";
-    hash = "sha256-PdvFEmtKfLT/xfaf6obomPR5hKC9F+wqpfi1heBphRk=";
+    hash = "sha256-FLL61HsZ6WaWBP9NqrJjhMFSVyVBIpVO0wv+kXMuAaU=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/sql/postgresql/ext/wal2json.nix
+++ b/pkgs/servers/sql/postgresql/ext/wal2json.nix
@@ -1,6 +1,7 @@
 {
   fetchFromGitHub,
   lib,
+  nix-update-script,
   nixosTests,
   postgresql,
   postgresqlBuildExtension,
@@ -8,19 +9,20 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "wal2json";
-  version = "${builtins.replaceStrings [ "_" ] [ "." ] (
-    lib.strings.removePrefix "wal2json_" finalAttrs.src.rev
-  )}";
+  version = "2.6";
 
   src = fetchFromGitHub {
     owner = "eulerto";
     repo = "wal2json";
-    tag = "wal2json_2_6";
+    tag = "wal2json_${lib.replaceString "." "_" finalAttrs.version}";
     hash = "sha256-+QoACPCKiFfuT2lJfSUmgfzC5MXf75KpSoc2PzPxKyM=";
   };
 
   makeFlags = [ "USE_PGXS=1" ];
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^wal2json_(\\d+)_(\\d+)$" ];
+  };
   passthru.tests = nixosTests.postgresql.wal2json.passthru.override postgresql;
 
   meta = {


### PR DESCRIPTION
PostgreSQL itself and some of its extensions use a `REL_X_Y_Z` versioning scheme, or similar - delimiting by `_` instead of `.`.

This fixes the update scripts for those packages. Depends on:
- [x] https://github.com/Mic92/nix-update/pull/401

## Things done

- [x] Tested by actually updating those 3 packages.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
