### PR TITLE
lib/types.nix: implement getSubOptions for either

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1439,6 +1439,9 @@ let
       # Either value of type `t1` or `t2`.
       either =
         t1: t2:
+        let
+          isEitherOrSubmodule = t: t.name == "either" || t.name == "submodule";
+        in
         mkOptionType rec {
           name = "either";
           description =
@@ -1520,6 +1523,32 @@ let
               t2
             ];
           };
+          # We have to be really careful of recursively-defined types here. either is the type used
+          # to allow finitely-sized values for recursively-defined types, so we have to put limits
+          # on how we recurse when looking for submodules. To that end, we'll look for submodule
+          # children, and only recurse into either itself. This means `either str submodule` will
+          # work, and `either str (attrsOf submodule)` won't, but that's better than nothing.
+          getSubOptions =
+            prefix:
+            lib.recursiveUpdateUntil
+              (
+                _: a: b:
+                lib.isOption a || lib.isOption b
+              )
+              (optionalAttrs (isEitherOrSubmodule t2) (t2.getSubOptions prefix))
+              (optionalAttrs (isEitherOrSubmodule t1) (t1.getSubOptions prefix));
+          getSubModules =
+            let
+              t1sm = if isEitherOrSubmodule t1 then t1.getSubModules else null;
+              t2sm = if isEitherOrSubmodule t2 then t2.getSubModules else null;
+            in
+            if t1sm == null then t2sm else t1sm;
+          substSubModules =
+            m:
+            let
+              t1sm = if isEitherOrSubmodule t1 then t1.getSubModules else null;
+            in
+            if t1sm == null then either t1 (t2.substSubModules m) else either (t1.substSubModules m) t2;
           nestedTypes.left = t1;
           nestedTypes.right = t2;
         };

--- a/nixos/modules/programs/dconf.nix
+++ b/nixos/modules/programs/dconf.nix
@@ -122,7 +122,7 @@ let
           type = attrs;
           default = { };
           description = "An attrset used to generate dconf keyfile.";
-          example = literalExpression ''
+          example = lib.literalExpression ''
             with lib.gvariant;
             {
               "com/raggesilver/BlackBox" = {
@@ -139,7 +139,7 @@ let
             A list of dconf keys to be lockdown. This doesn't take effect if `lockAll`
             is set.
           '';
-          example = literalExpression ''
+          example = lib.literalExpression ''
             [ "/org/gnome/desktop/background/picture-uri" ]
           '';
         };

--- a/nixos/modules/programs/pay-respects.nix
+++ b/nixos/modules/programs/pay-respects.nix
@@ -143,6 +143,7 @@ in
             };
             locale = mkOption {
               default = toLower (replaceStrings [ "_" ] [ "-" ] (substring 0 5 config.i18n.defaultLocale));
+              defaultText = literalExpression ''toLower (replaceStrings [ "_" ] [ "-" ] (substring 0 5 config.i18n.defaultLocale))'';
               example = "nl-be";
               type = str;
               description = ''

--- a/nixos/modules/services/backup/libvirtd-autosnapshot.nix
+++ b/nixos/modules/services/backup/libvirtd-autosnapshot.nix
@@ -185,7 +185,7 @@ in
                     default = null;
                     description = ''
                       Type of snapshot to create (internal or external).
-                      If not specified, uses global snapshotType (${toString cfg.snapshotType}).
+                      If not specified, uses global snapshotType.
                     '';
                   };
                   keep = lib.mkOption {
@@ -193,7 +193,7 @@ in
                     default = null;
                     description = ''
                       Number of snapshots to keep for this VM.
-                      If not specified, uses global keep (${toString cfg.keep}).
+                      If not specified, uses global keep.
                     '';
                   };
                 };

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -33,11 +33,13 @@ let
         owner = mkOption {
           type = types.str;
           default = "${cfg.user}";
+          defaultText = literalExpression "config.services.rspamd.user";
           description = "Owner to set on unix socket";
         };
         group = mkOption {
           type = types.str;
           default = "${cfg.group}";
+          defaultText = literalExpression "config.services.rspamd.group";
           description = "Group to set on unix socket";
         };
         rawEntry = mkOption {

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -91,6 +91,9 @@ let
         (enum [ "auto" ])
       ]);
     default = null;
+    description = ''
+      Port number or "auto".
+    '';
   };
   optionPorts =
     optionName:
@@ -114,6 +117,7 @@ let
             SessionGroup = lib.mkOption {
               type = nullOr int;
               default = null;
+              description = descriptionGeneric "SocksPort";
             };
           }
           // lib.genAttrs isolateFlags (
