### PR TITLE
[Backport release-25.05] paretosecurity: 0.2.34 -> 0.2.37

### DIFF
--- a/pkgs/by-name/pa/paretosecurity/package.nix
+++ b/pkgs/by-name/pa/paretosecurity/package.nix
@@ -17,13 +17,13 @@ buildGoModule (finalAttrs: {
     webkitgtk_4_1
   ];
   pname = "paretosecurity";
-  version = "0.2.34";
+  version = "0.2.36";
 
   src = fetchFromGitHub {
     owner = "ParetoSecurity";
     repo = "agent";
     rev = finalAttrs.version;
-    hash = "sha256-tTFdgLpu7RRWx2B2VMROqs1HgG0qMbfUOS5KNLQFHQw=";
+    hash = "sha256-PAH5aswkN8MxK+sZNucXgw50Fc2CkhBLM7+wwxkgAvs=";
   };
 
   vendorHash = "sha256-RAKYaNi+MXUfNnEJmZF5g9jFBDOPIVBOZWtqZp2FwWY=";

--- a/pkgs/by-name/pa/paretosecurity/package.nix
+++ b/pkgs/by-name/pa/paretosecurity/package.nix
@@ -17,16 +17,16 @@ buildGoModule (finalAttrs: {
     webkitgtk_4_1
   ];
   pname = "paretosecurity";
-  version = "0.2.36";
+  version = "0.2.37";
 
   src = fetchFromGitHub {
     owner = "ParetoSecurity";
     repo = "agent";
     rev = finalAttrs.version;
-    hash = "sha256-PAH5aswkN8MxK+sZNucXgw50Fc2CkhBLM7+wwxkgAvs=";
+    hash = "sha256-kwGZmj7YJtciFGNVYGKOE8yqGUxMlDBwivBNXmSAfQk=";
   };
 
-  vendorHash = "sha256-RAKYaNi+MXUfNnEJmZF5g9jFBDOPIVBOZWtqZp2FwWY=";
+  vendorHash = "sha256-nN2FS0XEZyyk83xXyoaQktZcGzPRtxND1qmskvqxEII=";
   proxyVendor = true;
 
   # Skip building the Windows installer


### PR DESCRIPTION
Manual backport of #420761 #422109 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.