### PR TITLE
[Backport release-25.05] sql-formatter: 15.6.1 -> 15.6.6

### DIFF
--- a/pkgs/by-name/sq/sql-formatter/package.nix
+++ b/pkgs/by-name/sq/sql-formatter/package.nix
@@ -11,13 +11,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "sql-formatter";
-  version = "15.6.5";
+  version = "15.6.6";
 
   src = fetchFromGitHub {
     owner = "sql-formatter-org";
     repo = "sql-formatter";
     rev = "v${version}";
-    hash = "sha256-oNUQvNsdlLJn2JQdCV0Kp3oaXuLJuPGH+Pfe+gRog2E=";
+    hash = "sha256-61E3DizwO9Lml0Uu4tOhpCbzaxiDrY5vPqk2TY7fIqo=";
   };
 
   yarnOfflineCache = fetchYarnDeps {

--- a/pkgs/by-name/sq/sql-formatter/package.nix
+++ b/pkgs/by-name/sq/sql-formatter/package.nix
@@ -11,13 +11,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "sql-formatter";
-  version = "15.6.1";
+  version = "15.6.2";
 
   src = fetchFromGitHub {
     owner = "sql-formatter-org";
     repo = "sql-formatter";
     rev = "v${version}";
-    hash = "sha256-Olq7DAhiopFlLnn6r78nJU6LjS2EiU93kc/iY4mLCL8=";
+    hash = "sha256-pqNxZ8bmnwQYPLIQ8vQrKct9fD8i0fiLn4h4f2779q4=";
   };
 
   yarnOfflineCache = fetchYarnDeps {

--- a/pkgs/by-name/sq/sql-formatter/package.nix
+++ b/pkgs/by-name/sq/sql-formatter/package.nix
@@ -11,13 +11,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "sql-formatter";
-  version = "15.6.2";
+  version = "15.6.4";
 
   src = fetchFromGitHub {
     owner = "sql-formatter-org";
     repo = "sql-formatter";
     rev = "v${version}";
-    hash = "sha256-pqNxZ8bmnwQYPLIQ8vQrKct9fD8i0fiLn4h4f2779q4=";
+    hash = "sha256-nrdr6h+q8jVXKM6xPXeQkGN3zqdUCPs/FVnPMfMPG3E=";
   };
 
   yarnOfflineCache = fetchYarnDeps {

--- a/pkgs/by-name/sq/sql-formatter/package.nix
+++ b/pkgs/by-name/sq/sql-formatter/package.nix
@@ -11,13 +11,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "sql-formatter";
-  version = "15.6.4";
+  version = "15.6.5";
 
   src = fetchFromGitHub {
     owner = "sql-formatter-org";
     repo = "sql-formatter";
     rev = "v${version}";
-    hash = "sha256-nrdr6h+q8jVXKM6xPXeQkGN3zqdUCPs/FVnPMfMPG3E=";
+    hash = "sha256-oNUQvNsdlLJn2JQdCV0Kp3oaXuLJuPGH+Pfe+gRog2E=";
   };
 
   yarnOfflineCache = fetchYarnDeps {


### PR DESCRIPTION
Manual backport of #410740 #416864 #419444 #422244 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.