### PR TITLE
[Backport release-25.05] chafa: 1.14.5 -> 1.16.2

### DIFF
--- a/pkgs/by-name/ch/chafa/package.nix
+++ b/pkgs/by-name/ch/chafa/package.nix
@@ -19,14 +19,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.16.1";
+  version = "1.16.2";
   pname = "chafa";
 
   src = fetchFromGitHub {
     owner = "hpjansson";
     repo = "chafa";
     tag = finalAttrs.version;
-    hash = "sha256-O57L/VR3M1dTMg+UES6NGh4hU2D7/e9boTMNo6sR/ws=";
+    hash = "sha256-bIFPnbciaog9piqBMSpe9zLwH7irp5CW1WG5frAMqpI=";
   };
 
   outputs = [

--- a/pkgs/by-name/ch/chafa/package.nix
+++ b/pkgs/by-name/ch/chafa/package.nix
@@ -69,7 +69,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postInstall = ''
-    installShellCompletion --cmd chafa tools/completions/zsh-completion.zsh
+    installShellCompletion --cmd chafa \
+      --fish tools/completions/fish-completion.fish \
+      --zsh tools/completions/zsh-completion.zsh
   '';
 
   meta = {

--- a/pkgs/by-name/ch/chafa/package.nix
+++ b/pkgs/by-name/ch/chafa/package.nix
@@ -19,14 +19,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.14.5";
+  version = "1.16.1";
   pname = "chafa";
 
   src = fetchFromGitHub {
     owner = "hpjansson";
     repo = "chafa";
-    rev = finalAttrs.version;
-    sha256 = "sha256-9RkN0yZnHf5cx6tsp3P6jsi0/xtplWxMm3hYCPjWj0M=";
+    tag = finalAttrs.version;
+    hash = "sha256-O57L/VR3M1dTMg+UES6NGh4hU2D7/e9boTMNo6sR/ws=";
   };
 
   outputs = [

--- a/pkgs/by-name/ch/chafa/package.nix
+++ b/pkgs/by-name/ch/chafa/package.nix
@@ -77,7 +77,10 @@ stdenv.mkDerivation rec {
     homepage = "https://hpjansson.org/chafa/";
     license = licenses.lgpl3Plus;
     platforms = platforms.all;
-    maintainers = [ maintainers.mog ];
+    maintainers = with maintainers; [
+      mog
+      prince213
+    ];
     mainProgram = "chafa";
   };
 }

--- a/pkgs/by-name/ch/chafa/package.nix
+++ b/pkgs/by-name/ch/chafa/package.nix
@@ -72,12 +72,12 @@ stdenv.mkDerivation rec {
     installShellCompletion --cmd chafa tools/completions/zsh-completion.zsh
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Terminal graphics for the 21st century";
     homepage = "https://hpjansson.org/chafa/";
-    license = licenses.lgpl3Plus;
-    platforms = platforms.all;
-    maintainers = with maintainers; [
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
       mog
       prince213
     ];

--- a/pkgs/by-name/ch/chafa/package.nix
+++ b/pkgs/by-name/ch/chafa/package.nix
@@ -18,14 +18,14 @@
   glib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "1.14.5";
   pname = "chafa";
 
   src = fetchFromGitHub {
     owner = "hpjansson";
     repo = "chafa";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-9RkN0yZnHf5cx6tsp3P6jsi0/xtplWxMm3hYCPjWj0M=";
   };
 
@@ -83,4 +83,4 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "chafa";
   };
-}
+})


### PR DESCRIPTION
Manual backport of #409337 #422571 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.