### PR TITLE
Revert "vulkan-hdr-layer-kwin6: remove"

### DIFF
--- a/pkgs/by-name/vu/vulkan-hdr-layer-kwin6/package.nix
+++ b/pkgs/by-name/vu/vulkan-hdr-layer-kwin6/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  libX11,
+  meson,
+  ninja,
+  pkg-config,
+  unstableGitUpdater,
+  vulkan-headers,
+  vulkan-loader,
+  wayland-scanner,
+  wayland,
+}:
+
+stdenv.mkDerivation {
+  pname = "vulkan-hdr-layer-kwin6";
+  version = "0-unstable-2025-05-22";
+
+  depsBuildBuild = [ pkg-config ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    cmake
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+    libX11
+    wayland
+  ];
+
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "Zamundaaa";
+    repo = "VK_hdr_layer";
+    rev = "1384036ea24a9bc38a5c684dac5122d5e3431ae6";
+    hash = "sha256-xm0S1vLE8MAov8gf6rN5ZKZAe6NMKfHDlUlmNd332qw=";
+    fetchSubmodules = true;
+  };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Vulkan Wayland HDR WSI Layer (Xaver Hugl's fork for KWin 6)";
+    homepage = "https://github.com/Zamundaaa/VK_hdr_layer";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ d4rk ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2086,7 +2086,6 @@ mapAliases {
   void = throw "'void' has been removed due to lack of upstream maintenance"; # Added 2025-01-25
   volnoti = throw "'volnoti' has been removed due to lack of maintenance upstream."; # Added 2024-12-04
   vuze = throw "'vuze' was removed because it is unmaintained upstream and insecure (CVE-2018-13417). BiglyBT is a maintained fork."; # Added 2024-11-22
-  vulkan-hdr-layer-kwin6 = throw "'vulkan-hdr-layer-kwin6' was removed as it is unnecessary since Mesa 25.1"; # Added 2025-06-30
   vwm = throw "'vwm' was removed as it is broken and not maintained upstream"; # Added 2025-05-17
   inherit (libsForQt5.mauiPackages) vvave; # added 2022-05-17
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#421268
Context: https://github.com/NixOS/nixpkgs/pull/421268#issuecomment-3022655352

> I think vulkan-hdr-layer-kwin6 is still required for HDR on NVIDIA drivers until NVIDIA implements it 
https://wiki.archlinux.org/title/HDR_monitor_support#Vulkan_HDR_WSI
https://forums.developer.nvidia.com/t/vulkan-extensions-needed-for-hdr-is-missing/334268
>
> _Originally posted by @chermnyx in https://github.com/NixOS/nixpkgs/issues/421268#issuecomment-3022655352_
            