### PR TITLE
mongosh: 2.5.2 -> 2.5.5

### DIFF
--- a/pkgs/by-name/mo/mongosh/package.nix
+++ b/pkgs/by-name/mo/mongosh/package.nix
@@ -2,32 +2,23 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  testers,
-  nix-update-script,
-  fetchpatch,
 }:
 
 buildNpmPackage (finalAttrs: {
   pname = "mongosh";
-  version = "2.5.2";
+  version = "2.5.5";
 
   src = fetchFromGitHub {
     owner = "mongodb-js";
     repo = "mongosh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0rol41XNdpfVRGY8KXFmQ0GHg5QqgnCaF21ZFyxfKeQ=";
+    hash = "sha256-dngguv/ShxwfFpbYyyfJ1SmQhSgEsDOKcRSXdjsfcmo=";
   };
 
-  npmDepsHash = "sha256-J4/CU+gdT/qecM1JwafLBewQjYdaONq/k4ax3Jw34XY=";
+  npmDepsHash = "sha256-W5qq3XUV+x0Ko1Ftp2JTHbaOSGsSG5a7qABthtnaU4o=";
 
   patches = [
     ./disable-telemetry.patch
-
-    # For tagged version 2.5.2
-    (fetchpatch {
-      url = "https://github.com/mongodb-js/mongosh/commit/8e775b58b95f1d7c0a3de9c677e957a40213da6a.patch";
-      hash = "sha256-Q80QuzC7JN6uqyjk7YuUljXm+365AwYRV5cct9TefUc=";
-    })
   ];
 
   npmFlags = [
@@ -45,15 +36,9 @@ buildNpmPackage (finalAttrs: {
   '';
 
   passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-    };
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--version-regex"
-        "^v(\\d+\\.\\d+\\.\\d+)$"
-      ];
-    };
+    # Version testing is skipped because upstream often forgets to update the version.
+
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/mo/mongosh/update.sh
+++ b/pkgs/by-name/mo/mongosh/update.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl nix-update jq
+
+# GitHub tags include many unrelated subpackage versions, making it unreliable to determine the latest mongosh version.
+# Fetch the latest mongosh version directly from the npm registry instead.
+version="$(curl -fsSL https://registry.npmjs.org/mongosh/latest | jq -r ".version")"
+
+nix-update --version "$version" mongosh


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
