### PR TITLE
maintainers: drop mrityunjaygr8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17016,12 +17016,6 @@
     githubId = 4009450;
     name = "Marcelo Giles";
   };
-  mrityunjaygr8 = {
-    email = "mrityunjaysaxena1996@gmail.com";
-    github = "mrityunjaygr8";
-    name = "Mrityunjay Saxena";
-    githubId = 14573967;
-  };
   mrkkrp = {
     email = "markkarpov92@gmail.com";
     github = "mrkkrp";

--- a/pkgs/by-name/go/go-jet/package.nix
+++ b/pkgs/by-name/go/go-jet/package.nix
@@ -50,7 +50,7 @@ buildGoModule rec {
   meta = with lib; {
     homepage = "https://github.com/go-jet/jet";
     description = "Type safe SQL builder with code generation and automatic query result data mapping";
-    maintainers = with maintainers; [ mrityunjaygr8 ];
+    maintainers = with maintainers; [ ];
     license = licenses.asl20;
     mainProgram = "jet";
   };

--- a/pkgs/by-name/sq/sqlboiler/package.nix
+++ b/pkgs/by-name/sq/sqlboiler/package.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
     homepage = "https://github.com/volatiletech/sqlboiler";
     changelog = "https://github.com/volatiletech/sqlboiler/releases/tag/v${version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ mrityunjaygr8 ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "sqlboiler";
   };
 }


### PR DESCRIPTION
Inactive since April 2023.

Added two packages, left one review, then was never seen again for the other 13-14 PRs:

https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr%20involves%3Amrityunjaygr8%20

Still active on GitHub apparently.

@mrityunjaygr8 do you still intend to maintain these packages?

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
