### PR TITLE
platformio-core: add missing dependencies and adjust path environment variable

### DIFF
--- a/pkgs/development/embedded/platformio/builder-prioritize-python-env-in-path.patch
+++ b/pkgs/development/embedded/platformio/builder-prioritize-python-env-in-path.patch
@@ -1,0 +1,11 @@
+--- a/platformio/builder/main.py
++++ b/platformio/builder/main.py
+@@ -46,6 +46,8 @@ clivars.AddVariables(
+     ("PROGRAM_ARGS",),
+ )
+ 
++os.environ["PATH"] = os.pathsep.join([os.path.dirname(get_pythonexe_path()), os.environ.get("PATH")])
++
+ DEFAULT_ENV_OPTIONS = dict(
+     tools=[
+         "ar",

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -32,7 +32,7 @@ buildPythonApplication rec {
 
   patches = [
     (replaceVars ./interpreter.patch {
-      interpreter = (python3Packages.python.withPackages (_: propagatedBuildInputs)).interpreter;
+      interpreter = (python3Packages.python.withPackages (_: dependencies)).interpreter;
     })
     (replaceVars ./use-local-spdx-license-list.patch {
       spdx_license_list_data = spdx-license-list-data.json;
@@ -45,6 +45,7 @@ buildPythonApplication rec {
       hash = "sha256-yq+/QHCkhAkFND11MbKFiiWT3oF1cHhgWj5JkYjwuY0=";
       revert = true;
     })
+    ./builder-prioritize-python-env-in-path.patch
   ];
 
   postPatch = ''
@@ -57,13 +58,14 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [
     installShellFiles
-    setuptools
     udevCheckHook
   ];
 
+  build-system = [ setuptools ];
+
   pythonRelaxDeps = true;
 
-  propagatedBuildInputs = [
+  dependencies = [
     aiofiles
     ajsonrpc
     bottle
@@ -71,10 +73,13 @@ buildPythonApplication rec {
     click-completion
     colorama
     git
+    intelhex
     lockfile
     marshmallow
+    pip
     pyelftools
     pyserial
+    pyyaml
     requests
     semantic-version
     setuptools
@@ -82,6 +87,7 @@ buildPythonApplication rec {
     starlette
     tabulate
     uvicorn
+    wheel
     wsproto
     zeroconf
   ]


### PR DESCRIPTION
This PR adds some of the additional `propagatedBuildInputs` that @Theaninova suggested [here](https://github.com/NixOS/nixpkgs/issues/227230#issuecomment-2996369093) to fix #227230 

It also includes a patch to adjust the PATH environment variable and forces the python-env version of Python to the front of the search order, see [here](https://github.com/NixOS/nixpkgs/issues/370611#issuecomment-2624576719). This fixes #370611

This has predominantly been tested with esphome.
Further testing against other esphome and non-esphome projects might be worthwhile.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
