### PR TITLE
ocamlPackages.bytesrw: init at 0.1.0; ocamlPackages.jsont: init at 0.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/bytesrw/default.nix
+++ b/pkgs/development/ocaml-modules/bytesrw/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchzip,
+  libblake3,
+  libmd,
+  xxHash,
+  zlib,
+  zstd,
+  buildTopkgPackage,
+}:
+
+buildTopkgPackage rec {
+  pname = "bytesrw";
+  version = "0.1.0";
+
+  minimalOCamlVersion = "4.14.0";
+
+  src = fetchzip {
+    url = "https://erratique.ch/software/bytesrw/releases/bytesrw-${version}.tbz";
+    hash = "sha256-leH3uo5Q8ba22A/Mbl9pio0tW/IxCTGp77Cra7l4D80=";
+  };
+
+  # docs say these are optional, but buildTopkgPackage doesn’t handle missing
+  # dependencies
+
+  buildInputs = [
+    libblake3
+    libmd
+    xxHash
+    zlib
+    zstd
+  ];
+
+  meta = {
+    description = "composable, memory efficient, byte stream readers and writers compatible with effect-based concurrency";
+    longDescription = ''
+      Bytesrw extends the OCaml Bytes module with composable, memory efficient,
+      byte stream readers and writers compatible with effect-based concurrency.
+
+      Except for byte slice life-times, these abstractions intentionnaly
+      separate away ressource management and the specifics of reading and
+      writing bytes.
+    '';
+    homepage = "https://erratique.ch/software/bytesrw";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+}

--- a/pkgs/development/ocaml-modules/jsont/default.nix
+++ b/pkgs/development/ocaml-modules/jsont/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchzip,
+  buildTopkgPackage,
+  brr,
+  bytesrw,
+  cmdliner,
+}:
+
+buildTopkgPackage rec {
+  pname = "jsont";
+  version = "0.1.1";
+
+  minimalOCamlVersion = "4.14.0";
+
+  src = fetchzip {
+    url = "https://erratique.ch/software/jsont/releases/jsont-${version}.tbz";
+    hash = "sha256-bLbTfRVz/Jzuy2LnQeTEHQGojfA34M+Xj7LODpBAVK4=";
+  };
+
+  # docs say these dependendencies are optional, but buildTopkgPackage doesn’t
+  # handle missing dependencies
+
+  buildInputs = [
+    cmdliner
+  ];
+
+  propagatedBuildInputs = [
+    brr
+    bytesrw
+  ];
+
+  meta = {
+    description = "declarative JSON data manipulation";
+    longDescription = ''
+      Jsont is an OCaml library for declarative JSON data manipulation. it
+      provides:
+
+      • Combinators for describing JSON data using the OCaml values of your
+        choice. The descriptions can be used by generic functions to decode,
+        encode, query and update JSON data without having to construct a
+        generic JSON representation
+      • A JSON codec with optional text location tracking and best-effort
+        layout preservation. The codec is compatible with effect-based
+        concurrency.
+
+      The descriptions are independent from the codec and can be used by
+      third-party processors or codecs.
+    '';
+    homepage = "https://erratique.ch/software/jsont";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -952,6 +952,8 @@ let
 
         jsonm = callPackage ../development/ocaml-modules/jsonm { };
 
+        jsont = callPackage ../development/ocaml-modules/jsont { };
+
         jsonrpc = callPackage ../development/ocaml-modules/ocaml-lsp/jsonrpc.nix { };
 
         junit = callPackage ../development/ocaml-modules/junit { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -141,6 +141,8 @@ let
 
         bwd = callPackage ../development/ocaml-modules/bwd { };
 
+        bytesrw = callPackage ../development/ocaml-modules/bytesrw { };
+
         bytestring = callPackage ../development/ocaml-modules/bytestring { };
 
         bz2 = callPackage ../development/ocaml-modules/bz2 { };


### PR DESCRIPTION
bytesrw is a dependency of jsont

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
