### PR TITLE
[Backport release-25.05] warp-terminal: 0.2025.05.07.08.12.stable_02 -> 0.2025.07.02.08.36.stable_02

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-7/gSUR9h9PzBrTgxERXNjqzJDtqxebjmD0cF3Vx2ySY=",
-    "version": "0.2025.06.25.08.12.stable_01"
+    "hash": "sha256-YXZbYooBqn3jGoWd+pvPs95Oq6V9sjEA2IC7dEsj2hs=",
+    "version": "0.2025.07.02.08.36.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-2VQzEBAAu6YasottOTu3YjQvvXR5gT3DAjGhp63wMNo=",
-    "version": "0.2025.06.25.08.12.stable_01"
+    "hash": "sha256-CXCCJhR6Re423ZxWTheh0qus7sh7EqsSHz2x0Tz0t1E=",
+    "version": "0.2025.07.02.08.36.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-5jpW7mUHLshGZUWigAJ8QgmpYnfosJN1JpRLeNvVK3Y=",
-    "version": "0.2025.06.25.08.12.stable_01"
+    "hash": "sha256-uaOTKWuufzfu9T8DW86Nur9QSRIcnNYCCahCrEEDPpg=",
+    "version": "0.2025.07.02.08.36.stable_02"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-AxPUNdZbvc6T4sFFTkQnOAg26vmzf86oaGbtzapybFc=",
-    "version": "0.2025.05.14.08.11.stable_03"
+    "hash": "sha256-II8VDM6qBkep+v017+hhOfx+wfHoMo5lR22IvvXmiy8=",
+    "version": "0.2025.05.28.08.11.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-vdBTwn3ElyOIIyPXNbScvymq6P5d15b41NKAg7QSigk=",
-    "version": "0.2025.05.14.08.11.stable_03"
+    "hash": "sha256-7/U/ZPJLNbBpk0fNAh0OHr68+x5zhYsbJn+vc09/h4w=",
+    "version": "0.2025.05.28.08.11.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-jpTVEvZUmLlsiYTJtECT2G899PyFTXZz5qa9+RPWzaI=",
-    "version": "0.2025.05.14.08.11.stable_03"
+    "hash": "sha256-TX1OYadvUdOp9R3eDdw1ONtN/wn7K8m1IH1IwIdSuJQ=",
+    "version": "0.2025.05.28.08.11.stable_02"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-oPBB3tCxLMogV3SEr7QHjFgOw8n7bfuwFSRdgWwSb9Y=",
-    "version": "0.2025.05.28.08.11.stable_03"
+    "hash": "sha256-xkrJqFLzKKEBPWr49JqpCC70CGEGpwrhb5GLCoGZiWI=",
+    "version": "0.2025.06.04.08.11.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-pVXmosjXXnSyOrLEUzZtLWs1KWkyDRXSjHV6rdvuK6U=",
-    "version": "0.2025.05.28.08.11.stable_03"
+    "hash": "sha256-OVS84RwWqspkE6Wfji/FuoaXvS2ZA2vWkI0kfQrEWSk=",
+    "version": "0.2025.06.04.08.11.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-LKFkJg5NEgtjvjK1gzo4ZQqQQbxmzRgP+CNznlgUfJo=",
-    "version": "0.2025.05.28.08.11.stable_03"
+    "hash": "sha256-K/RC1hYe7G+3symQVR8If/B1/VCACCTcq5JTSKLREIM=",
+    "version": "0.2025.06.04.08.11.stable_03"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-xkrJqFLzKKEBPWr49JqpCC70CGEGpwrhb5GLCoGZiWI=",
-    "version": "0.2025.06.04.08.11.stable_03"
+    "hash": "sha256-wlFmfHBSwBh9UFq6by52fGYN2EftP793u3L57XSDDKQ=",
+    "version": "0.2025.06.18.08.11.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-OVS84RwWqspkE6Wfji/FuoaXvS2ZA2vWkI0kfQrEWSk=",
-    "version": "0.2025.06.04.08.11.stable_03"
+    "hash": "sha256-7CfqTRUMkqLXmJg7RQK0liVEhucMOgMtsJl4/lrg4XI=",
+    "version": "0.2025.06.18.08.11.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-K/RC1hYe7G+3symQVR8If/B1/VCACCTcq5JTSKLREIM=",
-    "version": "0.2025.06.04.08.11.stable_03"
+    "hash": "sha256-iDXAchU/b2ApDsmV0dnkXI1o0VOaegYWz4DufHtPFJM=",
+    "version": "0.2025.06.18.08.11.stable_03"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-II8VDM6qBkep+v017+hhOfx+wfHoMo5lR22IvvXmiy8=",
-    "version": "0.2025.05.28.08.11.stable_02"
+    "hash": "sha256-oPBB3tCxLMogV3SEr7QHjFgOw8n7bfuwFSRdgWwSb9Y=",
+    "version": "0.2025.05.28.08.11.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-7/U/ZPJLNbBpk0fNAh0OHr68+x5zhYsbJn+vc09/h4w=",
-    "version": "0.2025.05.28.08.11.stable_02"
+    "hash": "sha256-pVXmosjXXnSyOrLEUzZtLWs1KWkyDRXSjHV6rdvuK6U=",
+    "version": "0.2025.05.28.08.11.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-TX1OYadvUdOp9R3eDdw1ONtN/wn7K8m1IH1IwIdSuJQ=",
-    "version": "0.2025.05.28.08.11.stable_02"
+    "hash": "sha256-LKFkJg5NEgtjvjK1gzo4ZQqQQbxmzRgP+CNznlgUfJo=",
+    "version": "0.2025.05.28.08.11.stable_03"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-wlFmfHBSwBh9UFq6by52fGYN2EftP793u3L57XSDDKQ=",
-    "version": "0.2025.06.18.08.11.stable_03"
+    "hash": "sha256-UJAirS6JFFLW0OsOYj8RNUfG85dRHnxXasNw2QHX1Xs=",
+    "version": "0.2025.06.20.22.47.stable_05"
   },
   "linux_x86_64": {
-    "hash": "sha256-7CfqTRUMkqLXmJg7RQK0liVEhucMOgMtsJl4/lrg4XI=",
-    "version": "0.2025.06.18.08.11.stable_03"
+    "hash": "sha256-h0ODaO3SJcZAxFRFBYYjWXQYsRAemGizn/YA7AF36pw=",
+    "version": "0.2025.06.20.22.47.stable_05"
   },
   "linux_aarch64": {
-    "hash": "sha256-iDXAchU/b2ApDsmV0dnkXI1o0VOaegYWz4DufHtPFJM=",
-    "version": "0.2025.06.18.08.11.stable_03"
+    "hash": "sha256-H4xldFBMpfu6UFGFA/IkA1zPFqhFN6abhfHTRdYNpGA=",
+    "version": "0.2025.06.20.22.47.stable_05"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-UJAirS6JFFLW0OsOYj8RNUfG85dRHnxXasNw2QHX1Xs=",
-    "version": "0.2025.06.20.22.47.stable_05"
+    "hash": "sha256-7/gSUR9h9PzBrTgxERXNjqzJDtqxebjmD0cF3Vx2ySY=",
+    "version": "0.2025.06.25.08.12.stable_01"
   },
   "linux_x86_64": {
-    "hash": "sha256-h0ODaO3SJcZAxFRFBYYjWXQYsRAemGizn/YA7AF36pw=",
-    "version": "0.2025.06.20.22.47.stable_05"
+    "hash": "sha256-2VQzEBAAu6YasottOTu3YjQvvXR5gT3DAjGhp63wMNo=",
+    "version": "0.2025.06.25.08.12.stable_01"
   },
   "linux_aarch64": {
-    "hash": "sha256-H4xldFBMpfu6UFGFA/IkA1zPFqhFN6abhfHTRdYNpGA=",
-    "version": "0.2025.06.20.22.47.stable_05"
+    "hash": "sha256-5jpW7mUHLshGZUWigAJ8QgmpYnfosJN1JpRLeNvVK3Y=",
+    "version": "0.2025.06.25.08.12.stable_01"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-c6+LEdAWgRrm3UrHRK8N0IGuxoxHpz4j5sgCz+eJOco=",
-    "version": "0.2025.05.07.08.12.stable_02"
+    "hash": "sha256-AxPUNdZbvc6T4sFFTkQnOAg26vmzf86oaGbtzapybFc=",
+    "version": "0.2025.05.14.08.11.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-uEaQecj5h6if5Hc7BjuXxxVO+SqOYE/xop08ujQFgGg=",
-    "version": "0.2025.05.07.08.12.stable_02"
+    "hash": "sha256-vdBTwn3ElyOIIyPXNbScvymq6P5d15b41NKAg7QSigk=",
+    "version": "0.2025.05.14.08.11.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-543oTSzBZLxWem3EnpqVyWgQvrbduurEhFEC7XpKHWk=",
-    "version": "0.2025.05.07.08.12.stable_02"
+    "hash": "sha256-jpTVEvZUmLlsiYTJtECT2G899PyFTXZz5qa9+RPWzaI=",
+    "version": "0.2025.05.14.08.11.stable_03"
   }
 }


### PR DESCRIPTION
Manual backport of #409691 #412988 #413593 #415923 #418680 #419615 #421039 #422689 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.