### PR TITLE
dynarmic: init at 6.7.0-unstable-2025-03-16; azahar: use system dynarmic, fix darwin build

### DIFF
--- a/pkgs/by-name/az/azahar/package.nix
+++ b/pkgs/by-name/az/azahar/package.nix
@@ -150,7 +150,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open-source 3DS emulator project based on Citra";
     homepage = "https://github.com/azahar-emu/azahar";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ arthsmn ];
+    maintainers = with lib.maintainers; [
+      arthsmn
+      marcin-serwin
+    ];
     mainProgram = "azahar";
   };
 })

--- a/pkgs/by-name/az/azahar/package.nix
+++ b/pkgs/by-name/az/azahar/package.nix
@@ -6,6 +6,7 @@
   cryptopp,
   cpp-jwt,
   doxygen,
+  dynarmic,
   enet,
   fetchpatch,
   fetchzip,
@@ -27,12 +28,14 @@
   pipewire,
   pkg-config,
   portaudio,
+  robin-map,
   SDL2,
   sndio,
   spirv-tools,
   soundtouch,
   stdenv,
   vulkan-headers,
+  xbyak,
   xorg,
   zstd,
   enableQtTranslations ? true,
@@ -73,6 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
       catch2_3
       cryptopp
       cpp-jwt
+      dynarmic
       enet
       fmt
       ffmpeg_6-headless
@@ -89,6 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
       openssl
       pipewire
       portaudio
+      robin-map
       qt6.qtbase
       qt6.qtmultimedia
       qt6.qttools
@@ -98,6 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
       sndio
       spirv-tools
       vulkan-headers
+      xbyak
       xorg.libX11
       xorg.libXext
       zstd
@@ -121,10 +127,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    # Fix "file not found" bug when looking in var/empty instead of opt
-    mkdir externals/dynarmic/src/dynarmic/ir/var
-    ln -s ../opt externals/dynarmic/src/dynarmic/ir/var/empty
-
     # We already know the submodules are present
     substituteInPlace CMakeLists.txt \
       --replace-fail "check_submodules_present()" ""
@@ -136,10 +138,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (cmakeBool "USE_SYSTEM_LIBS" true)
-    (cmakeBool "DISABLE_SYSTEM_DYNARMIC" true)
     (cmakeBool "DISABLE_SYSTEM_LODEPNG" true)
     (cmakeBool "DISABLE_SYSTEM_VMA" true)
-    (cmakeBool "DISABLE_SYSTEM_XBYAK" true)
     (cmakeBool "ENABLE_QT_TRANSLATION" enableQtTranslations)
     (cmakeBool "ENABLE_CUBEB" enableCubeb)
     (cmakeBool "USE_DISCORD_PRESENCE" useDiscordRichPresence)

