### PR TITLE
Add two MCP servers for use with the Lean proof assistant

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27313,6 +27313,12 @@
     github = "wuyoli";
     githubId = 104238274;
   };
+  wvhulle = {
+    name = "Willem Vanhulle";
+    email = "willemvanhulle@protonmail.com";
+    github = "wvhulle";
+    githubId = 7688680;
+  };
   wykurz = {
     email = "wykurz@gmail.com";
     github = "wykurz";

--- a/pkgs/by-name/le/lean-lsp-mcp/package.nix
+++ b/pkgs/by-name/le/lean-lsp-mcp/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "lean-lsp-mcp";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "oOo0oOo";
+    repo = "lean-lsp-mcp";
+    tag = "v${version}";
+    hash = "sha256-hCEbVoxiUBRysDiNvZyx9nZTxbaAQsgsQTiQvhyLosM=";
+  };
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    leanclient
+    mcp
+  ];
+
+  dontCheckRuntimeDeps = true;
+
+  meta = {
+    description = "Lean Theorem Prover MCP (Model Context Protocol) server";
+    longDescription = ''
+      A Model Context Protocol (MCP) server that provides access to Lean 4 theorem prover
+      functionality. This allows AI assistants and other tools to interact with Lean projects,
+      query definitions, and get theorem proving assistance.
+    '';
+    homepage = "https://github.com/oOo0oOo/lean-lsp-mcp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wvhulle ];
+    mainProgram = "lean-lsp-mcp";
+  };
+}

--- a/pkgs/by-name/le/leanexplore/package.nix
+++ b/pkgs/by-name/le/leanexplore/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  callPackage,
+  makeWrapper,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "lean-explore";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "justincasher";
+    repo = "lean-explore";
+    rev = "v${version}";
+    hash = "sha256-tXKfl9Itkr21pRsBkAXt40vSrOYOFNvL+O+dhOjxrSQ=";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3.pkgs; [
+    faiss
+    httpx
+    mcp
+    nltk
+    numpy
+    openai
+    openai-agents
+    pydantic
+    rank-bm25
+    sentence-transformers
+    sqlalchemy
+    toml
+    typer
+  ];
+  dontCheckRuntimeDeps = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  pythonImportsCheck = [ "lean_explore" ];
+
+  postInstall = ''
+    # Wrap the leanexplore command to ensure subprocesses have the correct PYTHONPATH
+    wrapProgram $out/bin/leanexplore \
+      --set PYTHONPATH "$PYTHONPATH"
+  '';
+
+  meta = {
+    description = "A search engine for Lean 4 declarations with MCP server support";
+    longDescription = ''
+      LeanExplore is a search engine for Lean 4 declarations that provides semantic search
+      capabilities across Lean codebases. It includes a Model Context Protocol (MCP) server
+      implementation that exposes LeanExplore's functionalities as tools consumable by 
+      external AI agent systems, enabling programmatic interaction for tasks like automated
+      theorem proving or AI-driven mathematical research. 
+
+      Launch a local `leanexplore` MCP server with:
+
+      ```bash
+      leanexplore mcp serve --api-key $YOUR_LEANEXPLORE_API_KEY
+      ```
+    '';
+    homepage = "https://github.com/justincasher/lean-explore";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ wvhulle ];
+    mainProgram = "leanexplore";
+  };
+}

--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "renovate";
-  version = "41.21.3";
+  version = "41.16.0";
 
   src = fetchFromGitHub {
     owner = "renovatebot";
     repo = "renovate";
     tag = finalAttrs.version;
-    hash = "sha256-np21ghEbfaM7Z4ETmrAWUjrauQOf5FW+krl156UB2Ek=";
+    hash = "sha256-hMcGK89YIqYCA201f+fxorHA3sseDL3nZTjH/90/JGQ=";
   };
 
   postPatch = ''
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-XOlFJFFyzbx8Bg92HXhVFFCI51j2GUK7+LJKfqVOQyU=";
+    hash = "sha256-VF2fq6o4O5Ua+98PJ1d+vj5W8TMYL4ks3ekf27eQmIY=";
   };
 
   env.COREPACK_ENABLE_STRICT = 0;

