### PR TITLE
kazv: 0.5.0 -> 0.6.0 (and dependencies)

### DIFF
--- a/pkgs/by-name/ka/kazv/package.nix
+++ b/pkgs/by-name/ka/kazv/package.nix
@@ -6,13 +6,11 @@
   cmake,
   cmark,
   cryptopp,
-  extra-cmake-modules,
   immer,
   kdePackages,
   lager,
   libkazv,
   nlohmann_json,
-  olm,
   pkg-config,
   qt6,
   zug,
@@ -20,14 +18,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kazv";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitLab {
     domain = "lily-is.land";
     owner = "kazv";
     repo = "kazv";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-WBS7TJJw0t57V4+NxsG8V8q4UKQXB8kRpWocvNy1Eto=";
+    hash = "sha256-ZQRxzwqPiFsAXJZ2Dd1qvt3KRihxriRdOAb8IpvR9VE=";
   };
 
   nativeBuildInputs = [
@@ -49,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     lager
     libkazv
     nlohmann_json
-    olm
     qt6.qtbase
     qt6.qtimageformats
     qt6.qtmultimedia

--- a/pkgs/by-name/li/libkazv/package.nix
+++ b/pkgs/by-name/li/libkazv/package.nix
@@ -12,21 +12,21 @@
   libhttpserver,
   libmicrohttpd,
   nlohmann_json,
-  olm,
   pkg-config,
+  vodozemac-bindings-cpp,
   zug,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libkazv";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitLab {
     domain = "lily-is.land";
     owner = "kazv";
     repo = "libkazv";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-bKujiuAR5otF7nc/BdVWVaEW9fSxdh2bcAgsQ5UO1Aw=";
+    hash = "sha256-rXQLbYPmD9UH0iXXqrAQSPF3KgIvjEyZ/97Q+/tl9Ec=";
   };
 
   nativeBuildInputs = [
@@ -42,8 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     libcpr
     libhttpserver
     libmicrohttpd
-    olm
     nlohmann_json
+    vodozemac-bindings-cpp
     zug
   ];
 

--- a/pkgs/by-name/vo/vodozemac-bindings-cpp/package.nix
+++ b/pkgs/by-name/vo/vodozemac-bindings-cpp/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cargo,
+  perl,
+  rustPlatform,
+  rustc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vodozemac-bindings-cpp";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    domain = "lily-is.land";
+    owner = "kazv";
+    repo = "vodozemac-bindings";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DOc5GxMgpecJeQtkDSwvGD+bOyCZ8XRQ/uC/RAnKQv4=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-puMPW87zCTJhhtO6HXUa2xl7edAk546xT1x1rpyDJWU=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    perl
+    rustPlatform.cargoSetupHook
+    rustc
+  ];
+
+  makeFlags = [ "-Ccpp" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "C++ bindings for the vodozemac cryptographic library";
+    homepage = "https://lily-is.land/kazv/vodozemac-bindings";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fgaz ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Replaces the `olm` dependency that is marked insecure

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
