### PR TITLE
treewide: populate `arch` and `platform` for more node packages

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -562,6 +562,51 @@ let
             # See https://go.dev/wiki/GoArm
             GOARM = toString (lib.intersectLists [ (final.parsed.cpu.version or "") ] [ "5" "6" "7" ]);
           };
+
+          node = {
+            # See these locations for a list of known architectures/platforms:
+            # - https://nodejs.org/api/os.html#osarch
+            # - https://nodejs.org/api/os.html#osplatform
+            arch =
+              if final.isAarch then
+                "arm" + lib.optionalString final.is64bit "64"
+              else if final.isMips32 then
+                "mips" + lib.optionalString final.isLittleEndian "el"
+              else if final.isMips64 && final.isLittleEndian then
+                "mips64el"
+              else if final.isPower then
+                "ppc" + lib.optionalString final.is64bit "64"
+              else if final.isx86_64 then
+                "x64"
+              else if final.isx86_32 then
+                "ia32"
+              else if final.isS390x then
+                "s390x"
+              else if final.isRiscV64 then
+                "riscv64"
+              else if final.isLoongArch64 then
+                "loong64"
+              else
+                null;
+
+            platform =
+              if final.isAndroid then
+                "android"
+              else if final.isDarwin then
+                "darwin"
+              else if final.isFreeBSD then
+                "freebsd"
+              else if final.isLinux then
+                "linux"
+              else if final.isOpenBSD then
+                "openbsd"
+              else if final.isSunOS then
+                "sunos"
+              else if final.isWindows then
+                "win32"
+              else
+                null;
+          };
         };
     in
     assert final.useAndroidPrebuilt -> final.isAndroid;

