### PR TITLE
strictdoc: 0.0.58 -> 0.9.3

### DIFF
--- a/pkgs/by-name/st/strictdoc/package.nix
+++ b/pkgs/by-name/st/strictdoc/package.nix
@@ -6,41 +6,48 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "strictdoc";
-  version = "0.0.58";
+  version = "0.9.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "strictdoc-project";
     repo = "strictdoc";
     tag = version;
-    hash = "sha256-0X74Lv25pUdOUgQzqQU6p+fjuxhC/JqfKEFI7c5t67U=";
+    hash = "sha256-3bZfyjylNrCK2UFXgCoNI/LckSa8FkVWD/kBopFIbec=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     python3.pkgs.hatchling
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     beautifulsoup4
+    datauri
     docutils
     fastapi
     graphviz
+    html2pdf4doc
     html5lib
     jinja2
+    lark
     lxml
+    openpyxl
     pybtex
     pygments
-    datauri
     python-multipart
-    selenium
-    requests
-    spdx-tools
-    webdriver-manager
     reqif
+    requests
+    robotframework
+    selenium
     setuptools
+    spdx-tools
     textx
     toml
+    tree-sitter
+    tree-sitter-grammars.tree-sitter-cpp
+    tree-sitter-grammars.tree-sitter-python
     uvicorn
+    webdriver-manager
     websockets
     xlrd
     xlsxwriter
@@ -60,18 +67,16 @@ python3.pkgs.buildPythonApplication rec {
   pythonRelaxDeps = [
     "python-datauri"
     "xlsxwriter"
-    "lxml"
-    "textx"
   ];
 
   pythonImportsCheck = [ "strictdoc" ];
 
-  meta = with lib; {
+  meta = {
     description = "Software for technical documentation and requirements management";
     homepage = "https://github.com/strictdoc-project/strictdoc";
     changelog = "https://github.com/strictdoc-project/strictdoc/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ yuu ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ yuu ];
     mainProgram = "strictdoc";
   };
 }

--- a/pkgs/development/python-modules/html2pdf4doc/default.nix
+++ b/pkgs/development/python-modules/html2pdf4doc/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  requests,
+  selenium,
+  versionCheckHook,
+  webdriver-manager,
+}:
+
+buildPythonPackage rec {
+  pname = "html2pdf4doc";
+  version = "0.0.20";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mettta";
+    repo = "html2pdf4doc_python";
+    tag = version;
+    hash = "sha256-VFNM66NbApB6qrmK5j0MaqkD4Riwzo7Cy6XjPW6/4lc=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    requests
+    selenium
+    webdriver-manager
+  ];
+
+  pythonImportsCheck = [ "html2pdf4doc" ];
+
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "-v";
+
+  meta = {
+    description = "Print HTML to PDF in the Browser – Python Package for HTML2PDF.js";
+    homepage = "https://github.com/mettta/html2pdf4doc_python";
+    changelog = "https://github.com/mettta/html2pdf4doc_python/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ puzzlewolf ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6587,6 +6587,8 @@ self: super: with self; {
 
   html2image = callPackage ../development/python-modules/html2image { };
 
+  html2pdf4doc = callPackage ../development/python-modules/html2pdf4doc { };
+
   html2text = callPackage ../development/python-modules/html2text { };
 
   html5-parser = callPackage ../development/python-modules/html5-parser { };


### PR DESCRIPTION
Closes #418333 

Replaces #418354, thank you for your work, @emaryn!

Upstream made made the new dependency `html2pdf4doc` Apache 2.0 [now](https://github.com/strictdoc-project/html2pdf4doc_python/issues/40#issuecomment-3033654476), so we can update `strictdoc` without license shenanigans 🎉

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
