### PR TITLE
c99sh: init at 1.1.1

### DIFF
--- a/pkgs/by-name/c9/c99sh/package.nix
+++ b/pkgs/by-name/c9/c99sh/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  patsh,
+  bashNonInteractive,
+  pkg-config,
+  gcc,
+  gsl,
+  targetPackages,
+  cc ? targetPackages.stdenv.cc,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "c99sh";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "RhysU";
+    repo = "c99sh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nLq6J1PRROTOSvScyyXUqwtj10MEfQCHC8YYNd+JxkA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ patsh ];
+
+  # Used by `patsh`
+  buildInputs = [
+    bashNonInteractive
+    pkg-config
+  ];
+
+  postPatch = ''
+    patsh c99sh \
+      --force --store-dir ${builtins.storeDir} --path "$HOST_PATH"
+
+    patchShebangs .
+
+    substituteInPlace c99sh \
+      --replace-fail -cc -${lib.getExe' cc "cc"} \
+      --replace-fail -c++ -${lib.getExe' cc "c++"}
+  '';
+
+  # FIXME: `patchShebangs` doesn't function in cross-builds
+  doCheck = !stdenvNoCC.hostPlatform.isDarwin;
+
+  nativeCheckInputs = [
+    pkg-config
+    gcc
+  ];
+
+  checkInputs = [ gsl ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    ./tests
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir --parents $out/bin
+    cp --no-dereference c*sh $out/bin # c11sh and cxxsh
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Shebang-friendly script for \"interpreting\" C files";
+    longDescription = ''
+      Shebang-friendly script for \"interpreting\" single C99, C11,
+      and C++ files, including rcfile support
+    '';
+    homepage = "https://github.com/RhysU/c99sh";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "c99sh";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
[c99sh](https://github.com/RhysU/c99sh) is a shebang-friendly script for "interpreting" single C99, C11, and C++ files, including rcfile support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- ~~[Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)~~
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
- ~~[NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)~~
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
