### PR TITLE
python3Packages.miraie-ac: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1481,6 +1481,12 @@
     github = "an-empty-string";
     githubId = 681716;
   };
+  ananthb = {
+    name = "Ananth Bhaskararaman";
+    email = "nixos-maint@devhuman.net";
+    github = "ananthb";
+    githubId = 3133350;
+  };
   anas = {
     email = "anas.elgarhy.dev@gmail.com";
     github = "0x61nas";

--- a/pkgs/development/python-modules/miraie-ac/default.nix
+++ b/pkgs/development/python-modules/miraie-ac/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  aiomqtt,
+  aiohttp,
+  certifi,
+}:
+
+buildPythonPackage rec {
+  pname = "miraie-ac";
+  version = "1.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "miraie_ac";
+    hash = "sha256-IiRDPz5IcD3Df+vw4YvR3zc0oThGjb7pBJfD4d98h/g=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    aiomqtt
+    aiohttp
+    certifi
+  ];
+
+  pythonRemoveDeps = [ "asyncio" ];
+
+  pythonImportsCheck = [ "miraie_ac" ];
+
+  meta = {
+    homepage = "https://github.com/rkzofficial/miraie-ac";
+    changelog = "https://github.com/rkzofficial/miraie-ac/releases";
+    description = "Python library for controlling Panasonic Miraie ACs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ananthb ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/miraie/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/miraie/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  miraie-ac,
+  aiomqtt,
+  nix-update-script,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "rkzofficial";
+  domain = "miraie";
+  version = "1.1.6";
+
+  src = fetchFromGitHub {
+    owner = "rkzofficial";
+    repo = "ha-miraie-ac";
+    tag = "v${version}";
+    hash = "sha256-5VpLfTKOLdx8P693jaW4o79CH2NKkgkgl7ai+I6JRQs=";
+  };
+
+  dependencies = [
+    miraie-ac
+    aiomqtt
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/rkzofficial/ha-miraie-ac/releases/tag/v${version}";
+    description = "Home Assistant component for Miraie ACs";
+    homepage = "https://github.com/rkzofficial/ha-miraie-ac";
+    maintainers = with lib.maintainers; [ ananthb ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9227,6 +9227,8 @@ self: super: with self; {
 
   mir-eval = callPackage ../development/python-modules/mir-eval { };
 
+  miraie-ac = callPackage ../development/python-modules/miraie-ac { };
+
   mirakuru = callPackage ../development/python-modules/mirakuru { };
 
   misaka = callPackage ../development/python-modules/misaka { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added the miraie-ac python library.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
