### PR TITLE
[Backport release-25.05] bikeshed: 5.1.2 -> 5.3.2; migrate to by-name

### DIFF
--- a/pkgs/applications/misc/bikeshed/default.nix
+++ b/pkgs/applications/misc/bikeshed/default.nix
@@ -102,6 +102,9 @@ buildPythonApplication rec {
     '';
     homepage = "https://tabatkins.github.io/bikeshed/";
     license = licenses.cc0;
-    maintainers = with lib.maintainers; [ hemera ];
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      hemera
+    ];
   };
 }

--- a/pkgs/applications/misc/bikeshed/default.nix
+++ b/pkgs/applications/misc/bikeshed/default.nix
@@ -10,6 +10,7 @@
   alive-progress,
   async-timeout,
   attrs,
+  cddlparser,
   certifi,
   charset-normalizer,
   cssselect,
@@ -38,12 +39,12 @@
 
 buildPythonApplication rec {
   pname = "bikeshed";
-  version = "5.1.2";
+  version = "5.2.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-QIADVcxgJreH2pvXRVIBE5p6nEEYZtTiSo00RrpFT+E=";
+    hash = "sha256-HUPkLEpwLRnrffUMN62WPqsZX2UsGqPfjEa91UMbUMM=";
   };
 
   build-system = [ setuptools ];
@@ -58,6 +59,7 @@ buildPythonApplication rec {
     alive-progress
     async-timeout
     attrs
+    cddlparser
     certifi
     charset-normalizer
     cssselect

--- a/pkgs/applications/misc/bikeshed/default.nix
+++ b/pkgs/applications/misc/bikeshed/default.nix
@@ -102,6 +102,6 @@ buildPythonApplication rec {
     '';
     homepage = "https://tabatkins.github.io/bikeshed/";
     license = licenses.cc0;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hemera ];
   };
 }

--- a/pkgs/by-name/bi/bikeshed/package.nix
+++ b/pkgs/by-name/bi/bikeshed/package.nix
@@ -6,12 +6,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "bikeshed";
-  version = "5.2.1";
+  version = "5.3.2";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-EMWIHtIomiq7BvnG6x0+gJeSkouWpZzcnqys5mSM7aI=";
+    hash = "sha256-+TY26g685eIMXUjTG876r9gryg/tR6EtMGWAhk2kkis=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/bi/bikeshed/package.nix
+++ b/pkgs/by-name/bi/bikeshed/package.nix
@@ -1,43 +1,10 @@
 {
   lib,
-  buildPythonApplication,
   fetchPypi,
-  # build inputs
-  about-time,
-  aiofiles,
-  aiohttp,
-  aiosignal,
-  alive-progress,
-  async-timeout,
-  attrs,
-  cddlparser,
-  certifi,
-  charset-normalizer,
-  cssselect,
-  frozenlist,
-  html5lib,
-  idna,
-  isodate,
-  json-home-client,
-  kdl-py,
-  lxml,
-  multidict,
-  pillow,
-  pygments,
-  requests,
-  result,
-  setuptools,
-  six,
-  tenacity,
-  typing-extensions,
-  uri-template,
-  urllib3,
-  webencodings,
-  widlparser,
-  yarl,
+  python3Packages,
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "bikeshed";
   version = "5.2.0";
   pyproject = true;
@@ -47,11 +14,11 @@ buildPythonApplication rec {
     hash = "sha256-HUPkLEpwLRnrffUMN62WPqsZX2UsGqPfjEa91UMbUMM=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ python3Packages.setuptools ];
 
   pythonRelaxDeps = true;
 
-  dependencies = [
+  dependencies = with python3Packages; [
     about-time
     aiofiles
     aiohttp

--- a/pkgs/by-name/bi/bikeshed/package.nix
+++ b/pkgs/by-name/bi/bikeshed/package.nix
@@ -6,12 +6,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "bikeshed";
-  version = "5.2.0";
+  version = "5.2.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-HUPkLEpwLRnrffUMN62WPqsZX2UsGqPfjEa91UMbUMM=";
+    hash = "sha256-EMWIHtIomiq7BvnG6x0+gJeSkouWpZzcnqys5mSM7aI=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1075,8 +1075,6 @@ with pkgs;
 
   auditwheel = with python3Packages; toPythonApplication auditwheel;
 
-  bikeshed = python3Packages.callPackage ../applications/misc/bikeshed { };
-
   davinci-resolve-studio = callPackage ../by-name/da/davinci-resolve/package.nix {
     studioVariant = true;
   };


### PR DESCRIPTION
Manual backport of #416063 #416066 #416288 #421687 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.