### PR TITLE
odin: use external Raylib instead of vendored

### DIFF
--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -80,6 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "odin";
     maintainers = with lib.maintainers; [
       astavie
+      diniamo
     ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isMusl;

--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -23,8 +23,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./darwin-remove-impure-links.patch
+    # The default behavior is to use the statically linked Raylib libraries,
+    # but GLFW still attempts to load Xlib at runtime, which won't normally be
+    # available on Nix based systems. Instead, use the "system" Raylib version,
+    # which can be provided by a pure Nix expression, for example in a shell.
+    ./system-raylib.patch
   ];
   postPatch = ''
+    rm -r vendor/raylib/{linux,macos,macos-arm64,wasm,windows}
+
     patchShebangs --build build_odin.sh
   '';
 

--- a/pkgs/by-name/od/odin/system-raylib.patch
+++ b/pkgs/by-name/od/odin/system-raylib.patch
@@ -1,0 +1,141 @@
+diff --git a/vendor/raylib/raygui.odin b/vendor/raylib/raygui.odin
+index 559437a60..cd31fbe43 100644
+--- a/vendor/raylib/raygui.odin
++++ b/vendor/raylib/raygui.odin
+@@ -2,34 +2,7 @@ package raylib
+ 
+ import "core:c"
+ 
+-RAYGUI_SHARED :: #config(RAYGUI_SHARED, false)
+-RAYGUI_WASM_LIB :: #config(RAYGUI_WASM_LIB, "wasm/libraygui.a")
+-
+-when ODIN_OS == .Windows {
+-	foreign import lib {
+-		"windows/rayguidll.lib" when RAYGUI_SHARED else "windows/raygui.lib",
+-	}
+-} else when ODIN_OS == .Linux  {
+-	foreign import lib {
+-		"linux/libraygui.so" when RAYGUI_SHARED else "linux/libraygui.a",
+-	}
+-} else when ODIN_OS == .Darwin {
+-	when ODIN_ARCH == .arm64 {
+-		foreign import lib {
+-			"macos-arm64/libraygui.dylib" when RAYGUI_SHARED else "macos-arm64/libraygui.a",
+-		}
+-	} else {
+-		foreign import lib {
+-			"macos/libraygui.dylib" when RAYGUI_SHARED else "macos/libraygui.a",
+-		}
+-	}
+-} else when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 {
+-	foreign import lib {
+-		RAYGUI_WASM_LIB,
+-	}
+-} else {
+-	foreign import lib "system:raygui"
+-}
++foreign import lib "system:raygui"
+ 
+ RAYGUI_VERSION :: "4.0"
+ 
+diff --git a/vendor/raylib/raylib.odin b/vendor/raylib/raylib.odin
+index 02bb6deea..0df93009b 100644
+--- a/vendor/raylib/raylib.odin
++++ b/vendor/raylib/raylib.odin
+@@ -99,42 +99,7 @@ MAX_TEXT_BUFFER_LENGTH :: #config(RAYLIB_MAX_TEXT_BUFFER_LENGTH, 1024)
+ 
+ #assert(size_of(rune) == size_of(c.int))
+ 
+-RAYLIB_SHARED :: #config(RAYLIB_SHARED, false)
+-RAYLIB_WASM_LIB :: #config(RAYLIB_WASM_LIB, "wasm/libraylib.a")
+-
+-when ODIN_OS == .Windows {
+-	@(extra_linker_flags="/NODEFAULTLIB:" + ("msvcrt" when RAYLIB_SHARED else "libcmt"))
+-	foreign import lib {
+-		"windows/raylibdll.lib" when RAYLIB_SHARED else "windows/raylib.lib" ,
+-		"system:Winmm.lib",
+-		"system:Gdi32.lib",
+-		"system:User32.lib",
+-		"system:Shell32.lib",
+-	}
+-} else when ODIN_OS == .Linux  {
+-	foreign import lib {
+-		// Note(bumbread): I'm not sure why in `linux/` folder there are
+-		// multiple copies of raylib.so, but since these bindings are for
+-		// particular version of the library, I better specify it. Ideally,
+-		// though, it's best specified in terms of major (.so.4)
+-		"linux/libraylib.so.550" when RAYLIB_SHARED else "linux/libraylib.a",
+-		"system:dl",
+-		"system:pthread",
+-	}
+-} else when ODIN_OS == .Darwin {
+-	foreign import lib {
+-		"macos/libraylib.550.dylib" when RAYLIB_SHARED else "macos/libraylib.a",
+-		"system:Cocoa.framework",
+-		"system:OpenGL.framework",
+-		"system:IOKit.framework",
+-	} 
+-} else when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 {
+-	foreign import lib {
+-		RAYLIB_WASM_LIB,
+-	}
+-} else {
+-	foreign import lib "system:raylib"
+-}
++foreign import lib "system:raylib"
+ 
+ VERSION_MAJOR :: 5
+ VERSION_MINOR :: 5
+diff --git a/vendor/raylib/rlgl/rlgl.odin b/vendor/raylib/rlgl/rlgl.odin
+index 6ac19695d..78a483a59 100644
+--- a/vendor/raylib/rlgl/rlgl.odin
++++ b/vendor/raylib/rlgl/rlgl.odin
+@@ -112,47 +112,12 @@ import rl "../."
+ 
+ VERSION :: "5.0"
+ 
+-RAYLIB_SHARED :: #config(RAYLIB_SHARED, false)
+-RAYLIB_WASM_LIB :: #config(RAYLIB_WASM_LIB, "../wasm/libraylib.a")
+-
+ // Note: We pull in the full raylib library. If you want a truly stand-alone rlgl, then:
+ // - Compile a separate rlgl library and use that in the foreign import blocks below.
+ // - Remove the `import rl "../."` line
+ // - Copy the code from raylib.odin for any types we alias from that package (see PixelFormat etc)
+ 
+-when ODIN_OS == .Windows {
+-	@(extra_linker_flags="/NODEFAULTLIB:" + ("msvcrt" when RAYLIB_SHARED else "libcmt"))
+-	foreign import lib {
+-		"../windows/raylibdll.lib" when RAYLIB_SHARED else "../windows/raylib.lib" ,
+-		"system:Winmm.lib",
+-		"system:Gdi32.lib",
+-		"system:User32.lib",
+-		"system:Shell32.lib",
+-	}
+-} else when ODIN_OS == .Linux  {
+-	foreign import lib {
+-		// Note(bumbread): I'm not sure why in `linux/` folder there are
+-		// multiple copies of raylib.so, but since these bindings are for
+-		// particular version of the library, I better specify it. Ideally,
+-		// though, it's best specified in terms of major (.so.4)
+-		"../linux/libraylib.so.550" when RAYLIB_SHARED else "../linux/libraylib.a",
+-		"system:dl",
+-		"system:pthread",
+-	}
+-} else when ODIN_OS == .Darwin {
+-	foreign import lib {
+-		"../macos/libraylib.550.dylib" when RAYLIB_SHARED else "../macos/libraylib.a",
+-		"system:Cocoa.framework",
+-		"system:OpenGL.framework",
+-		"system:IOKit.framework",
+-	} 
+-} else when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 {
+-	foreign import lib {
+-		RAYLIB_WASM_LIB,
+-	}
+-} else {
+-	foreign import lib "system:raylib"
+-}
++foreign import lib "system:raylib"
+ 
+ GRAPHICS_API_OPENGL_11  :: false
+ GRAPHICS_API_OPENGL_21  :: true


### PR DESCRIPTION
See the commit description and the issue for details.

Supersedes #411850
Fixes #348498

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
