### PR TITLE
rsync: fix `checkPhase` on sandboxed Darwin

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -31,6 +31,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-KSS8s6Hti1UfwQH3QLnw/gogKxFQJ2R89phQ1l/YjFI=";
   };
 
+  patches = [
+    ./testsuite-use-srcdir.patch
+  ];
+
   nativeBuildInputs = [
     updateAutotoolsGnuConfigScriptsHook
     perl
@@ -72,6 +76,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   passthru.tests = { inherit (nixosTests) rsyncd; };
+
+  __darwinAllowLocalNetworking = true;
 
   doCheck = true;
 

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -51,8 +51,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional enableOpenSSL openssl
   ++ lib.optional enableXXHash xxHash;
 
-  # fakeroot doesn't work well on darwin anymore, apparently
-  checkInputs = lib.optionals (!stdenv.isDarwin) [ fakeroot ];
+  checkInputs = [ fakeroot ];
 
   configureFlags = [
     (lib.enableFeature enableLZ4 "lz4")

--- a/pkgs/applications/networking/sync/rsync/testsuite-use-srcdir.patch
+++ b/pkgs/applications/networking/sync/rsync/testsuite-use-srcdir.patch
@@ -1,0 +1,41 @@
+diff --git a/testsuite/longdir.test b/testsuite/longdir.test
+index 8d66bb5f..22364dbe 100644
+--- a/testsuite/longdir.test
++++ b/testsuite/longdir.test
+@@ -15,11 +15,7 @@ longdir="$fromdir/$longname/$longname/$longname"
+ makepath "$longdir" || test_skipped "unable to create long directory"
+ touch "$longdir/1" || test_skipped "unable to create files in long directory"
+ date > "$longdir/1"
+-if [ -r /etc ]; then
+-    ls -la /etc >"$longdir/2"
+-else
+-    ls -la / >"$longdir/2"
+-fi
++ls -la "$srcdir" >"$longdir/2"
+ checkit "$RSYNC --delete -avH '$fromdir/' '$todir'" "$fromdir/" "$todir"
+ 
+ # The script would have aborted on error, so getting here means we've won.
+diff --git a/testsuite/rsync.fns b/testsuite/rsync.fns
+index 2ab97b69..ca8cc8a7 100644
+--- a/testsuite/rsync.fns
++++ b/testsuite/rsync.fns
+@@ -194,17 +194,9 @@ hands_setup() {
+     mkdir "$fromdir/dir/subdir"
+     echo some data > "$fromdir/dir/subdir/foobar.baz"
+     mkdir "$fromdir/dir/subdir/subsubdir"
+-    if [ -r /etc ]; then
+-	ls -ltr /etc > "$fromdir/dir/subdir/subsubdir/etc-ltr-list"
+-    else
+-	ls -ltr / > "$fromdir/dir/subdir/subsubdir/etc-ltr-list"
+-    fi
++    ls -ltr "$srcdir" > "$fromdir/dir/subdir/subsubdir/etc-ltr-list"
+     mkdir "$fromdir/dir/subdir/subsubdir2"
+-    if [ -r /bin ]; then
+-	ls -lt /bin > "$fromdir/dir/subdir/subsubdir2/bin-lt-list"
+-    else
+-	ls -lt / > "$fromdir/dir/subdir/subsubdir2/bin-lt-list"
+-    fi
++    ls -lt "$srcdir" > "$fromdir/dir/subdir/subsubdir2/bin-lt-list"
+ 
+ #      echo testing head:
+ #      ls -lR "$srcdir" | head -10 || echo failed


### PR DESCRIPTION
[The test scripts try to access directories which are inaccessible outside of the sandbox (/etc and /) which causes the tests to fail][1]. Add a patch to make the test scripts use an accessible directory (the source root) instead.

Also add fakeroot to checkInputs enable the currently-skipped chown and device tests (as it now works on Darwin).

[1]: https://gist.github.com/al3xtjames/698ce795e308a18ca1fa85bd883ed661

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
