### PR TITLE
[Backport release-25.05] pluto: 5.21.5 -> 5.21.8

### DIFF
--- a/pkgs/by-name/pl/pluto/package.nix
+++ b/pkgs/by-name/pl/pluto/package.nix
@@ -23,6 +23,8 @@ buildGoModule rec {
     "-X main.version=v${version}"
   ];
 
+  __darwinAllowLocalNetworking = true; # for tests
+
   meta = with lib; {
     homepage = "https://github.com/FairwindsOps/pluto";
     description = "Find deprecated Kubernetes apiVersions";

--- a/pkgs/by-name/pl/pluto/package.nix
+++ b/pkgs/by-name/pl/pluto/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule rec {
   pname = "pluto";
-  version = "5.21.7";
+  version = "5.21.8";
 
   src = fetchFromGitHub {
     owner = "FairwindsOps";
     repo = "pluto";
     rev = "v${version}";
-    hash = "sha256-1Sgq8WBx0jPPmuNvUfiDs9CvV0IjCp0+n8OUlVjGj3w=";
+    hash = "sha256-41ud7SRaivhmtBY6ekKIpRijTuLqJ/tLi0dTHDsGAps=";
   };
 
   vendorHash = "sha256-4kiLgwr8wr/L4anxgZVAE6IFdbBvTgcUlf5KIcT+lRk=";

--- a/pkgs/by-name/pl/pluto/package.nix
+++ b/pkgs/by-name/pl/pluto/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule rec {
   pname = "pluto";
-  version = "5.21.5";
+  version = "5.21.6";
 
   src = fetchFromGitHub {
     owner = "FairwindsOps";
     repo = "pluto";
     rev = "v${version}";
-    hash = "sha256-l6w/51vJOghCdKF+wwBoAbhlfaDQhdTzydMlQYsSlio=";
+    hash = "sha256-q0ScT1H93IyoWha4arkvTWUCOM6GI0MMps02Sq478zg=";
   };
 
-  vendorHash = "sha256-bGPq8rWuSquP7ybL+jqq6t292WffFSllbjf2+gJocHA=";
+  vendorHash = "sha256-4kiLgwr8wr/L4anxgZVAE6IFdbBvTgcUlf5KIcT+lRk=";
 
   ldflags = [
     "-w"

--- a/pkgs/by-name/pl/pluto/package.nix
+++ b/pkgs/by-name/pl/pluto/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule rec {
   pname = "pluto";
-  version = "5.21.6";
+  version = "5.21.7";
 
   src = fetchFromGitHub {
     owner = "FairwindsOps";
     repo = "pluto";
     rev = "v${version}";
-    hash = "sha256-q0ScT1H93IyoWha4arkvTWUCOM6GI0MMps02Sq478zg=";
+    hash = "sha256-1Sgq8WBx0jPPmuNvUfiDs9CvV0IjCp0+n8OUlVjGj3w=";
   };
 
   vendorHash = "sha256-4kiLgwr8wr/L4anxgZVAE6IFdbBvTgcUlf5KIcT+lRk=";


### PR DESCRIPTION
Manual backport of #408818 #412246 #420303 #422937 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.