### PR TITLE
quiet: 5.1.2 -> 6.0.0; add darwin support

### DIFF
--- a/pkgs/by-name/qu/quiet/package.nix
+++ b/pkgs/by-name/qu/quiet/package.nix
@@ -3,16 +3,13 @@
   stdenv,
   fetchurl,
   appimageTools,
+  makeWrapper,
+  _7zz,
 }:
 
-appimageTools.wrapType2 rec {
+let
   pname = "quiet";
   version = "5.1.2";
-
-  src = fetchurl {
-    url = "https://github.com/TryQuiet/quiet/releases/download/@quiet/desktop@${version}/Quiet-${version}.AppImage";
-    hash = "sha256-ahJUBvQVfU8CtGq5p+S8avpHRkXSn9kQv9HPN7TvJiM=";
-  };
 
   meta = {
     description = "Private, p2p alternative to Slack and Discord built on Tor & IPFS";
@@ -20,6 +17,57 @@ appimageTools.wrapType2 rec {
     changelog = "https://github.com/TryQuiet/quiet/releases/tag/@quiet/desktop@${version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ kashw2 ];
-    platforms = [ "x86_64-linux" ];
   };
-}
+
+  linux = appimageTools.wrapType2 {
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://github.com/TryQuiet/quiet/releases/download/@quiet/desktop@${version}/Quiet-${version}.AppImage";
+      hash = "sha256-YIkbS3L6DIof9gsgHKaguHIwGggVLjQXPM8o7810Wgs=";
+    };
+
+    meta = meta // {
+      platforms = lib.platforms.linux;
+    };
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://github.com/TryQuiet/quiet/releases/download/@quiet/desktop@${version}/Quiet-${version}.dmg";
+      hash = "sha256-B1rT+6U0gjScr1FPuh3xGxkpfumT/8feTJbEbCgXPpo=";
+    };
+
+    nativeBuildInputs = [
+      _7zz
+      makeWrapper
+    ];
+
+    sourceRoot = "Quiet ${version}";
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      7zz x $src -x!Quiet\ ${version}/Applications
+
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstallPhase
+
+      mkdir -p $out/{Applications,bin}
+      mv Quiet.app $out/Applications
+      makeWrapper $out/Applications/Quiet.app/Contents/MacOS/Quiet $out/bin/${pname}
+
+      runHook postInstallPhase
+    '';
+
+    meta = meta // {
+      platforms = lib.platforms.darwin;
+    };
+  };
+in
+if stdenv.hostPlatform.isDarwin then darwin else linux

--- a/pkgs/by-name/qu/quiet/package.nix
+++ b/pkgs/by-name/qu/quiet/package.nix
@@ -9,7 +9,7 @@
 
 let
   pname = "quiet";
-  version = "5.1.2";
+  version = "6.0.0";
 
   meta = {
     description = "Private, p2p alternative to Slack and Discord built on Tor & IPFS";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

supersedes: https://github.com/NixOS/nixpkgs/pull/421655

Built against aarch64-darwin, x86_64-darwin and x86_64-linux and ran as expected on x86_64-linux. I've also run this on my M1 Mac Mini (has rosetta installed) and the application ran as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
