### PR TITLE
distroav: 6.0.0 -> 6.1.1, ndi-6: 6.1.1 -> 6.2.0

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/distroav/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/distroav/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   pname = "distroav";
-  version = "6.0.0";
+  version = "6.1.1";
 
   nativeBuildInputs = [
     cmake
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     owner = "DistroAV";
     repo = "DistroAV";
     tag = version;
-    hash = "sha256-pr/5XCLo5fzergIQrYFC9o9K+KuP4leDk5/oRe5ct9Q=";
+    hash = "sha256-nbXh6bjpiKbvuntZSnuTWWpmhfAcep7Krjjq8FvbENk=";
   };
 
   # Modify plugin-main.cpp file to fix ndi libs path

--- a/pkgs/applications/video/obs-studio/plugins/distroav/hardcode-ndi-path.patch
+++ b/pkgs/applications/video/obs-studio/plugins/distroav/hardcode-ndi-path.patch
@@ -1,8 +1,8 @@
 diff --git a/src/plugin-main.cpp b/src/plugin-main.cpp
-index 0d94add..617af73 100644
+index 43f0e28..5e393c6 100644
 --- a/src/plugin-main.cpp
 +++ b/src/plugin-main.cpp
-@@ -369,14 +369,7 @@ const NDIlib_v5 *load_ndilib() 
+@@ -412,14 +412,7 @@ const NDIlib_v5 *load_ndilib()
  	if (!temp_path.isEmpty()) {
  		locations << temp_path;
  	}
@@ -15,4 +15,6 @@ index 0d94add..617af73 100644
 -	locations << "/usr/local/lib";
 -#endif
 +	locations << "@NDI@/lib";
-	auto lib_path = QString();
+ 	auto lib_path = QString();
+ #if defined(Q_OS_LINUX)
+ 	// Linux

--- a/pkgs/by-name/nd/ndi-6/version.json
+++ b/pkgs/by-name/nd/ndi-6/version.json
@@ -1,1 +1,1 @@
-{"hash": "sha256-6iqjexwILth2muLpXWQjDVTvOuMq4jM8KBYnpPmViU8=", "version": "6.1.1"}
+{"hash": "sha256-10pxvHLYbQ1p3NKSTC1I3YAFkPbYSCenXTEWukqy5TY=", "version": "6.2.0"}


### PR DESCRIPTION
Supercedes #421487

Updates to the latest DistroAV version and updates the patch associated with linking it to NDI.
https://github.com/DistroAV/DistroAV/releases/tag/6.1.1

Updates to the latest NDI version to fix build problems related to how NDI distributes releases.
https://docs.ndi.video/all/developing-with-ndi/sdk/release-notes#ndi-6.2

Closes #421487

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
