### PR TITLE
assimp: 5.4.3 -> 6.0.2, modernize

### DIFF
--- a/pkgs/by-name/as/assimp/package.nix
+++ b/pkgs/by-name/as/assimp/package.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "assimp";
-  version = "5.4.3";
+  version = "6.0.2";
   outputs = [
     "out"
     "lib"
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "assimp";
     repo = "assimp";
     rev = "v${version}";
-    hash = "sha256-sOYhYHBz3Tg+pi1OIJ1mGmsjEc6dPO6nFH0aolfpLRA=";
+    hash = "sha256-ixtqK+3iiL17GEbEVHz5S6+gJDDQP7bVuSfRMJMGEOY=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -28,11 +28,6 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [ "-DASSIMP_BUILD_ASSIMP_TOOLS=ON" ];
-
-  env.NIX_CFLAGS_COMPILE = toString ([
-    # Needed with GCC 12
-    "-Wno-error=array-bounds"
-  ]);
 
   meta = with lib; {
     description = "Library to import various 3D model formats";

--- a/pkgs/by-name/as/assimp/package.nix
+++ b/pkgs/by-name/as/assimp/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "assimp";
     homepage = "https://www.assimp.org/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ ehmry ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/development/libraries/qt-6/modules/qt3d.nix
+++ b/pkgs/development/libraries/qt-6/modules/qt3d.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   qtModule,
   qtbase,
   qtdeclarative,
@@ -8,10 +9,23 @@
 
 qtModule {
   pname = "qt3d";
+
+  # make absolutely sure the vendored assimp is not used
+  # patch cmake to accept assimp 6.x versions
+  postPatch = ''
+    rm -rf src/3rdparty/assimp/src
+    substituteInPlace src/core/configure.cmake --replace-fail "WrapQt3DAssimp 5" "WrapQt3DAssimp 6"
+  '';
+
   propagatedBuildInputs = [
     qtbase
     qtdeclarative
     qtmultimedia
     assimp
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "FEATURE_qt3d_system_assimp" true) # use nix assimp
+    (lib.cmakeBool "TEST_assimp" true) # required for internal cmake asserts
   ];
 }


### PR DESCRIPTION
## Release notes:
https://github.com/assimp/assimp/releases/tag/v6.0.2
https://github.com/assimp/assimp/releases/tag/v6.0.1
https://github.com/assimp/assimp/releases/tag/v6.0.0

## Security fixes:
CVE-2025-2751: https://github.com/advisories/GHSA-345v-qrhv-w227
CVE-2025-2757: https://github.com/advisories/GHSA-4p6w-747g-444c
CVE-2025-2750: https://github.com/advisories/GHSA-6x45-4j6r-r8x8
CVE-2025-3158: https://github.com/advisories/GHSA-6r79-vpvw-rfjj

## Supersedes:
https://github.com/NixOS/nixpkgs/pull/412783

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
