### PR TITLE
dbtpl: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23085,6 +23085,12 @@
     githubId = 251028;
     name = "Shell Turner";
   };
+  shellhazard = {
+    email = "shellhazard@tutanota.com";
+    github = "shellhazard";
+    githubId = 10951745;
+    name = "shellhazard";
+  };
   shelvacu = {
     name = "Shelvacu";
     email = "nix-maint@shelvacu.com";

--- a/pkgs/by-name/db/dbtpl/package.nix
+++ b/pkgs/by-name/db/dbtpl/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  buildPackages,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "dbtpl";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "xo";
+    repo = "dbtpl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-r0QIgfDSt7HWnIDnJWGbwkqkXWYWGXoF5H/+zS6gEtE=";
+  };
+
+  vendorHash = "sha256-scJRJaaccQovxhzC+/OHuPR4NRaE8+u57S1JY40bif8=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  modPostBuild = ''
+    substituteInPlace vendor/github.com/xo/ox/ox.go \
+        --replace-warn "ver := \"(devel)\"" "ver := \"${finalAttrs.version}\""
+  '';
+
+  postInstall =
+    let
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/dbtpl"
+        else
+          lib.getExe buildPackages.dbtpl;
+    in
+    ''
+      installShellCompletion --cmd dbtpl \
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command line tool to generate idiomatic Go code for SQL databases supporting PostgreSQL, MySQL, SQLite, Oracle, and Microsoft SQL Server";
+    homepage = "https://github.com/xo/dbtpl";
+    changelog = "https://github.com/xo/dbtpl/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      xiaoxiangmoe
+      shellhazard
+    ];
+    mainProgram = "dbtpl";
+  };
+})


### PR DESCRIPTION
> dbtpl is a command-line tool to inspect and generate templated code based on a database schema or a custom database query. In addition to being able to generate standardized "model" code for a database, dbtpl is also capable of creating schema creation scripts for a database, generating JSON/YAML definitions, and [Graphviz](https://graphviz.org/) diagrams for schemas.

Note that `dbtpl` supersedes [package `xo`](https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/by-name/xo/xo/package.nix#L53) - the name of the tool has been changed with the latest tagged version - so the previous maintainer has been added here. Additionally, note that the method used to display the version has changed and now depends on building within a git repository (ldflags aren't enough), so we patch the vendor directory instead.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
