### PR TITLE
prometheus-mktxp-exporter NixOS module init + mktxp bump

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -88,6 +88,7 @@ let
         "lnd"
         "mail"
         "mailman3"
+        "mktxp"
         "mikrotik"
         "modemmanager"
         "mongodb"

--- a/nixos/modules/services/monitoring/prometheus/exporters/mktxp.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mktxp.nix
@@ -1,0 +1,586 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    mkPackageOption
+    mkOption
+    types
+    escapeShellArgs
+    concatStringsSep
+    ;
+  inherit (lib.generators) mkKeyValueDefault mkValueStringDefault;
+  inherit (lib.attrsets) recursiveUpdate;
+
+  cfg = config.services.prometheus.exporters.mktxp;
+
+  settingsFormat = pkgs.formats.ini {
+    mkKeyValue = mkKeyValueDefault rec {
+      mkValueString =
+        v:
+        if builtins.isNull v then
+          "None"
+        else if builtins.isBool v then
+          (if v then "True" else "False")
+        else if builtins.isList v then
+          # Join lists as "a, b, c"
+          concatStringsSep ", " (map mkValueString v)
+        else
+          mkValueStringDefault { } v;
+    } "=";
+  };
+
+  sectionType = settingsFormat.lib.types.atom; # attrsOf INI atom
+
+  configFile =
+    if cfg.configFile != null then
+      cfg.configFile
+    else
+      let
+        mktxpSettings = {
+          MKTXP.listen = "${cfg.listenAddress}:${toString cfg.port}";
+        };
+        merged = recursiveUpdate mktxpSettings cfg.settings;
+      in
+      settingsFormat.generate "mktxp.conf" merged;
+in
+{
+  port = 49090;
+
+  extraOpts = {
+    package = mkPackageOption pkgs "mktxp" { };
+
+    configFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        The path to the mktxp configuration ini file. For more info see
+        https://github.com/akpw/mktxp
+
+        Note that setting this option is mutually exclusive with setting
+        the `settings` option.
+      '';
+    };
+
+    settings =
+      let
+        mkMktxpSection = types.submodule {
+          freeformType = sectionType;
+          options = {
+            socket_timeout = mkOption {
+              type = types.int;
+              default = 5;
+              description = "";
+            };
+
+            initial_delay_on_failure = mkOption {
+              type = types.int;
+              default = 120;
+              description = "";
+            };
+
+            max_delay_on_failure = mkOption {
+              type = types.int;
+              default = 900;
+              description = "";
+            };
+
+            delay_inc_div = mkOption {
+              type = types.int;
+              default = 5;
+              description = "";
+            };
+
+            bandwidth = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Turns metrics bandwidth metrics collection on / off";
+            };
+
+            bandwidth_test_dns_server = mkOption {
+              type = types.str;
+              default = "8.8.8.8";
+              description = "The DNS server to be used for the bandwidth test connectivity check";
+            };
+
+            bandwidth_test_interval = mkOption {
+              type = types.int;
+              default = 600;
+              description = "Interval for collecting bandwidth metrics";
+            };
+
+            minimal_collect_interval = mkOption {
+              type = types.int;
+              default = 5;
+              description = "Minimal metric collection interval";
+            };
+
+            verbose_mode = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Set it on for troubleshooting";
+            };
+
+            fetch_routers_in_parallel = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Fetch metrics from multiple routers in parallel / sequentially";
+            };
+
+            max_worker_threads = mkOption {
+              type = types.int;
+              default = 5;
+              description = "Max number of worker threads that can fetch routers (parallel fetch only)";
+            };
+
+            max_scrape_duration = mkOption {
+              type = types.int;
+              default = 30;
+              description = "Max duration of individual routers' metrics collection (parallel fetch only)";
+            };
+
+            total_max_scrape_duration = mkOption {
+              type = types.int;
+              default = 90;
+              description = "Max overall duration of all metrics collection (parallel fetch only)";
+            };
+
+            persistent_router_connection_pool = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Use a persistent router connections pool between scrapes";
+            };
+
+            persistent_dhcp_cache = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Persist DHCP cache between metric collections";
+            };
+
+            compact_default_conf_values = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Compact mktxp.conf, so only specific values are kept on the individual routers' level";
+            };
+
+            prometheus_headers_deduplication = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Deduplicate Prometheus HELP / TYPE headers in the metrics output";
+            };
+          };
+        };
+
+        mkDeviceSection = types.submodule {
+          freeformType = sectionType;
+          options = {
+            enabled = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Turns metrics collection for this RouterOS device on / off";
+            };
+
+            hostname = mkOption {
+              type = types.str;
+              default = "localhost";
+              description = "RouterOS IP address";
+            };
+
+            port = mkOption {
+              type = types.port;
+              default = 8728;
+              description = "RouterOS IP Port";
+            };
+
+            username = mkOption {
+              type = types.str;
+              default = "username";
+              description = "RouterOS user, needs to have 'read' and 'api' permissions";
+            };
+
+            password = mkOption {
+              type = types.str;
+              default = "password";
+              description = "RouterOS user plaintext password";
+            };
+
+            credentials_file = mkOption {
+              type = types.nullOr types.path;
+              default = null;
+              # NOTE: mktxp uses "" to indicate no credentials_file
+              apply = v: if builtins.isNull v then "" else toString v;
+              description = "To use an external file in YAML format for both username and password, specify the path here";
+            };
+
+            # NOTE: mktxp uses None here to indicate emptiness
+            custom_labels = mkOption {
+              type = types.nullOr (types.listOf types.str);
+              default = null;
+              description = "Custom labels to be injected to all device metrics, strings of `key:value` or `key=value` pairs";
+            };
+
+            use_ssl = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Enables connection via API-SSL servis";
+            };
+
+            no_ssl_certificate = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Enables API_SSL connect without router SSL certificate";
+            };
+
+            ssl_certificate_verify = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Turns SSL certificate verification on / off";
+            };
+
+            ssl_ca_file = mkOption {
+              type = types.nullOr types.path;
+              default = null;
+              # NOTE: mktxp uses "" to indicate no ssl_ca_file
+              apply = v: if builtins.isNull v then "" else toString v;
+
+              description = "path to the certificate authority file to validate against, null to use system store";
+            };
+
+            plaintext_login = mkOption {
+              type = types.bool;
+              default = true;
+              description = "For legacy RouterOS versions below 6.43 use false";
+            };
+
+            health = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect System Health metrics";
+            };
+
+            installed_packages = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect installed packages";
+            };
+
+            dhcp = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect DHCP general metrics";
+            };
+
+            dhcp_lease = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect DHCP lease metrics";
+            };
+
+            connections = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect IP connections metrics";
+            };
+
+            connection_stats = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect open IP connections metrics";
+            };
+
+            interface = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect interfaces traffic metrics";
+            };
+
+            route = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect IPv4 Routes metrics";
+            };
+
+            pool = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect IPv4 Pool metrics";
+            };
+
+            firewall = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect IPv4 Firewall rules traffic metrics";
+            };
+
+            neighbor = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect IPv4 Reachable Neighbors";
+            };
+
+            address_list = mkOption {
+              type = types.listOf types.str;
+              default = [ ];
+              description = "Firewall Address List metrics, a list of names";
+            };
+
+            dns = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect DNS stats";
+            };
+
+            ipv6_route = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect IPv6 Routes metrics";
+            };
+
+            ipv6_pool = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect IPv6 Pool metrics";
+            };
+
+            ipv6_firewall = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect IPv6 Firewall rules traffic metrics";
+            };
+
+            ipv6_neighbor = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect IPv6 Reachable Neighbors";
+            };
+
+            ipv6_address_list = mkOption {
+              type = types.listOf types.str;
+              default = [ ];
+              description = "IPv6 Firewall Address List metrics, a list of names";
+            };
+
+            poe = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect POE metrics";
+            };
+
+            monitor = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect interface monitor metrics";
+            };
+
+            netwatch = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect netwatch metrics";
+            };
+
+            public_ip = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect public IP metrics";
+            };
+
+            wireless = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect WLAN general metrics";
+            };
+
+            wireless_clients = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect WLAN clients metrics";
+            };
+
+            capsman = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect CAPsMAN general metrics";
+            };
+
+            capsman_clients = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect CAPsMAN clients metrics";
+            };
+
+            w60g = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect W60G metrics";
+            };
+
+            eoip = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect EoIP status metrics";
+            };
+
+            gre = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect GRE status metrics";
+            };
+
+            ipip = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect IPIP status metrics";
+            };
+
+            lte = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect LTE signal and status metrics (requires additional 'test' permission policy on RouterOS v6)";
+            };
+
+            ipsec = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect IPSec active peer metrics";
+            };
+
+            switch_port = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect Switch Port metrics";
+            };
+
+            kid_control_assigned = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Allow Kid Control metrics for connected devices with assigned users";
+            };
+
+            kid_control_dynamic = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Allow Kid Control metrics for all connected devices, including those without assigned user";
+            };
+
+            user = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect Active Users metrics";
+            };
+
+            queue = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Collect Queues metrics";
+            };
+
+            bfd = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect BFD sessions metrics";
+            };
+
+            bgp = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect BGP sessions metrics";
+            };
+
+            routing_stats = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect Routing process stats";
+            };
+
+            certificate = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect Certificates metrics";
+            };
+
+            container = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Collect Containers metrics";
+            };
+
+            remote_dhcp_entry = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "An MKTXP entry to provide for remote DHCP info / resolution";
+            };
+
+            remote_capsman_entry = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = "An MKTXP entry to provide for remote capsman info";
+            };
+
+            use_comments_over_names = mkOption {
+              type = types.bool;
+              default = true;
+              description = "when available, forces using comments over the interfaces names";
+            };
+
+            check_for_updates = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Check for available ROS updates";
+            };
+          };
+        };
+      in
+      mkOption {
+        type = types.submodule {
+          freeformType = types.attrsOf mkDeviceSection;
+          options = {
+            # [MKTXP]
+            MKTXP = mkOption {
+              type = mkMktxpSection;
+              default = { };
+              description = "Global MKTXP settings (rendered as the [MKTXP] section).";
+            };
+
+            # [default]
+            default = mkOption {
+              type = mkDeviceSection;
+              default = { };
+              description = "Defaults for all devices (rendered as the [default] section).";
+            };
+
+            # general [<device>] included in freeformType
+          };
+        };
+        default = { };
+        description = ''
+          Structured mktxp configuration. For more info see
+          https://github.com/akpw/mktxp
+
+          Note that setting this option is mutually exclusive with setting
+          the `configFile` option.
+        '';
+      };
+
+  };
+
+  serviceOpts = {
+    # NOTE: mktxp unfortunately does not support passing a custom
+    # configuration file or a custom config directory, it always reads what is
+    # present in $HOME/mktxp/mktxp.conf, so we populate a dynamics user's
+    # home directory with a symlink to the pure store configuration file.
+    environment.HOME = "/var/run/mktxp/";
+    preStart = ''
+      mkdir -p "$HOME/mktxp"
+      ln -sf "${configFile}" "$HOME/mktxp/mktxp.conf"
+    '';
+    serviceConfig = {
+      DynamicUser = true;
+      RuntimeDirectory = "mktxp";
+      ExecStart = "${getExe cfg.package} export ${escapeShellArgs cfg.extraFlags}";
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -875,6 +875,31 @@ let
       '';
     };
 
+    mktxp = {
+      exporterConfig = {
+        enable = true;
+        settings = {
+          MKTXP = {
+            bandwidth = true;
+          };
+          default = {
+            enabled = true;
+          };
+          customDevice = {
+            enabled = true;
+            username = "customUser";
+          };
+        };
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-mktxp-exporter.service")
+        wait_for_open_port(49090)
+        succeed(
+            "curl -sSf http://localhost:49090/metrics | grep '^python_info'"
+        )
+      '';
+    };
+
     modemmanager = {
       exporterConfig = {
         enable = true;

--- a/pkgs/by-name/mk/mktxp/package.nix
+++ b/pkgs/by-name/mk/mktxp/package.nix
@@ -32,6 +32,7 @@ python3Packages.buildPythonApplication {
     speedtest-cli
     waitress
     packaging
+    pyyaml
   ];
 
   meta = {

--- a/pkgs/by-name/mk/mktxp/package.nix
+++ b/pkgs/by-name/mk/mktxp/package.nix
@@ -6,7 +6,7 @@
   which,
 }:
 let
-  version = "1.2.14";
+  version = "1.2.15";
 in
 python3Packages.buildPythonApplication {
   pname = "mktxp";
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication {
     owner = "akpw";
     repo = "mktxp";
     tag = "v${version}";
-    hash = "sha256-4+0aw/r71FcVrxASco3AkYzi7zbFeiEkJB7acGdb1FQ=";
+    hash = "sha256-I3V1P3/+60oLz7jscLPBWgD/V2myG0cz7X6srVQ4BO0=";
   };
 
   nativeBuildInputs = with python3Packages; [

--- a/pkgs/by-name/mk/mktxp/package.nix
+++ b/pkgs/by-name/mk/mktxp/package.nix
@@ -2,6 +2,8 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  makeWrapper,
+  which,
 }:
 let
   version = "1.2.14";
@@ -21,6 +23,7 @@ python3Packages.buildPythonApplication {
   nativeBuildInputs = with python3Packages; [
     pypaInstallHook
     setuptoolsBuildHook
+    makeWrapper
   ];
 
   dependencies = with python3Packages; [
@@ -34,6 +37,11 @@ python3Packages.buildPythonApplication {
     packaging
     pyyaml
   ];
+
+  postFixup = ''
+    wrapProgram "$out/bin/mktxp" \
+      --prefix PATH : ${lib.makeBinPath [ which ]}
+  '';
 
   meta = {
     homepage = "https://github.com/akpw/mktxp";

--- a/pkgs/by-name/mk/mktxp/package.nix
+++ b/pkgs/by-name/mk/mktxp/package.nix
@@ -49,7 +49,10 @@ python3Packages.buildPythonApplication {
     description = "Prometheus Exporter for Mikrotik RouterOS devices";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.BonusPlay ];
+    maintainers = [
+      lib.maintainers.BonusPlay
+      lib.maintainers.tsandrini
+    ];
     mainProgram = "mktxp";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Sets up a NixOS module for the popular https://github.com/akpw/mktxp prometheus mikrotik exporter :pray:  . This extends the already present work since the mktxp package itself is already prepared in nixpkgs -> https://github.com/NixOS/nixpkgs/blob/dbe18835a88a1572f2ece46eac03be2f920590ea/pkgs/by-name/mk/mktxp/package.nix

~~**Important note**: mktxp only recently added support for loading `username` + `password` via a `credentials_file` secrets option (https://github.com/akpw/mktxp/pull/249), which is why I also bumped the version of the mktxp package in a separate commit, because without this the NixOS module is frankly rather useless in real world scenarios.~~

~~**Edit**: In the meantime mktxp `1.2.14` has been merged into master, so the previous paragraph no longer applies and this PR introduces only one commit -> the mktxp module init.~~

Changes made:

- ~~bumped mktxp from 1.2.9 -> 1.2.11 + also appended myself as an additional maintainer~~
- initialized the NixOS module - there are a few quirks regarding the implementation which I've explained in the accompanied doccomments 
- added a simple NixOS test - more extensive testing would require some sort of mikrotik device mocking
- bumped mktxp to `1.2.15` and included various fixes of the mktxp derivation, for explanation see the comments lower in this PR

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
