### PR TITLE
wireguard-go: clean up, use versionCheckHook

### DIFF
--- a/pkgs/by-name/wi/wireguard-go/package.nix
+++ b/pkgs/by-name/wi/wireguard-go/package.nix
@@ -1,70 +1,65 @@
 {
   lib,
   buildGoModule,
-  fetchzip,
+  fetchgit,
   testers,
   wireguard-go,
 }:
 
-buildGoModule (
-  finalAttrs:
-  let
-    version = "0.0.20250522";
-  in
-  {
-    pname = "wireguard-go";
-    inherit version;
+buildGoModule (finalAttrs: {
+  pname = "wireguard-go";
+  version = "0.0.20250522";
 
-    src = fetchzip {
-      url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${version}.tar.xz";
-      hash = "sha256-GRr8NKKb4SHd0WxmNL84eiofFHcauDDmSyNNrXermcA=";
-    };
+  src = fetchgit {
+    url = "https://git.zx2c4.com/wireguard-go";
+    tag = finalAttrs.version;
+    hash = "sha256-GRr8NKKb4SHd0WxmNL84eiofFHcauDDmSyNNrXermcA=";
+  };
 
-    postPatch = ''
-      # Skip formatting tests
-      rm -f format_test.go
-    '';
+  postPatch = ''
+    # Skip formatting tests
+    rm -f format_test.go
+  '';
 
-    vendorHash = "sha256-sCajxTV26jjlmgmbV4GG6hg9NkLGS773ZbFyKucvuBE=";
+  vendorHash = "sha256-sCajxTV26jjlmgmbV4GG6hg9NkLGS773ZbFyKucvuBE=";
 
-    subPackages = [ "." ];
+  subPackages = [ "." ];
 
-    ldflags = [ "-s" ];
+  ldflags = [ "-s" ];
 
-    # No tests besides the formatting one are in root.
-    # We can't override subPackages per-phase (and we don't
-    # want to needlessly build packages that have build
-    # constraints), so just use the upstream Makefile (that
-    # runs `go test ./...`) to actually run the tests.
-    checkPhase = ''
-      runHook preCheck
-      export GOFLAGS=''${GOFLAGS//-trimpath/}
-      make test
-      runHook postCheck
-    '';
+  # No tests besides the formatting one are in root.
+  # We can't override subPackages per-phase (and we don't
+  # want to needlessly build packages that have build
+  # constraints), so just use the upstream Makefile (that
+  # runs `go test ./...`) to actually run the tests.
+  checkPhase = ''
+    runHook preCheck
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+    make test
+    runHook postCheck
+  '';
 
-    # Tests require networking.
-    __darwinAllowLocalNetworking = finalAttrs.doCheck;
+  # Tests require networking.
+  __darwinAllowLocalNetworking = finalAttrs.doCheck;
 
-    postInstall = ''
-      mv $out/bin/wireguard $out/bin/wireguard-go
-    '';
+  postInstall = ''
+    mv $out/bin/wireguard $out/bin/wireguard-go
+  '';
 
-    passthru.tests.version = testers.testVersion {
-      package = wireguard-go;
-      version = "v${version}";
-    };
+  passthru.tests.version = testers.testVersion {
+    package = wireguard-go;
+    version = "v${finalAttrs.version}";
+  };
 
-    meta = {
-      description = "Userspace Go implementation of WireGuard";
-      homepage = "https://git.zx2c4.com/wireguard-go/about/";
-      license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [
-        kirelagin
-        winter
-        zx2c4
-      ];
-      mainProgram = "wireguard-go";
-    };
-  }
-)
+  meta = {
+    description = "Userspace Go implementation of WireGuard";
+    homepage = "https://git.zx2c4.com/wireguard-go/about/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kirelagin
+      winter
+      zx2c4
+    ];
+    mainProgram = "wireguard-go";
+  };
+})

--- a/pkgs/by-name/wi/wireguard-go/package.nix
+++ b/pkgs/by-name/wi/wireguard-go/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildGoModule,
   fetchgit,
-  testers,
-  wireguard-go,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -46,10 +45,8 @@ buildGoModule (finalAttrs: {
     mv $out/bin/wireguard $out/bin/wireguard-go
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = wireguard-go;
-    version = "v${finalAttrs.version}";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Userspace Go implementation of WireGuard";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
