### PR TITLE
python3Packages.sentence-transformers: disable test that segfaults on Darwin

### DIFF
--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -101,23 +102,28 @@ buildPythonPackage rec {
     "test_trainer_multi_dataset_errors"
   ];
 
-  disabledTestPaths = [
-    # Tests require network access
-    "tests/cross_encoder/test_cross_encoder.py"
-    "tests/cross_encoder/test_train_stsb.py"
-    "tests/evaluation/test_information_retrieval_evaluator.py"
-    "tests/sparse_encoder/models/test_csr.py"
-    "tests/sparse_encoder/models/test_sparse_static_embedding.py"
-    "tests/sparse_encoder/test_opensearch_models.py"
-    "tests/sparse_encoder/test_pretrained.py"
-    "tests/sparse_encoder/test_sparse_encoder.py"
-    "tests/test_compute_embeddings.py"
-    "tests/test_model_card_data.py"
-    "tests/test_multi_process.py"
-    "tests/test_pretrained_stsb.py"
-    "tests/test_sentence_transformer.py"
-    "tests/test_train_stsb.py"
-  ];
+  disabledTestPaths =
+    [
+      # Tests require network access
+      "tests/cross_encoder/test_cross_encoder.py"
+      "tests/cross_encoder/test_train_stsb.py"
+      "tests/evaluation/test_information_retrieval_evaluator.py"
+      "tests/sparse_encoder/models/test_csr.py"
+      "tests/sparse_encoder/models/test_sparse_static_embedding.py"
+      "tests/sparse_encoder/test_opensearch_models.py"
+      "tests/sparse_encoder/test_pretrained.py"
+      "tests/sparse_encoder/test_sparse_encoder.py"
+      "tests/test_compute_embeddings.py"
+      "tests/test_model_card_data.py"
+      "tests/test_multi_process.py"
+      "tests/test_pretrained_stsb.py"
+      "tests/test_sentence_transformer.py"
+      "tests/test_train_stsb.py"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Segfault
+      "tests/test_sparse_tensor.py"
+    ];
 
   # Sentence-transformer needs a writable hf_home cache
   postInstall = ''


### PR DESCRIPTION
Disabled `tests/test_sparse_tensor.py` on Darwin due to a segfault.

Requires #422747

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
