### PR TITLE
Reapply "nixos/dovecot: improve and harden systemd unit"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -70,6 +70,8 @@
 
 - []{#sec-release-25.11-incompatibilities-sourcehut-removed} The `services.sourcehut` module and corresponding `sourcehut` packages were removed due to being broken and unmaintained.
 
+- The `dovecot` systemd service was renamed from `dovecot2` to `dovecot`. The former is now just an alias. Update any overrides on the systemd unit to the new name.
+
 - The `yeahwm` package and `services.xserver.windowManager.yeahwm` module were removed due to the package being broken and unmaintained upstream.
 
 - The `services.postgresql` module now sets up a systemd unit `postgresql.target`. Depending on `postgresql.target` guarantees that postgres is in read-write mode and initial/ensure scripts were executed. Depending on `postgresql.service` only guarantees a read-only connection.

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -692,23 +692,69 @@ in
 
     environment.etc."dovecot/dovecot.conf".source = cfg.configFile;
 
-    systemd.services.dovecot2 = {
+    systemd.services.dovecot = {
+      aliases = [ "dovecot2.service" ];
       description = "Dovecot IMAP/POP3 server";
+      documentation = [
+        "man:dovecot(1)"
+        "https://doc.dovecot.org"
+      ];
 
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      restartTriggers = [
-        cfg.configFile
-      ];
+      restartTriggers = [ cfg.configFile ];
 
       startLimitIntervalSec = 60; # 1 min
       serviceConfig = {
         Type = "notify";
         ExecStart = "${dovecotPkg}/sbin/dovecot -F";
         ExecReload = "${dovecotPkg}/sbin/doveadm reload";
+
+        CapabilityBoundingSet = [
+          "CAP_CHOWN"
+          "CAP_DAC_OVERRIDE"
+          "CAP_FOWNER"
+          "CAP_KILL" # Required for child process management
+          "CAP_NET_BIND_SERVICE"
+          "CAP_SETGID"
+          "CAP_SETUID"
+          "CAP_SYS_CHROOT"
+          "CAP_SYS_RESOURCE"
+        ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = false; # e.g for sendmail
+        OOMPolicy = "continue";
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = lib.mkDefault false;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "full";
+        PrivateDevices = true;
         Restart = "on-failure";
         RestartSec = "1s";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK" # e.g. getifaddrs in sieve handling
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = false; # sets sgid on maildirs
         RuntimeDirectory = [ "dovecot2" ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service @resources"
+          "~@privileged"
+          "@chown @setuid capset chroot"
+        ];
       };
 
       # When copying sieve scripts preserve the original time stamp
@@ -772,6 +818,12 @@ in
       {
         assertion = cfg.sieve.scripts != { } -> (cfg.mailUser != null && cfg.mailGroup != null);
         message = "dovecot requires mailUser and mailGroup to be set when `sieve.scripts` is set";
+      }
+      {
+        assertion = config.systemd.services ? dovecot2 == false;
+        message = ''
+          Your configuration sets options on the `dovecot2` systemd service. These have no effect until they're migrated to the `dovecot` service.
+        '';
       }
     ];
 

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -296,6 +296,20 @@ in
 
     enableLmtp = mkEnableOption "starting the LMTP listener (when Dovecot is enabled)";
 
+    hasNewUnitName = mkOption {
+      type = types.bool;
+      default = true;
+      readOnly = true;
+      internal = true;
+      description = ''
+        Inspectable option to confirm that the dovecot module uses the new
+        `dovecot.service` name, instead of `dovecot2.service`.
+
+        This is a helper added for the nixos-mailserver project and can be
+        removed after branching off nixos-25.11.
+      '';
+    };
+
     protocols = mkOption {
       type = types.listOf types.str;
       default = [ ];

--- a/nixos/tests/dovecot.nix
+++ b/nixos/tests/dovecot.nix
@@ -84,11 +84,13 @@
 
   testScript = ''
     machine.wait_for_unit("postfix.service")
-    machine.wait_for_unit("dovecot2.service")
+    machine.wait_for_unit("dovecot.service")
     machine.succeed("send-testmail")
     machine.succeed("send-lda")
     machine.wait_until_fails('[ "$(postqueue -p)" != "Mail queue is empty" ]')
     machine.succeed("test-imap")
     machine.succeed("test-pop")
+
+    machine.log(machine.succeed("systemd-analyze security dovecot.service | grep -v ✓"))
   '';
 }


### PR DESCRIPTION
This reverts commit a794031c597bd8a1898a1305b70952508e2d3612 , reapplying https://github.com/NixOS/nixpkgs/pull/418722.

With three new additions:

Allow `CAP_KILL`, so the dovecot master process may interrupt its child
processes.

Allow new privileges, so dovecot and call the setuid sendmail executable.

Allow AF_NETLINK sockets, so dovecot sieve handling can use the
getifaddrs syscall.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
