### PR TITLE
lightning-terminal: init `updateScript`

### DIFF
--- a/pkgs/by-name/li/lightning-terminal/package.nix
+++ b/pkgs/by-name/li/lightning-terminal/package.nix
@@ -16,6 +16,7 @@
   _experimental-update-script-combinators,
   gitUpdater,
   nurl,
+  nix,
   gitMinimal,
   writeShellScript,
 }:
@@ -137,6 +138,7 @@ buildGoModule rec {
           PATH="${
             lib.makeBinPath [
               gitMinimal
+              nix
               nurl
             ]
           }:$PATH"

--- a/pkgs/by-name/li/lightning-terminal/package.nix
+++ b/pkgs/by-name/li/lightning-terminal/package.nix
@@ -23,12 +23,12 @@
 
 buildGoModule rec {
   pname = "lightning-terminal";
-  version = "0.15.0-alpha";
+  version = "0.15.1-alpha";
   src = fetchFromGitHub {
     owner = "lightninglabs";
     repo = "lightning-terminal";
     tag = "v${version}";
-    hash = "sha256-g+pf2o0JFEFny/w5yn9KQswajw3gEBTPQjBY5ocdk0k=";
+    hash = "sha256-aCZ1dzbj1SYBYQ6ysnk9MQs4V6ysljZYOYp0gOw0WFQ=";
     leaveDotGit = true;
     # Populate values that require us to use git.
     postFetch = ''
@@ -41,7 +41,7 @@ buildGoModule rec {
     '';
   };
 
-  vendorHash = "sha256-eGqM0cIC55/bZB1rcD9fKZ/CrP6w3HCZyZvFeUWnDZo=";
+  vendorHash = "sha256-tjNF6Llsaba/IlhtrOU4ebzSRHGVy+LPzwhBsS5xJgQ=";
 
   buildInputs = [ lightning-app ];
   postUnpack = ''

--- a/pkgs/by-name/li/lightning-terminal/package.nix
+++ b/pkgs/by-name/li/lightning-terminal/package.nix
@@ -22,12 +22,12 @@
 
 buildGoModule rec {
   pname = "lightning-terminal";
-  version = "0.14.1-alpha";
+  version = "0.15.0-alpha";
   src = fetchFromGitHub {
     owner = "lightninglabs";
     repo = "lightning-terminal";
     tag = "v${version}";
-    hash = "sha256-sv/NsjAAF0vwD2xjRuGwHwV0L1gjCFQEw0SVp14Zyz0=";
+    hash = "sha256-g+pf2o0JFEFny/w5yn9KQswajw3gEBTPQjBY5ocdk0k=";
     leaveDotGit = true;
     # Populate values that require us to use git.
     postFetch = ''
@@ -40,7 +40,7 @@ buildGoModule rec {
     '';
   };
 
-  vendorHash = "sha256-Gbx4uz6q9Ef4QNv6DpIoCACjhT66iZ7GPNpd/g9MgKQ=";
+  vendorHash = "sha256-eGqM0cIC55/bZB1rcD9fKZ/CrP6w3HCZyZvFeUWnDZo=";
 
   buildInputs = [ lightning-app ];
   postUnpack = ''
@@ -166,7 +166,7 @@ buildGoModule rec {
     version = "0.0.1";
     yarnOfflineCache = fetchYarnDeps {
       yarnLock = "${src}/app/yarn.lock";
-      hash = "sha256-ulOgKQRLG4cRi1N1DajmbZ0L7d08g5cYDA9itXu+Esw=";
+      hash = "sha256-FYRWyZxTPo4YwN5AiXsuubZoCVRcOeCrsUU/+ON4gx4=";
     };
 
     # Remove this command from package.json. It requires Git and it is not


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- [X] Add `passthru.updateScript`. Can be used manually with:
`nix-shell maintainers/scripts/update.nix --argstr package lightning-terminal --argstr commit true`.
But I hope it will also be able to work during the automatic updates of packages.
I was not able to make `nix-update` find the correct latest release tag, nor update all the hashes, so I used a custom script. 
 
- [X] Update `lightning-terminal` to latest (non release candidate) version.

- [X] Rebase after https://github.com/NixOS/nixpkgs/pull/418337 has been merged.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---
Ping @HannahMR and @starius 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
