### PR TITLE
cgns: init at 4.5.0

### DIFF
--- a/pkgs/by-name/cg/cgns/package.nix
+++ b/pkgs/by-name/cg/cgns/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gfortran,
+  tk,
+  hdf5,
+  xorg,
+  libGLU,
+  withTools ? false,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cgns";
+  version = "4.5.0";
+
+  src = fetchFromGitHub {
+    owner = "cgns";
+    repo = "cgns";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lPbXIC+O4hTtacxUcyNjZUWpEwo081MjEWhfIH3MWus=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/cgnstools/tkogl/tkogl.c \
+      --replace-fail "<tk-private/generic/tkInt.h>" "<tkInt.h>"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  buildInputs =
+    [
+      hdf5
+    ]
+    ++ lib.optionals withTools [
+      tk
+      xorg.libXmu
+      libGLU
+    ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CGNS_ENABLE_FORTRAN" true)
+    (lib.cmakeBool "CGNS_ENABLE_LEGACY" true)
+    (lib.cmakeBool "CGNS_ENABLE_HDF5" true)
+    (lib.cmakeBool "HDF5_NEED_MPI" hdf5.mpiSupport)
+    (lib.cmakeBool "CGNS_BUILD_CGNSTOOLS" withTools)
+    (lib.cmakeBool "CGNS_ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "CGNS_BUILD_SHARED" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  doCheck = true;
+
+  enableParallelChecking = false;
+
+  # Remove broken .desktop files
+  postFixup = ''
+    rm -f $out/bin/*.desktop
+  '';
+
+  passthru.tests.cmake-config = testers.hasCmakeConfigModules {
+    moduleNames = [ "cgns" ];
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "CFD General Notation System standard library";
+    homepage = "https://cgns.github.io";
+    downloadPage = "https://github.com/cgns/cgns";
+    changelog = "https://github.com/cgns/cgns/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [ zlib ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+})


### PR DESCRIPTION
cgns: CFD General Notation System standard library

downloadPage: https://github.com/cgns/cgns

external dependency of vtk. license borrowed from zlib.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
