### PR TITLE
python313Packages.badsecrets: init at 0.10.35, python313Packages.flask-unsign: init at 1.2.1

### DIFF
--- a/pkgs/by-name/ba/badsecrets/package.nix
+++ b/pkgs/by-name/ba/badsecrets/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication badsecrets

--- a/pkgs/by-name/fl/flask-unsign/package.nix
+++ b/pkgs/by-name/fl/flask-unsign/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication flask-unsign

--- a/pkgs/development/python-modules/badsecrets/default.nix
+++ b/pkgs/development/python-modules/badsecrets/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  colorama,
+  django,
+  fetchFromGitHub,
+  flask-unsign,
+  poetry-core,
+  poetry-dynamic-versioning,
+  pycryptodome,
+  pyjwt,
+  requests,
+  viewstate,
+}:
+
+buildPythonPackage rec {
+  pname = "badsecrets";
+  version = "0.10.35";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "blacklanternsecurity";
+    repo = "badsecrets";
+    tag = "v${version}";
+    hash = "sha256-i80f4qPX695HFdNefIT2sqcKsdMTEiYXUltF2Gj6aAI=";
+  };
+
+  build-system = [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
+
+  dependencies = [
+    colorama
+    django
+    flask-unsign
+    pycryptodome
+    pyjwt
+    requests
+    viewstate
+  ];
+
+  pythonImportsCheck = [ "badsecrets" ];
+
+  meta = {
+    description = "Module for detecting known secrets across many web frameworks";
+    homepage = "https://github.com/blacklanternsecurity/badsecrets";
+    changelog = "https://github.com/blacklanternsecurity/badsecrets/releases/tag/${src.tag}";
+    license = with lib.licenses; [
+      agpl3Only
+      gpl3Only
+    ];
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/flask-unsign/default.nix
+++ b/pkgs/development/python-modules/flask-unsign/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flask,
+  itsdangerous,
+  markupsafe,
+  pytestCheckHook,
+  requests,
+  setuptools,
+  werkzeug,
+}:
+
+buildPythonPackage rec {
+  pname = "flask-unsign";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Paradoxis";
+    repo = "Flask-Unsign";
+    tag = "v${version}";
+    hash = "sha256-/WK3g6Ef3mSKeT3aaSAh5J8estUN4sNmM9Tq9An/18A=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    flask
+    itsdangerous
+    markupsafe
+    requests
+    werkzeug
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "flask_unsign" ];
+
+  pytestFlagsArray = [ "tests/flask_unsign.py" ];
+
+  meta = {
+    description = "Command line tool to fetch, decode, brute-force and craft session cookies of Flask applications";
+    homepage = "https://github.com/Paradoxis/Flask-Unsign";
+    changelog = "https://github.com/Paradoxis/Flask-Unsign/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "flask-unsign";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1631,6 +1631,8 @@ self: super: with self; {
 
   bacpypes = callPackage ../development/python-modules/bacpypes { };
 
+  badsecrets = callPackage ../development/python-modules/badsecrets { };
+
   bagit = callPackage ../development/python-modules/bagit { };
 
   baize = callPackage ../development/python-modules/baize { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5236,6 +5236,8 @@ self: super: with self; {
 
   flask-themes2 = callPackage ../development/python-modules/flask-themes2 { };
 
+  flask-unsign = callPackage ../development/python-modules/flask-unsign { };
+
   flask-versioned = callPackage ../development/python-modules/flask-versioned { };
 
   flask-webtest = callPackage ../development/python-modules/flask-webtest { };


### PR DESCRIPTION
Module for detecting known secrets across many web frameworks

https://github.com/blacklanternsecurity/badsecrets

Related to https://github.com/NixOS/nixpkgs/issues/81418

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
