### PR TITLE
bpftools: Re-apply patch to fix build on powerpc64*

### DIFF
--- a/pkgs/by-name/bp/bpftools/include-asm-types-for-powerpc64.patch
+++ b/pkgs/by-name/bp/bpftools/include-asm-types-for-powerpc64.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -ruN a/tools/include/uapi/linux/types.h b/tools/include/uapi/linux/types.h
+--- a/tools/include/uapi/linux/types.h	2025-05-18 06:26:10.000000000 +0000
++++ b/tools/include/uapi/linux/types.h	2025-07-04 08:00:39.772748792 +0000
+@@ -2,7 +2,7 @@
+ #ifndef _UAPI_LINUX_TYPES_H
+ #define _UAPI_LINUX_TYPES_H
+ 
+-#include <asm-generic/int-ll64.h>
++#include <asm/types.h>
+ 
+ /* copied from linux:include/uapi/linux/types.h */
+ #define __bitwise

--- a/pkgs/by-name/bp/bpftools/package.nix
+++ b/pkgs/by-name/bp/bpftools/package.nix
@@ -22,6 +22,12 @@ stdenv.mkDerivation rec {
 
   separateDebugInfo = true;
 
+  patches = [
+    # fix unknown type name '__vector128' on powerpc64*
+    # https://www.spinics.net/lists/bpf/msg28613.html
+    ./include-asm-types-for-powerpc64.patch
+  ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [
     python3


### PR DESCRIPTION
Patch was previously added in https://github.com/NixOS/nixpkgs/pull/198587, and removed in https://github.com/NixOS/nixpkgs/pull/380729 (CC @wolfgangwalther). It still seems necessary for building the debugger.

Previously, it only indicated that it was necessary for powerpc64le, but I've run into this on powerpc64 as well now.

```
  CC      bpf_dbg.o
In file included from /nix/store/zdsdr1j59by3ab1ryvqkx5kpdz30g7k2-glibc-2.40-66-dev/include/asm/sigcontext.h:14,
                 from /nix/store/zdsdr1j59by3ab1ryvqkx5kpdz30g7k2-glibc-2.40-66-dev/include/bits/sigcontext.h:30,
                 from /nix/store/zdsdr1j59by3ab1ryvqkx5kpdz30g7k2-glibc-2.40-66-dev/include/signal.h:301,
                 from /build/linux-6.14.7/tools/bpf/bpf_dbg.c:51:
/nix/store/zdsdr1j59by3ab1ryvqkx5kpdz30g7k2-glibc-2.40-66-dev/include/asm/elf.h:162:9: error: unknown type name '__vector128'; did you mean '__vector_quad'?
  162 | typedef __vector128 elf_vrreg_t;
      |         ^~~~~~~~~~~
      |         __vector_quad
make: *** [Makefile:64: bpf_dbg.o] Error 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] powerpc64-linux
  - [x] aarch64-linux (cross)
  - [x] riscv64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
