### PR TITLE
rustc: Add support for bootstrapping ppc64-elfv1

### DIFF
--- a/pkgs/development/compilers/rust/1_87.nix
+++ b/pkgs/development/compilers/rust/1_87.nix
@@ -117,6 +117,7 @@ import ./default.nix
       aarch64-unknown-linux-musl = "6f301f0ee7d3be2fdd245432c01543a4c61413b5d0a62493e5b0d57d9756b0b6";
       x86_64-apple-darwin = "867a84a93c6ba0b468b78b52004a6307d6f5e2e5598e64f65726c6810b6f7c82";
       aarch64-apple-darwin = "249496972e6f845f052036b9d7e73f816418412de2b266ec717b9050c1810dc3";
+      powerpc64-unknown-linux-gnu = "27dd377367d7ba1757e1c768b259622d25a9cd927e126c9788dce9e880ffa925";
       powerpc64le-unknown-linux-gnu = "3f8f68d79460475396a52b5ae70eee73d6fb194fff1c4ff4286b64fbebee4429";
       riscv64gc-unknown-linux-gnu = "ea25b048bad7737188345392d1a0dfa92aa3ed6c00834b0974bdba52cb2398c4";
       s390x-unknown-linux-gnu = "198d3bda0daef12f86b8171025c62fee0a3caa59fa82c22c364d1a69305d8f46";

--- a/pkgs/development/compilers/rust/print-hashes.sh
+++ b/pkgs/development/compilers/rust/print-hashes.sh
@@ -17,6 +17,7 @@ PLATFORMS=(
   aarch64-unknown-linux-musl
   x86_64-apple-darwin
   aarch64-apple-darwin
+  powerpc64-unknown-linux-gnu
   powerpc64le-unknown-linux-gnu
   riscv64gc-unknown-linux-gnu
   s390x-unknown-linux-gnu


### PR DESCRIPTION
Add `powerpc64-unknown-linux-gnu` to the hash printing script, and add the entry to `bootstrapHashes`.

With https://github.com/NixOS/nixpkgs/pull/422748, this allows bootstrapping and building of `rustc` on ELFv1 powerpc64. With some further fixes to other packages, `fd` can be built.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (ELFv1)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
