### PR TITLE
brush: 0.2.19 -> 0.2.20

### DIFF
--- a/pkgs/by-name/br/brush/package.nix
+++ b/pkgs/by-name/br/brush/package.nix
@@ -12,17 +12,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "brush";
-  version = "0.2.19";
+  version = "0.2.20";
 
   src = fetchFromGitHub {
     owner = "reubeno";
     repo = "brush";
     tag = "brush-shell-v${version}";
-    hash = "sha256-IwBPeOD4BNaeDWlZBWfixhrpMtPu3mcbCFVDMMa8UmY=";
+    hash = "sha256-yPd/dU/GOnx+R8tqkvWs+WsN0Zb6AHFITaE+N4m2rco=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-Z2K+0q8sPsudMhw+IY4Aq+gt9bSPRau0Z6cwpi98c+s=";
+  cargoHash = "sha256-IrjBd+RswBjk/2QW0syU4Hkj2rLfOn/W+czvdEw86RE=";
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Diff: https://github.com/reubeno/brush/compare/brush-shell-v0.2.19...brush-shell-v0.2.20
Release Note: https://github.com/reubeno/brush/releases/tag/brush-shell-v0.2.20

The main purpose of this PR is to generalize the brush binary cache, as addressed in upstream pull request https://github.com/reubeno/brush/pull/600.

Recently, the latest binary cache for `x86_64-linux` has been raising an `Illegal instruction (core dumped)` error on my devices (ZEN2, ZEN3)

* bash: `Illegal instruction (core dumped)`
* zsh: `zsh: illegal hardware instruction (core dumped)`

This issue appears to have started around 2025-06-19 with the build https://hydra.nixos.org/build/300564410, even though Hydra completed the build and `installCheckPhase` successfully.

```console
> nix run 'github:NixOS/nixpkgs/641c8533d1b751f4b0f5cdd3769c3dc2ba26e497#brush' -- --version
brush 0.2.18 (cargo:0.2.18)

> nix run 'github:NixOS/nixpkgs/b8515387500d6b3a8eaa276cc0bccb8d29618a10#brush' -- --version
Illegal instruction (core dumped)

> nix run 'github:NixOS/nixpkgs/605cfcce80bf61ff47815aa8a8d3e275c0655312#brush' -- --version
Illegal instruction (core dumped)
```

```console
> hydra-check brush
Build Status for nixpkgs.brush.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.brush.x86_64-linux
✔  brush-0.2.19  2025-07-04  https://hydra.nixos.org/build/301612776
✔  brush-0.2.18  2025-06-19  https://hydra.nixos.org/build/300564410
✔  brush-0.2.18  2025-05-26  https://hydra.nixos.org/build/298258333
✔  brush-0.2.17  2025-05-16  https://hydra.nixos.org/build/297127207
✔  brush-0.2.17  2025-05-06  https://hydra.nixos.org/build/296132248
✔  brush-0.2.17  2025-04-28  https://hydra.nixos.org/build/295880082
✔  brush-0.2.16  2025-04-17  https://hydra.nixos.org/build/294960965
✔  brush-0.2.16  2025-03-28  https://hydra.nixos.org/build/293696490
✔  brush-0.2.15  2025-03-23  https://hydra.nixos.org/build/292985577
✔  brush-0.2.15  2025-03-13  https://hydra.nixos.org/build/292282887
```

I suspect this is the same issue as described in  https://github.com/NixOS/nixpkgs/pull/393166 and https://github.com/NixOS/hydra/issues/589.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```console
> nix-build --attr pkgs.brush.passthru.tests
...
brush-0.2.20/bin/brush --version
brush 0.2.20 (cargo:0.2.20)
Finished versionCheckPhase
no Makefile or custom installCheckPhase, doing nothing
building '/nix/store/xjsp56cx6ifxw3yxpvxnp81sl9zd815d-actual.drv'...
building '/nix/store/dgk8yhj6zi6hr03kynsa65lq90jk2bzb-equal-contents-brushinfo-performs-to-inspect-completions.drv'...
Checking:
brushinfo performs to inspect completions
expected /nix/store/64q9kw9zkz010mpwm3fndb7zkpl1vb8v-expected and actual /nix/store/yakkdh9axw9bqxz68i92qd71126fx37i-actual match.
OK
/nix/store/va8n9k91ny10mb2c2wl6sdyn63s79bbh-equal-contents-brushinfo-performs-to-inspect-completions
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
