### PR TITLE
Patch to allow Workrave GNOME extension to work

### DIFF
--- a/pkgs/by-name/wo/workrave/fix-workrave-paths.patch
+++ b/pkgs/by-name/wo/workrave/fix-workrave-paths.patch
@@ -1,0 +1,152 @@
+diff -ru workrave-1_10_53-orig/backend/src/GSettingsConfigurator.cc workrave-1_10_53-changed/backend/src/GSettingsConfigurator.cc
+--- workrave-1_10_53-orig/backend/src/GSettingsConfigurator.cc	2025-02-16 07:00:20.000000000 -0500
++++ workrave-1_10_53-changed/backend/src/GSettingsConfigurator.cc	2025-07-01 20:17:12.468762711 -0400
+@@ -29,6 +29,7 @@
+ #  include "Configurator.hh"
+ #  include "Core.hh"
+ #  include "StringUtil.hh"
++#  include "Exception.hh"
+ 
+ using namespace workrave;
+ using namespace std;
+@@ -211,7 +212,10 @@
+   TRACE_ENTER("GSettingsConfigurator::add_children");
+   int len = schema_base.length();
+ 
+-  GSettingsSchemaSource *global_schema_source = g_settings_schema_source_get_default();
++  GSettingsSchemaSource *global_schema_source =
++    g_settings_schema_source_new_from_directory("@workrave_schema_path@",
++						g_settings_schema_source_get_default(),
++						TRUE, NULL);
+ 
+   gchar **schemas = NULL;
+   g_settings_schema_source_list_schemas(global_schema_source, TRUE, &schemas, NULL);
+@@ -220,13 +224,29 @@
+     {
+       if (g_ascii_strncasecmp(schemas[i], schema_base.c_str(), len) == 0)
+         {
+-          GSettings *gsettings = g_settings_new(schemas[i]);
++	  GSettingsSchema *schema = g_settings_schema_source_lookup(global_schema_source,
++								    schemas[i], FALSE);
++
++	  if (schema == NULL) {
++	    string err_msg = "schema for schema id ";
++	    err_msg += schemas[i];
++	    err_msg += " not found!";
++	    
++	    TRACE_MSG(err_msg);
++	    throw Exception(err_msg);
++	  }
++	  
++          GSettings *gsettings = g_settings_new_full(schema, NULL, NULL);
+ 
+           settings[schemas[i]] = gsettings;
+           g_signal_connect(gsettings, "changed", G_CALLBACK(on_settings_changed), this);
++
++	  g_settings_schema_unref(schema);
+         }
+     }
+ 
++  g_settings_schema_source_unref(global_schema_source);
++
+   TRACE_EXIT();
+ }
+ 
+diff -ru workrave-1_10_53-orig/frontend/applets/common/src/control.c workrave-1_10_53-changed/frontend/applets/common/src/control.c
+--- workrave-1_10_53-orig/frontend/applets/common/src/control.c	2025-02-16 07:00:20.000000000 -0500
++++ workrave-1_10_53-changed/frontend/applets/common/src/control.c	2025-07-01 19:52:26.137713925 -0400
+@@ -461,9 +461,21 @@
+ workrave_timerbox_control_create_dbus(WorkraveTimerboxControl *self)
+ {
+   WorkraveTimerboxControlPrivate *priv = workrave_timerbox_control_get_instance_private(self);
+-  GSettings *settings = g_settings_new("org.workrave.gui");
++
++  GSettingsSchemaSource *global_schema_source =
++    g_settings_schema_source_new_from_directory("@workrave_schema_path@",
++						g_settings_schema_source_get_default(),
++						TRUE, NULL);
++
++  GSettingsSchema *schema = g_settings_schema_source_lookup(global_schema_source,
++							    "org.workrave.gui", FALSE);
++  
++  GSettings *settings = g_settings_new_full(schema, NULL, NULL);
+   gboolean autostart = g_settings_get_boolean(settings, "autostart");
++  
+   g_object_unref(settings);
++  g_settings_schema_unref(schema);
++  g_settings_schema_source_unref(global_schema_source);
+ 
+   GDBusProxyFlags flags = autostart ? 0 : G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START;
+ 
+diff -ru workrave-1_10_53-orig/frontend/applets/common/src/timerbox.c workrave-1_10_53-changed/frontend/applets/common/src/timerbox.c
+--- workrave-1_10_53-orig/frontend/applets/common/src/timerbox.c	2025-02-16 07:00:20.000000000 -0500
++++ workrave-1_10_53-changed/frontend/applets/common/src/timerbox.c	2025-07-01 19:50:29.254132502 -0400
+@@ -108,13 +108,26 @@
+   priv->enabled = FALSE;
+   priv->force_icon = FALSE;
+   priv->mode = g_strdup("normal");
+-  priv->settings = g_settings_new("org.workrave.gui");
++  
++  GSettingsSchemaSource *global_schema_source =
++    g_settings_schema_source_new_from_directory("@workrave_schema_path@",
++						g_settings_schema_source_get_default(),
++						TRUE, NULL);
++
++  GSettingsSchema *schema = g_settings_schema_source_lookup(global_schema_source,
++							    "org.workrave.gui", FALSE);
++  
++  priv->settings = g_settings_new_full(schema, NULL, NULL);
++  
+   g_signal_connect(priv->settings, "changed", G_CALLBACK(workrave_on_settings_changed), self);
+ 
+   priv->normal_sheep_icon = NULL;
+   priv->quiet_sheep_icon = NULL;
+   priv->suspended_sheep_icon = NULL;
+ 
++  g_settings_schema_unref(schema);
++  g_settings_schema_source_unref(global_schema_source);
++
+   workrave_timerbox_init_images(self);
+ }
+ 
+diff -ru workrave-1_10_53-orig/frontend/applets/gnome-shell-45/src/extension.js workrave-1_10_53-changed/frontend/applets/gnome-shell-45/src/extension.js
+--- workrave-1_10_53-orig/frontend/applets/gnome-shell-45/src/extension.js	2025-02-16 07:00:20.000000000 -0500
++++ workrave-1_10_53-changed/frontend/applets/gnome-shell-45/src/extension.js	2025-07-01 18:48:42.276241686 -0400
+@@ -11,7 +11,10 @@
+   gettext as _,
+ } from "resource:///org/gnome/shell/extensions/extension.js";
+ 
+-import Workrave from "gi://Workrave?version=2.0";
++import GIRepository from 'gi://GIRepository';
++
++GIRepository.Repository.prepend_search_path('@workrave_typelib_path@');
++const Workrave = (await import("gi://Workrave?version=2.0")).default;
+ 
+ let start = GLib.get_monotonic_time();
+ console.log("workrave-applet: start @ " + start);
+diff -ru workrave-1_10_53-orig/frontend/applets/indicator/src/indicator-workrave.c workrave-1_10_53-changed/frontend/applets/indicator/src/indicator-workrave.c
+--- workrave-1_10_53-orig/frontend/applets/indicator/src/indicator-workrave.c	2025-02-16 07:00:20.000000000 -0500
++++ workrave-1_10_53-changed/frontend/applets/indicator/src/indicator-workrave.c	2025-07-01 19:52:18.944739850 -0400
+@@ -451,9 +451,21 @@
+ indicator_workrave_create_dbus(IndicatorWorkrave *self)
+ {
+   IndicatorWorkravePrivate *priv = INDICATOR_WORKRAVE_GET_PRIVATE(self);
+-  GSettings *settings = g_settings_new("org.workrave.gui");
++  
++  GSettingsSchemaSource *global_schema_source =
++    g_settings_schema_source_new_from_directory("@workrave_schema_path@",
++						g_settings_schema_source_get_default(),
++						TRUE, NULL);
++
++  GSettingsSchema *schema = g_settings_schema_source_lookup(global_schema_source,
++							    "org.workrave.gui", FALSE);
++  
++  GSettings *settings = g_settings_new_full(schema, NULL, NULL);
+   gboolean autostart = g_settings_get_boolean(settings, "autostart");
++  
+   g_object_unref(settings);
++  g_settings_schema_unref(schema);
++  g_settings_schema_source_unref(global_schema_source);
+ 
+   GDBusProxyFlags flags = autostart ?: G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START;
+ 

--- a/pkgs/by-name/wo/workrave/package.nix
+++ b/pkgs/by-name/wo/workrave/package.nix
@@ -86,14 +86,14 @@ stdenv.mkDerivation rec {
   patches = [ ./fix-workrave-paths.patch ];
 
   postPatch = ''
-     substituteInPlace frontend/applets/gnome-shell-45/src/extension.js \
-        --subst-var-by workrave_typelib_path "$out/lib/girepository-1.0"
+    substituteInPlace frontend/applets/gnome-shell-45/src/extension.js \
+       --subst-var-by workrave_typelib_path "$out/lib/girepository-1.0"
 
-     substituteInPlace backend/src/GSettingsConfigurator.cc \
-        frontend/applets/common/src/control.c \
-        frontend/applets/common/src/timerbox.c \
-        frontend/applets/indicator/src/indicator-workrave.c \
-        --subst-var-by workrave_schema_path ${glib.makeSchemaPath "$out" "${pname}-${version}"}
+    substituteInPlace backend/src/GSettingsConfigurator.cc \
+       frontend/applets/common/src/control.c \
+       frontend/applets/common/src/timerbox.c \
+       frontend/applets/indicator/src/indicator-workrave.c \
+       --subst-var-by workrave_schema_path ${glib.makeSchemaPath "$out" "${pname}-${version}"}
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/wo/workrave/package.nix
+++ b/pkgs/by-name/wo/workrave/package.nix
@@ -18,6 +18,7 @@
   glib,
   glibmm,
   gtkmm3,
+  gtk4,
   atk,
   pango,
   pangomm,
@@ -63,6 +64,7 @@ stdenv.mkDerivation rec {
     glib
     glibmm
     gtkmm3
+    gtk4
     atk
     pango
     pangomm
@@ -78,6 +80,21 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = "./autogen.sh";
+
+  configureFlags = [ "--enable-gnome45" ];
+
+  patches = [ ./fix-workrave-paths.patch ];
+
+  postPatch = ''
+     substituteInPlace frontend/applets/gnome-shell-45/src/extension.js \
+        --subst-var-by workrave_typelib_path "$out/lib/girepository-1.0"
+
+     substituteInPlace backend/src/GSettingsConfigurator.cc \
+        frontend/applets/common/src/control.c \
+        frontend/applets/common/src/timerbox.c \
+        frontend/applets/indicator/src/indicator-workrave.c \
+        --subst-var-by workrave_schema_path ${glib.makeSchemaPath "$out" "${pname}-${version}"}
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
This addresses Issue #420671. It both patches the JavaScript in the GNOME extension itself, as well as patches to the C and C++ source so that Workrave's GSettings schemas can be found by the parts of Workrave that are used in the extension, which are *not* affected by the wrapper that allows the main Workrave app to function. (If they were affected, patches to the C and C++ source would not be necessary.)

This is for the extension for GNOME versions 45 and up.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