--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -104,13 +104,8 @@ lib.extendMkDerivation {
       dontStrip = args.dontStrip or true;
 
       env = {
-        npm_config_arch =
-          {
-            "x86_64" = "x64";
-            "aarch64" = "arm64";
-          }
-          .${stdenv.hostPlatform.parsed.cpu.name} or stdenv.hostPlatform.parsed.cpu.name;
-        npm_config_platform = stdenv.hostPlatform.parsed.kernel.name;
+        npm_config_arch = stdenv.hostPlatform.node.arch;
+        npm_config_platform = stdenv.hostPlatform.node.platform;
       } // (args.env or { });
 
       meta = (args.meta or { }) // {

--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -103,11 +103,6 @@ lib.extendMkDerivation {
       # Stripping takes way too long with the amount of files required by a typical Node.js project.
       dontStrip = args.dontStrip or true;
 
-      env = {
-        npm_config_arch = stdenv.hostPlatform.node.arch;
-        npm_config_platform = stdenv.hostPlatform.node.platform;
-      } // (args.env or { });
-
       meta = (args.meta or { }) // {
         platforms = args.meta.platforms or nodejs.meta.platforms;
       };

--- a/pkgs/build-support/node/build-npm-package/hooks/default.nix
+++ b/pkgs/build-support/node/build-npm-package/hooks/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   srcOnly,
+  stdenv,
   makeSetupHook,
   makeWrapper,
   nodejs,
@@ -18,6 +19,8 @@
     substitutions = {
       nodeSrc = srcOnly nodejs;
       nodeGyp = "${nodejs}/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js";
+      npmArch = stdenv.targetPlatform.node.arch;
+      npmPlatform = stdenv.targetPlatform.node.platform;
 
       # Specify `diff`, `jq`, and `prefetch-npm-deps` by abspath to ensure that the user's build
       # inputs do not cause us to find the wrong binaries.

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -16,6 +16,8 @@ npmConfigHook() {
     export HOME="$TMPDIR"
     export npm_config_nodedir="@nodeSrc@"
     export npm_config_node_gyp="@nodeGyp@"
+    export npm_config_arch="@npmArch@"
+    export npm_config_platform="@npmPlatform@"
 
     if [ -z "${npmDeps-}" ]; then
         echo

--- a/pkgs/by-name/af/affine-bin/package.nix
+++ b/pkgs/by-name/af/affine-bin/package.nix
@@ -13,14 +13,8 @@
 }:
 let
   hostPlatform = stdenvNoCC.hostPlatform;
-  nodePlatform = hostPlatform.parsed.kernel.name; # nodejs's `process.platform`
-  nodeArch = # nodejs's `process.arch`
-    {
-      "x86_64" = "x64";
-      "aarch64" = "arm64";
-    }
-    .${hostPlatform.parsed.cpu.name}
-      or (throw "affine-bin(${buildType}): unsupported CPU family ${hostPlatform.parsed.cpu.name}");
+  nodePlatform = hostPlatform.node.platform;
+  nodeArch = hostPlatform.node.arch;
 in
 stdenvNoCC.mkDerivation (
   finalAttrs:

--- a/pkgs/by-name/af/affine/package.nix
+++ b/pkgs/by-name/af/affine/package.nix
@@ -26,14 +26,8 @@
 }:
 let
   hostPlatform = stdenvNoCC.hostPlatform;
-  nodePlatform = hostPlatform.parsed.kernel.name; # nodejs's `process.platform`
-  nodeArch = # nodejs's `process.arch`
-    {
-      "x86_64" = "x64";
-      "aarch64" = "arm64";
-    }
-    .${hostPlatform.parsed.cpu.name}
-      or (throw "affine(${buildType}): unsupported CPU family ${hostPlatform.parsed.cpu.name}");
+  nodePlatform = hostPlatform.node.platform;
+  nodeArch = hostPlatform.node.arch;
   electron = electron_35;
   nodejs = nodejs_22;
   yarn-berry = yarn-berry_4.override { inherit nodejs; };

--- a/pkgs/by-name/el/element-desktop/keytar/default.nix
+++ b/pkgs/by-name/el/element-desktop/keytar/default.nix
@@ -52,16 +52,7 @@ stdenv.mkDerivation rec {
     # Make sure the native modules are built against electron's ABI
     "--nodedir=${electron.headers}"
     # https://nodejs.org/api/os.html#osarch
-    "--arch=${
-      if stdenv.hostPlatform.parsed.cpu.name == "i686" then
-        "ia32"
-      else if stdenv.hostPlatform.parsed.cpu.name == "x86_64" then
-        "x64"
-      else if stdenv.hostPlatform.parsed.cpu.name == "aarch64" then
-        "arm64"
-      else
-        stdenv.hostPlatform.parsed.cpu.name
-    }"
+    "--arch=${stdenv.hostPlatform.node.arch}"
   ];
 
   installPhase = ''

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -130,5 +130,9 @@ in
   configHook = makeSetupHook {
     name = "pnpm-config-hook";
     propagatedBuildInputs = [ pnpm ];
+    substitutions = {
+      npmArch = stdenvNoCC.targetPlatform.node.arch;
+      npmPlatform = stdenvNoCC.targetPlatform.node.platform;
+    };
   } ./pnpm-config-hook.sh;
 }

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -16,6 +16,8 @@ pnpmConfigHook() {
 
     export HOME=$(mktemp -d)
     export STORE_PATH=$(mktemp -d)
+    export npm_config_arch="@npmArch@"
+    export npm_config_platform="@npmPlatform@"
 
     cp -Tr "$pnpmDeps" "$STORE_PATH"
     chmod -R +w "$STORE_PATH"

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -70,30 +70,6 @@ let
       "freebsd"
     else
       throw "unsupported os ${platform.uname.system}";
-  destCPU =
-    let
-      platform = stdenv.hostPlatform;
-    in
-    if platform.isAarch then
-      "arm" + lib.optionalString platform.is64bit "64"
-    else if platform.isMips32 then
-      "mips" + lib.optionalString platform.isLittleEndian "le"
-    else if platform.isMips64 && platform.isLittleEndian then
-      "mips64el"
-    else if platform.isPower then
-      "ppc" + lib.optionalString platform.is64bit "64"
-    else if platform.isx86_64 then
-      "x64"
-    else if platform.isx86_32 then
-      "ia32"
-    else if platform.isS390x then
-      "s390x"
-    else if platform.isRiscV64 then
-      "riscv64"
-    else if platform.isLoongArch64 then
-      "loong64"
-    else
-      throw "unsupported cpu ${platform.uname.processor}";
   destARMFPU =
     let
       platform = stdenv.hostPlatform;
@@ -258,7 +234,7 @@ let
           # --cross-compiling flag enables use of CC_host et. al
           (if canExecute || canEmulate then "--no-cross-compiling" else "--cross-compiling")
           "--dest-os=${destOS}"
-          "--dest-cpu=${destCPU}"
+          "--dest-cpu=${stdenv.hostPlatform.node.arch}"
         ]
         ++ lib.optionals (destARMFPU != null) [ "--with-arm-fpu=${destARMFPU}" ]
         ++ lib.optionals (destARMFloatABI != null) [ "--with-arm-float-abi=${destARMFloatABI}" ]


### PR DESCRIPTION
- fixes `nix-build -A pkgsCross.aarch64-multiplatform.jellyseerr -A pkgsCross.aarch64-multiplatform.karakeep`
- gets `signal-desktop.signal-sqlcipher` _closer_ to successful cross compilation

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