@@ -121,6 +125,7 @@ let
             lib.mkOption {
               type = types.bool;
               default = false;
+              description = descriptionGeneric "SocksPort";
             }
           );
           config = {
@@ -183,6 +188,7 @@ let
             SessionGroup = lib.mkOption {
               type = nullOr int;
               default = null;
+              description = descriptionGeneric "SocksPort";
             };
           }
           // lib.genAttrs flags (
@@ -190,6 +196,7 @@ let
             lib.mkOption {
               type = types.bool;
               default = false;
+              description = descriptionGeneric "SocksPort";
             }
           );
           config = lib.mkIf doConfig {
@@ -204,6 +211,7 @@ let
   optionFlags = lib.mkOption {
     type = with lib.types; listOf str;
     default = [ ];
+    internal = true;
   };
   optionORPort =
     optionName:
@@ -239,6 +247,7 @@ let
                   lib.mkOption {
                     type = types.bool;
                     default = false;
+                    description = descriptionGeneric "ORPort";
                   }
                 );
                 config = {
@@ -727,7 +736,9 @@ in
                         { ... }:
                         {
                           options = {
-                            port = optionPort;
+                            port = optionPort // {
+                              description = "Virtual port number.";
+                            };
                             target = lib.mkOption {
                               default = null;
                               type = nullOr (
@@ -737,11 +748,14 @@ in
                                     options = {
                                       unix = optionUnix;
                                       addr = optionAddress;
-                                      port = optionPort;
+                                      port = optionPort // {
+                                        description = "Port number."; # we shouldn't accept auto here
+                                      };
                                     };
                                   }
                                 )
                               );
+                              description = descriptionGeneric "HiddenServicePort";
                             };
                           };
                         }
@@ -924,6 +938,7 @@ in
                         lib.mkOption {
                           type = types.bool;
                           default = false;
+                          description = descriptionGeneric "ControlPort";
                         }
                       );
                       config = {

--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -295,11 +295,12 @@ in
                     };
                   };
                 };
+                description = "Script minification options";
               };
               style = mkOption {
                 type = types.submodule {
                   options = {
-                    enable = mkEnableOption "Script minification via Lightning CSS";
+                    enable = mkEnableOption "Style minification via Lightning CSS";
                     target = mkOption {
                       type = types.nullOr types.nonEmptyStr;
                       default = null;
@@ -311,6 +312,7 @@ in
                     };
                   };
                 };
+                description = "Style minification options";
               };
               svg = mkOption {
                 type = types.submodule {
@@ -318,6 +320,7 @@ in
                     enable = mkEnableOption "SVG minification via Scour";
                   };
                 };
+                description = "SVG minification options";
               };
             };
           }


### PR DESCRIPTION
This implements `getSubOptions`, `getSubModules`, and `substSubModules` for the `either` type. This allows us to generate documentation for a bunch of options that were getting missed before.

Because `either` is the key to making recursive types, I had to be careful about the implementation here to avoid breaking on a type like `(pkgs.formats.json {}).type`. To that end, this implementation only looks at child types if they're `submodule` or another `either`. This does mean types like `either str (listOf submodule)` will still be missed, but I'm not sure how else to handle this besides recursively searching all nested types to see if any are equal (`==`) to the current type, and I don't like that solution. I also considered simply stopping on `attrsOf` and `listOf` and allowing other children (this would allow e.g. `either str (nullOr submodule)`) but I thought that was sufficiently fragile. And I considered looking for any recursively-defined type in nixpkgs and overriding `getSubOptions`/`getSubModules` explicitly, but that would mean types defined outside of nixpkgs could still be broken by this.

For the case of `either submodule submodule` I decided that `getSubOptions` should merge all returned options, but `getSubModules` and `substSubModules` should ensure only one child actually has submodules. I don't expect this to matter because a type like that isn't really going to work, this logic makes more sense for something like `either submodule (attrsOf submodule)` except for the fact that we won't recurse into the `attrsOf` (to avoid problems on recursive types).

With this change, I found a number of options whose documentation were missing or broken. Fixes for each of those modules are included as separate commits. Most of them were pretty straightforward, but the `tor` module had a lot of generated options and it wasn't always clear what the best way to handle it was.

I tested this with `nix-build nixos/release.nix -A manual.aarch64-linux`, I'm not sure if there's any other documentation set that I should have tested too. I also didn't touch the lib tests, I'm not sure if this change should have an explicit test written for it, but I did make sure `lib/tests/modules.sh` passes. I'm also not sure if this change warrants a release note.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
