### PR TITLE
opencv.passthru.tests.opencv4-tests: refactor and fix CUDA tests

### DIFF
--- a/pkgs/development/libraries/opencv/tests.nix
+++ b/pkgs/development/libraries/opencv/tests.nix
@@ -1,85 +1,131 @@
 {
-  opencv4,
-  testDataSrc,
-  stdenv,
-  lib,
-  runCommand,
-  gst_all_1,
-  runAccuracyTests,
-  runPerformanceTests,
   enableGStreamer,
   enableGtk2,
   enableGtk3,
+  gst_all_1,
+  lib,
+  opencv4,
+  runAccuracyTests,
+  runCommand,
+  runPerformanceTests,
+  stdenv,
+  testDataSrc,
+  writableTmpDirAsHomeHook,
   xvfb-run,
 }:
 let
-  testNames =
-    [
+  inherit (lib) getExe optionals optionalString;
+  inherit (opencv4.passthru) cudaSupport;
+  inherit (stdenv.hostPlatform) isAarch64 isDarwin;
+in
+runCommand "opencv4-tests"
+  {
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    nativeBuildInputs =
+      [ writableTmpDirAsHomeHook ]
+      ++ optionals enableGStreamer (
+        with gst_all_1;
+        [
+          gstreamer
+          gst-plugins-base
+          gst-plugins-good
+        ]
+      );
+
+    ignoredTests =
+      [
+        "AsyncAPICancelation/cancel*"
+        "Photo_CalibrateDebevec.regression"
+      ]
+      ++ optionals cudaSupport [
+        # opencv4-tests> /build/source/modules/photo/test/test_denoising.cuda.cpp:115: Failure
+        # opencv4-tests> The max difference between matrices "bgr_gold" and "dbgr" is 2 at (339, 486), which exceeds "1", where "bgr_gold" at (339, 486) evaluates to (182, 239, 239), "dbgr" at (339, 486) evaluates to (184, 239, 239), "1" evaluates to 1
+        # opencv4-tests> [  FAILED  ] CUDA_FastNonLocalMeans.Regression (48 ms)
+        "CUDA_FastNonLocalMeans.Regression"
+      ];
+
+    inherit runAccuracyTests;
+
+    accuracyTestNames =
+      [
+        "calib3d"
+        "core"
+        "features2d"
+        "flann"
+        "imgcodecs"
+        "imgproc"
+        "ml"
+        "objdetect"
+        "photo"
+        "stitching"
+        "video"
+        #"videoio" # - a lot of GStreamer warnings and failed tests
+        #"dnn" #- some caffe tests failed, probably because github workflow also downloads additional models
+      ]
+      ++ optionals (!isAarch64 && enableGStreamer) [ "gapi" ]
+      ++ optionals (enableGtk2 || enableGtk3) [ "highgui" ];
+
+    inherit runPerformanceTests;
+
+    performanceTestNames = [
       "calib3d"
       "core"
       "features2d"
-      "flann"
       "imgcodecs"
       "imgproc"
-      "ml"
       "objdetect"
       "photo"
       "stitching"
       "video"
-      #"videoio" # - a lot of GStreamer warnings and failed tests
-      #"dnn" #- some caffe tests failed, probably because github workflow also downloads additional models
-    ]
-    ++ lib.optionals (!stdenv.hostPlatform.isAarch64 && enableGStreamer) [ "gapi" ]
-    ++ lib.optionals (enableGtk2 || enableGtk3) [ "highgui" ];
-  perfTestNames = [
-    "calib3d"
-    "core"
-    "features2d"
-    "imgcodecs"
-    "imgproc"
-    "objdetect"
-    "photo"
-    "stitching"
-    "video"
-  ] ++ lib.optionals (!stdenv.hostPlatform.isAarch64 && enableGStreamer) [ "gapi" ];
-  testRunner = lib.optionalString (!stdenv.hostPlatform.isDarwin) "${lib.getExe xvfb-run} -a ";
-  testsPreparation = ''
-    touch $out
+    ] ++ optionals (!isAarch64 && enableGStreamer) [ "gapi" ];
+
+    testRunner = optionalString (!isDarwin) "${getExe xvfb-run} -a ";
+
+    requiredSystemFeatures = optionals cudaSupport [ "cuda" ];
+  }
+  ''
+    set -euo pipefail
+
     # several tests want a write access, so we have to copy files