--- a/pkgs/development/python-modules/leanclient/default.nix
+++ b/pkgs/development/python-modules/leanclient/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  orjson,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "leanclient";
+  version = "0.1.12";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-yPALTn0WG9D6fT6jDInRt0y10/iyNIUuPEo42srLcIY=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    orjson
+    tqdm
+  ];
+
+  # Add proper tests if available
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Lean client library for Python";
+    homepage = "https://pypi.org/project/leanclient/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wvhulle ];
+  };
+}

--- a/pkgs/development/python-modules/openai-agents/default.nix
+++ b/pkgs/development/python-modules/openai-agents/default.nix
@@ -1,0 +1,61 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  graphviz,
+  griffe,
+  hatchling,
+  lib,
+  mcp,
+  numpy,
+  openai,
+  pydantic,
+  requests,
+  types-requests,
+  typing-extensions,
+  websockets,
+}:
+
+buildPythonPackage rec {
+  pname = "openai-agents";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "openai";
+    repo = "openai-agents-python";
+    rev = "v${version}";
+    hash = "sha256-2Kn+pG/pxl7ffBr54YFViNMnAkIy49Jy0njdb4PLhRI=";
+  };
+
+  patches = [ ./fix-import.patch ];
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    griffe
+    mcp
+    openai
+    pydantic
+    requests
+    types-requests
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    voice = [
+      numpy
+      websockets
+    ];
+    viz = [ graphviz ];
+  };
+
+  doCheck = false;
+  pythonImportsCheck = [ "agents" ];
+
+  meta = with lib; {
+    description = "OpenAI Agents SDK - A lightweight, powerful framework for multi-agent workflows";
+    homepage = "https://github.com/openai/openai-agents-python";
+    license = licenses.mit;
+    maintainers = [ wvhulle ];
+  };
+}

--- a/pkgs/development/python-modules/openai-agents/fix-import.patch
+++ b/pkgs/development/python-modules/openai-agents/fix-import.patch
@@ -1,0 +1,17 @@
+--- a/src/agents/agent.py
++++ b/src/agents/agent.py
+@@ -7,7 +7,14 @@ from dataclasses import dataclass, field
+ from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, cast
+ 
+-from openai.types.responses.response_prompt_param import ResponsePromptParam
++# Handle import for different OpenAI versions
++try:
++    from openai.types.responses.response_prompt_param import ResponsePromptParam
++except (ImportError, AttributeError):
++    # Fallback for cases where ResponsePromptParam is not available
++    from typing import Dict, Any as AnyType
++    ResponsePromptParam = Dict[str, AnyType]
++
+ from typing_extensions import NotRequired, TypeAlias, TypedDict
+ 
+ from .agent_output import AgentOutputSchemaBase

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7909,6 +7909,8 @@ self: super: with self; {
 
   leanblueprint = callPackage ../development/python-modules/leanblueprint { };
 
+  leanclient = callPackage ../development/python-modules/leanclient { };
+
   leaone-ble = callPackage ../development/python-modules/leaone-ble { };
 
   leather = callPackage ../development/python-modules/leather { };
@@ -10636,6 +10638,8 @@ self: super: with self; {
   open-meteo = callPackage ../development/python-modules/open-meteo { };
 
   openai = callPackage ../development/python-modules/openai { };
+
+  openai-agents = callPackage ../development/python-modules/openai-agents { };
 
   openai-whisper = callPackage ../development/python-modules/openai-whisper { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds two new MCP server package definitions to nixpkgs:

- [leanexplore](https://github.com/justincasher/lean-explore)
- [lean-lsp-mcp](https://github.com/oOo0oOo/lean-lsp-mcp)

I also had to package `openai-agents`.

This MCP servers can be used to improve responses from LLM clients in the context of Lean (proof assistant) projects.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
