### PR TITLE
sysbar: init at 0-unstable-2025-05-02

### DIFF
--- a/pkgs/by-name/sy/sysbar/package.nix
+++ b/pkgs/by-name/sy/sysbar/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  makeWrapper,
+  pkg-config,
+
+  gtkmm4,
+  curl,
+  gtk4-layer-shell,
+  jsoncpp,
+  dbus,
+  wireplumber,
+  playerctl,
+  libnl,
+  wayland-scanner,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sysbar";
+  version = "0-unstable-2025-05-02";
+
+  src = fetchFromGitHub {
+    owner = "System64fumo";
+    repo = "sysbar";
+    rev = "7040925b06617aabd9f8837fd4f9370bd45ae4c8";
+    hash = "sha256-hWqzgWMcae8/SGcNZgpqF2dFPT5t6K4GHX2/apOxZHE=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtkmm4
+    curl
+    gtk4-layer-shell
+    jsoncpp
+    dbus
+    wireplumber
+    playerctl
+    libnl
+    wayland-scanner
+  ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${libnl.dev}/include/libnl3" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  # Wrap the sysbar binary to include its own lib directory in
+  # LD_LIBRARY_PATH.  Please see:
+  # https://github.com/System64fumo/sysbar/issues/6
+  postInstall = ''
+    wrapProgram $out/bin/sysbar \
+      --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath finalAttrs.buildInputs}"
+  '';
+
+  meta = {
+    description = "Modular status bar for wayland";
+    homepage = "https://github.com/System64fumo/sysbar";
+    license = lib.licenses.wtfpl;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "sysbar";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Resolves #375668

cc @Prince527GitHub for testing

Most of the things are working, except loading the default config, because `sysbar` hard codes default config to `/usr/share/` (it's doable, only cuz my skill issue...), which I don't believe is a big problem for initial testing since the user config can just override the system-wide config.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] ~x86_64-darwin~
  - [ ] ~aarch64-darwin~
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] ~`sandbox = relaxed`~
  - [ ] ~`sandbox = true`~
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] ~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] ~(Package updates) Added a release notes entry if the change is major or breaking~
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] ~(Module updates) Added a release notes entry if the change is significant~
  - [ ] ~(Module addition) Added a release notes entry if adding a new NixOS module~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc