### PR TITLE
[Backport release-25.05] positron-bin: 2025.05.0-75 -> 2025.07.0-204; add aarch64-linux platform

### DIFF
--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -22,7 +22,7 @@
 }:
 let
   pname = "positron-bin";
-  version = "2025.07.0-112";
+  version = "2025.07.0-204";
 in
 stdenv.mkDerivation {
   inherit version pname;
@@ -30,18 +30,18 @@ stdenv.mkDerivation {
   src =
     if stdenv.hostPlatform.isDarwin then
       fetchurl {
-        url = "https://cdn.posit.co/positron/dailies/mac/universal/Positron-${version}.dmg";
-        hash = "sha256-vprBr+0XBndCiFTauiOa3gjOlxj/w2ZhQlXNJdly7oU=";
+        url = "https://cdn.posit.co/positron/releases/mac/universal/Positron-${version}-universal.dmg";
+        hash = "sha256-f1EQw6fKH4pgVG7+YcLPv6FawJ2TN507hYLD0pn+PlM=";
       }
     else if stdenv.hostPlatform.system == "aarch64-linux" then
       fetchurl {
-        url = "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${version}-arm64.deb";
-        hash = "sha256-TYFBW3sRpgsdVC66WB9SYNsmAxGCq/3gQSexOVtvGZs=";
+        url = "https://cdn.posit.co/positron/releases/deb/arm64/Positron-${version}-arm64.deb";
+        hash = "sha256-SxjQPZ2wUmSIYOxBB6AS6Ue7ajXzMkY32nHdkZkNhBA=";
       }
     else
       fetchurl {
-        url = "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${version}-x64.deb";
-        hash = "sha256-yueD2PEBXiG8FPghRWvBS6TPtyZ1Q8utKOS8QDMNlk8=";
+        url = "https://cdn.posit.co/positron/releases/deb/x86_64/Positron-${version}-x64.deb";
+        hash = "sha256-f27LC4+SXnkyePw/fw8r9JYsOQKVoIiFkAet/QtwbNg=";
       };
 
   buildInputs =

--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -22,7 +22,7 @@
 }:
 let
   pname = "positron-bin";
-  version = "2025.06.0-146";
+  version = "2025.07.0-112";
 in
 stdenv.mkDerivation {
   inherit version pname;
@@ -31,17 +31,17 @@ stdenv.mkDerivation {
     if stdenv.hostPlatform.isDarwin then
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/mac/universal/Positron-${version}.dmg";
-        hash = "sha256-V9ADtOskxEbGZryXD/6aiUDeTvqPzoY372f/Vo5195s=";
+        hash = "sha256-vprBr+0XBndCiFTauiOa3gjOlxj/w2ZhQlXNJdly7oU=";
       }
     else if stdenv.hostPlatform.system == "aarch64-linux" then
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${version}-arm64.deb";
-        hash = "sha256-FiCTF5Bmfp4id9HXuB4luSGT9A7OoquaRW/QIh0A3ZY=";
+        hash = "sha256-TYFBW3sRpgsdVC66WB9SYNsmAxGCq/3gQSexOVtvGZs=";
       }
     else
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${version}-x64.deb";
-        hash = "sha256-FnNoLV9uqgUeumYpHtRJuHrFA6mL65KI4jru7Ebq0/o=";
+        hash = "sha256-yueD2PEBXiG8FPghRWvBS6TPtyZ1Q8utKOS8QDMNlk8=";
       };
 
   buildInputs =

--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -33,6 +33,11 @@ stdenv.mkDerivation {
         url = "https://cdn.posit.co/positron/dailies/mac/universal/Positron-${version}.dmg";
         hash = "sha256-dmRYKysQJYrNWyGvH9DsNIC0tIHYNix7QWagVtuGx1g=";
       }
+    else if stdenv.hostPlatform.system == "aarch64-linux" then
+      fetchurl {
+        url = "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${version}-arm64.deb";
+        hash = "sha256-RPSQONl6Oj9UgFD2EIqGcbiCtuNJug1I+xaKiWeOyls=";
+      }
     else
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${version}-x64.deb";
@@ -133,6 +138,9 @@ stdenv.mkDerivation {
       detroyejr
     ];
     mainProgram = "positron";
-    platforms = [ "x86_64-linux" ] ++ platforms.darwin;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ] ++ platforms.darwin;
   };
 }

--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -22,7 +22,7 @@
 }:
 let
   pname = "positron-bin";
-  version = "2025.05.0-75";
+  version = "2025.06.0-146";
 in
 stdenv.mkDerivation {
   inherit version pname;
@@ -31,17 +31,17 @@ stdenv.mkDerivation {
     if stdenv.hostPlatform.isDarwin then
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/mac/universal/Positron-${version}.dmg";
-        hash = "sha256-dmRYKysQJYrNWyGvH9DsNIC0tIHYNix7QWagVtuGx1g=";
+        hash = "sha256-V9ADtOskxEbGZryXD/6aiUDeTvqPzoY372f/Vo5195s=";
       }
     else if stdenv.hostPlatform.system == "aarch64-linux" then
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${version}-arm64.deb";
-        hash = "sha256-RPSQONl6Oj9UgFD2EIqGcbiCtuNJug1I+xaKiWeOyls=";
+        hash = "sha256-FiCTF5Bmfp4id9HXuB4luSGT9A7OoquaRW/QIh0A3ZY=";
       }
     else
       fetchurl {
         url = "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${version}-x64.deb";
-        hash = "sha256-dmJrDE3g44aoCsVBvSDDFLt38uIqxzaXPBhcmu/U5Oo=";
+        hash = "sha256-FnNoLV9uqgUeumYpHtRJuHrFA6mL65KI4jru7Ebq0/o=";
       };
 
   buildInputs =

--- a/pkgs/by-name/po/positron-bin/update.sh
+++ b/pkgs/by-name/po/positron-bin/update.sh
@@ -27,7 +27,7 @@ new_hash=$(nix store prefetch-file --json --hash-type sha256 \
 
 sed -i "s|$current_hash|$new_hash|g" $positron_nix
 
-# Update Linux hash.
+# Update Linux x86_64 hash.
 current_hash=$(nix store prefetch-file --json --hash-type sha256 \
     "https://cdn.posit.co/positron/dailies/deb/x86_64/Positron-${current_version}-x64.deb" \
     | jq -r .hash)
@@ -38,17 +38,16 @@ new_hash=$(nix store prefetch-file --json --hash-type sha256 \
 
 sed -i "s|$current_hash|$new_hash|g" $positron_nix
 
+# Update Linux aarch64 hash.
+current_hash=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${current_version}-arm64.deb" \
+    | jq -r .hash)
+
+new_hash=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://cdn.posit.co/positron/dailies/deb/arm64/Positron-${new_version}-arm64.deb" \
+    | jq -r .hash)
+
+sed -i "s|$current_hash|$new_hash|g" $positron_nix
+
 # Update version
 sed -i "s|$current_version|$new_version|g" $positron_nix
-
-# Attempt to build.
-export NIXPKGS_ALLOW_UNFREE=1
-
-if ! nix-build -A positron-bin "$nixpkgs"; then
-  echo "The updated positron-bin failed to build."
-  exit 1
-fi
-
-# Commit changes
-git add "$positron_nix"
-git commit -m "positron-bin: ${current_version} -> ${new_version}"


### PR DESCRIPTION
Manual backport of #411516 #418696 #421845 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.