### PR TITLE
hostname-debian: set main program and use in more places

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -832,7 +832,7 @@ in
           pkgs.gawk
           pkgs.gnugrep
           pkgs.gnused
-          pkgs.nettools
+          pkgs.hostname-debian
           pkgs.util-linux
         ];
       };

--- a/nixos/modules/virtualisation/ec2-data.nix
+++ b/nixos/modules/virtualisation/ec2-data.nix
@@ -34,7 +34,7 @@ with lib;
         ${optionalString (config.networking.hostName == "") ''
           echo "setting host name..."
           if [ -s /etc/ec2-metadata/hostname ]; then
-              ${pkgs.nettools}/bin/hostname $(cat /etc/ec2-metadata/hostname)
+              ${lib.getExe hostname-debian} -F /etc/ec2-metadata/hostname
           fi
         ''}
 

--- a/pkgs/by-name/ho/hostname-debian/package.nix
+++ b/pkgs/by-name/ho/hostname-debian/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://tracker.debian.org/pkg/hostname";
     license = licenses.gpl2Plus;
+    mainProgram = "hostname";
     maintainers = with maintainers; [ posch ];
     platforms = platforms.gnu;
   };

--- a/pkgs/by-name/ho/hostname-debian/package.nix
+++ b/pkgs/by-name/ho/hostname-debian/package.nix
@@ -1,27 +1,32 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  fetchFromGitLab,
 }:
 
 stdenv.mkDerivation rec {
   pname = "hostname-debian";
-  version = "3.23";
+  version = "3.25";
 
-  src = fetchurl {
-    url = "https://deb.debian.org/debian/pool/main/h/hostname/hostname_${version}.tar.gz";
-    sha256 = "sha256-vG0ZVLIoSYaf+LKmAuOfCLFwL2htS1jdeSfN61tIdu8=";
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "meskes";
+    repo = "hostname";
+    tag = "debian/${version}";
+    hash = "sha256-Yq8P5bF/RRZnWuFW0y2u08oZrydAKfopOtbrwbeIu3w=";
   };
 
-  postPatch = ''
-    substituteInPlace Makefile --replace 'install -o root -g root' 'install'
-  '';
   makeFlags = [
-    "BINDIR=$(out)/bin"
-    "MANDIR=$(out)/share/man"
+    "prefix=${placeholder "out"}"
   ];
 
   meta = with lib; {
+    changelog = "https://salsa.debian.org/meskes/hostname/-/blob/${src.tag}/debian/changelog";
     description = "Utility to set/show the host name or domain name";
     longDescription = ''
       This package provides commands which can be used to display the system's

--- a/pkgs/by-name/xd/xdg-utils/package.nix
+++ b/pkgs/by-name/xd/xdg-utils/package.nix
@@ -21,8 +21,8 @@
   glib,
   gnugrep,
   gnused,
+  hostname-debian,
   jq,
-  nettools,
   procps,
   which,
   xdg-user-dirs,
@@ -166,7 +166,7 @@ let
       scripts = [ "bin/xdg-open" ];
       interpreter = "${bash}/bin/bash";
       inputs = commonDeps ++ [
-        nettools
+        hostname-debian
         glib.bin
         "${placeholder "out"}/bin"
       ];
@@ -206,7 +206,7 @@ let
       scripts = [ "bin/xdg-screensaver" ];
       interpreter = "${bash}/bin/bash";
       inputs = commonDeps ++ [
-        nettools
+        hostname-debian
         perl
         procps
       ];

--- a/pkgs/by-name/xd/xdg-utils/package.nix
+++ b/pkgs/by-name/xd/xdg-utils/package.nix
@@ -340,7 +340,6 @@ stdenv.mkDerivation (self: {
         preferLocalBuild = true;
         xenias = lib.mapAttrsToList (hash: urls: fetchurl { inherit hash urls; }) {
           "sha256-SL95tM1AjOi7vDnCyT10s0tvQvc+ZSZBbkNOYXfbOy0=" = [
-            "https://staging.cohostcdn.org/attachment/0f5d9832-0cda-4d07-b35f-832b287feb6c/kernelkisser.png"
             "https://static1.e621.net/data/0e/76/0e7672980d48e48c2d1373eb2505db5a.png"
           ];
           "sha256-Si9AtB7J9o6rK/oftv+saST77CNaeWomWU5ECfbRioM=" = [


### PR DESCRIPTION
The debian hostname utility is a small replacement for the version from net-tools. The net-tools suite has been badly maintained since at least a decade, so we should phase out its use.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
