### PR TITLE
vscode-html-languageserver: init at 1.101.2

### DIFF
--- a/pkgs/by-name/vs/vscode-html-languageserver/add-typescript-deps.patch
+++ b/pkgs/by-name/vs/vscode-html-languageserver/add-typescript-deps.patch
@@ -1,0 +1,44 @@
+diff --git a/package-lock.json b/package-lock.json
+index 8de56453512..e2d5fc6f722 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -10,6 +10,7 @@
+       "license": "MIT",
+       "dependencies": {
+         "@vscode/l10n": "^0.0.18",
++        "typescript": "^5.8.3",
+         "vscode-css-languageservice": "^6.3.6",
+         "vscode-html-languageservice": "^5.5.0",
+         "vscode-languageserver": "^10.0.0-next.13",
+@@ -45,6 +46,19 @@
+       "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+       "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
+     },
++    "node_modules/typescript": {
++      "version": "5.8.3",
++      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
++      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
++      "license": "Apache-2.0",
++      "bin": {
++        "tsc": "bin/tsc",
++        "tsserver": "bin/tsserver"
++      },
++      "engines": {
++        "node": ">=14.17"
++      }
++    },
+     "node_modules/undici-types": {
+       "version": "6.20.0",
+       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+diff --git a/package.json b/package.json
+index 64b426fa41a..a372f64f249 100644
+--- a/package.json
++++ b/package.json
+@@ -10,6 +10,7 @@
+   "main": "./out/node/htmlServerMain",
+   "dependencies": {
+     "@vscode/l10n": "^0.0.18",
++    "typescript": "^5.8.3",
+     "vscode-css-languageservice": "^6.3.6",
+     "vscode-html-languageservice": "^5.5.0",
+     "vscode-languageserver": "^10.0.0-next.13",

--- a/pkgs/by-name/vs/vscode-html-languageserver/package.nix
+++ b/pkgs/by-name/vs/vscode-html-languageserver/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nodejs,
+  typescript,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "vscode-html-languageserver";
+  version = "1.101.2";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "vscode";
+    tag = finalAttrs.version;
+    hash = "sha256-wdI6VlJ4WoSNnwgkb6dkVYcq/P/yzflv5mE9PuYBVx4=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/extensions/html-language-features/server";
+
+  npmDepsHash = "sha256-ONORb/r/jowASsdMdDlh0B6b2mG6Gkt2nHTMRSFMZiM=";
+
+  patches = [ ./add-typescript-deps.patch ];
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    typescript
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    tsc -p .
+    runHook postBuild
+  '';
+
+  dontNpmBuild = true;
+
+  postInstall = ''
+    makeBinaryWrapper ${lib.getExe' nodejs "node"} $out/bin/vscode-html-languageserver \
+      --add-flags $out/lib/node_modules/vscode-html-languageserver/out/node/htmlServerMain.js
+    ln -s $out/bin/vscode-html-languageserver $out/bin/vscode-html-language-server
+  '';
+
+  meta = {
+    description = "HTML language server";
+    homepage = "https://github.com/microsoft/vscode/tree/${finalAttrs.src.tag}/extensions/html-language-features/server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryota2357 ];
+    mainProgram = "vscode-html-languageserver";
+  };
+})


### PR DESCRIPTION
HTML language server under VSCode.

https://github.com/microsoft/vscode/tree/main/extensions/html-language-features/server

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
