### PR TITLE
moonring: init at 0.0.950

### DIFF
--- a/pkgs/by-name/mo/moonring/package.nix
+++ b/pkgs/by-name/mo/moonring/package.nix
@@ -1,0 +1,95 @@
+{
+  copyDesktopItems,
+  icoutils,
+  imagemagick,
+  lib,
+  love,
+  makeDesktopItem,
+  makeWrapper,
+  p7zip,
+  requireFile,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "moonring";
+  version = "0.0.950";
+
+  src = requireFile {
+    name = "moonring-win.zip"; # Windows build is easiest to extract
+    url = "https://dene.itch.io/moonring#download";
+    # Use `nix --extra-experimental-features nix-command hash file --sri --type sha256` to get the correct hash
+    hash = "sha256-DHTgl5wTv0yM416AzUNOsz0iTcRrcSKUg1lPoojQXLA=";
+  };
+
+  nativeBuildInputs = [
+    p7zip
+    copyDesktopItems
+    icoutils
+    imagemagick
+    makeWrapper
+  ];
+  buildInputs = [ love ];
+
+  dontUnpack = true;
+  buildPhase = ''
+    runHook preBuild
+
+    # Unzip the file a user would download
+    tmpdir=$(mktemp -d)
+    7z x ${finalAttrs.src} -o$tmpdir -y
+
+    # Unzip the executable contained within
+    tmpdir2=$(mktemp -d)
+    7z x $tmpdir/Moonring.exe -o$tmpdir2 -y
+
+    # Reassemble
+    patchedExe=$(mktemp -u).zip
+    7z a $patchedExe $tmpdir2/*
+
+    # Extract icon
+    tmpdir3=$(mktemp -d)
+    wrestool -x -t 14 $tmpdir/Moonring.exe > $tmpdir3/moonring.ico
+    magick $tmpdir3/moonring.ico $tmpdir3/moonring.png
+
+    runHook postBuild
+  '';
+
+  # The `cat` bit is a hack suggested by whitelje (https://github.com/ethangreen-dev/lovely-injector/pull/66#issuecomment-2319615509)
+  # to make it so that love will pick up Moonring as the game name.
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 $tmpdir3/moonring-6.png -t $out/share/icons
+
+    cat ${lib.getExe love} $patchedExe > $out/share/Moonring
+    chmod +x $out/share/Moonring
+
+    makeWrapper $out/share/Moonring $out/bin/moonring
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "moonring";
+      desktopName = "Moonring";
+      exec = "moonring";
+      keywords = [ "Game" ];
+      categories = [ "Game" ];
+      icon = "moonring";
+    })
+  ];
+
+  meta = {
+    description = "Retro, Ultima-inspired RPG";
+    longDescription = ''
+      Moonring is a retro-inspired open-world, turn-based, tile RPG in the
+      style of the old Ultima games, but created with modern design
+      sensibilities, and a unique neon aesthetic.
+    '';
+    license = lib.licenses.unfree;
+    homepage = "https://store.steampowered.com/app/2373630/Moonring/";
+    maintainers = [ lib.maintainers.jonhermansen ];
+    platforms = love.meta.platforms;
+    mainProgram = "moonring";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://store.steampowered.com/app/2373630/Moonring/

https://dene.itch.io/moonring

> Moonring is a retro-inspired open-world, turn-based, tile RPG in the style of the old Ultima games, but created with modern design sensibilities, and a unique neon aesthetic.

My second derivation, I'm new to nixpkgs! Wanted to try porting a Love2D game over after being inspired by Balatro. I checked with the creator and they said they're cool with packaging it for NixOS: https://itch.io/t/5054642/packaging-for-linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
