### PR TITLE
Revert "[Backport release-25.05] deploy-rs: 0-unstable-2024-06-12 -> 0-unstable-2025-06-05"

### DIFF
--- a/pkgs/by-name/de/deploy-rs/package.nix
+++ b/pkgs/by-name/de/deploy-rs/package.nix
@@ -6,26 +6,23 @@
 
 rustPlatform.buildRustPackage {
   pname = "deploy-rs";
-  version = "0-unstable-2025-06-05";
+  version = "0-unstable-2024-06-12";
 
   src = fetchFromGitHub {
     owner = "serokell";
     repo = "deploy-rs";
-    rev = "6bc76b872374845ba9d645a2f012b764fecd765f";
-    hash = "sha256-hXh76y/wDl15almBcqvjryB50B0BaiXJKk20f314RoE=";
+    rev = "3867348fa92bc892eba5d9ddb2d7a97b9e127a8a";
+    hash = "sha256-FaGrf7qwZ99ehPJCAwgvNY5sLCqQ3GDiE/6uLhxxwSY=";
   };
 
-  cargoHash = "sha256-9O93YTEz+e2oxenE0gwxsbz55clbKo9+37yVOqz7ErE=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-e+Exc0lEamAieZ7QHJBYvmnmM/9YHdLRD3La4U5FRMo=";
 
   meta = {
     description = "Multi-profile Nix-flake deploy tool";
     homepage = "https://github.com/serokell/deploy-rs";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [
-      teutat3s
-      jk
-    ];
-    teams = [ lib.teams.serokell ];
+    maintainers = with lib.maintainers; [ teutat3s ];
     mainProgram = "deploy";
   };
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#419993

Resolves regression (#422524) but puts deploy-rs back 1 year of updates

<h3>Target <code>Cargo.lock</code></h3>
<h4>Vulnerabilities (9)</h4>
<table>
    <tr>
        <th>Package</th>
        <th>ID</th>
        <th>Severity</th>
        <th>Installed Version</th>
        <th>Fixed Version</th>
    </tr>
    <tr>
        <td><code>atty</code></td>
        <td>GHSA-g98v-hv3f-hcfr</td>
        <td>LOW</td>
        <td>0.2.14</td>
        <td></td>
    </tr>
    <tr>
        <td><code>mio</code></td>
        <td>CVE-2024-27308</td>
        <td>HIGH</td>
        <td>0.7.6</td>
        <td>0.8.11</td>
    </tr>
    <tr>
        <td><code>mio</code></td>
        <td>CVE-2024-27308</td>
        <td>HIGH</td>
        <td>0.8.6</td>
        <td>0.8.11</td>
    </tr>
    <tr>
        <td><code>time</code></td>
        <td>CVE-2020-26235</td>
        <td>MEDIUM</td>
        <td>0.1.44</td>
        <td>0.2.23</td>
    </tr>
    <tr>
        <td><code>tokio</code></td>
        <td>CVE-2021-45710</td>
        <td>HIGH</td>
        <td>1.9.0</td>
        <td>1.8.4, 1.13.1</td>
    </tr>
    <tr>
        <td><code>tokio</code></td>
        <td>CVE-2023-22466</td>
        <td>MEDIUM</td>
        <td>1.9.0</td>
        <td>1.18.4, 1.20.3, 1.23.1</td>
    </tr>
    <tr>
        <td><code>tokio</code></td>
        <td>GHSA-4q83-7cq4-p6wg</td>
        <td>LOW</td>
        <td>1.9.0</td>
        <td>1.24.2, 1.20.4, 1.18.5</td>
    </tr>
    <tr>
        <td><code>tokio</code></td>
        <td>GHSA-rr8g-9fpq-6wmg</td>
        <td>LOW</td>
        <td>1.9.0</td>
        <td>1.44.2, 1.38.2, 1.43.1</td>
    </tr>
    <tr>
        <td><code>whoami</code></td>
        <td>GHSA-w5w5-8vfh-xcjq</td>
        <td>HIGH</td>
        <td>0.9.0</td>
        <td>1.5.0</td>
    </tr>
</table>