### PR TITLE
qmapshack: 1.17.1 → 1.18.0 

### DIFF
--- a/pkgs/by-name/qm/qmapshack/package.nix
+++ b/pkgs/by-name/qm/qmapshack/package.nix
@@ -3,13 +3,10 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  wrapQtAppsHook,
-  qtscript,
-  qtwebengine,
+  libsForQt5,
   gdal,
   proj,
   routino,
-  quazip,
 }:
 
 stdenv.mkDerivation rec {
@@ -25,16 +22,16 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtscript
-    qtwebengine
+    libsForQt5.qtscript
+    libsForQt5.qtwebengine
     gdal
     proj
     routino
-    quazip
+    libsForQt5.quazip
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/qm/qmapshack/package.nix
+++ b/pkgs/by-name/qm/qmapshack/package.nix
@@ -3,39 +3,44 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  libsForQt5,
+  qt6,
+  qt6Packages,
+  alglib,
   gdal,
   proj,
   routino,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qmapshack";
-  version = "1.17.1";
+  version = "1.18.0";
 
   src = fetchFromGitHub {
     owner = "Maproom";
     repo = "qmapshack";
-    rev = "V_${version}";
-    hash = "sha256-wqztKmaUxY3qd7IgPM7kV7x0BsrTMTX3DbcdM+lsarI=";
+    tag = "V_${finalAttrs.version}";
+    hash = "sha256-+M76EZeZOsBQ7RXtVplsrbrDgU0plRAht4/jz/GpIhM=";
   };
 
   nativeBuildInputs = [
     cmake
-    libsForQt5.wrapQtAppsHook
+    qt6.qttools
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
-    libsForQt5.qtscript
-    libsForQt5.qtwebengine
+    alglib
     gdal
     proj
     routino
-    libsForQt5.quazip
+    qt6.qtwebengine
+    qt6Packages.quazip
   ];
 
   cmakeFlags = [
-    "-DROUTINO_XML_PATH=${routino}/share/routino"
+    (lib.cmakeFeature "ALGLIB_INCLUDE_DIRS" "${alglib}/include/alglib")
+    (lib.cmakeFeature "ALGLIB_LIBRARIES" "alglib3")
+    (lib.cmakeFeature "ROUTINO_XML_PATH" "${routino}/share/routino")
   ];
 
   qtWrapperArgs = [
@@ -50,12 +55,12 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Consumer grade GIS software";
     homepage = "https://github.com/Maproom/qmapshack";
-    changelog = "https://github.com/Maproom/qmapshack/blob/V_${version}/changelog.txt";
+    changelog = "https://github.com/Maproom/qmapshack/blob/V_${finalAttrs.version}/changelog.txt";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       dotlambda
       sikmir
     ];
-    platforms = with lib.platforms; linux;
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11721,8 +11721,6 @@ with pkgs;
 
   qgis = callPackage ../applications/gis/qgis { };
 
-  qmapshack = libsForQt5.callPackage ../applications/gis/qmapshack { };
-
   spatialite-gui = callPackage ../by-name/sp/spatialite-gui/package.nix {
     wxGTK = wxGTK32;
   };


### PR DESCRIPTION
https://github.com/Maproom/qmapshack/releases/tag/V_1.18.0

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
