### PR TITLE
nixos/drupal: extend module tests

### DIFF
--- a/nixos/tests/drupal.nix
+++ b/nixos/tests/drupal.nix
@@ -1,27 +1,85 @@
 { lib, ... }:
-
-{
-  name = "drupal";
-
+let
   nodes = {
-    machine_default =
-      { pkgs, ... }:
-      {
-        services.drupal = {
+
+    "drupal_nginx" = _: {
+      services.drupal.webserver = "nginx";
+      services.drupal.enable = true;
+      services.drupal.sites = {
+        "site1.local" = {
+          database.tablePrefix = "site1_";
+          enable = true;
+        };
+        "site2.local" = {
+          database.tablePrefix = "site2_";
           enable = true;
         };
       };
+
+      networking.firewall.allowedTCPPorts = [ 80 ];
+      networking.hosts."127.0.0.1" = [
+        "site1.local"
+        "site2.local"
+      ];
+    };
+
+    "drupal_caddy" = _: {
+      services.drupal.enable = true;
+      services.drupal.webserver = "caddy";
+      services.drupal.sites = {
+        "site1.local" = {
+          enable = true;
+          database.tablePrefix = "site1_";
+        };
+        "site2.local" = {
+          enable = true;
+          database.tablePrefix = "site2_";
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [
+        80
+        443
+      ];
+      networking.hosts."127.0.0.1" = [
+        "site1.local"
+        "site2.local"
+      ];
+    };
   };
-
-  testScript = ''
-    machine_default.start()
-    machine_default.wait_for_unit("phpfpm-drupal-localhost.service")
-    machine_default.wait_for_unit("nginx.service")
-    machine_default.wait_for_unit("mysql.service")
-  '';
-
+in
+{
+  name = "drupal";
   meta.maintainers = [
     lib.maintainers.drupol
     lib.maintainers.OulipianSummer
   ];
+
+  inherit nodes;
+
+  testScript = ''
+    start_all()
+
+    ${lib.concatStrings (
+      lib.mapAttrsToList (name: value: ''
+        ${name}.wait_for_unit("${(value null).services.drupal.webserver}")
+      '') nodes
+    )}
+
+    site_names = ["site1.local", "site2.local"]
+
+    for machine in (${lib.concatStringsSep ", " (builtins.attrNames nodes)}):
+        for site_name in site_names:
+            machine.wait_for_unit(f"phpfpm-drupal-{site_name}")
+
+            with subtest("website returns welcome screen"):
+                assert "Choose language" in machine.succeed(f"curl -k -L {site_name}")
+
+            with subtest("website is installable"):
+                assert "Database configuration" in machine.succeed(f"curl -k -L \"{site_name}/core/install.php?langcode=en&profile=standard\"")
+
+            with subtest("drupal-state-init went through"):
+                info = machine.get_unit_info(f"drupal-state-init-{site_name}")
+                assert info["Result"] == "success"
+  '';
 }


### PR DESCRIPTION
This PR extends the Drupal module tests in NixOS. Currently, the Drupal module's tests suite only checks to see if the default webserver, PHPFM, and SQL server are running. They do not check whether or not the site is installable, if the site is responding to HTTP requests properly, and it does not do checks for individual webservers (caddy vs. nginx).

These tests are more thorough and are designed to catch common bugs during development.

This also solves the issue https://github.com/NixOS/nixpkgs/issues/420301.
When https://github.com/NixOS/nixpkgs/pull/418254 is merged, it will also do proper HTTPS testing for caddy.
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
