### PR TITLE
git-statuses: init at 0.3.1

### DIFF
--- a/pkgs/by-name/gi/git-statuses/package.nix
+++ b/pkgs/by-name/gi/git-statuses/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "git-statuses";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "bircni";
+    repo = "git-statuses";
+    tag = finalAttrs.version;
+    hash = "sha256-pnqg32FH26NTtt7N5db/JGjjR3MbPOFPtMA2iZNFiSI=";
+  };
+
+  patches = [
+    # This commit requires Rust 1.88, which is not yet in Nixpkgs.
+    (fetchpatch {
+      url = "https://github.com/bircni/git-statuses/commit/8bc32d1bd47d2a9e48f1408a9137213bae925912.patch";
+      hash = "sha256-JNWsv0DjwrSbMu/j2+XMoZKgvB1OgUA3b2BNuZTM/cA=";
+      revert = true;
+    })
+  ];
+
+  # fix tests, ref. https://github.com/bircni/git-statuses/pull/8
+  postPatch = ''
+    substituteInPlace src/tests/gitinfo_test.rs --replace-fail \
+      'let repo = git2::Repository::init(tmp_dir.path()).unwrap();' \
+      'let repo = git2::Repository::init(tmp_dir.path()).unwrap();
+       let mut config = repo.config().unwrap();
+       config.set_str("user.name", "Test User").unwrap();
+       config.set_str("user.email", "test@example.com").unwrap();'
+  '';
+
+  cargoHash = "sha256-thLyIxuAACtexqCddKWuUE8Vl0CeUEBP7XxDPYT23lg=";
+
+  # Needed to get openssl-sys to use pkg-config.
+  env.OPENSSL_NO_VENDOR = 1;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  buildInputs = [
+    openssl
+  ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-line tool to display the status of multiple Git repositories in a clear, tabular format";
+    homepage = "https://github.com/bircni/git-statuses";
+    changelog = "https://github.com/bircni/git-statuses/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "git-statuses";
+  };
+})


### PR DESCRIPTION
## Things done

In a directory with 60 repos : 1.5s to get all statuses

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
