### PR TITLE
nixosTests.miniflux: fix test

### DIFF
--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -81,7 +81,7 @@ in
           '';
         };
         systemd.services.postgresql-setup.postStart = lib.mkAfter ''
-          $PSQL -tAd miniflux -c 'CREATE EXTENSION hstore;'
+          psql -tAd miniflux -c 'CREATE EXTENSION hstore;'
         '';
         networking.firewall.allowedTCPPorts = [ config.services.postgresql.settings.port ];
       };


### PR DESCRIPTION
Followed up on #422835 and looked for stray `$PSQL` instances in nixpkgs.

This broke in 41c5662cbec9930b337a895c7cb010948d9766a9, where $PSQL was removed and added to PATH instead.

## Things done

(still building the linux kernel before I can actually run the test)

- Built on platform(s)
  - [ ] x86_64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
