### PR TITLE
stalwart-mail: Fix spam-filter missing from `/etc`

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18284,6 +18284,13 @@
     ];
     matrix = "@normalcea:matrix.org";
   };
+  norpol = {
+    name = "Syd Lightyear";
+    email = "norpol+nixpkgs@exaple.org";
+    matrix = "@phileas:asra.gr";
+    github = "norpol";
+    githubId = 98636020;
+  };
   nosewings = {
     name = "Nicholas Coltharp";
     email = "coltharpnicholas@gmail.com";

--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -107,7 +107,7 @@ in
       resolver.public-suffix = lib.mkDefault [
         "file://${pkgs.publicsuffix-list}/share/publicsuffix/public_suffix_list.dat"
       ];
-      spam-filter.resource = lib.mkDefault "file://${cfg.package}/etc/stalwart/spamfilter.toml";
+      spam-filter.resource = lib.mkDefault "file://${cfg.package.spam-filter}/spam-filter.toml";
       webadmin =
         let
           hasHttpListener = builtins.any (listener: listener.protocol == "http") (
@@ -232,6 +232,7 @@ in
       happysalada
       euxane
       onny
+      norpol
     ];
   };
 }

--- a/pkgs/by-name/st/stalwart-mail/package.nix
+++ b/pkgs/by-name/st/stalwart-mail/package.nix
@@ -162,6 +162,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     inherit rocksdb; # make used rocksdb version available (e.g., for backup scripts)
     webadmin = callPackage ./webadmin.nix { };
+    spam-filter = callPackage ./spam-filter.nix { };
     updateScript = nix-update-script { };
     tests.stalwart-mail = nixosTests.stalwart-mail;
   };
@@ -187,6 +188,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       onny
       oddlama
       pandapip1
+      norpol
     ];
   };
 })

--- a/pkgs/by-name/st/stalwart-mail/spam-filter.nix
+++ b/pkgs/by-name/st/stalwart-mail/spam-filter.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  stalwart-mail,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "spam-filter";
+  version = "2.0.3";
+
+  src = fetchFromGitHub {
+    owner = "stalwartlabs";
+    repo = "spam-filter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NhD/qUiGhgESwR2IOzAHfDATRlgWMcCktlktvVfDONk=";
+  };
+
+  buildPhase = ''
+    bash ./build.sh
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp spam-filter.toml $out/
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Secure & modern all-in-one mail server Stalwart (spam-filter module)";
+    homepage = "https://github.com/stalwartlabs/spam-filter";
+    changelog = "https://github.com/stalwartlabs/spam-filter/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    inherit (stalwart-mail.meta) maintainers;
+  };
+})

--- a/pkgs/by-name/st/stalwart-mail/webadmin.nix
+++ b/pkgs/by-name/st/stalwart-mail/webadmin.nix
@@ -15,20 +15,19 @@
   zip,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "webadmin";
   version = "0.1.28";
 
   src = fetchFromGitHub {
     owner = "stalwartlabs";
     repo = "webadmin";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-OgZ2qs84zVM2zNmBQSPnb9Uy4mahzNC81vbWM9wmrn4=";
   };
 
   npmDeps = fetchNpmDeps {
-    inherit src;
-    name = "${pname}-npm-deps";
+    name = "${finalAttrs.pname}-npm-deps";
     hash = "sha256-na1HEueX8w7kuDp8LEtJ0nD1Yv39cyk6sEMpS1zix2s=";
   };
 
@@ -72,8 +71,8 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Secure & modern all-in-one mail server Stalwart (webadmin module)";
     homepage = "https://github.com/stalwartlabs/webadmin";
-    changelog = "https://github.com/stalwartlabs/webadmin/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/stalwartlabs/webadmin/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
     inherit (stalwart-mail.meta) maintainers;
   };
-}
+})

--- a/pkgs/by-name/st/stalwart-mail/webadmin.nix
+++ b/pkgs/by-name/st/stalwart-mail/webadmin.nix
@@ -1,6 +1,7 @@
 {
   lib,
   rustPlatform,
+  stalwart-mail,
   fetchFromGitHub,
   trunk,
   tailwindcss_3,
@@ -73,6 +74,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/stalwartlabs/webadmin";
     changelog = "https://github.com/stalwartlabs/webadmin/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ onny ];
+    inherit (stalwart-mail.meta) maintainers;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10765,6 +10765,7 @@ with pkgs;
   };
 
   stalwart-mail-webadmin = stalwart-mail.webadmin;
+  stalwart-mail-spam-filter = stalwart-mail.spam-filter;
 
   stalwart-mail-enterprise = stalwart-mail.override {
     stalwartEnterprise = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* [x] add norpol to nixpkgs maintainers
* [x] chore work with nixpkgs style preferences in other sub packages
* [x] The current nix unstable package doesn't contain the `spamfilter.toml` anylonger. This pull requests packages the spam-filter as an additional package.


```
$ find /nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/bin
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/bin/stalwart-cli
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/bin/stalwart
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/lib
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/lib/systemd
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/lib/systemd/system
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/lib/systemd/system/stalwart-mail.service
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/etc
/nix/store/jwznrq528mx0z844ka6j4rfqk5bhj463-stalwart-mail-0.12.4/etc/stalwart
```

Note: Stalwart will still download additional data through the `spam-filter.toml`. I don't think this has changed across the releases. I don't see that the ASN IPs, geolite, domains_mx, free_email_providers, ... are feasible to package into nixpkgs. So I'm not even sure whether it is advisable to not pull the spam-filters automatically from GitHub as well (so staying with the upstream config).

Also I'm unsure whether the auto-update flag has only an impact on the filter rules or also the http URLs downloaded through the filters.

```
$ grep 'https://'  /nix/store/ij1msx3awgpajyk4ci3zws3pyyixawkf-spam-filter-2.0.3/spam-filter.toml
asn = [ "https://cdn.jsdelivr.net/npm/@ip-location-db/asn/asn-ipv4.csv",
        "https://cdn.jsdelivr.net/npm/@ip-location-db/asn/asn-ipv6.csv" ]
geo = [ "https://cdn.jsdelivr.net/npm/@ip-location-db/geolite2-geo-whois-asn-country/geolite2-geo-whois-asn-country-ipv4.csv",
        "https://cdn.jsdelivr.net/npm/@ip-location-db/geolite2-geo-whois-asn-country/geolite2-geo-whois-asn-country-ipv4.csv" ]
url = "https://openphish.com/feed.txt"
url = "https://disposable.github.io/disposable-email-domains/domains_mx.txt"
url = "https://gist.githubusercontent.com/okutbay/5b4974b70673dfdcc21c517632c1f984/raw/993a35930a8d24a1faab1b988d19d38d92afbba4/free_email_provider_domains.txt"
```

built generates the same result
```
sha256sum /nix/store/ij1msx3awgpajyk4ci3zws3pyyixawkf-spam-filter-2.0.3/spam-filter.toml <(curl -qs -L -o - https://github.com/stalwartlabs/spam-filter/releases/download/v2.0.3/spam-filter.toml)
1b614bc004284116f6c98b5dfb2ce663872b5f60a0a8782c06ded9dcf3da2cd2  /nix/store/ij1msx3awgpajyk4ci3zws3pyyixawkf-spam-filter-2.0.3/spam-filter.toml
1b614bc004284116f6c98b5dfb2ce663872b5f60a0a8782c06ded9dcf3da2cd2  /proc/self/fd/11
```


* 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
