### PR TITLE
viskores: init at 1.0.0

### DIFF
--- a/pkgs/by-name/vi/viskores/package.nix
+++ b/pkgs/by-name/vi/viskores/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch2,
+  cmake,
+  ninja,
+  llvmPackages,
+  tbb,
+  mpi,
+  mpiSupport ? true,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "viskores";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "viskores";
+    repo = "viskores";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jKuDM/NPfbMIfNpDNsDpmXdKuVobsr3s9+iht1zBLvI=";
+  };
+
+  patches = [
+    # https://github.com/Viskores/viskores/pull/137
+    (fetchpatch2 {
+      url = "https://github.com/Viskores/viskores/commit/36bf609511adb5530e6952bc14daefeafdf4ab11.patch?full_index=1";
+      hash = "sha256-SKmgVZhkCk1/X17dLXZ8ceF9Pq1Kkc2sXuFdrvotsdo=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  propagatedBuildInputs =
+    [
+      tbb
+    ]
+    ++ lib.optional mpiSupport mpi
+    ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
+  cmakeFlags = [
+    (lib.cmakeBool "Viskores_ENABLE_OPENMP" true)
+    (lib.cmakeBool "Viskores_ENABLE_TBB" true)
+    (lib.cmakeBool "Viskores_ENABLE_MPI" mpiSupport)
+    (lib.cmakeBool "Viskores_USE_DEFAULT_TYPES_FOR_VTK" true)
+    (lib.cmakeFeature "Viskores_INSTALL_INCLUDE_DIR" "include")
+    (lib.cmakeFeature "Viskores_INSTALL_CONFIG_DIR" "lib/cmake/viskores")
+    (lib.cmakeFeature "Viskores_INSTALL_SHARE_DIR" "share/viskores")
+  ];
+
+  passthru.tests.cmake-config = testers.hasCmakeConfigModules {
+    moduleNames = [ "Viskores" ];
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Visualization library for many-threaded devices";
+    homepage = "https://github.com/Viskores/viskores";
+    changelog = "https://github.com/Viskores/viskores/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [ bsd3 ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+})


### PR DESCRIPTION
viskores: Visualization library for many-threaded devices

Homepage: https://github.com/Viskores/viskores

viskores is the external dependency of vtk. It has a custom license functionally very similar to BSD3 license despite that:
- Specific references to U.S. government contracts
- Slightly more legal boilerplate related to DOE labs
- Custom license, not OSI-approved but still permissive

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
