### PR TITLE
trevorspray: init at 2.3.1

### DIFF
--- a/pkgs/by-name/tr/trevorproxy/package.nix
+++ b/pkgs/by-name/tr/trevorproxy/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication trevorproxy

--- a/pkgs/by-name/tr/trevorspray/package.nix
+++ b/pkgs/by-name/tr/trevorspray/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  python3,
+  fetchPypi,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "trevorspray";
+  version = "2.3.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-2kprXyZUAe8lBV48mBpmkhBtOoxgrP/TOTdS3Kw2WTE=";
+  };
+
+  build-system = with python3.pkgs; [ poetry-core ];
+
+  dependencies = with python3.pkgs; [
+    beautifulsoup4
+    exchangelib
+    mechanicalsoup
+    pygments
+    pysocks
+    sh
+    tldextract
+    trevorproxy
+  ];
+
+  meta = {
+    description = "Modular password spraying tool";
+    homepage = "https://github.com/blacklanternsecurity/TREVORspray";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "trevorspray";
+  };
+}

--- a/pkgs/development/python-modules/mechanicalsoup/default.nix
+++ b/pkgs/development/python-modules/mechanicalsoup/default.nix
@@ -4,20 +4,19 @@
   buildPythonPackage,
   fetchFromGitHub,
   lxml,
+  pytest-cov-stub,
   pytest-httpbin,
   pytest-mock,
   pytestCheckHook,
-  pythonOlder,
-  requests,
   requests-mock,
+  requests,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "mechanicalsoup";
   version = "1.4.0";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.7";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "MechanicalSoup";
@@ -31,10 +30,12 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "'pytest-runner'" ""
     substituteInPlace setup.cfg \
-      --replace " --cov --cov-config .coveragerc --flake8" ""
+      --replace " --flake8" ""
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     beautifulsoup4
     lxml
     requests
@@ -43,6 +44,7 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   nativeCheckInputs = [
+    pytest-cov-stub
     pytest-httpbin
     pytest-mock
     pytestCheckHook
@@ -50,6 +52,11 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "mechanicalsoup" ];
+
+  disabledTests = [
+    # Missing module
+    "test_select_form_associated_elements"
+  ];
 
   meta = with lib; {
     description = "Python library for automating interaction with websites";

--- a/pkgs/development/python-modules/trevorproxy/default.nix
+++ b/pkgs/development/python-modules/trevorproxy/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  sh,
+}:
+
+buildPythonPackage rec {
+  pname = "trevorproxy";
+  version = "1.0.9";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ZUOqtJmLiZbe2LBkpTGELeKFkmzA0WCJ/TXPi9eyRXs=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ sh ];
+
+  pythonImportsCheck = [ "trevorproxy" ];
+
+  meta = {
+    description = "Module to rotate the source IP address via SSH proxies and other methods";
+    homepage = "https://github.com/blacklanternsecurity/TREVORproxy";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "trevorproxy";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18067,6 +18067,8 @@ self: super: with self; {
 
   treq = callPackage ../development/python-modules/treq { };
 
+  trevorproxy = callPackage ../development/python-modules/trevorproxy { };
+
   trezor = callPackage ../development/python-modules/trezor { };
 
   trezor-agent = callPackage ../development/python-modules/trezor-agent {


### PR DESCRIPTION
Modular password spraying tool

https://github.com/blacklanternsecurity/TREVORspray

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