--- a/pkgs/by-name/az/azahar/update-cmake-lists.patch
+++ b/pkgs/by-name/az/azahar/update-cmake-lists.patch
@@ -1,0 +1,43 @@
+From d9e7361a174f0f491c49fe78cd96a823c65e97dd Mon Sep 17 00:00:00 2001
+From: qr243vbi <uiguruigurovich@gmail.com>
+Date: Sat, 7 Jun 2025 01:18:03 +0300
+Subject: [PATCH 1/2] Update CMakeLists.txt
+
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 54051a4ef2..531c46abbe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,6 +16,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/cmake-modules")
+ include(DownloadExternals)
+ include(CMakeDependentOption)
++include(FindPkgConfig)
+ 
+ project(citra LANGUAGES C CXX ASM)
+ 
+
+From 679a4036e2fbb96d1d6a803f3f59ae8f01f9e691 Mon Sep 17 00:00:00 2001
+From: qr243vbi <uiguruigurovich@gmail.com>
+Date: Sat, 7 Jun 2025 12:49:07 +0300
+Subject: [PATCH 2/2] Add missing find_package directive
+
+---
+ src/citra_qt/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/citra_qt/CMakeLists.txt b/src/citra_qt/CMakeLists.txt
+index 1b78605a0a..de00dc4609 100644
+--- a/src/citra_qt/CMakeLists.txt
++++ b/src/citra_qt/CMakeLists.txt
+@@ -273,6 +273,7 @@ if (ENABLE_VULKAN)
+ endif()
+ 
+ if (NOT WIN32)
++    find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
+     target_include_directories(citra_qt PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+ endif()
+ 

--- a/pkgs/by-name/dy/dynarmic/0001-CMakeLists-update-mcl-version-to-0.1.13.patch
+++ b/pkgs/by-name/dy/dynarmic/0001-CMakeLists-update-mcl-version-to-0.1.13.patch
@@ -1,0 +1,29 @@
+From cdbf3ba41ddce41d8ae375464e514f72d158ec0b Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Sat, 5 Jul 2025 22:26:49 +0200
+Subject: [PATCH] CMakeLists: update mcl version to 0.1.13
+
+The mcl in externals is already at this version, but it wasn't bumped
+here which makes it impossible to use prebuilt mcl.
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e95050da..edd153d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -145,7 +145,7 @@ set(TSL_ROBIN_MAP_ENABLE_INSTALL ON)
+ 
+ find_package(Boost 1.57 REQUIRED)
+ find_package(fmt 9 CONFIG)
+-find_package(mcl 0.1.12 EXACT CONFIG)
++find_package(mcl 0.1.13 EXACT CONFIG)
+ find_package(tsl-robin-map CONFIG)
+ 
+ if ("arm64" IN_LIST ARCHITECTURE OR DYNARMIC_TESTS)
+-- 
+2.49.0
+

--- a/pkgs/by-name/dy/dynarmic/0001-xbyak-Fix-tests-when-using-newer-versions.patch
+++ b/pkgs/by-name/dy/dynarmic/0001-xbyak-Fix-tests-when-using-newer-versions.patch
@@ -1,0 +1,27 @@
+From 40e8205b3efd126b9676a783c8306793e61d3f00 Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Sun, 6 Jul 2025 10:08:26 +0200
+Subject: [PATCH] xbyak: Fix tests when using newer versions
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ src/dynarmic/CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/dynarmic/CMakeLists.txt b/src/dynarmic/CMakeLists.txt
+index 6f0813ca..21a5576c 100644
+--- a/src/dynarmic/CMakeLists.txt
++++ b/src/dynarmic/CMakeLists.txt
+@@ -267,6 +267,9 @@ if ("x86_64" IN_LIST ARCHITECTURE)
+             xbyak::xbyak
+             Zydis::Zydis
+     )
++    # Newer versions of xbyak (>= 7.25.0) have stricter checks that currently
++    # fail in dynarmic
++    target_compile_definitions(dynarmic PRIVATE XBYAK_STRICT_CHECK_MEM_REG_SIZE=0)
+ 
+     target_architecture_specific_sources(dynarmic "x86_64"
+         backend/x64/abi.cpp
+-- 
+2.49.0
+

--- a/pkgs/by-name/dy/dynarmic/package.nix
+++ b/pkgs/by-name/dy/dynarmic/package.nix
@@ -1,0 +1,145 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  boost,
+  robin-map,
+  catch2_3,
+  fmt,
+  xbyak,
+  zydis,
+  nix-update-script,
+  azahar,
+  darwin,
+}:
+let
+  oaknut = stdenv.mkDerivation {
+    pname = "oaknut";
+    version = "1.2.2-unstable-2024-03-01";
+
+    src = fetchFromGitHub {
+      owner = "merryhime";
+      repo = "oaknut";
+      rev = "94c726ce0338b054eb8cb5ea91de8fe6c19f4392";
+      hash = "sha256-IhP/110NGN42/FvpGIEm9MgsSiPYdtD8kNxL0cAWbqM=";
+    };
+
+    nativeBuildInputs = [
+      cmake
+      ninja
+    ];
+  };
+
+  mcl = stdenv.mkDerivation {
+    pname = "mcl";
+    version = "0.1.13-unstable-2025-03-16";
+
+    src = fetchFromGitHub {
+      owner = "azahar-emu";
+      repo = "mcl";
+      rev = "7b08d83418f628b800dfac1c9a16c3f59036fbad";
+      hash = "sha256-uTOiOlMzKbZSjKjtVSqFU+9m8v8horoCq3wL0O2E8sI=";
+    };
+
+    nativeBuildInputs = [
+      cmake
+      ninja
+    ];
+
+    buildInputs = [
+      fmt
+    ];
+
+    checkInputs = [
+      catch2_3
+    ];
+
+    doCheck = true;
+    checkPhase = ''
+      tests/mcl-tests
+    '';
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dynarmic";
+  version = "6.7.0-unstable-2025-03-16";
+
+  src = fetchFromGitHub {
+    owner = "azahar-emu";
+    repo = "dynarmic";
+    rev = "278405bd71999ed3f3c77c5f78344a06fef798b9";
+    hash = "sha256-D7nXn5y0h8FV0V8Tc8uBlRoeEU+gcpt44afujZvG+1A=";
+  };
+
+  patches = [
+    # https://github.com/azahar-emu/dynarmic/pull/2
+    ./0001-CMakeLists-update-mcl-version-to-0.1.13.patch
+    # https://github.com/azahar-emu/dynarmic/pull/3
+    ./0001-xbyak-Fix-tests-when-using-newer-versions.patch
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs =
+    [
+      cmake
+      ninja
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.DarwinTools # sw_ver
+      darwin.bootstrap_cmds # mig
+    ];
+
+  buildInputs =
+    [
+      boost
+      robin-map
+      mcl
+      fmt
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+      oaknut
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+      xbyak
+      zydis
+    ];
+
+  checkInputs = [
+    catch2_3
+    oaknut
+  ];
+
+  # This changes `ir/opt` to `ir/var/empty` in `CMakeLists.txt`
+  # making the build fail, as that path does not exist
+  dontFixCmake = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "DYNARMIC_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  env = lib.optionalAttrs stdenv.cc.isGNU {
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117063
+    NIX_CFLAGS_COMPILE = "-Wno-error=stringop-overread";
+  };
+
+  doCheck = true;
+
+  passthru = {
+    inherit mcl oaknut;
+
+    updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+    tests = { inherit azahar; };
+  };
+
+  meta = {
+    description = "Dynamic recompiler for ARM";
+    homepage = "https://github.com/azahar-emu/dynarmic";
+    maintainers = with lib.maintainers; [ marcin-serwin ];
+    license = lib.licenses.bsd0;
+    platforms = with lib.platforms; x86_64 ++ aarch64;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
