### PR TITLE
icann-rdap: init at 0.0.22

### DIFF
--- a/pkgs/by-name/ic/icann-rdap/package.nix
+++ b/pkgs/by-name/ic/icann-rdap/package.nix
@@ -9,24 +9,23 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "icann-rdap";
-  version = "0.0.22";
+  version = "0.0.23";
 
   src = fetchFromGitHub {
     owner = "icann";
     repo = "icann-rdap";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-J8uvFTjFY7YrohxlD7UwzrQUUoHHEb5mzZoQ64XUQHY=";
+    hash = "sha256-1e8r8JkRUokleQnDzxYLClC82R4HXlctNXxfSN3DicY=";
   };
 
-  cargoHash = "sha256-2R6GrcuksEOk8GiVkFhMljS12V2n0J1rCw9MCOtwMjA=";
+  cargoHash = "sha256-4PFLQeLMcUYEK2v0dR0EmHUcqtRqZ3UamFVOzUNAPwE=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 
   env.OPENSSL_NO_VENDOR = true;
 
-  # https://github.com/icann/icann-rdap/issues/138
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Official ICANN RDAP tools, containing cli client and server";

--- a/pkgs/by-name/ic/icann-rdap/package.nix
+++ b/pkgs/by-name/ic/icann-rdap/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "icann-rdap";
+  version = "0.0.22";
+
+  src = fetchFromGitHub {
+    owner = "icann";
+    repo = "icann-rdap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-J8uvFTjFY7YrohxlD7UwzrQUUoHHEb5mzZoQ64XUQHY=";
+  };
+
+  cargoHash = "sha256-2R6GrcuksEOk8GiVkFhMljS12V2n0J1rCw9MCOtwMjA=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  # https://github.com/icann/icann-rdap/issues/138
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  meta = {
+    description = "Official ICANN RDAP tools, containing cli client and server";
+    mainProgram = "rdap";
+    homepage = "https://github.com/icann/icann-rdap";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ paumr ];
+  };
+})


### PR DESCRIPTION
On the 27.01.2025 ICANN replaced it's WHOIS services with RDAP. Users are now encouraged to use icann-rdap.

source:
https://www.icann.org/en/announcements/details/icann-update-launching-rdap-sunsetting-whois-27-01-2025-en

This PR introduces mentioned tool to nixpkgs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
