### PR TITLE
[Backport release-25.05] pmbootstrap: 3.3.2 -> 3.5.2

### DIFF
--- a/pkgs/by-name/pm/pmbootstrap/package.nix
+++ b/pkgs/by-name/pm/pmbootstrap/package.nix
@@ -15,14 +15,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pmbootstrap";
-  version = "3.5.0";
+  version = "3.5.2";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "postmarketOS";
     repo = "pmbootstrap";
     tag = version;
-    hash = "sha256-wdJl7DrSm1Jht0KEqZ9+qjqlkE+Y6oBdzEHTCgIGJ84=";
+    hash = "sha256-fkzDVMO0huAuJDJIt0dyNGnRD6Go7XZ/YRv/JMtlbss=";
     domain = "gitlab.postmarketos.org";
   };
 

--- a/pkgs/by-name/pm/pmbootstrap/package.nix
+++ b/pkgs/by-name/pm/pmbootstrap/package.nix
@@ -15,14 +15,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pmbootstrap";
-  version = "3.4.0";
+  version = "3.4.2";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "postmarketOS";
     repo = "pmbootstrap";
     tag = version;
-    hash = "sha256-vNa0MMU5NHO8RjgfKxNjhQDKQ2Rd/ZGU0HndOD2Sypo=";
+    hash = "sha256-5N8yAd/1gSzHP2wXpqZb+LpylQ/LYspJ+YaY2YaWCSs=";
     domain = "gitlab.postmarketos.org";
   };
 
@@ -80,7 +80,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     description = "Sophisticated chroot/build/flash tool to develop and install postmarketOS";
-    homepage = "https://gitlab.com/postmarketOS/pmbootstrap";
+    homepage = "https://gitlab.postmarketos.org/postmarketOS/pmbootstrap";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       onny

--- a/pkgs/by-name/pm/pmbootstrap/package.nix
+++ b/pkgs/by-name/pm/pmbootstrap/package.nix
@@ -15,14 +15,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pmbootstrap";
-  version = "3.3.2";
+  version = "3.4.0";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "postmarketOS";
-    repo = pname;
+    repo = "pmbootstrap";
     tag = version;
-    hash = "sha256-A/hWJwyx/k9+NNOJBuor2qQi5gRB3Rpp5qnRloFM0FM=";
+    hash = "sha256-vNa0MMU5NHO8RjgfKxNjhQDKQ2Rd/ZGU0HndOD2Sypo=";
     domain = "gitlab.postmarketos.org";
   };
 
@@ -52,10 +52,16 @@ python3Packages.buildPythonApplication rec {
   '';
 
   # skip impure tests
-  disabledTests = [
-    "test_pkgrepo_pmaports"
-    "test_random_valid_deviceinfos"
-  ];
+  disabledTests =
+    [
+      "test_pkgrepo_pmaports"
+      "test_random_valid_deviceinfos"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+      # assert chroot.type == ChrootType.BUILDROOT
+      # AssertionError: assert <ChrootType.NATIVE: 'native'> == <ChrootType.BUILDROOT: 'buildroot'>
+      "test_valid_chroots"
+    ];
 
   versionCheckProgramArg = "--version";
 

--- a/pkgs/by-name/pm/pmbootstrap/package.nix
+++ b/pkgs/by-name/pm/pmbootstrap/package.nix
@@ -15,14 +15,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pmbootstrap";
-  version = "3.4.2";
+  version = "3.5.0";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "postmarketOS";
     repo = "pmbootstrap";
     tag = version;
-    hash = "sha256-5N8yAd/1gSzHP2wXpqZb+LpylQ/LYspJ+YaY2YaWCSs=";
+    hash = "sha256-wdJl7DrSm1Jht0KEqZ9+qjqlkE+Y6oBdzEHTCgIGJ84=";
     domain = "gitlab.postmarketos.org";
   };
 


### PR DESCRIPTION
Manual backport of #407265 #412686 #416877 #421856 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.