### PR TITLE
nixos/bookstack: Updated to accommodate passwordless login for mysql & Module now creates themes directory; nixosTests.bookstack: Updated to also test passwordless login for mysql; bookstack: Changed to allow themes directory to be writable

### DIFF
--- a/nixos/tests/bookstack.nix
+++ b/nixos/tests/bookstack.nix
@@ -1,12 +1,14 @@
 { pkgs, ... }:
 
 let
-  db-pass = "Test2Test2";
   app-key = "TestTestTestTestTestTestTestTest";
 in
 {
   name = "bookstack";
-  meta.maintainers = [ pkgs.lib.maintainers.savyajha ];
+  meta = {
+    maintainers = [ pkgs.lib.maintainers.savyajha ];
+    platforms = pkgs.lib.platforms.linux;
+  };
 
   nodes.bookstackMysql = {
     services.bookstack = {
@@ -19,7 +21,6 @@ in
         SITE_OWNER = "mail@example.com";
         DB_DATABASE = "bookstack";
         DB_USERNAME = "bookstack";
-        DB_PASSWORD_FILE = pkgs.writeText "mysql-pass" db-pass;
         DB_SOCKET = "/run/mysqld/mysqld.sock";
       };
     };
@@ -27,12 +28,18 @@ in
     services.mysql = {
       enable = true;
       package = pkgs.mariadb;
-      initialScript = pkgs.writeText "bookstack-init.sql" ''
-        create database bookstack DEFAULT CHARACTER SET utf8mb4;
-        create user 'bookstack'@'localhost' identified by '${db-pass}';
-        grant all on bookstack.* to 'bookstack'@'localhost';
-      '';
       settings.mysqld.character-set-server = "utf8mb4";
+      ensureDatabases = [
+        "bookstack"
+      ];
+      ensureUsers = [
+        {
+          name = "bookstack";
+          ensurePermissions = {
+            "bookstack.*" = "ALL PRIVILEGES";
+          };
+        }
+      ];
     };
   };
 

--- a/pkgs/by-name/bo/bookstack/package.nix
+++ b/pkgs/by-name/bo/bookstack/package.nix
@@ -27,10 +27,11 @@ php83.buildComposerProject2 (finalAttrs: {
   postInstall = ''
     chmod -R u+w $out/share
     mv $out/share/php/bookstack/* $out
-    rm -R $out/share $out/storage $out/bootstrap/cache $out/public/uploads
+    rm -R $out/share $out/storage $out/bootstrap/cache $out/public/uploads $out/themes
     ln -s ${dataDir}/storage $out/storage
     ln -s ${dataDir}/cache $out/bootstrap/cache
     ln -s ${dataDir}/public/uploads $out/public/uploads
+    ln -s ${dataDir}/themes $out/themes
   '';
 
   meta = {


### PR DESCRIPTION
Changed the bookstack module so that one does not need to use a password file for db auth and changed the test to test for this use case working.

In response to https://github.com/NixOS/nixpkgs/issues/422234

@HritwikSinghal 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
