### PR TITLE
nixos-rebuild-ng: do not create result symlink in test/dry-activate

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -134,7 +134,8 @@ def _build_system(
     flake_common_flags: Args,
 ) -> Path:
     dry_run = action == Action.DRY_BUILD
-    no_link = action in (Action.SWITCH, Action.BOOT)
+    # actions that we will not add a /result symlink in CWD
+    no_link = action in (Action.SWITCH, Action.BOOT, Action.TEST, Action.DRY_ACTIVATE)
 
     match (action, args.rollback, build_host, flake):
         case (Action.SWITCH | Action.BOOT, True, _, _):

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -118,13 +118,34 @@ def _get_system_attr(
     return attr
 
 
+def _rollback_system(
+    action: Action,
+    args: argparse.Namespace,
+    target_host: Remote | None,
+    profile: Profile,
+) -> Path:
+    match action:
+        case Action.SWITCH | Action.BOOT:
+            path_to_config = nix.rollback(profile, target_host, sudo=args.sudo)
+        case Action.TEST | Action.BUILD:
+            maybe_path_to_config = nix.rollback_temporary_profile(
+                profile,
+                target_host,
+                sudo=args.sudo,
+            )
+            if maybe_path_to_config:
+                path_to_config = maybe_path_to_config
+            else:
+                raise NixOSRebuildError("could not find previous generation")
+
+    return path_to_config
+
+
 def _build_system(
     attr: str,
     action: Action,
-    args: argparse.Namespace,
     build_host: Remote | None,
     target_host: Remote | None,
-    profile: Profile,
     flake: Flake | None,
     build_attr: BuildAttr,
     build_flags: Args,
@@ -137,22 +158,8 @@ def _build_system(
     # actions that we will not add a /result symlink in CWD
     no_link = action in (Action.SWITCH, Action.BOOT, Action.TEST, Action.DRY_ACTIVATE)
 
-    match (action, args.rollback, build_host, flake):
-        case (Action.SWITCH | Action.BOOT, True, _, _):
-            path_to_config = nix.rollback(profile, target_host, sudo=args.sudo)
-        case (Action.TEST | Action.BUILD, True, _, _):
-            maybe_path_to_config = nix.rollback_temporary_profile(
-                profile,
-                target_host,
-                sudo=args.sudo,
-            )
-            if maybe_path_to_config:  # kinda silly but this makes mypy happy
-                path_to_config = maybe_path_to_config
-            else:
-                raise NixOSRebuildError("could not find previous generation")
-        case (_, True, _, _):
-            raise NixOSRebuildError(f"--rollback is incompatible with '{action}'")
-        case (_, False, Remote(_), Flake(_)):
+    match (build_host, flake):
+        case (Remote(_), Flake(_)):
             path_to_config = nix.build_remote_flake(
                 attr,
                 flake,
@@ -162,14 +169,14 @@ def _build_system(
                 | {"no_link": no_link, "dry_run": dry_run},
                 copy_flags=copy_flags,
             )
-        case (_, False, None, Flake(_)):
+        case (None, Flake(_)):
             path_to_config = nix.build_flake(
                 attr,
                 flake,
                 flake_build_flags=flake_build_flags
                 | {"no_link": no_link, "dry_run": dry_run},
             )
-        case (_, False, Remote(_), None):
+        case (Remote(_), None):
             path_to_config = nix.build_remote(
                 attr,
                 build_attr,
@@ -178,26 +185,19 @@ def _build_system(
                 instantiate_flags=build_flags,
                 copy_flags=copy_flags,
             )
-        case (_, False, None, None):
+        case (None, None):
             path_to_config = nix.build(
                 attr,
                 build_attr,
                 build_flags=build_flags | {"no_out_link": no_link, "dry_run": dry_run},
             )
-        case never:
-            # should never happen, but mypy is not smart enough to
-            # handle this with assert_never
-            # https://github.com/python/mypy/issues/16650
-            # https://github.com/python/mypy/issues/16722
-            raise AssertionError(f"expected code to be unreachable, but got: {never}")
 
-    if not args.rollback:
-        nix.copy_closure(
-            path_to_config,
-            to_host=target_host,
-            from_host=build_host,
-            copy_flags=copy_flags,
-        )
+    nix.copy_closure(
+        path_to_config,
+        to_host=target_host,
+        from_host=build_host,
+        copy_flags=copy_flags,
+    )
 
     return path_to_config
 
@@ -291,23 +291,31 @@ def build_and_activate_system(
         common_flags=common_flags,
         flake_common_flags=flake_common_flags,
     )
-    path_to_config = _build_system(
-        attr,
-        action=action,
-        args=args,
-        build_host=build_host,
-        target_host=target_host,
-        profile=profile,
-        flake=flake,
-        build_attr=build_attr,
-        build_flags=build_flags,
-        common_flags=common_flags,
-        copy_flags=copy_flags,
-        flake_build_flags=flake_build_flags,
-        flake_common_flags=flake_common_flags,
-    )
+
+    if args.rollback:
+        path_to_config = _rollback_system(
+            action=action,
+            args=args,
+            target_host=target_host,
+            profile=profile,
+        )
+    else:
+        path_to_config = _build_system(
+            attr=attr,
+            action=action,
+            build_host=build_host,
+            target_host=target_host,
+            flake=flake,
+            build_attr=build_attr,
+            build_flags=build_flags,
+            common_flags=common_flags,
+            copy_flags=copy_flags,
+            flake_build_flags=flake_build_flags,
+            flake_common_flags=flake_common_flags,
+        )
+
     _activate_system(
-        path_to_config,
+        path_to_config=path_to_config,
         action=action,
         args=args,
         target_host=target_host,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -1020,6 +1020,7 @@ def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
                     "build",
                     "--print-out-paths",
                     'github:user/repo#nixosConfigurations."hostname".config.system.build.toplevel',
+                    "--no-link",
                 ],
                 check=True,
                 stdout=PIPE,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix #170000.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
