### PR TITLE
libreswan: remove afranchuk as maintainer

### DIFF
--- a/pkgs/by-name/li/libreswan/package.nix
+++ b/pkgs/by-name/li/libreswan/package.nix
@@ -133,7 +133,6 @@ stdenv.mkDerivation rec {
       mpl20
     ];
     maintainers = with maintainers; [
-      afranchuk
       rnhmjoj
     ];
     mainProgram = "ipsec";


### PR DESCRIPTION
This removes afranchuk (me) as a maintainer of the libreswan package. I haven't used the package nor NixOS in almost a decade.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
