### PR TITLE
treewide: remove usage of emulator for shell completions

### DIFF
--- a/pkgs/by-name/ba/bacon/package.nix
+++ b/pkgs/by-name/ba/bacon/package.nix
@@ -59,13 +59,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall =
     let
-      bacon = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/bacon";
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/bacon"
+        else
+          lib.getExe buildPackages.bacon;
     in
-    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+    ''
       installShellCompletion --cmd bacon \
-        --bash <(COMPLETE=bash ${bacon}) \
-        --fish <(COMPLETE=fish ${bacon}) \
-        --zsh <(COMPLETE=zsh ${bacon})
+        --bash <(COMPLETE=bash ${exe}) \
+        --fish <(COMPLETE=fish ${exe}) \
+        --zsh <(COMPLETE=zsh ${exe})
     '';
 
   passthru = {

--- a/pkgs/by-name/br/broot/package.nix
+++ b/pkgs/by-name/br/broot/package.nix
@@ -54,21 +54,26 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   postInstall =
-    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+    let
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/broot"
+        else
+          lib.getExe buildPackages.broot;
+    in
+    ''
       # Install shell function for bash.
-      ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function bash > br.bash
+      ${exe} --print-shell-function bash > br.bash
       install -Dm0444 -t $out/etc/profile.d br.bash
 
       # Install shell function for zsh.
-      ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function zsh > br.zsh
+      ${exe} --print-shell-function zsh > br.zsh
       install -Dm0444 br.zsh $out/share/zsh/site-functions/br
 
       # Install shell function for fish
-      ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function fish > br.fish
+      ${exe} --print-shell-function fish > br.fish
       install -Dm0444 -t $out/share/fish/vendor_functions.d br.fish
 
-    ''
-    + ''
       # install shell completion files
       OUT_DIR=$releaseDir/build/broot-*/out
 

--- a/pkgs/by-name/fl/flawz/package.nix
+++ b/pkgs/by-name/fl/flawz/package.nix
@@ -38,31 +38,39 @@ rustPlatform.buildRustPackage rec {
     "man"
   ];
 
-  postInstall =
-    let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
-      flawz-mangen = "${emulator} $out/bin/flawz-mangen";
-      flawz-completions = "${emulator} $out/bin/flawz-completions";
-    in
-    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
-      export OUT_DIR=$(mktemp -d)
+  postInstall = ''
+    ${lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      # bash
+      ''
+        export OUT_DIR=$(mktemp -d)
 
-      # Generate the man pages
-      ${flawz-mangen}
-      installManPage $OUT_DIR/flawz.1
+        # Generate the man pages
+        $out/bin/flawz-mangen
+        installManPage $OUT_DIR/flawz.1
 
-      # Generate shell completions
-      ${flawz-completions}
-      installShellCompletion \
-        --bash $OUT_DIR/flawz.bash \
-        --fish $OUT_DIR/flawz.fish \
-        --zsh $OUT_DIR/_flawz
+        # Generate shell completions
+        $out/bin/flawz-completions
+        installShellCompletion \
+          --bash $OUT_DIR/flawz.bash \
+          --fish $OUT_DIR/flawz.fish \
+          --zsh $OUT_DIR/_flawz
 
-      # Clean up temporary directory
-      rm -rf $OUT_DIR
-      # No need for these binaries to end up in the output
-      rm $out/bin/flawz-{completions,mangen}
-    '';
+        # Clean up temporary directory
+        rm -rf $OUT_DIR
+      ''
+    }
+    ${lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      # bash
+      ''
+        # copy man pages and shell completions from buildPackage
+        mkdir -p $out/share $man/share/man
+        cp -rp ${buildPackages.flawz}/share $out
+        cp -rp ${buildPackages.flawz.man}/share $man
+      ''
+    }
+    # No need for these binaries to end up in the output
+    rm $out/bin/flawz-{completions,mangen}
+  '';
 
   meta = {
     description = "Terminal UI for browsing CVEs";

--- a/pkgs/by-name/fo/foxglove-cli/package.nix
+++ b/pkgs/by-name/fo/foxglove-cli/package.nix
@@ -50,17 +50,20 @@ buildGoModule (finalAttrs: {
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/foxglove"
+        else
+          lib.getExe buildPackages.foxglove-cli;
     in
     ''
       installShellCompletion --cmd foxglove \
-        --bash <(${emulator} $out/bin/foxglove completion bash) \
-        --fish <(${emulator} $out/bin/foxglove completion fish) \
-        --zsh <(${emulator} $out/bin/foxglove completion zsh)
-    ''
-  );
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/gh/gh-classroom/package.nix
+++ b/pkgs/by-name/gh/gh-classroom/package.nix
@@ -28,17 +28,20 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/gh-classroom"
+        else
+          lib.getExe buildPackages.gh-classroom;
     in
     ''
       installShellCompletion --cmd gh-classroom \
-        --bash <(${emulator} $out/bin/gh-classroom --bash-completion) \
-        --fish <(${emulator} $out/bin/gh-classroom --fish-completion) \
-        --zsh <(${emulator} $out/bin/gh-classroom --zsh-completion)
-    ''
-  );
+        --bash <(${exe} --bash-completion) \
+        --fish <(${exe} --fish-completion) \
+        --zsh <(${exe} --zsh-completion)
+    '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/gi/gitoxide/package.nix
+++ b/pkgs/by-name/gi/gitoxide/package.nix
@@ -12,9 +12,16 @@
 }:
 
 let
-  canRunCmd = stdenv.hostPlatform.emulatorAvailable buildPackages;
-  gix = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/gix";
-  ein = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/ein";
+  gix =
+    if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+      "$out/bin/gix"
+    else
+      lib.getExe' buildPackages.gitoxide "gix";
+  ein =
+    if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+      "$out/bin/ein"
+    else
+      lib.getExe' buildPackages.gitoxide "ein";
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gitoxide";
@@ -38,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [ curl ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ openssl ];
 
-  preFixup = lib.optionalString canRunCmd ''
+  preFixup = ''
     installShellCompletion --cmd gix \
       --bash <(${gix} completions --shell bash) \
       --fish <(${gix} completions --shell fish) \

--- a/pkgs/by-name/gu/guesswidth/package.nix
+++ b/pkgs/by-name/gu/guesswidth/package.nix
@@ -30,17 +30,20 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/guesswidth"
+        else
+          lib.getExe buildPackages.guesswidth;
     in
     ''
       installShellCompletion --cmd guesswidth \
-        --bash <(${emulator} $out/bin/guesswidth completion bash) \
-        --fish <(${emulator} $out/bin/guesswidth completion fish) \
-        --zsh <(${emulator} $out/bin/guesswidth completion zsh)
-    ''
-  );
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/ju/jujutsu/package.nix
+++ b/pkgs/by-name/ju/jujutsu/package.nix
@@ -68,9 +68,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall =
     let
