### PR TITLE
pkgs-lib/hocon: types refactoring

### DIFF
--- a/pkgs/pkgs-lib/formats/hocon/default.nix
+++ b/pkgs/pkgs-lib/formats/hocon/default.nix
@@ -97,36 +97,52 @@ in
               optional = value.optional or false;
               _type = "substitution";
             };
-      };
 
+        types = {
+          hoconInclude = lib.types.listOf (
+            lib.mkOptionType {
+              name = "hoconInclude";
+              description = "hocon include statement";
+              check = value: lib.isAttrs value && value._type or null == "include";
+              merge = lib.mergeEqualOption;
+            }
+          );
+
+          hoconAppend = lib.mkOptionType {
+            name = "hoconAppend";
+            description = "hocon append";
+            check = value: lib.isAttrs value && value._type or null == "append";
+            merge = lib.mergeEqualOption;
+          };
+
+          hoconSubstitution = lib.mkOptionType {
+            name = "hoconSubstitution";
+            description = "hocon substitution";
+            check = value: lib.isAttrs value && value._type or null == "substitution";
+            merge = lib.mergeEqualOption;
+          };
+        };
+      };
     in
     {
       type =
         let
-          type' =
+          valueType =
             with lib.types;
-            let
-              atomType = nullOr (oneOf [
-                bool
-                float
-                int
-                path
-                str
-              ]);
-
-              includeType = addCheck attrs (x: (x._type or null) == "include");
-            in
-            (oneOf [
-              atomType
-              (addCheck (listOf atomType) (lib.all atomType.check))
-              (addCheck (listOf includeType) (lib.all includeType.check))
-              (attrsOf type')
+            nullOr (oneOf [
+              bool
+              int
+              float
+              str
+              path
+              (attrsOf valueType)
+              (listOf valueType)
             ])
             // {
               description = "HOCON value";
             };
         in
-        type';
+        valueType;
 
       lib = hoconLib;
 


### PR DESCRIPTION
Today I got error while trying to add list of attrs inside freeform type submodule using `pkgs.formats.hocon { }).type` as type inside `mkOption`.

I tried to fix it and initially came up with this:

```nix
{
  type =
    let
      includeType = lib.types.listOf (
        lib.mkOptionType {
          name = "hoconInclude";
          description = "hocon include statement";
          check = value: isAttrs value && value._type or null == "include";
          merge = lib.mergeEqualOption;
        }
      );
      type' =
        with lib.types;
        nullOr (oneOf [
          bool
          int
          float
          str
          path
          (listOf type')
          (attrsOf (either type' includeType))
        ])
        // {
          description = "HOCON value";
        };
    in
    lib.types.either type' includeType;
}
```

But then I realized: "It seems like there's no reason to implement `includeType` inside top-level type, because it just represents a set attribute from the base HOCON types." After that, I decided to just reuse the type from the JSON format, since HOCON is essentially human-readable JSON.

Regarding the types in lib: previously, `includeType` was defined as `types.attrs` with an additional check:

```nix
{
  includeType = addCheck attrs (x: (x._type or null) == "include");
}
```

But as noted in [NixOS Manual](https://nixos.org/manual/nixos/unstable/#sec-option-types-basic) it is depricated. So I created types that represents definitions for each mk<Name> functions. So instead, I created types that correspond to the definitions returned by the different `mk<Name>` functions. Also, I used `types.listOf` for include type because, as far as I understand, there's no way to use that type outside of a list


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