-    tmpPath="$(mktemp -d "/tmp/opencv_extra_XXXXXX")"
-    cp -R ${testDataSrc} $tmpPath/opencv_extra
-    chmod -R +w $tmpPath/opencv_extra
-    export OPENCV_TEST_DATA_PATH="$tmpPath/opencv_extra/testdata"
+    nixLog "Preparing test data"
+    cp -R "${testDataSrc}" "$HOME/opencv_extra"
+    chmod -R +w "$HOME/opencv_extra"
+    export OPENCV_TEST_DATA_PATH="$HOME/opencv_extra/testdata"
     export OPENCV_SAMPLES_DATA_PATH="${opencv4.package_tests}/samples/data"
 
     # ignored tests because of gtest error - "Test code is not available due to compilation error with GCC 11"
     # ignore test due to numerical instability
-    export GTEST_FILTER="-AsyncAPICancelation/cancel*:Photo_CalibrateDebevec.regression"
-  '';
-  accuracyTests = lib.optionalString runAccuracyTests ''
-    ${builtins.concatStringsSep "\n" (
-      map (
-        test:
-        "${testRunner}${opencv4.package_tests}/opencv_test_${test} --test_threads=$NIX_BUILD_CORES --gtest_filter=$GTEST_FILTER"
-      ) testNames
-    )}
-  '';
-  performanceTests = lib.optionalString runPerformanceTests ''
-    ${builtins.concatStringsSep "\n" (
-      map (
-        test:
-        "${testRunner}${opencv4.package_tests}/opencv_perf_${test} --perf_impl=plain --perf_min_samples=10 --perf_force_samples=10 --perf_verify_sanity --skip_unstable=1 --gtest_filter=$GTEST_FILTER"
-      ) perfTestNames
-    )}
-  '';
-in
-runCommand "opencv4-tests" {
-  nativeBuildInputs = lib.optionals enableGStreamer (
-    with gst_all_1;
-    [
-      gstreamer
-      gst-plugins-base
-      gst-plugins-good
-    ]
-  );
-} (testsPreparation + accuracyTests + performanceTests)
+    if [[ -n ''${ignoredTests+x} ]]; then
+      export GTEST_FILTER="-$(concatStringsSep ":" ignoredTests)"
+      nixLog "Using GTEST_FILTER: $GTEST_FILTER"
+    fi
+
+    if [[ -n $runAccuracyTests ]]; then
+      nixLog "Running accuracy tests"
+      for testName in "''${accuracyTestNames[@]}"; do
+        nixLog "Running accuracy test: $testName"
+        ''${testRunner}${opencv4.package_tests}/opencv_test_''${testName} \
+          --test_threads=$NIX_BUILD_CORES
+      done
+      nixLog "Finished running accuracy tests"
+    fi
+
+    if [[ -n $runPerformanceTests ]]; then
+      nixLog "Running performance tests"
+      for testName in "''${performanceTestNames[@]}"; do
+        nixLog "Running performance test: $testName"
+        ''${testRunner}${opencv4.package_tests}/opencv_perf_''${testName} \
+          --perf_impl=plain \
+          --perf_min_samples=10 \
+          --perf_force_samples=10 \
+          --perf_verify_sanity \
+          --skip_unstable=1
+      done
+      nixLog "Finished running performance tests"
+    fi
+
+    nixLog "Finished running tests"
+    touch "$out"
+  ''


### PR DESCRIPTION
Refactors the OpenCV tests to reduce the amount of templating necessary through `__structuredAttrs`.

Enables running tests with CUDA support on NixOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
