### PR TITLE
maintainers: drop pimeys

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19823,12 +19823,6 @@
     github = "pilz0";
     githubId = 48645439;
   };
-  pimeys = {
-    email = "julius@nauk.io";
-    github = "pimeys";
-    githubId = 34967;
-    name = "Julius de Bruijn";
-  };
   pinage404 = {
     email = "pinage404+nixpkgs@gmail.com";
     github = "pinage404";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/package.nix
@@ -48,6 +48,6 @@ melpaBuild {
   meta = {
     description = "Core APIs of the Emacs binding for tree-sitter";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pimeys ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/by-name/dy/dynein/package.nix
+++ b/pkgs/by-name/dy/dynein/package.nix
@@ -47,6 +47,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/awslabs/dynein";
     license = licenses.asl20;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ pimeys ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/ma/matrix-conduit/package.nix
+++ b/pkgs/by-name/ma/matrix-conduit/package.nix
@@ -59,7 +59,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       pstn
-      pimeys
     ];
     mainProgram = "conduit";
   };

--- a/pkgs/by-name/pr/prisma-engines/package.nix
+++ b/pkgs/by-name/pr/prisma-engines/package.nix
@@ -72,7 +72,6 @@ rustPlatform.buildRustPackage rec {
     platforms = platforms.unix;
     mainProgram = "prisma";
     maintainers = with maintainers; [
-      pimeys
       tomhoule
       aqrln
     ];

--- a/pkgs/by-name/ps/pscale/package.nix
+++ b/pkgs/by-name/ps/pscale/package.nix
@@ -51,7 +51,6 @@ buildGoModule rec {
     homepage = "https://www.planetscale.com/";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      pimeys
       kashw2
     ];
   };


### PR DESCRIPTION
No activity since October 2024 as can be seen when going back in the list of PRs/Issues with pings:

https://github.com/NixOS/nixpkgs/pulls?q=involves%3Apimeys%20sort%3Aupdated-desc

Also doesn't seem to be a member of the org (anymore), so can't actually be "requested for review", just pinged by r-ryantm.

@pimeys if you'd like to remain a maintainer, please say so. Ofc, also welcome to say so, if you're OK with the drop.

Will wait for [about a week](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#how-to-lose-maintainer-status) before merging.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
