### PR TITLE
nixos-rebuild-ng: do not resolve Flake

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -61,46 +61,7 @@ class BuildAttr:
         return cls(Path(file or "default.nix"), attr)
 
 
-def discover_git(location: Path) -> Path | None:
-    """
-    Discover the current git repository in the given location.
-    """
-    current = location.resolve()
-    previous = None
-
-    while current.is_dir() and current != previous:
-        dotgit = current / ".git"
-        if dotgit.is_dir():
-            return current
-        elif dotgit.is_file():  # this is a worktree
-            with dotgit.open() as f:
-                dotgit_content = f.read().strip()
-                if dotgit_content.startswith("gitdir: "):
-                    return Path(dotgit_content.split("gitdir: ")[1])
-        previous = current
-        current = current.parent
-
-    return None
-
-
-def discover_closest_flake(location: Path) -> Path | None:
-    """
-    Discover the closest flake.nix file starting from the given location upwards.
-    """
-    current = location.resolve()
-    previous = None
-
-    while current.is_dir() and current != previous:
-        flake_file = current / "flake.nix"
-        if flake_file.is_file():
-            return current
-        previous = current
-        current = current.parent
-
-    return None
-
-
-def get_hostname(target_host: Remote | None) -> str | None:
+def _get_hostname(target_host: Remote | None) -> str | None:
     if target_host:
         try:
             return run_wrapper(
@@ -133,25 +94,13 @@ class Flake:
         assert m is not None, f"got no matches for {flake_str}"
         attr = m.group("attr")
         nixos_attr = (
-            f'nixosConfigurations."{attr or get_hostname(target_host) or "default"}"'
+            f'nixosConfigurations."{attr or _get_hostname(target_host) or "default"}"'
         )
-        path_str = m.group("path")
-        if ":" in path_str:
-            return cls(path_str, nixos_attr)
-        else:
-            path = Path(path_str)
-            git_repo = discover_git(path)
-            if git_repo is not None:
-                url = f"git+file://{git_repo}"
-                flake_path = discover_closest_flake(path)
-                if (
-                    flake_path is not None
-                    and flake_path != git_repo
-                    and flake_path.is_relative_to(git_repo)
-                ):
-                    url += f"?dir={flake_path.relative_to(git_repo)}"
-                return cls(url, nixos_attr)
+        path = m.group("path")
+        if ":" in path:
             return cls(path, nixos_attr)
+        else:
+            return cls(Path(path), nixos_attr)
 
     @classmethod
     def from_arg(cls, flake_arg: Any, target_host: Remote | None) -> Self | None:  # noqa: ANN401

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -30,13 +30,13 @@ def test_build_attr_to_attr() -> None:
     )
 
 
-@patch("platform.node", autospec=True, return_value="hostname")
+@patch("platform.node", autospec=True, return_value=None)
 def test_flake_parse(mock_node: Mock, tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
     assert m.Flake.parse("/path/to/flake#attr") == m.Flake(
         Path("/path/to/flake"), 'nixosConfigurations."attr"'
     )
     assert m.Flake.parse("/path/ to /flake") == m.Flake(
-        Path("/path/ to /flake"), 'nixosConfigurations."hostname"'
+        Path("/path/ to /flake"), 'nixosConfigurations."default"'
     )
     with patch(
         get_qualified_name(m.run_wrapper, m),
@@ -47,40 +47,18 @@ def test_flake_parse(mock_node: Mock, tmpdir: Path, monkeypatch: MonkeyPatch) ->
         assert m.Flake.parse("/path/to/flake", target_host) == m.Flake(
             Path("/path/to/flake"), 'nixosConfigurations."remote"'
         )
-    # change directory to tmpdir
-    with monkeypatch.context() as patch_context:
-        patch_context.chdir(tmpdir)
-        assert m.Flake.parse(".#attr") == m.Flake(
-            Path("."), 'nixosConfigurations."attr"'
-        )
-        assert m.Flake.parse("#attr") == m.Flake(
-            Path("."), 'nixosConfigurations."attr"'
-        )
-        assert m.Flake.parse(".") == m.Flake(
-            Path("."), 'nixosConfigurations."hostname"'
-        )
+    assert m.Flake.parse(".#attr") == m.Flake(Path("."), 'nixosConfigurations."attr"')
+    assert m.Flake.parse("#attr") == m.Flake(Path("."), 'nixosConfigurations."attr"')
+    assert m.Flake.parse(".") == m.Flake(Path("."), 'nixosConfigurations."default"')
     assert m.Flake.parse("path:/to/flake#attr") == m.Flake(
         "path:/to/flake", 'nixosConfigurations."attr"'
     )
 
-    # from here on  we should return "default"
-    mock_node.return_value = None
+    # from here on  we should return "hostname"
+    mock_node.return_value = "hostname"
 
     assert m.Flake.parse("github:user/repo/branch") == m.Flake(
-        "github:user/repo/branch", 'nixosConfigurations."default"'
-    )
-    git_root = tmpdir / "git_root"
-    git_root.mkdir()
-    (git_root / ".git").mkdir()
-    assert m.Flake.parse(str(git_root)) == m.Flake(
-        f"git+file://{git_root}", 'nixosConfigurations."default"'
-    )
-
-    work_tree = tmpdir / "work_tree"
-    work_tree.mkdir()
-    (work_tree / ".git").write_text("gitdir: /path/to/git", "utf-8")
-    assert m.Flake.parse(str(work_tree)) == m.Flake(
-        "git+file:///path/to/git", 'nixosConfigurations."default"'
+        "github:user/repo/branch", 'nixosConfigurations."hostname"'
     )
 
 
@@ -134,14 +112,9 @@ def test_flake_from_arg(
             autospec=True,
             return_value=False,
         ),
-        patch(
-            get_qualified_name(m.discover_git),
-            autospec=True,
-            return_value="/etc/nixos",
-        ),
     ):
         assert m.Flake.from_arg(None, None) == m.Flake(
-            "git+file:///etc/nixos", 'nixosConfigurations."hostname"'
+            Path("/etc/nixos"), 'nixosConfigurations."hostname"'
         )
 
     with (

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -307,8 +307,8 @@ def test_edit(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_editd_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
-    flake = m.Flake.parse(f"{tmpdir}#attr")
+def test_edit_flake(mock_run: Mock) -> None:
+    flake = m.Flake.parse(".#attr")
     n.edit_flake(flake, {"commit_lock_file": True})
     mock_run.assert_called_with(
         [
@@ -318,7 +318,7 @@ def test_editd_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
             "edit",
             "--commit-lock-file",
             "--",
-            f'{tmpdir}#nixosConfigurations."attr"',
+            '.#nixosConfigurations."attr"',
         ],
         check=False,
     )


### PR DESCRIPTION
This code seems to be causing yet another issue related to Git submodules. Considering the amount of issues that this code is causing, I think it is better to remove it.

Manual revert of #375493.

Fix #422940.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
