### PR TITLE
mullvad{,-vpn}: 2025.{6,3} -> 2025.7, openvpn-mullvad: 2.6.0 -> 2.6.8

### DIFF
--- a/pkgs/applications/networking/mullvad/mullvad.nix
+++ b/pkgs/applications/networking/mullvad/mullvad.nix
@@ -30,18 +30,18 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "mullvad";
-  version = "2025.6";
+  version = "2025.7";
 
   src = fetchFromGitHub {
     owner = "mullvad";
     repo = "mullvadvpn-app";
     tag = version;
     fetchSubmodules = true;
-    hash = "sha256-WWJcfnp1v1LhEElJQdLx6Gz+bj7MdgbefD6BQ4nihMs=";
+    hash = "sha256-q5RYgU7VlhTXAN0uQeHNTJ1eFCQZzymLo/eiKr805O8=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-r6WogC25hpzw2pHa8RQOhr9SWks9RKKatpVHblfs+Nc=";
+  cargoHash = "sha256-UUYAmNdzTthoWOIU5wr7Q059MAezpuRvCadGTjwoKGM=";
 
   cargoBuildFlags = [
     "-p mullvad-daemon --bin mullvad-daemon"
@@ -95,7 +95,6 @@ rustPlatform.buildRustPackage rec {
       cp dist-assets/ca.crt $out/share/mullvad
       ln -s ${openvpn-mullvad}/bin/openvpn $out/share/mullvad
       ln -s ${shadowsocks-rust}/bin/sslocal $out/share/mullvad
-      ln -s $out/lib/libtalpid_openvpn_plugin.so $out/share/mullvad
     ''
     +
       # Set the directory where Mullvad will look for its resources by default to
@@ -123,7 +122,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Mullvad VPN command-line client tools";
     homepage = "https://github.com/mullvad/mullvadvpn-app";
-    changelog = "https://github.com/mullvad/mullvadvpn-app/blob/2025.6/CHANGELOG.md";
+    changelog = "https://github.com/mullvad/mullvadvpn-app/blob/${version}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ cole-h ];
     mainProgram = "mullvad";

--- a/pkgs/applications/networking/mullvad/openvpn.nix
+++ b/pkgs/applications/networking/mullvad/openvpn.nix
@@ -22,11 +22,11 @@ openvpn.overrideAttrs (
   in
   rec {
     pname = "openvpn-mullvad";
-    version = "2.6.0";
+    version = "2.6.8";
 
     src = fetchurl {
       url = "https://swupdate.openvpn.net/community/releases/openvpn-${version}.tar.gz";
-      sha256 = "sha256-6+yTMmPJhQ72984SXi8iIUvmCxy7jM/xiJJkP+CDro8=";
+      sha256 = "sha256-Xt4VZcim2IAQD38jUxen7p7qg9UFLbVUfxOp52r3gF0=";
     };
 
     nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [
@@ -69,38 +69,38 @@ openvpn.overrideAttrs (
       # https://github.com/mullvad/openvpn/tags
       (fetchMullvadPatch {
         # "Reduce PUSH_REQUEST_INTERVAL to one second"
-        commit = "4084b49de84e64c56584a378e85faf37973b6d6d";
+        commit = "6fb5e33345831e2bb1df884343893b67ecb83be3";
         sha256 = "sha256-MmYeFSw6c/QJh0LqLgkx+UxrbtTVv6zEFcnYEqznR1c=";
       })
       (fetchMullvadPatch {
         # "Send an event to any plugins when authentication fails"
-        commit = "f24de7922d70c6e1ae06acf18bce1f62d9fa6b07";
-        sha256 = "sha256-RvlQbR6/s4NorYeA6FL7tE6geg6MIoZJtHeYxkVbdwA=";
+        commit = "96d5bf40610927684ed5d13f8b512b63e8f764ef";
+        sha256 = "sha256-HsVx0ZlK7VIFSFet4bG+UEG9W38tavNIP/udesH+Mmg=";
       })
       (fetchMullvadPatch {
         # "Shutdown when STDIN is closed"
-        commit = "81ae84271c044359b67991b15ebfb0cf9a32b3ad";
-        sha256 = "sha256-ilKMyU97ha2m0p1FD64aNQncnKo4Tyi/nATuD5yPmVw=";
+        commit = "30708cefbd067928c896e3ef2420b22b82167ab8";
+        sha256 = "sha256-apL5CWc470DvleQ/pjracsTL+v0zT00apj5cTHWPQZs=";
       })
       (fetchMullvadPatch {
         # "Undo dependency on Python docutils"
-        commit = "a5064b4b6c598b68d8cabc3f4006e5addef1ec1e";
-        sha256 = "sha256-+B6jxL0M+W5LzeukXkir26hn1OaYnycVNBwMYFq6gsE=";
+        commit = "debde9db82d8c2bd4857482c5242722eb1c08e6a";
+        sha256 = "sha256-UKbQa3MDTJLKg0kZ47N7Gier3a6HP2yB6A551yqhWZU=";
       })
       (fetchMullvadPatch {
         # "Prevent signal when stdin is closed from being cleared (#10)"
-        commit = "abe529e6d7f71228a036007c6c02624ec98ad6c1";
-        sha256 = "sha256-qJQeEtZO/+8kenXTKv4Bx6NltUYe8AwzXQtJcyhrjfc=";
+        commit = "78812c51f3b2b6cb9efb73225e1002d055800889";
+        sha256 = "sha256-XaAE90nMgS862NZ5PWcdWKa0YClxr4S24Nq1OVXezTc=";
       })
       (fetchMullvadPatch {
         # "Disable libcap-ng"
-        commit = "598014de7c063fa4e8ba1fffa01434229faafd04";
-        sha256 = "sha256-+cFX5gmMuG6XFkTs6IV7utiKRF9E47F5Pgo93c+zBXo=";
+        commit = "ca3d25f2eff82b5fbfe1012ce900a961d35b35de";
+        sha256 = "sha256-6bEUJ1FHXi1mzxkAaNdrMIHVrhewWenhRnW53rr2o6E=";
       })
       (fetchMullvadPatch {
         # "Remove libnsl dep"
-        commit = "845727e01ab3ec9bd58fcedb31b3cf2ebe2d5226";
-        sha256 = "sha256-Via62wKVfMWHTmO7xIXXO7b5k0KYHs1D0JVg3qnXkeM=";
+        commit = "2d9821971fb29fff7243b49292a74eedb4036236";
+        sha256 = "sha256-Eeci6U6go1ujmbVQvIVM/xa4GSambLPSaowVIvtYlzQ=";
       })
     ];
     postPatch =

--- a/pkgs/by-name/mu/mullvad-vpn/package.nix
+++ b/pkgs/by-name/mu/mullvad-vpn/package.nix
@@ -67,7 +67,7 @@ let
     systemd
   ];
 
-  version = "2025.3";
+  version = "2025.7";
 
   selectSystem =
     attrs:
@@ -79,8 +79,8 @@ let
   };
 
   hash = selectSystem {
-    x86_64-linux = "sha256-yELDdBoa8/Z4ttE/zR6246RBlNzq4YPWo3jcYWsF6M4=";
-    aarch64-linux = "sha256-0KmJGfee+YwiWU3r1G3f6u1bNLyup2Qt97ra4ChRSAs=";
+    x86_64-linux = "sha256-wKmwCLF+H/ByZFYGQMEJT6gmAt2Aa0vZalqaMptPjhU=";
+    aarch64-linux = "sha256-lsHpbxVxThxi+eKY+9c7VcXlDdxBTds6NQKrS0rxt34=";
   };
 in
 


### PR DESCRIPTION
Updates the Mullvad stack to 2025.7. Also includes an `openvpn-mullvad` update.

Closes #422530

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
