### PR TITLE
_1password-gui{,-beta}: Re-enable Wayland support

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/linux.nix
+++ b/pkgs/by-name/_1/_1password-gui/linux.nix
@@ -146,12 +146,8 @@ stdenv.mkDerivation {
     makeShellWrapper $out/share/1password/1password $out/bin/1password \
       "''${gappsWrapperArgs[@]}" \
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]} \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
-      # Currently half broken on wayland (e.g. no copy functionality)
-      # See: https://github.com/NixOS/nixpkgs/pull/232718#issuecomment-1582123406
-      # Remove this comment when upstream fixes:
-      # https://1password.community/discussion/comment/624011/#Comment_624011
-      #--add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]} \
+      --add-flags "\''${NIXOS_OZONE_WL:+--ozone-platform-hint=auto}"
   '';
 
   passthru.updateScript = ./update.sh;


### PR DESCRIPTION
- Gate Electron's Ozone platform hint behind NIXOS_OZONE_WL env var.
- No need to gate on WAYLAND_DISPLAY because Electron will first check XDG_SESSION_TYPE==wayland [^1], if it fails, then it will check for WAYLAND_DISPLAY[^2], even setting it to `wayland-0` if it finds a `wayland-0` socket under $XDG_SESSION_DIR.
- No need to restore `--enable-features=WaylandWindowDecorations` switch as it's been enabled by default since Aug 2023. https://github.com/electron/electron/pull/39644/files
- No point in passing --enable-wayland-ime=true, which requires GTK4 but 1Password ships linking only against GTK3.

### More testing appreciated
Even though latest 1Password Beta mentions addition of [secure clipboard support for Wayland environments.](https://releases.1password.com/linux/beta/#1password-for-linux-8.11.0-25), with `--ozone-platform-hint=auto` clipboard access from 1Password (stable) channel worked for me since Feb 2024, using 1Password 8.10.24 (released Jan 23, 2024).
I'm using vanilla Gnome (with Mutter), only enabling NIXOS_OZONE_WL.

I'd really appreciate reports from KDE, Sway, Hyprland, Niri, etc. users.   

[^1] linux/display_server_utils.cc:MaybeFixPlatformName - https://source.chromium.org/chromium/chromium/src/+/main:ui/linux/display_server_utils.cc;l=72-74;drc=3a35ef8d20836722c95b230f7248c73faea599e7;bpv=0;bpt=1 [^2] linux/display_server_utils.cc:InspectWaylandDisplay - https://source.chromium.org/chromium/chromium/src/+/main:ui/linux/display_server_utils.cc;l=34-51;drc=3a35ef8d20836722c95b230f7248c73faea599e7;bpv=1;bpt=1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
