### PR TITLE
nixos/systemd/repart: add extraArgs option and Encrypt=tpm2 test

### DIFF
--- a/nixos/modules/system/boot/systemd/repart.nix
+++ b/nixos/modules/system/boot/systemd/repart.nix
@@ -85,6 +85,16 @@ in
         '';
         default = true;
       };
+
+      extraArgs = lib.mkOption {
+        description = ''
+          Extra command-line arguments to pass to systemd-repart.
+
+          See {manpage}`systemd-repart(8)` for all available options.
+        '';
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
     };
 
     systemd.repart = {
@@ -177,6 +187,7 @@ in
                                   --dry-run=no \
                                   --empty=${initrdCfg.empty} \
                                   --discard=${lib.boolToString initrdCfg.discard} \
+                                  ${utils.escapeSystemdExecArgs initrdCfg.extraArgs} \
                                   ${lib.optionalString (initrdCfg.device != null) initrdCfg.device}
               ''
             ];

--- a/nixos/tests/systemd-repart.nix
+++ b/nixos/tests/systemd-repart.nix
@@ -9,30 +9,37 @@ with pkgs.lib;
 
 let
   # A testScript fragment that prepares a disk with some empty, unpartitioned
-  # space. and uses it to boot the test with. Takes a single argument `machine`
-  # from which the diskImage is extracted.
-  useDiskImage = machine: ''
-    import os
-    import shutil
-    import subprocess
-    import tempfile
+  # space. and uses it to boot the test with.
+  # Takes two arguments, `machine` from which the diskImage is extracted,
+  # as well an optional `sizeDiff` (defaulting to +32M), describing how should
+  # be resized.
+  useDiskImage =
+    {
+      machine,
+      sizeDiff ? "+32M",
+    }:
+    ''
+      import os
+      import shutil
+      import subprocess
+      import tempfile
 
-    tmp_disk_image = tempfile.NamedTemporaryFile()
+      tmp_disk_image = tempfile.NamedTemporaryFile()
 
-    shutil.copyfile("${machine.system.build.diskImage}/nixos.img", tmp_disk_image.name)
+      shutil.copyfile("${machine.system.build.diskImage}/nixos.img", tmp_disk_image.name)
 
-    subprocess.run([
-      "${machine.virtualisation.qemu.package}/bin/qemu-img",
-      "resize",
-      "-f",
-      "raw",
-      tmp_disk_image.name,
-      "+32M",
-    ])
+      subprocess.run([
+        "${machine.virtualisation.qemu.package}/bin/qemu-img",
+        "resize",
+        "-f",
+        "raw",
+        tmp_disk_image.name,
+        "${sizeDiff}",
+      ])
 
-    # Set NIX_DISK_IMAGE so that the qemu script finds the right disk image.
-    os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
-  '';
+      # Set NIX_DISK_IMAGE so that the qemu script finds the right disk image.
+      os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
+    '';
 
   common =
     {
@@ -98,7 +105,7 @@ in
     testScript =
       { nodes, ... }:
       ''
-        ${useDiskImage nodes.machine}
+        ${useDiskImage { inherit (nodes) machine; }}
 
         machine.start()
         machine.wait_for_unit("multi-user.target")
@@ -128,7 +135,7 @@ in
     testScript =
       { nodes, ... }:
       ''
-        ${useDiskImage nodes.machine}
+        ${useDiskImage { inherit (nodes) machine; }}
 
         machine.start()
         machine.wait_for_unit("multi-user.target")
@@ -196,7 +203,7 @@ in
     testScript =
       { nodes, ... }:
       ''
-        ${useDiskImage nodes.machine}
+        ${useDiskImage { inherit (nodes) machine; }}
 
         machine.start()
         machine.wait_for_unit("multi-user.target")


### PR DESCRIPTION
This adds an `extraArgs` option for `systemd-repart`, then includes a test that makes use of the `Encrypt=tmp2` functionality, setting `--tpm2-pcrs=7`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
