### PR TITLE
nixos/outline: add discord auth

### DIFF
--- a/nixos/modules/services/web-apps/outline.nix
+++ b/nixos/modules/services/web-apps/outline.nix
@@ -294,6 +294,45 @@ in
       );
     };
 
+    discordAuthentication = lib.mkOption {
+      description = ''
+        To configure Discord auth, you'll need to create an application at
+        https://discord.com/developers/applications/
+
+        See https://docs.getoutline.com/s/hosting/doc/discord-g4JdWFFub6
+        for details on setting up your Discord app.
+      '';
+      default = null;
+      type = lib.types.nullOr (
+        lib.types.submodule {
+          options = {
+            clientId = lib.mkOption {
+              type = lib.types.str;
+              description = "Authentication client identifier.";
+            };
+            clientSecretFile = lib.mkOption {
+              type = lib.types.str;
+              description = "File path containing the authentication secret.";
+            };
+            serverId = lib.mkOption {
+              type = lib.types.str;
+              default = "";
+              description = ''
+                Restrict logins to a specific server (optional, but recommended).
+                You can find a Discord server's ID by right-clicking the server icon,
+                and select “Copy Server ID”.
+              '';
+            };
+            serverRoles = lib.mkOption {
+              type = lib.types.commas;
+              default = "";
+              description = "Optionally restrict logins to a comma-separated list of role IDs";
+            };
+          };
+        }
+      );
+    };
+
     oidcAuthentication = lib.mkOption {
       description = ''
         To configure generic OIDC auth, you'll need some kind of identity
@@ -721,6 +760,12 @@ in
             SLACK_MESSAGE_ACTIONS = builtins.toString cfg.slackIntegration.messageActions;
           })
 
+          (lib.mkIf (cfg.discordAuthentication != null) {
+            DISCORD_CLIENT_ID = cfg.discordAuthentication.clientId;
+            DISCORD_SERVER_ID = cfg.discordAuthentication.serverId;
+            DISCORD_SERVER_ROLES = cfg.discordAuthentication.serverRoles;
+          })
+
           (lib.mkIf (cfg.smtp != null) {
             SMTP_HOST = cfg.smtp.host;
             SMTP_PORT = builtins.toString cfg.smtp.port;
@@ -759,6 +804,9 @@ in
           ''}
           ${lib.optionalString (cfg.oidcAuthentication != null) ''
             export OIDC_CLIENT_SECRET="$(head -n1 ${lib.escapeShellArg cfg.oidcAuthentication.clientSecretFile})"
+          ''}
+          ${lib.optionalString (cfg.discordAuthentication != null) ''
+            export DISCORD_CLIENT_SECRET="$(head -n1 ${lib.escapeShellArg cfg.discordAuthentication.clientSecretFile})"
           ''}
           ${lib.optionalString (cfg.sslKeyFile != null) ''
             export SSL_KEY="$(head -n1 ${lib.escapeShellArg cfg.sslKeyFile})"


### PR DESCRIPTION
Added discord authentication support to Outline's module, since it is officially supported and has additional config not found in OID (specifically server and role limiting)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
