### PR TITLE
walker: 0.12.23 -> 0.12.28

### DIFF
--- a/pkgs/by-name/wa/walker/package.nix
+++ b/pkgs/by-name/wa/walker/package.nix
@@ -9,20 +9,21 @@
   gtk4,
   gtk4-layer-shell,
   nix-update-script,
+  libqalculate,
 }:
 
 buildGoModule rec {
   pname = "walker";
-  version = "0.12.23";
+  version = "0.12.28";
 
   src = fetchFromGitHub {
     owner = "abenz1267";
     repo = "walker";
     rev = "v${version}";
-    hash = "sha256-DUbOu45ls/h0Nnrrue/t0R12yNOhL6GegjGL1pV6BAQ=";
+    hash = "sha256-OHBhSYWZ11wEMIwHlh6tK1AM/0JWV5PcoMC783uOUVs=";
   };
 
-  vendorHash = "sha256-6PPNVnsH1eU4fLcZpxiBoHCzN/TUUxfTfmxDsBDPDKQ=";
+  vendorHash = "sha256-SG1JTl/Al9bRyDkzN7xliuZIAMifQJZdIeC5fr0WpWw=";
   subPackages = [ "cmd/walker.go" ];
 
   passthru.updateScript = nix-update-script { };
@@ -37,6 +38,7 @@ buildGoModule rec {
     gtk4
     vips
     gtk4-layer-shell
+    libqalculate
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Things done

Updates walker to version 0.12.28.

## Changes
- Updated version from 0.12.23 to 0.12.28
- Added `libqalculate` as build dep

## Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

## Testing
- [x] Package builds successfully with `nix-build -A walker`
- [x] Application runs and displays correct version
- [x] No build warnings or errors