### PR TITLE
rosenpass: clean up & add updateScript and NGI team

### DIFF
--- a/pkgs/tools/networking/rosenpass/default.nix
+++ b/pkgs/tools/networking/rosenpass/default.nix
@@ -52,6 +52,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = with lib.maintainers; [ wucke13 ];
+    teams = with lib.teams; [ ngi ];
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/pkgs/tools/networking/rosenpass/default.nix
+++ b/pkgs/tools/networking/rosenpass/default.nix
@@ -8,6 +8,7 @@
   cmake,
   libsodium,
   pkg-config,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rosenpass";
@@ -42,7 +43,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installManPage doc/rosenpass.1
   '';
 
-  passthru.tests.rosenpass = nixosTests.rosenpass;
+  passthru = {
+    tests = { inherit (nixosTests) rosenpass; };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Build post-quantum-secure VPNs with WireGuard";

--- a/pkgs/tools/networking/rosenpass/default.nix
+++ b/pkgs/tools/networking/rosenpass/default.nix
@@ -9,14 +9,14 @@
   libsodium,
   pkg-config,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rosenpass";
   version = "0.2.2";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev = "v${version}";
+    owner = "rosenpass";
+    repo = "rosenpass";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-fQIeKGyTkFWUV9M1o256G4U1Os5OlVsRZu+5olEkbD4=";
   };
 
@@ -60,4 +60,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "rosenpass";
   };
-}
+})

--- a/pkgs/tools/networking/rosenpass/default.nix
+++ b/pkgs/tools/networking/rosenpass/default.nix
@@ -44,14 +44,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru.tests.rosenpass = nixosTests.rosenpass;
 
-  meta = with lib; {
+  meta = {
     description = "Build post-quantum-secure VPNs with WireGuard";
     homepage = "https://rosenpass.eu/";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [ wucke13 ];
+    maintainers = with lib.maintainers; [ wucke13 ];
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/pkgs/tools/networking/rosenpass/default.nix
+++ b/pkgs/tools/networking/rosenpass/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "rosenpass";
     repo = "rosenpass";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-fQIeKGyTkFWUV9M1o256G4U1Os5OlVsRZu+5olEkbD4=";
   };
 


### PR DESCRIPTION
This PR causes 0 rebuilds.

Related-to:
- https://github.com/ngi-nix/ngipkgs/issues/1047
- https://github.com/NixOS/nixpkgs/issues/277994
- https://github.com/NixOS/nixpkgs/issues/310373
- https://github.com/NixOS/nixpkgs/issues/371862

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