-      jj = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/jj";
+      jj =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/jj"
+        else
+          lib.getExe buildPackages.jujutsu;
     in
-    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+    ''
       mkdir -p $out/share/man
       ${jj} util install-man-pages $out/share/man/
 

--- a/pkgs/by-name/ku/kubectl-rook-ceph/package.nix
+++ b/pkgs/by-name/ku/kubectl-rook-ceph/package.nix
@@ -21,23 +21,23 @@ buildGoModule (finalAttrs: {
   postInstall = ''
     mv $out/bin/cmd $out/bin/kubectl-rook-ceph
   '';
+
   # FIXME: uncomment once https://github.com/rook/kubectl-rook-ceph/issues/353 has been resolved
   # nativeBuildInputs = [ installShellFiles ];
   # postInstall =
-  #   ''
-  #     ln -s $out/bin/cmd $out/bin/kubectl-rook-ceph
-  #   ''
-  #   + lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
-  #     let
-  #       emulator = stdenv.hostPlatform.emulator buildPackages;
-  #     in
-  #     ''
-  #       installShellCompletion --cmd kubectl-rook-ceph \
-  #       --bash <(${emulator} $out/bin/kubectl-rook-ceph completion bash) \
-  #       --fish <(${emulator} $out/bin/kubectl-rook-ceph completion fish) \
-  #       --zsh <(${emulator} $out/bin/kubectl-rook-ceph completion zsh)
-  #     ''
-  #   );
+  #   let
+  #    exe =
+  #      if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+  #        "$out/bin/kubectl-rook-ceph"
+  #      else
+  #        lib.getExe buildPackages.kubectl-rook-ceph;
+  #  in
+  #  ''
+  #    installShellCompletion --cmd kubectl-rook-ceph \
+  #    --bash <(${exe} completion bash) \
+  #    --fish <(${exe} completion fish) \
+  #    --zsh <(${exe} completion zsh)
+  #  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/mc/mcap-cli/package.nix
+++ b/pkgs/by-name/mc/mcap-cli/package.nix
@@ -46,17 +46,21 @@ buildGoModule {
     "-skip=TestCat|TestInfo"
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/mcap"
+        else
+          lib.getExe buildPackages.mcap-cli;
     in
     ''
       installShellCompletion --cmd mcap \
-        --bash <(${emulator} $out/bin/mcap completion bash) \
-        --fish <(${emulator} $out/bin/mcap completion fish) \
-        --zsh <(${emulator} $out/bin/mcap completion zsh)
-    ''
-  );
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
+
   passthru = {
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/md/mdtsql/package.nix
+++ b/pkgs/by-name/md/mdtsql/package.nix
@@ -24,17 +24,20 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/mdtsql"
+        else
+          lib.getExe buildPackages.mdtsql;
     in
     ''
       installShellCompletion --cmd mdtsql \
-        --bash <(${emulator} $out/bin/mdtsql completion bash) \
-        --fish <(${emulator} $out/bin/mdtsql completion fish) \
-        --zsh <(${emulator} $out/bin/mdtsql completion zsh)
-    ''
-  );
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/mo/moon/package.nix
+++ b/pkgs/by-name/mo/moon/package.nix
@@ -35,17 +35,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellFiles
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/moon"
+        else
+          lib.getExe buildPackages.moon;
     in
     ''
       installShellCompletion --cmd moon \
-        --bash <(${emulator} $out/bin/moon completions --shell bash) \
-        --fish <(${emulator} $out/bin/moon completions --shell fish) \
-        --zsh <(${emulator} $out/bin/moon completions --shell zsh)
-    ''
-  );
+        --bash <(${exe} completions --shell bash) \
+        --fish <(${exe} completions --shell fish) \
+        --zsh <(${exe} completions --shell zsh)
+    '';
 
   # Some tests fail, because test using internet connection and install NodeJS by example
   doCheck = false;

--- a/pkgs/by-name/mr/mrpack-install/package.nix
+++ b/pkgs/by-name/mr/mrpack-install/package.nix
@@ -61,13 +61,17 @@ buildGoModule {
 
   postInstall =
     let
-      mrpack-install = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/mrpack-install";
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/mrpack-install"
+        else
+          lib.getExe buildPackages.mrpack-install;
     in
-    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+    ''
       installShellCompletion --cmd mrpack-install \
-        --bash <(${mrpack-install} completion bash) \
-        --fish <(${mrpack-install} completion fish) \
-        --zsh <(${mrpack-install} completion zsh)
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
     '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ne/nelm/package.nix
+++ b/pkgs/by-name/ne/nelm/package.nix
@@ -36,18 +36,21 @@ buildGoModule (finalAttrs: {
     unset subPackages
   '';
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/nelm"
+        else
+          lib.getExe buildPackages.nelm;
     in
     ''
       for shell in bash fish zsh; do
         installShellCompletion \
           --cmd nelm \
-          --$shell <(${emulator} $out/bin/nelm completion $shell)
+          --$shell <(${exe} completion $shell)
       done
-    ''
-  );
+    '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;

--- a/pkgs/by-name/nh/nh/package.nix
+++ b/pkgs/by-name/nh/nh/package.nix
@@ -34,20 +34,23 @@ rustPlatform.buildRustPackage (finalAttrs: {
     makeBinaryWrapper
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/nh"
+        else
+          lib.getExe buildPackages.nh;
     in
     ''
       mkdir completions
 
       for shell in bash zsh fish; do
-        NH_NO_CHECKS=1 ${emulator} $out/bin/nh completions $shell > completions/nh.$shell
+        NH_NO_CHECKS=1 ${exe} completions $shell > completions/nh.$shell
       done
 
       installShellCompletion completions/*
-    ''
-  );
+    '';
 
   postFixup = ''
     wrapProgram $out/bin/nh \

--- a/pkgs/by-name/pi/pixi/package.nix
+++ b/pkgs/by-name/pi/pixi/package.nix
@@ -44,17 +44,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # As the version is updated, the number of failed tests continues to grow.
   doCheck = false;
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/pixi"
+        else
+          lib.getExe buildPackages.pixi;
     in
     ''
       installShellCompletion --cmd pixi \
-        --bash <(${emulator} $out/bin/pixi completion --shell bash) \
-        --fish <(${emulator} $out/bin/pixi completion --shell fish) \
-        --zsh <(${emulator} $out/bin/pixi completion --shell zsh)
-    ''
-  );
+        --bash <(${exe} completion --shell bash) \
+        --fish <(${exe} completion --shell fish) \
+        --zsh <(${exe} completion --shell zsh)
+    '';
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/po/podman-bootc/package.nix
+++ b/pkgs/by-name/po/podman-bootc/package.nix
@@ -47,17 +47,21 @@ buildGoModule rec {
 
   postInstall =
     let
-      podman-bootc = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/podman-bootc";
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/podman-bootc"
+        else
+          lib.getExe buildPackages.podman-bootc;
     in
-    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+    ''
       # podman-bootc always tries to touch cache and run dirs, no matter the command
       export HOME=$TMPDIR
       export XDG_RUNTIME_DIR=$TMPDIR
 
       installShellCompletion --cmd podman-bootc \
-        --bash <(${podman-bootc} completion bash) \
-        --fish <(${podman-bootc} completion fish) \
-        --zsh <(${podman-bootc} completion zsh)
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
     '';
 
   meta = {

--- a/pkgs/by-name/ra/rattler-build/package.nix
+++ b/pkgs/by-name/ra/rattler-build/package.nix
@@ -39,17 +39,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoBuildFlags = [ "--bin rattler-build" ]; # other bin like `generate-cli-docs` shouldn't be distributed.
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/rattler-build"
+        else
+          lib.getExe buildPackages.rattler-build;
     in
     ''
       installShellCompletion --cmd rattler-build \
-        --bash <(${emulator} $out/bin/rattler-build completion --shell bash) \
-        --fish <(${emulator} $out/bin/rattler-build completion --shell fish) \
-        --zsh <(${emulator} $out/bin/rattler-build completion --shell zsh)
-    ''
-  );
+        --bash <(${exe} completion --shell bash) \
+        --fish <(${exe} completion --shell fish) \
+        --zsh <(${exe} completion --shell zsh)
+    '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/ru/ruff/package.nix
+++ b/pkgs/by-name/ru/ruff/package.nix
@@ -36,17 +36,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rust-jemalloc-sys
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/ruff"
+        else
+          lib.getExe buildPackages.ruff;
     in
     ''
       installShellCompletion --cmd ruff \
-        --bash <(${emulator} $out/bin/ruff generate-shell-completion bash) \
-        --fish <(${emulator} $out/bin/ruff generate-shell-completion fish) \
-        --zsh <(${emulator} $out/bin/ruff generate-shell-completion zsh)
-    ''
-  );
+        --bash <(${exe} generate-shell-completion bash) \
+        --fish <(${exe} generate-shell-completion fish) \
+        --zsh <(${exe} generate-shell-completion zsh)
+    '';
 
   # Run cargo tests
   checkType = "debug";

--- a/pkgs/by-name/si/siketyan-ghr/package.nix
+++ b/pkgs/by-name/si/siketyan-ghr/package.nix
@@ -40,12 +40,16 @@ rustPlatform.buildRustPackage rec {
 
   postInstall =
     let
-      ghr = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/ghr";
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/ghr"
+        else
+          lib.getExe buildPackages.siketyan-ghr;
     in
-    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+    ''
       installShellCompletion --cmd ghr \
-        --bash <(${ghr} shell --completion bash) \
-        --fish <(${ghr} shell --completion fish)
+        --bash <(${exe} shell --completion bash) \
+        --fish <(${exe} shell --completion fish)
     '';
 
   env = {

--- a/pkgs/by-name/st/starship/package.nix
+++ b/pkgs/by-name/st/starship/package.nix
@@ -28,22 +28,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   postInstall =
+    let
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/starship"
+        else
+          lib.getExe buildPackages.starship;
+    in
     ''
       presetdir=$out/share/starship/presets/
       mkdir -p $presetdir
       cp docs/public/presets/toml/*.toml $presetdir
-    ''
-    + lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
-      let
-        emulator = stdenv.hostPlatform.emulator buildPackages;
-      in
-      ''
-        installShellCompletion --cmd starship \
-          --bash <(${emulator} $out/bin/starship completions bash) \
-          --fish <(${emulator} $out/bin/starship completions fish) \
-          --zsh <(${emulator} $out/bin/starship completions zsh)
-      ''
-    );
+      installShellCompletion --cmd starship \
+        --bash <(${exe} completions bash) \
+        --fish <(${exe} completions fish) \
+        --zsh <(${exe} completions zsh)
+    '';
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-cxDWaPlNK7POJ3GhA21NlJ6q62bqHdA/4sru5pLkvOA=";

--- a/pkgs/by-name/st/strip-ansi/package.nix
+++ b/pkgs/by-name/st/strip-ansi/package.nix
@@ -8,8 +8,11 @@
   installShellFiles,
 }:
 let
-  canRunStripAnsi = stdenv.hostPlatform.emulatorAvailable buildPackages;
-  stripAnsiCompletions = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/strip-ansi-completions";
+  stripAnsiCompletions =
+    if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+      "$out/bin/strip-ansi-completions"
+    else
+      lib.getExe' buildPackages.strip-ansi "strip-ansi-completions";
 in
 rustPlatform.buildRustPackage {
   pname = "strip-ansi";
@@ -27,7 +30,7 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = lib.optionalString canRunStripAnsi ''
+  postInstall = ''
     installShellCompletion --cmd strip-ansi \
       --bash <(${stripAnsiCompletions} bash) \
       --fish <(${stripAnsiCompletions} fish) \

--- a/pkgs/by-name/ti/tinymist/package.nix
+++ b/pkgs/by-name/ti/tinymist/package.nix
@@ -57,17 +57,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=semantic_tokens_full::tests::test"
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/tinymist"
+        else
+          lib.getExe buildPackages.tinymist;
     in
     ''
       installShellCompletion --cmd tinymist \
-        --bash <(${emulator} $out/bin/tinymist completion bash) \
-        --fish <(${emulator} $out/bin/tinymist completion fish) \
-        --zsh <(${emulator} $out/bin/tinymist completion zsh)
-    ''
-  );
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/ty/ty/package.nix
+++ b/pkgs/by-name/ty/ty/package.nix
@@ -60,17 +60,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/ty"
+        else
+          lib.getExe buildPackages.ty;
     in
     ''
       installShellCompletion --cmd ty \
-        --bash <(${emulator} $out/bin/ty generate-shell-completion bash) \
-        --fish <(${emulator} $out/bin/ty generate-shell-completion fish) \
-        --zsh <(${emulator} $out/bin/ty generate-shell-completion zsh)
-    ''
-  );
+        --bash <(${exe} generate-shell-completion bash) \
+        --fish <(${exe} generate-shell-completion fish) \
+        --zsh <(${exe} generate-shell-completion zsh)
+    '';
 
   passthru = {
     updateScript = nix-update-script { extraArgs = [ "--version=unstable" ]; };

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -44,17 +44,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Tests require python3
   doCheck = false;
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/uv"
+        else
+          lib.getExe buildPackages.uv;
     in
     ''
       installShellCompletion --cmd uv \
-        --bash <(${emulator} $out/bin/uv generate-shell-completion bash) \
-        --fish <(${emulator} $out/bin/uv generate-shell-completion fish) \
-        --zsh <(${emulator} $out/bin/uv generate-shell-completion zsh)
-    ''
-  );
+        --bash <(${exe} generate-shell-completion bash) \
+        --fish <(${exe} generate-shell-completion fish) \
+        --zsh <(${exe} generate-shell-completion zsh)
+    '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";

--- a/pkgs/by-name/vr/vrc-get/package.nix
+++ b/pkgs/by-name/vr/vrc-get/package.nix
@@ -25,17 +25,19 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-cG6fcSIQ0E1htEM4H914SSKDNRGM5fj52SUoLqRYzoc=";
 
-  # Execute the resulting binary to generate shell completions, using emulation if necessary when cross-compiling.
-  # If no emulator is available, then give up on generating shell completions
   postInstall =
     let
-      vrc-get = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/vrc-get";
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/vrc-get"
+        else
+          lib.getExe buildPackages.vrc-get;
     in
-    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+    ''
       installShellCompletion --cmd vrc-get \
-        --bash <(${vrc-get} completion bash) \
-        --fish <(${vrc-get} completion fish) \
-        --zsh <(${vrc-get} completion zsh)
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
     '';
 
   meta = with lib; {

--- a/pkgs/by-name/xl/xlsxsql/package.nix
+++ b/pkgs/by-name/xl/xlsxsql/package.nix
@@ -30,17 +30,20 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/xlsxsql"
+        else
+          lib.getExe buildPackages.xlsxsql;
     in
     ''
       installShellCompletion --cmd xlsxsql \
-        --bash <(${emulator} $out/bin/xlsxsql completion bash) \
-        --fish <(${emulator} $out/bin/xlsxsql completion fish) \
-        --zsh <(${emulator} $out/bin/xlsxsql completion zsh)
-    ''
-  );
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/xo/xo/package.nix
+++ b/pkgs/by-name/xo/xo/package.nix
@@ -29,17 +29,20 @@ buildGoModule rec {
     installShellFiles
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  postInstall =
     let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/xo"
+        else
+          lib.getExe buildPackages.xo;
     in
     ''
       installShellCompletion --cmd xo \
-        --bash <(${emulator} $out/bin/xo completion bash) \
-        --fish <(${emulator} $out/bin/xo completion fish) \
-        --zsh <(${emulator} $out/bin/xo completion zsh)
-    ''
-  );
+        --bash <(${exe} completion bash) \
+        --fish <(${exe} completion fish) \
+        --zsh <(${exe} completion zsh)
+    '';
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/yg/ygot/package.nix
+++ b/pkgs/by-name/yg/ygot/package.nix
@@ -30,22 +30,22 @@ buildGoModule (finalAttrs: {
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall =
+    let
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/gnmidiff"
+        else
+          lib.getExe' buildPackages.ygot "gnmidiff";
+    in
     ''
       # The normal binary names are far too generic
       mv $out/bin/generator $out/bin/ygot_generator
       mv $out/bin/proto_generator $out/bin/ygot_proto_generator
-    ''
-    + lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
-      let
-        emulator = stdenv.hostPlatform.emulator buildPackages;
-      in
-      ''
         installShellCompletion --cmd gnmidiff \
-          --bash <(${emulator} $out/bin/gnmidiff completion bash) \
-          --zsh <(${emulator} $out/bin/gnmidiff completion zsh) \
-          --fish <(${emulator} $out/bin/gnmidiff completion fish)
-      ''
-    );
+          --bash <(${exe} completion bash) \
+          --zsh <(${exe} completion zsh) \
+          --fish <(${exe} completion fish)
+    '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
context: https://github.com/NixOS/nixpkgs/issues/308283#issuecomment-2443991607 and https://github.com/NixOS/nixpkgs/pull/308055#discussion_r1586598623

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

cc @sky1e

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
