### PR TITLE
libgcrypt: fix build for riscv64-linux

### DIFF
--- a/pkgs/by-name/li/libgcrypt/package.nix
+++ b/pkgs/by-name/li/libgcrypt/package.nix
@@ -69,10 +69,22 @@ stdenv.mkDerivation rec {
     "build"
   ];
 
-  postConfigure = ''
-    sed -i configure \
-        -e 's/NOEXECSTACK_FLAGS=$/NOEXECSTACK_FLAGS="-Wa,--noexecstack"/'
-  '';
+  postConfigure =
+    ''
+      sed -i configure \
+          -e 's/NOEXECSTACK_FLAGS=$/NOEXECSTACK_FLAGS="-Wa,--noexecstack"/'
+    ''
+    # The cipher/simd-common-riscv.h wasn't added to the release tarball, please remove this hack on next version update
+    # https://dev.gnupg.org/T7647
+    + lib.optionalString stdenv.hostPlatform.isRiscV ''
+      cp ${
+        fetchurl {
+          url = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=blob_plain;f=cipher/simd-common-riscv.h;h=8381000f9ac148c60a6963a1d9ec14a3fee1c576;hb=81ce5321b1b79bde6dfdc3c164efb40c13cf656b";
+          hash = "sha256-Toe15YLAOYULnLc2fGMMv/xzs/q1t3LsyiqtL7imc+8=";
+          name = "simd-common-riscv.h";
+        }
+      } cipher/simd-common-riscv.h
+    '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Fixes the following error:
```
libtool: compile:  riscv64-unknown-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I.. -I../src -I../src -I../mpi -I../mpi -I/nix/store/kva3r0bwa554vhxg9z9zl9c29ygq4n5z-libgpg-error-riscv64-unknown-linux-gnu-1.55-dev/include -g -O2 -fvisibility=hidden -fno-delete-null-pointer-checks -Wall -O2 -march=rv64imafdcv -mstrict-align -c chacha20-riscv-v.c  -fPIC -DPIC -o .libs/chacha20-riscv-v.o
chacha20-riscv-v.c:26:10: fatal error: simd-common-riscv.h: No such file or directory
   26 | #include "simd-common-riscv.h"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:1724: chacha20-riscv-v.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
rijndael-vp-riscv.c:58:10: fatal error: simd-common-riscv.h: No such file or directory
   58 | #include "simd-common-riscv.h"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:1730: rijndael-vp-riscv.lo] Error 1
make[2]: Leaving directory '/build/libgcrypt-1.11.1/cipher'
make[1]: *** [Makefile:500: all-recursive] Error 1
make[1]: Leaving directory '/build/libgcrypt-1.11.1'
make: *** [Makefile:432: all] Error 2
```

See https://dev.gnupg.org/T7647
Broken in https://github.com/NixOS/nixpkgs/pull/321154


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (pkgsCross.riscv64.libgcrypt)
  - [X] riscv64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
