### PR TITLE
[Backport release-25.05] python3Packages.azure-search-documents: 11.4.0 -> 11.5.2

### DIFF
--- a/pkgs/development/python-modules/azure-search-documents/default.nix
+++ b/pkgs/development/python-modules/azure-search-documents/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "azure-search-documents";
-  version = "11.4.0";
+  version = "14.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Azure";
     repo = "azure-sdk-for-python";
-    rev = "azure-search-documents_${version}";
-    hash = "sha256-0J9AXDH7TOkcKDwFbICiMatLAwiFq3Jtoji8fJSOg8k=";
+    tag = "azure-mgmt-containerregistry_${version}";
+    hash = "sha256-FRdXdk3+G/xPraB2laTV6Xs/yNY65gebvMCKPOgby1g=";
   };
 
   sourceRoot = "${src.name}/sdk/search/azure-search-documents";
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   meta = {
     description = "Microsoft Azure Cognitive Search Client Library for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/search/azure-search-documents";
-    changelog = "https://github.com/Azure/azure-sdk-for-python/blob/${src.rev}/sdk/search/azure-search-documents/CHANGELOG.md";
+    changelog = "https://github.com/Azure/azure-sdk-for-python/blob/${src.tag}/sdk/search/azure-search-documents/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ natsukium ];
   };

--- a/pkgs/development/python-modules/azure-search-documents/default.nix
+++ b/pkgs/development/python-modules/azure-search-documents/default.nix
@@ -6,18 +6,19 @@
   azure-common,
   azure-core,
   isodate,
+  gitUpdater,
 }:
 
 buildPythonPackage rec {
   pname = "azure-search-documents";
-  version = "14.0.0";
+  version = "11.5.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Azure";
     repo = "azure-sdk-for-python";
-    tag = "azure-mgmt-containerregistry_${version}";
-    hash = "sha256-FRdXdk3+G/xPraB2laTV6Xs/yNY65gebvMCKPOgby1g=";
+    tag = "azure_search_documents_${version}";
+    hash = "sha256-RcVdqI50lsYed9L6Kz7faNLec1Y9zq685SGnwaEw6Qc=";
   };
 
   sourceRoot = "${src.name}/sdk/search/azure-search-documents";
@@ -35,8 +36,11 @@ buildPythonPackage rec {
   # require devtools_testutils which is a internal package for azure-sdk
   doCheck = false;
 
-  # multiple packages in the repo and the updater picks the wrong tag
-  passthru.skipBulkUpdate = true;
+  passthru = {
+    # multiple packages in the repo and the updater picks the wrong tag
+    skipBulkUpdate = true;
+    updateScript = gitUpdater { rev-prefix = "azure.search.documents_"; };
+  };
 
   meta = {
     description = "Microsoft Azure Cognitive Search Client Library for Python";


### PR DESCRIPTION
Manual backport of #406969 #410946 to `release-25.05`.

Changelog: https://github.com/Azure/azure-sdk-for-python/blob/release/azure-azure-search-documents/11.5.3/sdk/search/azure-search-documents/CHANGELOG.md

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.