### PR TITLE
Add Postgresql database support to clightning 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11895,6 +11895,11 @@
     githubId = 51518420;
     name = "jitwit";
   };
+  jjacke13 = {
+    email = "jjacke@proton.me";
+    github = "jjacke13";
+    githubId = 156372486;
+    name = "Vaios K";
   jjjollyjim = {
     email = "jamie@kwiius.com";
     github = "JJJollyjim";

--- a/pkgs/by-name/cl/clightning/package.nix
+++ b/pkgs/by-name/cl/clightning/package.nix
@@ -19,6 +19,7 @@
   sqlite,
   zlib,
   jq,
+  postgresql
 }:
 let
   py3 = python3.withPackages (p: [
@@ -62,12 +63,21 @@ stdenv.mkDerivation rec {
     sqlite
     zlib
     jq
+    postgresql
   ];
 
   # this causes some python trouble on a darwin host so we skip this step.
   # also we have to tell libwally-core to use sed instead of gsed.
-  postPatch =
-    if !stdenv.hostPlatform.isDarwin then
+  # also, postgresql support is forced via Nix build by linking its libraries
+  postPatch = ''
+      # Force PostgreSQL detection in configure script
+    sed -i configure \
+      -e '/We need a database, but neither sqlite3 nor postgres found/c\echo "PostgreSQL forced via Nix build"' \
+      -e 's/^HAVE_POSTGRES=.*/HAVE_POSTGRES=1/' \
+      -e "s|^POSTGRES_INCLUDE=.*|POSTGRES_INCLUDE=\"-I${postgresql.dev}/include\"|" \
+      -e "s|^POSTGRES_LDLIBS=.*|POSTGRES_LDLIBS=\"-L${postgresql.lib}/lib -lpq\"|"
+  '' +
+    (if !stdenv.hostPlatform.isDarwin then
       ''
         patchShebangs \
           tools/generate-wire.py \
@@ -80,7 +90,7 @@ stdenv.mkDerivation rec {
       ''
         substituteInPlace external/libwally-core/tools/autogen.sh --replace gsed sed && \
         substituteInPlace external/libwally-core/configure.ac --replace gsed sed
-      '';
+      '');
 
   configureFlags = [ "--disable-valgrind" ];
 
@@ -107,6 +117,7 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [
       jb55
       prusnak
+      jjacke13
     ];
     license = licenses.mit;
     platforms = platforms.linux ++ platforms.darwin;


### PR DESCRIPTION
Added support for postgresql database backend


<!--
Core lightning can use postgresql as its backend database. This change integrates postgresql support in the Nix build process by linking its libraries.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
