### PR TITLE
[Backport release-25.05] jetbrains: 2025.1 -> 2025.1.3; plugin additions and updates

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -11,58 +11,58 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "2f747d7240d70b65ed98d736dbcd6ac2b98ac93aff993a63c5f8bd0f65918ac5",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.1.tar.gz",
-      "build_number": "251.25410.104"
+      "version": "2025.1.2",
+      "sha256": "3bdd0cd731bcdcd15de7ebee3ec36a13b82b72f68a77f6e6e780e36d88acd51e",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2.tar.gz",
+      "build_number": "251.26094.123"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "47d1c891a34f12f371aeab2364b9280766e1e99b27933f8d11c3c3832ed865ca",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.2.tar.gz",
-      "build_number": "251.25410.123"
+      "version": "2025.1.3",
+      "sha256": "b672b2b50e2ae539af24e32ac7678ff32a8b207e6692e12c8b891eaf78200d24",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3.tar.gz",
+      "build_number": "251.26094.87"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.tar.gz",
-      "version": "2025.1",
-      "sha256": "d0078ceae9f7ae8cc6b57223874e3a818383aedf10fa8b73b2d34a522c52e53d",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.tar.gz",
-      "build_number": "251.23774.439"
+      "version": "2025.1.1",
+      "sha256": "e0711b629ad45d6d051fd9796bf81689d46212fdd8f21306128a8522097ca3e9",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.1.1.tar.gz",
+      "build_number": "251.25410.158"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "edccd3d877407dfc628d9ba2a8ee767c11a861532dd4e0b1cb2a4d8787476ea8",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.1.tar.gz",
-      "build_number": "251.25410.139"
+      "version": "2025.1.2",
+      "sha256": "666ea22f7bdfdbf327dd77b7292e2abf5a3ac356ae043fe8b35102d78437d7f2",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.2.tar.gz",
+      "build_number": "251.26094.128"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "fb94d5df43942db47a5506b50e511457cf845b986e70168171b9f5324b7d0d77",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.1.tar.gz",
-      "build_number": "251.25410.140"
+      "version": "2025.1.2",
+      "sha256": "18d4465e8c50911d8f4ecd7ba75ee1aa14cf3d05eb4df39790729cf67bf2a638",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.2.tar.gz",
+      "build_number": "251.26094.127"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
-      "version": "2025.1.1.1",
-      "sha256": "36b72ac85e8e1536dfccb300b5a435461b1e2953585a90a5d8f06e1b263b0b5c",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.1.1.tar.gz",
-      "build_number": "251.25410.129"
+      "version": "2025.1.2",
+      "sha256": "70dc870bd31fda67de30d3a132cfed543d5e67c15c7db52f6f4c4691a044930a",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2.tar.gz",
+      "build_number": "251.26094.121"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
-      "version": "2025.1.1.1",
-      "sha256": "337d34b20cdaa8da30d71b98e1b36817bdfe2f2245c491ef38f0cee02f0d0316",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.1.1.tar.gz",
-      "build_number": "251.25410.129"
+      "version": "2025.1.2",
+      "sha256": "1e675bda1314ae914b64b31a22309ba2eba6f35e6659e53d4b291e73c2fb856b",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2.tar.gz",
+      "build_number": "251.26094.121"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -75,27 +75,27 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "b64722ea715db8566754978af617716016deaa2cda3521cf05e4a049e5bbf6a3",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.1.tar.gz",
-      "build_number": "251.25410.148",
+      "version": "2025.1.2",
+      "sha256": "229f3afde8e3466e1d262de915420f66a5fc97858788cc08f7d0f0b826c2a77b",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.2.tar.gz",
+      "build_number": "251.26094.133",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "d2df49f8ec2df88039f535e0d8706d35f608db3e58b9411f5e8e726536788237",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.1.tar.gz",
-      "build_number": "251.25410.122"
+      "version": "2025.1.2",
+      "sha256": "193fbbb638235c4c671bb6c6b432f43a2d46f7f7ebd6b5f2cc8a1db7db93c5d6",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2.tar.gz",
+      "build_number": "251.26094.141"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "b1e8660b1c947f3bb746d0736e1e9c247635fadedb52f230ef5c64862893ad0b",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.1.tar.gz",
-      "build_number": "251.25410.122"
+      "version": "2025.1.2",
+      "sha256": "4a407779c5df9728e29698eeabdb4533911e755ead224d0c1deff959876c3108",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2.tar.gz",
+      "build_number": "251.26094.141"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
@@ -108,26 +108,26 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "f5014b52770be4d1c743c5a60f0e20d0dd1a1c172018180d05c0a22f1ffd1027",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.1.tar.gz",
-      "build_number": "251.25410.120"
+      "version": "2025.1.2",
+      "sha256": "2d4127e0284a262acb015c9d4247b654592e045b61664043a4de56029b45174f",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2.tar.gz",
+      "build_number": "251.26094.122"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "b2974feb5406153817797b7dc93baaafe35c7b3687d38091d5d1b5d010a03132",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.2.tar.gz",
-      "build_number": "251.25410.115"
+      "version": "2025.1.3",
+      "sha256": "b3c4999f1d7ef7deffa56bfe75f011a012842bec5c199b0090d2ac45af78ea5e",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.3.tar.gz",
+      "build_number": "251.25410.170"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "411b6d93e47d7743aa9189f4a3cab3956c573ce406908da5621f8dee0098ad99",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.1.tar.gz",
-      "build_number": "251.25410.117"
+      "version": "2025.1.2",
+      "sha256": "055510371e3c6a8d9fbfcd352645d847d2c092309c4746222babe4af240c2eac",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2.tar.gz",
+      "build_number": "251.26094.131"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -150,58 +150,58 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "dcd7373dc9dd941703d18ae602dd384ce6d154a90745c37c3358bf1f6b41ed2e",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.104"
+      "version": "2025.1.2",
+      "sha256": "911568cef55f23b134a4c316b5436214c2b51638c14a3b243785e19e354c2d4c",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.123"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "fb34b6469c96a54018b3c728f96787d03da0ec92c88a80f52e8f89a0eecc8d01",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.25410.123"
+      "version": "2025.1.3",
+      "sha256": "ca0b5a6685e8494311e3276ad22c097ea3a2f8925baff39951a45c467f3c547c",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3-aarch64.tar.gz",
+      "build_number": "251.26094.87"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.tar.gz",
-      "version": "2025.1",
-      "sha256": "e55cfc4e3327aff6bd3447e2980cd1e5cbd9223c8e0330688d65031b1e95d0fd",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1-aarch64.tar.gz",
-      "build_number": "251.23774.439"
+      "version": "2025.1.1",
+      "sha256": "4f7f05141bee346dd29ed48dafcea24197494aa8bbc02409df9089da1c8e0be8",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.1.1-aarch64.tar.gz",
+      "build_number": "251.25410.158"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "869882db293640328f5e1ae80c5cf60183ba850f6087ab1b3cf95ec77b3837be",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.139"
+      "version": "2025.1.2",
+      "sha256": "306a3eea012a9c398d95e1579fab38c5979297390ae048c98bd32026bd0fbe7f",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.128"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "949e86c6991e14d90adcaea75c18f679b1ab029ec0c00f00f464a631e999c036",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.140"
+      "version": "2025.1.2",
+      "sha256": "71f8c4addac839823b9875e6f01f8ab98d7cf77ab9acf03c09e057cc5d030757",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.127"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.tar.gz",
-      "version": "2025.1.1.1",
-      "sha256": "7860b836a18b82827fdb54a86cc5601fe8ef28aab4253981f238ef975a982915",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.129"
+      "version": "2025.1.2",
+      "sha256": "d98c8d7bdc3e274d278b81ba2b6c1baa38f67be9407b4bfd3bad3413c6f128f1",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.121"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
-      "version": "2025.1.1.1",
-      "sha256": "756baa32d72bd982d9b8c06f86cd42755d2677a9f1ea37bd6ad6a963d17226b2",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.129"
+      "version": "2025.1.2",
+      "sha256": "0f982a4f4424bde5a33206c20df053a7afe174fe9d590943665504814a273c9d",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.121"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -214,27 +214,27 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "6e479318f5627ec1d6ccd47610a93aa9e9a56c9badd2be4d8f935008d0e71b9e",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.148",
+      "version": "2025.1.2",
+      "sha256": "2c3b703fc1d97e87fa02664bd1165ecf8439898b0a4561f522edd0252606ab5a",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.133",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "d717e039a91587e5396c69d056ebd91f640ae03ddf398e575c8f8eb3817d8afb",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.122"
+      "version": "2025.1.2",
+      "sha256": "10e7426804d649d3c5bdbfc365cf85fe73dd7e74e67fd1e4c82645e8532d17e7",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.141"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "3f8f8a3773652ec99ea7a05b55dff41b5683548838f009e5e3d132ea644384d9",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.122"
+      "version": "2025.1.2",
+      "sha256": "831f5563a354e617158cd88c2a63c0bda80b21c3a64fc98a3b6dc7ae22151805",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.141"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
@@ -247,26 +247,26 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "00b7526795af4e7eba1c65fc5e10a963e717770e68c5bfd28b10163f9fa37f8c",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.120"
+      "version": "2025.1.2",
+      "sha256": "13ed96cc82771ec49ce8e9f72179ac12829f4bc2ffae6a9ab553708aec47d4a9",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.122"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "4660f8f2fd37b166bae904385b863157ab596fac35869de17a39df999efde8ce",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.25410.115"
+      "version": "2025.1.3",
+      "sha256": "4fcd2d8560dd7fe60c3262474dd1fcea1d54b476869a62ede0de86b8d115fce9",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.3-aarch64.tar.gz",
+      "build_number": "251.25410.170"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "0156affae3222afb51cfe8a82e1eabf26f62bd91a74a2822fa821afd1eab9bad",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.117"
+      "version": "2025.1.2",
+      "sha256": "c182bcd17ff4d0188c0e024952677dd21415456a421c5c1aaa356870f2efa009",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2-aarch64.tar.gz",
+      "build_number": "251.26094.131"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -289,58 +289,58 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2025.1.1",
-      "sha256": "e7558d0196390c18e2c11143aa59f2ad56c020d43ebd05057f997fa117abb484",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.1.dmg",
-      "build_number": "251.25410.104"
+      "version": "2025.1.2",
+      "sha256": "f7dde8532ba52d4cfaab37828ba52fa2e159d82baf1fa555c1a0e65bb1186a86",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2.dmg",
+      "build_number": "251.26094.123"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "a6b7dadb262813d867281d700456c7bca82b61bea99e52fd54edec05cd07180e",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.2.dmg",
-      "build_number": "251.25410.123"
+      "version": "2025.1.3",
+      "sha256": "006fb7a0875c8fd205cd1d4204dee3be87d1fe359375b75e20ee6e0d21ca7d00",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3.dmg",
+      "build_number": "251.26094.87"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.dmg",
-      "version": "2025.1",
-      "sha256": "dd856c72855b0309ea98774a3b4c38cf899b6e307dbd3ced316cd8cc721faa38",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.dmg",
-      "build_number": "251.23774.439"
+      "version": "2025.1.1",
+      "sha256": "a0b3bd8513f98e448a90132dfb61b221cab22938d8a3992627f9cb141cf71926",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.1.1.dmg",
+      "build_number": "251.25410.158"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}.dmg",
-      "version": "2025.1.1",
-      "sha256": "c849cd16b77b5268ee2e8279bddf02c21a925a25885549d0b1922a785f18120f",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.1.dmg",
-      "build_number": "251.25410.139"
+      "version": "2025.1.2",
+      "sha256": "b4e45266159352598d0cbd7b03283cb53260d20866ca77d57a43150e81cf3d09",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.2.dmg",
+      "build_number": "251.26094.128"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
-      "version": "2025.1.1",
-      "sha256": "0b00984d45430b37538bf9c55f8f93f1476f819fba1bdea2588ffd36d7e91cb3",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.1.dmg",
-      "build_number": "251.25410.140"
+      "version": "2025.1.2",
+      "sha256": "6d3c732fb3aadc7dad9bb6dafd294be04c82a4dd994223e4982b77213bf9a4b6",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.2.dmg",
+      "build_number": "251.26094.127"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
-      "version": "2025.1.1.1",
-      "sha256": "ee1577a44930b94112819b200acd617cbb3efdfa039df7911094051e9a10e465",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.1.1.dmg",
-      "build_number": "251.25410.129"
+      "version": "2025.1.2",
+      "sha256": "c64c7ff7fe2e73d7552f1727d912bb5f901d040c7269b4292f94190475580c2b",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2.dmg",
+      "build_number": "251.26094.121"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
-      "version": "2025.1.1.1",
-      "sha256": "eccd0ba3f9b1f2f680b946a3658830562fd4369dd11cc618b86671c8e237c375",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.1.1.dmg",
-      "build_number": "251.25410.129"
+      "version": "2025.1.2",
+      "sha256": "bacfa3bcf48d57d8e8ca8d352895025ffc42ce395b9b0074b3b566dc217324c9",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2.dmg",
+      "build_number": "251.26094.121"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -353,27 +353,27 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
-      "version": "2025.1.1",
-      "sha256": "2f7c9b0ec1947c7bb2247fd3a949de9921e82e9a2801e388f6cf9d4421073dbd",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.1.dmg",
-      "build_number": "251.25410.148",
+      "version": "2025.1.2",
+      "sha256": "18b63995efa4e5ef555f08089c998694b4e3fcda84013155e970524f92c1b90e",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.2.dmg",
+      "build_number": "251.26094.133",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
-      "version": "2025.1.1",
-      "sha256": "3d439ad29771d8618b03f28497899f09a6eb696c96c789b54aac9ac1bfb4766c",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.1.dmg",
-      "build_number": "251.25410.122"
+      "version": "2025.1.2",
+      "sha256": "38283e62677079d7d830217087c563ac6daf5e71422c03e56082bde9572e3908",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2.dmg",
+      "build_number": "251.26094.141"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
-      "version": "2025.1.1",
-      "sha256": "cd56a7e1072f4562e2d3ef67e70f227606376572634120170f5689d3b970b570",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.1.dmg",
-      "build_number": "251.25410.122"
+      "version": "2025.1.2",
+      "sha256": "41c6187f4f044522d02749f979cef8f127337b2945772070a0ba44c53a6ebf0c",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2.dmg",
+      "build_number": "251.26094.141"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
@@ -386,26 +386,26 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2025.1.1",
-      "sha256": "97b154079ef326c9a3ce229129d7d220faee30f266954288f74bf6f27ee43942",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.1.dmg",
-      "build_number": "251.25410.120"
+      "version": "2025.1.2",
+      "sha256": "059d3d4c089b9277089bd7d64b8f6eedcf039fe791cddc694af434a1c5ad88c8",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2.dmg",
+      "build_number": "251.26094.122"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "1419d2aac23965838e16c2bedc31851045f8b9d99ccf93594838a4e329059d92",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.2.dmg",
-      "build_number": "251.25410.115"
+      "version": "2025.1.3",
+      "sha256": "2ed48a8d1f0afb13a5a2d59a1f478128bff406028f82290db1f9b2847a1e6ade",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.3.dmg",
+      "build_number": "251.25410.170"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2025.1.1",
-      "sha256": "44363b71b4ad461c07c2c0ae8424f6efabe356b347a2974765f88549a8ee183c",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.1.dmg",
-      "build_number": "251.25410.117"
+      "version": "2025.1.2",
+      "sha256": "c33853a8d8a2dd47ce3a795202e2d802a9f1888b2c998c91cdfc9bc66f9bb19a",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2.dmg",
+      "build_number": "251.26094.131"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -428,58 +428,58 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2025.1.1",
-      "sha256": "475280e277cc94d18de228bf5f81ebd6ff14084c2e1d2b0db5b4612007dc46fe",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.1-aarch64.dmg",
-      "build_number": "251.25410.104"
+      "version": "2025.1.2",
+      "sha256": "9a47d3d86f2465f4b741408ad3a792d63a4dff486a05103825e479dae4d63932",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.123"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "6d12a59053db3dfa33079ac79b1ea263e5b3ec6fde01d1d803f6d27afea033de",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.2-aarch64.dmg",
-      "build_number": "251.25410.123"
+      "version": "2025.1.3",
+      "sha256": "83da07ddd46fe95aed36d98cbb61c7f81097dc38abe5515933653746859b396c",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3-aarch64.dmg",
+      "build_number": "251.26094.87"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.dmg",
-      "version": "2025.1",
-      "sha256": "f6dd63c5458ea2adeb76a9042ab3316b124fd9cbdcccd4d4b08c2d90e17b49b8",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1-aarch64.dmg",
-      "build_number": "251.23774.439"
+      "version": "2025.1.1",
+      "sha256": "65bbf4da47e5ceecfab5e19f80bec7ddd5f66bfcdc8dc75691cad98958e72af1",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.1.1-aarch64.dmg",
+      "build_number": "251.25410.158"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
-      "version": "2025.1.1",
-      "sha256": "abad0e061896590bea9bd1d4bead2183be3c1e71d6dfcba89ce2408f34af3536",
-      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.1-aarch64.dmg",
-      "build_number": "251.25410.139"
+      "version": "2025.1.2",
+      "sha256": "1cf7dcdbb5408c9c7711a436e4c763df147ce332ce2e1f260fa246af87b0a58e",
+      "url": "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.128"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
-      "version": "2025.1.1",
-      "sha256": "52e62d5a616b6ab6bf36f0d40d1925e9f477fcf84e187a2a1194d56d5ccae6ec",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.1-aarch64.dmg",
-      "build_number": "251.25410.140"
+      "version": "2025.1.2",
+      "sha256": "a30940d1b2659487ababc3a9ad8e4770236e90ad6c732cb1fd0c24690829a0ce",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.127"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2025.1.1.1",
-      "sha256": "92ea35ebfcd9e34cd9bda0103ca036fe1f9eb900c005ae33a9295050ad636dae",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.1.1-aarch64.dmg",
-      "build_number": "251.25410.129"
+      "version": "2025.1.2",
+      "sha256": "61a64b8abf0b350cb14f963975fc87ec574bc4b50ae7944980c43c816ffad5a8",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.121"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2025.1.1.1",
-      "sha256": "5207878b28df2a13e4248c1936ee4fff7c89495e3d4ffdaa3b8da3f21548117e",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.1.1-aarch64.dmg",
-      "build_number": "251.25410.129"
+      "version": "2025.1.2",
+      "sha256": "1c1afc32c8edcf1d2057a505f7f0b0dd1f1a20a6859172c1dd6a91a311a3167b",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.121"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -492,27 +492,27 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2025.1.1",
-      "sha256": "8bb7acf16076e4a32b522107bc359197bb2ee0eeebe0ed5feb1d25d9110830c1",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.1-aarch64.dmg",
-      "build_number": "251.25410.148",
+      "version": "2025.1.2",
+      "sha256": "0437ba56e1b12b1781ba132d10f9f66c6375cb0609b4755982c7edd1778a3a3b",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.133",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2025.1.1",
-      "sha256": "4e493ce20dd840402ed040f4447d06cab62e59514b5ab2058e94421877f72270",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.1-aarch64.dmg",
-      "build_number": "251.25410.122"
+      "version": "2025.1.2",
+      "sha256": "cdcdea2e167c3621f5b5ea8e0150c62d24495192edd2282616676d3f53b06063",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.141"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2025.1.1",
-      "sha256": "76a97e0d1ca75cbfbcc0acb046154daec1113010c052318077a128ff89fb55a6",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.1-aarch64.dmg",
-      "build_number": "251.25410.122"
+      "version": "2025.1.2",
+      "sha256": "89a463c896e4e7f6cf6a624b78305d881756b2a350780bfcecd15d6cb766e54b",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.141"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
@@ -525,26 +525,26 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2025.1.1",
-      "sha256": "6b8bd9c8ffeec01b0a907604d99cc77ede865aa9abf350e76957d9675ab8a810",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.1-aarch64.dmg",
-      "build_number": "251.25410.120"
+      "version": "2025.1.2",
+      "sha256": "1da265fa947d5d1cf3075495414b9e65ec519a5bd9bee5ca2fa7df67bafdc352",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.122"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "3f12ad41285d6b67dcc577526976b5c394b44caa3f243147143968a505144a79",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.2-aarch64.dmg",
-      "build_number": "251.25410.115"
+      "version": "2025.1.3",
+      "sha256": "552145a2d550cfcb2dc59530605dbe4af179102a99dab4b69acb80d9504d0ef3",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.3-aarch64.dmg",
+      "build_number": "251.25410.170"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2025.1.1",
-      "sha256": "7acfa46536b598b576775892ac46bb570dd06bc9461cc58c51b9efd4afd09139",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.1-aarch64.dmg",
-      "build_number": "251.25410.117"
+      "version": "2025.1.2",
+      "sha256": "298d53fcd1a979e6910f97d9a29ac9bc0ed12386838a93a6d279bb415cf4708f",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2-aarch64.dmg",
+      "build_number": "251.26094.131"
     },
     "writerside": {
       "update-channel": "Writerside EAP",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -17,17 +17,17 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip"
       },
       "name": "ideavim"
     },
@@ -36,7 +36,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/631/737817/python-251.25410.129.zip"
+        "251.26094.121": "https://plugins.jetbrains.com/files/631/766544/python-251.26094.121.zip"
       },
       "name": "python"
     },
@@ -46,8 +46,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/1347/748379/scala-intellij-bin-2025.1.24.zip"
+        "243.22562.218": null,
+        "251.26094.121": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip"
       },
       "name": "scala"
     },
@@ -69,16 +69,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
       },
       "name": "string-manipulation"
     },
@@ -100,16 +100,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip"
       },
       "name": "handlebars-mustache"
     },
@@ -131,16 +131,16 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.104": null,
-        "251.25410.115": null,
-        "251.25410.117": null,
         "251.25410.119": null,
-        "251.25410.120": null,
-        "251.25410.122": null,
-        "251.25410.123": null,
-        "251.25410.129": null,
-        "251.25410.140": null,
-        "251.25410.148": null
+        "251.25410.170": null,
+        "251.26094.121": null,
+        "251.26094.122": null,
+        "251.26094.123": null,
+        "251.26094.127": null,
+        "251.26094.131": null,
+        "251.26094.133": null,
+        "251.26094.141": null,
+        "251.26094.87": null
       },
       "name": "kotlin"
     },
@@ -162,16 +162,16 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/6981/724264/ini-251.23774.466.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip"
       },
       "name": "ini"
     },
@@ -193,16 +193,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -224,16 +224,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
       },
       "name": "grep-console"
     },
@@ -255,16 +255,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip"
       },
       "name": "file-watchers"
     },
@@ -274,8 +274,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7179/617030/MavenHelper-4.29.0-IJ2022.2.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7179/617030/MavenHelper-4.29.0-IJ2022.2.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip"
       },
       "name": "maven-helper"
     },
@@ -297,16 +297,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip"
       },
       "name": "cucumber-for-java"
     },
@@ -316,8 +316,8 @@
         "phpstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/7219/739169/Symfony_Plugin-2025.1.279.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7219/739169/Symfony_Plugin-2025.1.279.zip"
+        "251.26094.121": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip"
       },
       "name": "symfony-plugin"
     },
@@ -327,8 +327,8 @@
         "phpstorm"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip"
+        "251.26094.121": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip"
       },
       "name": "php-annotations"
     },
@@ -346,14 +346,14 @@
       ],
       "builds": {
         "243.22562.218": null,
-        "251.25410.104": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip"
       },
       "name": "python-community-edition"
     },
@@ -374,17 +374,17 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip"
       },
       "name": "asciidoc"
     },
@@ -404,18 +404,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.23774.423": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.104": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.115": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.117": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.120": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.122": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.123": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.140": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar"
+        "243.22562.218": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.23774.423": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.25410.119": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.25410.170": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26094.122": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26094.123": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26094.127": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26094.131": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26094.141": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
       },
       "name": "wakatime"
     },
@@ -437,16 +437,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip"
       },
       "name": "gittoolbox"
     },
@@ -468,16 +468,16 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/7724/724240/clouds-docker-impl-251.23774.466.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip"
       },
       "name": "docker"
     },
@@ -499,16 +499,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip"
       },
       "name": "graphql"
     },
@@ -529,15 +529,15 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.104": null,
-        "251.25410.117": null,
         "251.25410.119": null,
-        "251.25410.120": null,
-        "251.25410.122": null,
-        "251.25410.123": null,
-        "251.25410.129": null,
-        "251.25410.140": null,
-        "251.25410.148": null
+        "251.26094.121": null,
+        "251.26094.122": null,
+        "251.26094.123": null,
+        "251.26094.127": null,
+        "251.26094.131": null,
+        "251.26094.133": null,
+        "251.26094.141": null,
+        "251.26094.87": null
       },
       "name": "-deprecated-rust"
     },
@@ -558,15 +558,15 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.104": null,
-        "251.25410.117": null,
         "251.25410.119": null,
-        "251.25410.120": null,
-        "251.25410.122": null,
-        "251.25410.123": null,
-        "251.25410.129": null,
-        "251.25410.140": null,
-        "251.25410.148": null
+        "251.26094.121": null,
+        "251.26094.122": null,
+        "251.26094.123": null,
+        "251.26094.127": null,
+        "251.26094.131": null,
+        "251.26094.133": null,
+        "251.26094.141": null,
+        "251.26094.87": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -588,16 +588,16 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/8195/715934/toml-251.23774.429.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip"
       },
       "name": "toml"
     },
@@ -608,7 +608,7 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/8327/718480/Minecraft_Development-2025.1-1.8.4.zip"
+        "251.26094.121": "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip"
       },
       "name": "minecraft-development"
     },
@@ -630,16 +630,16 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/8554/716074/featuresTrainer-251.23774.436.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -661,16 +661,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
       },
       "name": "nixidea"
     },
@@ -692,16 +692,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip"
       },
       "name": "gherkin"
     },
@@ -723,16 +723,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip"
       },
       "name": "-env-files"
     },
@@ -742,8 +742,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "251.25410.129": "https://plugins.jetbrains.com/files/9568/728728/go-plugin-251.25410.59.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/9568/728728/go-plugin-251.25410.59.zip"
+        "251.26094.121": "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip"
       },
       "name": "go"
     },
@@ -765,16 +765,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/9707/702582/ANSI_Highlighter_Premium-24.3.4.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.104": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.115": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.117": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
         "251.25410.119": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.120": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.122": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.123": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.129": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.140": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.148": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar"
+        "251.25410.170": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26094.121": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26094.122": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26094.123": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26094.127": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26094.131": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26094.133": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26094.141": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar"
       },
       "name": "ansi-highlighter-premium"
     },
@@ -796,16 +796,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
     },
@@ -827,16 +827,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
       },
       "name": "randomness"
     },
@@ -858,16 +858,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
       },
       "name": "csv-editor"
     },
@@ -889,16 +889,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip"
       },
       "name": "rainbow-brackets"
     },
@@ -920,16 +920,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
     },
@@ -951,16 +951,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
       },
       "name": "hocon"
     },
@@ -981,15 +981,15 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip"
       },
       "name": "go-template"
     },
@@ -1011,16 +1011,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip"
       },
       "name": "extra-icons"
     },
@@ -1040,18 +1040,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/11349/743145/aws-toolkit-jetbrains-standalone-3.71-243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/11349/768106/aws-toolkit-jetbrains-standalone-3.74.243.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1082,16 +1082,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip"
       },
       "name": "vscode-keymap"
     },
@@ -1113,16 +1113,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -1144,16 +1144,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
     },
@@ -1175,16 +1175,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -1206,16 +1206,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
     },
@@ -1237,16 +1237,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip"
       },
       "name": "protocol-buffers"
     },
@@ -1268,16 +1268,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.104": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.115": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.117": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "251.25410.119": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.120": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.122": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.123": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.129": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.140": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.148": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "251.25410.170": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26094.121": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26094.122": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26094.123": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26094.127": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26094.131": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26094.133": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26094.141": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -1299,16 +1299,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.104": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.115": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.117": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "251.25410.119": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.120": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.122": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.123": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.129": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.140": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.148": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "251.25410.170": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26094.121": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26094.122": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26094.123": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26094.127": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26094.131": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26094.133": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26094.141": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
     },
@@ -1329,17 +1329,17 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.23774.423": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.104": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.115": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.117": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.120": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.122": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.123": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.129": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.140": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "251.25410.148": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar"
+        "251.23774.423": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.25410.119": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.25410.170": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26094.121": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26094.122": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26094.123": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26094.127": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26094.131": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26094.133": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26094.141": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar"
       },
       "name": "which-key"
     },
@@ -1361,16 +1361,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1390,18 +1390,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip"
       },
       "name": "github-copilot"
     },
@@ -1423,16 +1423,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1454,16 +1454,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1485,16 +1485,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/18824/694222/CodeGlancePro-1.9.7-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
       },
       "name": "codeglance-pro"
     },
@@ -1514,18 +1514,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.23774.423": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.104": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.115": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.117": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.120": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.122": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.123": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.129": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.140": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
-        "251.25410.148": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar"
+        "243.22562.218": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.23774.423": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.25410.119": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.25410.170": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.26094.121": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.26094.122": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.26094.123": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.26094.127": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.26094.131": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.26094.133": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.26094.141": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
+        "251.26094.87": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1547,16 +1547,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
     },
@@ -1578,16 +1578,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip"
       },
       "name": "mermaid"
     },
@@ -1609,16 +1609,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
     },
@@ -1640,16 +1640,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip"
       },
       "name": "code-complexity"
     },
@@ -1671,16 +1671,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1696,14 +1696,14 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.104": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip"
       },
       "name": "dev-containers"
     },
@@ -1714,9 +1714,9 @@
         "rust-rover"
       ],
       "builds": {
-        "251.25410.104": "https://plugins.jetbrains.com/files/22407/736889/intellij-rust-251.25410.127.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/22407/736889/intellij-rust-251.25410.127.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/22407/736889/intellij-rust-251.25410.127.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip"
       },
       "name": "rust"
     },
@@ -1736,18 +1736,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip"
       },
       "name": "continue"
     },
@@ -1769,16 +1769,16 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip"
       },
       "name": "gitlab"
     },
@@ -1798,18 +1798,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.25410.170": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
       },
       "name": "catppuccin-icons"
     },
@@ -1831,16 +1831,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
     },
@@ -1862,16 +1862,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/23806/664310/Oxocarbon-1.4.5.zip",
         "251.23774.423": null,
-        "251.25410.104": null,
-        "251.25410.115": null,
-        "251.25410.117": null,
         "251.25410.119": null,
-        "251.25410.120": null,
-        "251.25410.122": null,
-        "251.25410.123": null,
-        "251.25410.129": null,
-        "251.25410.140": null,
-        "251.25410.148": null
+        "251.25410.170": null,
+        "251.26094.121": null,
+        "251.26094.122": null,
+        "251.26094.123": null,
+        "251.26094.127": null,
+        "251.26094.131": null,
+        "251.26094.133": null,
+        "251.26094.141": null,
+        "251.26094.87": null
       },
       "name": "oxocarbon"
     },
@@ -1893,16 +1893,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip"
       },
       "name": "extra-ide-tweaks"
     },
@@ -1924,16 +1924,16 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip"
       },
       "name": "extra-tools-pack"
     },
@@ -1950,15 +1950,15 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.104": null,
-        "251.25410.115": null,
-        "251.25410.117": null,
         "251.25410.119": null,
-        "251.25410.120": null,
-        "251.25410.123": null,
-        "251.25410.129": null,
-        "251.25410.140": null,
-        "251.25410.148": null
+        "251.25410.170": null,
+        "251.26094.121": null,
+        "251.26094.122": null,
+        "251.26094.123": null,
+        "251.26094.127": null,
+        "251.26094.131": null,
+        "251.26094.133": null,
+        "251.26094.87": null
       },
       "name": "nix-lsp"
     },
@@ -1978,16 +1978,16 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
         "251.25410.119": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip"
+        "251.25410.170": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26094.121": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26094.122": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26094.123": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26094.127": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26094.131": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26094.133": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26094.141": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.26094.87": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip"
       },
       "name": "markdtask"
     }
@@ -2001,8 +2001,8 @@
     "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip": "sha256-6pZ8vHw8C08IUvU76meMTGShoSMntQABv/KBX4BRDYs=",
     "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip": "sha256-zX1nEdq84wwQvGhV664V5bNBPVTI4zWo306JtjXcGkE=",
     "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip": "sha256-trVQyV4PcxI1BeLtIg3fP1dOITiFRheIGpxU3GuA83w=",
-    "https://plugins.jetbrains.com/files/11349/743145/aws-toolkit-jetbrains-standalone-3.71-243.zip": "sha256-vmVmsichxO8hpzqCtLdqxScHbjwAN+7tVDnbCAh7Kuc=",
-    "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip": "sha256-aH9P8oYlUSKGJHzbwPZe+gOUekuGZc8PPQoJXKahfCY=",
+    "https://plugins.jetbrains.com/files/11349/768106/aws-toolkit-jetbrains-standalone-3.74.243.zip": "sha256-eWAEs18QSUate1bvO1412v+XniVEhjykgNsEn/rhGH0=",
+    "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip": "sha256-yklhTCVPh6vJo/ppVh3W6d7Cy8mfzfHbfOiXZT/vyI4=",
     "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip": "sha256-SWIXjxnwAf9dju1oOgzePrTY0lPNNX54Afp5OIkGGi4=",
     "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
     "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip": "sha256-obbLL8n6gK8oFw8NnJbdAylPHfTv4GheBDnVFOUpwL0=",
@@ -2012,22 +2012,22 @@
     "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip": "sha256-VQqK0Cm9ddXN63KYIqimuGOh7EB9VvdlErp/VrWx8SA=",
     "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip": "sha256-DKkgt0z/ui0bOLSbnKy51RL7+9HIqeriroi2otZ64mQ=",
     "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip": "sha256-eKwDE+PMtYhrGbDDZPS5cimssH+1xV4GF6RXXg/3urU=",
-    "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip": "sha256-4I75KqXyFl73S63O+00usrg8QBcuBRBgfjRmCQMpNks=",
-    "https://plugins.jetbrains.com/files/1347/748379/scala-intellij-bin-2025.1.24.zip": "sha256-S0VowbZJFSPwbydmAYoZ9mMOvgXHB90Rx+KECdybQwI=",
+    "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip": "sha256-h9GNGjqTc+h+x/0TRilKmqGoPsxhPmXIKoGC/s4/PKg=",
     "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip": "sha256-Tgu8CfDhO6KugfuLNhmxe89dMm+Qo3fmAg/8hwjUaoc=",
     "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip": "sha256-ZYn365EY8+VP1TKM4wBotMj1hYbSSr4J1K5oIZlE2SE=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar": "sha256-mB09zvUg1hLXl9lgW1NEU+DyVel1utZv6s+mFykckYY=",
     "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar": "sha256-2FlEaHf2rO6xgG3LnZIPt/XKgRGjpLSiEXCncfAf3bI=",
+    "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar": "sha256-Z3q0d4jCqeBwzW0jSSM3q4MTAPaTqQuwnV3ZVHfOMR4=",
     "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip": "sha256-yKpWQZGxfsKwPVTJLHpF4KGJ5ANCd73uxHlfdFE4Qf4=",
-    "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip": "sha256-v9GD6SHR1MuhXrqLit/eQm2R9c50aZTjpUJN/UOKCa0=",
+    "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip": "sha256-W5CtJqmejx2braLiJEYGPU29fCSOZNSQG0HZxqdOJIk=",
     "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip": "sha256-9DLY2HIyQR2w8xPVVKa2l7OZWqfoTvHkLGZYEnDV7/A=",
-    "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip": "sha256-wSIGsDmgZV8o6F9ekf84b06Ul16rw+wXdQx/X4D/rCI=",
+    "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip": "sha256-GKCOuZJerzhkhbl4zXWukonkygCT/Dm/tV4zRxFAP+g=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip": "sha256-fa9GiD/PNGy8AEao99vW3DBF1FKSulu3t+wO7mdr5fk=",
     "https://plugins.jetbrains.com/files/18824/694222/CodeGlancePro-1.9.7-signed.zip": "sha256-8RjKjmadd1o/M+WTLtKPn354bbKgEht4nvWnMcRPN9w=",
     "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip": "sha256-/1lyQq7JANhcKmIaaBHZ8ZCR4p23sLjLTTq9/68Fz+c=",
-    "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar": "sha256-BAFShNv5PYuOSTysEk1A7ykqtJBAXhkMsGWGwU3X+hY=",
+    "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar": "sha256-NjhQX8TY9B+aOPm3RrR42OyPM2GnZ5d0/+L83fcaGM0=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
     "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip": "sha256-jGWRU0g120qYvvFiUFI10zvprTsemuIq3XmIjYxZGts=",
     "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip": "sha256-QqEjnN6lUUtHkDRFWPeV3vqgGB/ZfWGVDqtk8gwJEqY=",
@@ -2036,51 +2036,58 @@
     "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip": "sha256-2qDeC2Fxp4/IfiLPL1JDquJDCzONCp4m92Ht2fnCn/M=",
     "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip": "sha256-lOPUSxlbgagD0SuXTw+fEdwTxxfUHP1Kl6L+u/oa4fs=",
     "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip": "sha256-kfXB36mIOn82pq+22ryztxY9K6CgwwNarNKcLuIH9G4=",
-    "https://plugins.jetbrains.com/files/22407/736889/intellij-rust-251.25410.127.zip": "sha256-ynht10qwZ9cXWDhNJPuFOdhEAuwdr62ZAI5pRsrn7Rs=",
-    "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip": "sha256-H83yxmkzqwkV5W89xuGogm4n5OSppjZAymtIZdnVXWI=",
+    "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip": "sha256-drL4D+lWFdKkmjMHDsPl8nJ+0oMldR6fs4MpyuiVWYg=",
+    "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip": "sha256-Jdt7S5goBdA8kf09pjDdLLyRXi3AVy2BdnC1zUDm46Y=",
     "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip": "sha256-zNNFPPPnYLkSzXX3CA1IMA0cjeXMcPY58+v80/KjVkg=",
     "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip": "sha256-PwxExt+Dlq11Y5UdEwFr/2BJPST3EYY7r/3gsXoxGzo=",
-    "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip": "sha256-w2vt4kuGd5T8OA5DcTTik2ksvCu0T3oynvTqYtMsVyo=",
+    "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip": "sha256-0x7t3Lo29Bwmo5pItUD/D+na2yIfd2shPiAVCZp9j/w=",
+    "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip": "sha256-TZNCi4kRc7NNcV89j2UhT6y1+l1L512xTN/yTztjQfY=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
     "https://plugins.jetbrains.com/files/23806/664310/Oxocarbon-1.4.5.zip": "sha256-zF89Q1LE6xwBeDKv4FSQ6H6cbABjz74Z/qGwddRWp7M=",
     "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip": "sha256-bwZSaUkfJ2D6XLr0e7EoismsTmvNCyRzGd4OWu6u9n0=",
     "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip": "sha256-SC8IMca0EYEmZFrMsaK3oadaemM4FQnYiTxOTt1zQGg=",
     "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip": "sha256-rRSyr7nShG1q9tVSO7VRo3KoGnBcrND4D4+38gNBtqI=",
-    "https://plugins.jetbrains.com/files/631/737817/python-251.25410.129.zip": "sha256-ieQ+ZWowWGwoTj1vxxCnO4hhNeGVE36V12V5Q5MOUr8=",
+    "https://plugins.jetbrains.com/files/631/766544/python-251.26094.121.zip": "sha256-gj3s+D04AcmPxzhKDWdYFED8Ab+iHIp6fpZhxasofUQ=",
     "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip": "sha256-pFKAZ8xFNfUh7/Hi4NYPDQAhRRYm4WKTpCQELqBfb40=",
     "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip": "sha256-34s7pOsqMaGoVYhCuAZtylNwplQOtNQJUppepsl4F4Q=",
     "https://plugins.jetbrains.com/files/6981/724264/ini-251.23774.466.zip": "sha256-CnoNNfcsbP9IipuqsBV1OZu+l3h7Yrs6MSofriDvI34=",
     "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip": "sha256-dcFDO0/mzbjkrsgM+RdHBAA5davTqD5is2D7JYQiTxc=",
+    "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip": "sha256-pyB9/Rutax3lp69NcvbVKy4b4OpZZ3cJst6UrrsQCho=",
     "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip": "sha256-BW47ZEUINVnhV0RZ1np7Dkf3lfyrtKoZ9ej/SVct2Xs=",
     "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip": "sha256-KY5VRiLJJwa9OVVog1W3MboZjwVboYwYm+i4eqooo44=",
     "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip": "sha256-8IHS3kmmbL8uQYnaMW7NgBIpBKT+XDJ4QDiiPZa5pzo=",
     "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip": "sha256-jNHP/vaCaolmvNUQRGmIgSR1ykjDtKqyJ69UIn5cz70=",
-    "https://plugins.jetbrains.com/files/7179/617030/MavenHelper-4.29.0-IJ2022.2.zip": "sha256-BA6gbStpYb76VS+61WCxakZyGM9Zuxokc3zfx2OBGn4=",
+    "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip": "sha256-Xsw4P/KddgOuwcNBzT3UWkaQBYXLqGop+fQhoL65Dfg=",
     "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip": "sha256-q8LjYzKuTK5da+A/29Z2+bHhWKmvsIUVG1MprbsIoLM=",
     "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip": "sha256-I7gwjCnW8OXzM5eioM7h6RW9qYaQX0MWJPfHOOL9KJA=",
-    "https://plugins.jetbrains.com/files/7219/739169/Symfony_Plugin-2025.1.279.zip": "sha256-OiUfPbbSuEFTHTmAdRNev7/StLnz5d1ziebSpuEHCPA=",
+    "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip": "sha256-SgldikXjVx6hUw3LqcN8/NxLLBfnr/LUc/SrIIACl7k=",
     "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip": "sha256-HfTd3zT/7sOrYutEkEzpFAu6AijrFrpHJg1ftP3N87Y=",
     "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip": "sha256-gN9XqO/x41scgJ9dzTdC4i4hIZJpwSeR7OjU2BG8gzU=",
+    "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip": "sha256-8om1u4KfXRkMUV8YzXWa1cgMeqTCRKSvDUh86ZBzPTE=",
     "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip": "sha256-3RJ7YVFtynyqeLIzdrirCMbWNZmUkJ+DT/9my71H0Dk=",
-    "https://plugins.jetbrains.com/files/7391/722116/asciidoctor-intellij-plugin-0.44.5.zip": "sha256-OqjgUctKp9bxVX3zXR48NGGUgZxmwBK6Olcsz0ZWEZ8=",
-    "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar": "sha256-Z7ZWDomXnTdHFKOElMkt53imef6aT7H5XeD6lOOFxfQ=",
+    "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip": "sha256-//bXaBJI+eIAYCuXek0pl9h7Utmrtui68QC1vrxPY8c=",
+    "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar": "sha256-DobKZKokueqq0z75d2Fo3BD8mWX9+LpGdT9C7Eu2fHc=",
     "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip": "sha256-cnVK5tsExjEAqP3cuh1PgNjrZYt2dVGQ/RL/jr89Zew=",
     "https://plugins.jetbrains.com/files/7724/724240/clouds-docker-impl-251.23774.466.zip": "sha256-2o1CaX3Xe86ZksIMW9ZqvnuvfvnqSddDDxEU/SFWER8=",
     "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip": "sha256-p+7U17bTsrxGFVR+Kguma43FOHW0d3NQKRjwxONqL1g=",
+    "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip": "sha256-+WJP3tXjIC4eGkssPrNf+tGEIKGQeLP3CcFtyXYUlQg=",
     "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip": "sha256-rr2pO0mIsqWXYZgwEhcQJlk0lQabxnIPxqRCGdTFaTw=",
     "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip": "sha256-O+gSW36MwqQqUiZBQl8J4NFNK+jFowtT9k1ykhSraxM=",
+    "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip": "sha256-5QQ3zmfgtcy4cSyGale9GvENuiWV8cQmzTEfxPkox2A=",
     "https://plugins.jetbrains.com/files/8195/715934/toml-251.23774.429.zip": "sha256-cNWs+ycKlqednnqJAm4AkqF3LTdMt8jhwWWiEDdKQE4=",
     "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip": "sha256-DYgGpnlqpr/d/hJXD6uYsa2tzErM4uCofgok/3WayYs=",
+    "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip": "sha256-l1dKtjk1YkO2Bd5H/4MDIGAyqi3tNMsDIrVNoMDwzEs=",
     "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip": "sha256-4c1nxjbEsNs9twmQnJllk1OIVmm0nnUYZ0R7f/6bJt4=",
-    "https://plugins.jetbrains.com/files/8327/718480/Minecraft_Development-2025.1-1.8.4.zip": "sha256-PNKG9qHZRrPDw95ZWs8gwkcomxFFLl5WEvCk6NR7gSk=",
+    "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip": "sha256-JD/OcG0B/KUMNmNsnRmiWzZ3QWVcFjaqNnQW8WbV1zc=",
     "https://plugins.jetbrains.com/files/8554/716074/featuresTrainer-251.23774.436.zip": "sha256-P6ux6UgbjeJW3lF4w696bZ73zumY8hEm1iM98IsKgTQ=",
     "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip": "sha256-iK3cy0Nf87rLV0m/t3LJv65Klij/9L5l9ad2UW9O00w=",
+    "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip": "sha256-qcMxLM2Y/Q18r718VasRMAlKppbH+ra/6eKCkmVL88s=",
     "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip": "sha256-OFisV6Vs/xlbDvchxfrREDVgVh7wcfGnot+zUrgQU6M=",
     "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip": "sha256-aG15ecfrsvNkpLjHclJEVKEW95GvBH+dEaqa+VCRkUo=",
     "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip": "sha256-Boy61dRieXmWrnTMfqqYZbdG/DNQ24KdguKN2fcZ+eg=",
     "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip": "sha256-hR7hC2phDJnHXxPy80WlEDFAhZHtMCu7nqYvAb0VeTI=",
     "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip": "sha256-0c/2qbuu+M6z0gvpme+Mkv23JlQKNTUU+9GL9mh2IFw=",
-    "https://plugins.jetbrains.com/files/9568/728728/go-plugin-251.25410.59.zip": "sha256-hBZozpcXPSsvSH5/8hJ2OhA3ukCsLXvXGlqYMv2GtFA=",
+    "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip": "sha256-P6XLFObtTrnxNWvNZag73hFVVY82t3+YQ2G31cwAVgg=",
     "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar": "sha256-XYCD4kOHDeIKhti0T175xhBHR8uscaFN4c9CNlUaCDs=",
     "https://plugins.jetbrains.com/files/9707/702582/ANSI_Highlighter_Premium-24.3.4.jar": "sha256-STDhSOshNJU8YOjd1ZMxNl4WaHEp81t9TimFVQGZgWw=",
     "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip": "sha256-Mzmmq0RzMKZeKfBSo7FHvzeEtPGIrwqEDLAONQEsR1M=",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -47,7 +47,7 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/1347/735853/scala-intellij-bin-2025.1.23.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/1347/748379/scala-intellij-bin-2025.1.24.zip"
       },
       "name": "scala"
     },
@@ -267,6 +267,48 @@
         "251.25410.148": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip"
       },
       "name": "file-watchers"
+    },
+    "7179": {
+      "compatible": [
+        "idea-community",
+        "idea-ultimate"
+      ],
+      "builds": {
+        "243.22562.218": "https://plugins.jetbrains.com/files/7179/617030/MavenHelper-4.29.0-IJ2022.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7179/617030/MavenHelper-4.29.0-IJ2022.2.zip"
+      },
+      "name": "maven-helper"
+    },
+    "7212": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "243.22562.218": "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.104": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.115": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.117": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.120": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.122": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.123": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.140": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.25410.148": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip"
+      },
+      "name": "cucumber-for-java"
     },
     "7219": {
       "compatible": [
@@ -632,6 +674,37 @@
       },
       "name": "nixidea"
     },
+    "9164": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "243.22562.218": "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.104": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.115": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.117": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.120": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.122": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.123": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.140": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.25410.148": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip"
+      },
+      "name": "gherkin"
+    },
     "9525": {
       "compatible": [
         "clion",
@@ -891,6 +964,35 @@
       },
       "name": "hocon"
     },
+    "10581": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "243.22562.218": "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.104": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.115": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.117": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.120": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.122": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.123": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.25410.148": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip"
+      },
+      "name": "go-template"
+    },
     "11058": {
       "compatible": [
         "clion",
@@ -938,18 +1040,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/11349/737408/aws-toolkit-jetbrains-standalone-3.70-243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/11349/743145/aws-toolkit-jetbrains-standalone-3.71-243.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.104": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.115": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.117": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.120": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.122": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.123": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.140": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip",
+        "251.25410.148": "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1288,18 +1390,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.104": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.115": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.117": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.120": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.122": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.123": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.140": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip",
+        "251.25410.148": "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip"
       },
       "name": "github-copilot"
     },
@@ -1350,18 +1452,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.104": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.115": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.117": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.120": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.122": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.123": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.140": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.25410.148": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1412,18 +1514,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.23774.423": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.104": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.115": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.117": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.120": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.122": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.123": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.129": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.140": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar",
-        "251.25410.148": "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar"
+        "243.22562.218": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.23774.423": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.104": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.115": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.117": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.119": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.120": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.122": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.123": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.140": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar",
+        "251.25410.148": "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1567,18 +1669,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.23774.423": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.104": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.115": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.117": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.120": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.122": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.123": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.140": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.25410.148": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1667,16 +1769,16 @@
       "builds": {
         "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip",
-        "251.25410.104": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip",
-        "251.25410.115": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip",
-        "251.25410.117": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip",
-        "251.25410.120": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip",
-        "251.25410.122": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip",
-        "251.25410.123": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip",
-        "251.25410.129": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip",
-        "251.25410.140": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip",
-        "251.25410.148": "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip"
+        "251.25410.104": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.115": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.117": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.120": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.122": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.123": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.140": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.25410.148": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip"
       },
       "name": "gitlab"
     },
@@ -1875,17 +1977,17 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "251.25410.104": null,
-        "251.25410.115": null,
-        "251.25410.117": null,
-        "251.25410.119": null,
-        "251.25410.120": null,
-        "251.25410.122": null,
-        "251.25410.123": null,
-        "251.25410.129": null,
-        "251.25410.140": null,
-        "251.25410.148": null
+        "243.22562.218": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.104": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.115": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.117": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.119": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.120": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.122": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.123": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.140": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
+        "251.25410.148": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip"
       },
       "name": "markdtask"
     }
@@ -1896,9 +1998,11 @@
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
     "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip": "sha256-Bnnvy+HDNkx2DQM7N+JUa8hQzIA3H/5Y0WpWAjPmhUI=",
     "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip": "sha256-GO0bXJsHx9O1A6M9NUCv9m4JwKHs5plwSssgx+InNqE=",
+    "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip": "sha256-6pZ8vHw8C08IUvU76meMTGShoSMntQABv/KBX4BRDYs=",
+    "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip": "sha256-zX1nEdq84wwQvGhV664V5bNBPVTI4zWo306JtjXcGkE=",
     "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip": "sha256-trVQyV4PcxI1BeLtIg3fP1dOITiFRheIGpxU3GuA83w=",
-    "https://plugins.jetbrains.com/files/11349/737408/aws-toolkit-jetbrains-standalone-3.70-243.zip": "sha256-KtMvtJjV1Oos3H+bffQX6RTTiLj5BIQbOzbRnOu212s=",
-    "https://plugins.jetbrains.com/files/11349/737411/aws-toolkit-jetbrains-standalone-3.70-251.zip": "sha256-u55hK8kuHIbdNxj/lCF2J8jy+n8Kben23kjIJ8u9r1g=",
+    "https://plugins.jetbrains.com/files/11349/743145/aws-toolkit-jetbrains-standalone-3.71-243.zip": "sha256-vmVmsichxO8hpzqCtLdqxScHbjwAN+7tVDnbCAh7Kuc=",
+    "https://plugins.jetbrains.com/files/11349/743148/aws-toolkit-jetbrains-standalone-3.71-251.zip": "sha256-aH9P8oYlUSKGJHzbwPZe+gOUekuGZc8PPQoJXKahfCY=",
     "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip": "sha256-SWIXjxnwAf9dju1oOgzePrTY0lPNNX54Afp5OIkGGi4=",
     "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
     "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip": "sha256-obbLL8n6gK8oFw8NnJbdAylPHfTv4GheBDnVFOUpwL0=",
@@ -1909,7 +2013,7 @@
     "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip": "sha256-DKkgt0z/ui0bOLSbnKy51RL7+9HIqeriroi2otZ64mQ=",
     "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip": "sha256-eKwDE+PMtYhrGbDDZPS5cimssH+1xV4GF6RXXg/3urU=",
     "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip": "sha256-4I75KqXyFl73S63O+00usrg8QBcuBRBgfjRmCQMpNks=",
-    "https://plugins.jetbrains.com/files/1347/735853/scala-intellij-bin-2025.1.23.zip": "sha256-y81nA9MBa3NA8cilX3EIuhlBrKRf3RHP5VSElhguLg8=",
+    "https://plugins.jetbrains.com/files/1347/748379/scala-intellij-bin-2025.1.24.zip": "sha256-S0VowbZJFSPwbydmAYoZ9mMOvgXHB90Rx+KECdybQwI=",
     "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip": "sha256-Tgu8CfDhO6KugfuLNhmxe89dMm+Qo3fmAg/8hwjUaoc=",
     "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip": "sha256-ZYn365EY8+VP1TKM4wBotMj1hYbSSr4J1K5oIZlE2SE=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
@@ -1918,30 +2022,30 @@
     "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip": "sha256-yKpWQZGxfsKwPVTJLHpF4KGJ5ANCd73uxHlfdFE4Qf4=",
     "https://plugins.jetbrains.com/files/164/736911/IdeaVIM-2.24.0.zip": "sha256-v9GD6SHR1MuhXrqLit/eQm2R9c50aZTjpUJN/UOKCa0=",
     "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip": "sha256-9DLY2HIyQR2w8xPVVKa2l7OZWqfoTvHkLGZYEnDV7/A=",
-    "https://plugins.jetbrains.com/files/17718/736879/github-copilot-intellij-1.5.44-243.zip": "sha256-YReboCD5Fy6nM1c0s/azNzip2LTSCDCaur9UmMD0kKQ=",
+    "https://plugins.jetbrains.com/files/17718/743191/github-copilot-intellij-1.5.45-243.zip": "sha256-wSIGsDmgZV8o6F9ekf84b06Ul16rw+wXdQx/X4D/rCI=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
-    "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip": "sha256-QOF3nAXOfYhNl3YUK1fc9z5H2uXTPm2X+6fVZ5QP8ZQ=",
+    "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip": "sha256-fa9GiD/PNGy8AEao99vW3DBF1FKSulu3t+wO7mdr5fk=",
     "https://plugins.jetbrains.com/files/18824/694222/CodeGlancePro-1.9.7-signed.zip": "sha256-8RjKjmadd1o/M+WTLtKPn354bbKgEht4nvWnMcRPN9w=",
     "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip": "sha256-/1lyQq7JANhcKmIaaBHZ8ZCR4p23sLjLTTq9/68Fz+c=",
-    "https://plugins.jetbrains.com/files/18922/734995/GerryThemes.jar": "sha256-bNZQnoCUpAyPzSRNeT1w8WOhILncjxh3ul6nOpglkK4=",
+    "https://plugins.jetbrains.com/files/18922/747693/GerryThemes.jar": "sha256-BAFShNv5PYuOSTysEk1A7ykqtJBAXhkMsGWGwU3X+hY=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
     "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip": "sha256-jGWRU0g120qYvvFiUFI10zvprTsemuIq3XmIjYxZGts=",
     "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip": "sha256-QqEjnN6lUUtHkDRFWPeV3vqgGB/ZfWGVDqtk8gwJEqY=",
     "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip": "sha256-N66Bh0AwHmg5N9PNguRAGtpJ/dLMWMp3rxjTgz9poFo=",
     "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip": "sha256-TZPup3EJ0cBv4i2eVAQwVmmzy0rmt4KptEsk3C7baEM=",
     "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip": "sha256-2qDeC2Fxp4/IfiLPL1JDquJDCzONCp4m92Ht2fnCn/M=",
-    "https://plugins.jetbrains.com/files/21904/726853/intellij-developer-tools-plugin-7.0.0-signed.zip": "sha256-8ZxPJoqlCGLaVBJjBp0OLJWeU+WL+B+QKECYB+VueSQ=",
+    "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip": "sha256-lOPUSxlbgagD0SuXTw+fEdwTxxfUHP1Kl6L+u/oa4fs=",
     "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip": "sha256-kfXB36mIOn82pq+22ryztxY9K6CgwwNarNKcLuIH9G4=",
     "https://plugins.jetbrains.com/files/22407/736889/intellij-rust-251.25410.127.zip": "sha256-ynht10qwZ9cXWDhNJPuFOdhEAuwdr62ZAI5pRsrn7Rs=",
     "https://plugins.jetbrains.com/files/22707/738247/continue-intellij-extension-1.0.16.zip": "sha256-H83yxmkzqwkV5W89xuGogm4n5OSppjZAymtIZdnVXWI=",
     "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip": "sha256-zNNFPPPnYLkSzXX3CA1IMA0cjeXMcPY58+v80/KjVkg=",
-    "https://plugins.jetbrains.com/files/22857/736969/vcs-gitlab-IU-251.25410.123-IU.zip": "sha256-MolxGVW15UD2anFjEw2G3VJzwZn7BjfpZKI3TL6uogQ=",
+    "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip": "sha256-PwxExt+Dlq11Y5UdEwFr/2BJPST3EYY7r/3gsXoxGzo=",
     "https://plugins.jetbrains.com/files/23029/702798/Catppuccin_Icons-1.11.0.zip": "sha256-w2vt4kuGd5T8OA5DcTTik2ksvCu0T3oynvTqYtMsVyo=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
     "https://plugins.jetbrains.com/files/23806/664310/Oxocarbon-1.4.5.zip": "sha256-zF89Q1LE6xwBeDKv4FSQ6H6cbABjz74Z/qGwddRWp7M=",
     "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip": "sha256-bwZSaUkfJ2D6XLr0e7EoismsTmvNCyRzGd4OWu6u9n0=",
     "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip": "sha256-SC8IMca0EYEmZFrMsaK3oadaemM4FQnYiTxOTt1zQGg=",
-    "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip": "sha256-NFHB5zWH8pUwz6OT8F7eIiapeEvHX24fj0Eo1qH45Aw=",
+    "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip": "sha256-rRSyr7nShG1q9tVSO7VRo3KoGnBcrND4D4+38gNBtqI=",
     "https://plugins.jetbrains.com/files/631/737817/python-251.25410.129.zip": "sha256-ieQ+ZWowWGwoTj1vxxCnO4hhNeGVE36V12V5Q5MOUr8=",
     "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip": "sha256-pFKAZ8xFNfUh7/Hi4NYPDQAhRRYm4WKTpCQELqBfb40=",
     "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip": "sha256-34s7pOsqMaGoVYhCuAZtylNwplQOtNQJUppepsl4F4Q=",
@@ -1951,6 +2055,9 @@
     "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip": "sha256-KY5VRiLJJwa9OVVog1W3MboZjwVboYwYm+i4eqooo44=",
     "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip": "sha256-8IHS3kmmbL8uQYnaMW7NgBIpBKT+XDJ4QDiiPZa5pzo=",
     "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip": "sha256-jNHP/vaCaolmvNUQRGmIgSR1ykjDtKqyJ69UIn5cz70=",
+    "https://plugins.jetbrains.com/files/7179/617030/MavenHelper-4.29.0-IJ2022.2.zip": "sha256-BA6gbStpYb76VS+61WCxakZyGM9Zuxokc3zfx2OBGn4=",
+    "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip": "sha256-q8LjYzKuTK5da+A/29Z2+bHhWKmvsIUVG1MprbsIoLM=",
+    "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip": "sha256-I7gwjCnW8OXzM5eioM7h6RW9qYaQX0MWJPfHOOL9KJA=",
     "https://plugins.jetbrains.com/files/7219/739169/Symfony_Plugin-2025.1.279.zip": "sha256-OiUfPbbSuEFTHTmAdRNev7/StLnz5d1ziebSpuEHCPA=",
     "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip": "sha256-HfTd3zT/7sOrYutEkEzpFAu6AijrFrpHJg1ftP3N87Y=",
     "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip": "sha256-gN9XqO/x41scgJ9dzTdC4i4hIZJpwSeR7OjU2BG8gzU=",
@@ -1969,6 +2076,8 @@
     "https://plugins.jetbrains.com/files/8554/716074/featuresTrainer-251.23774.436.zip": "sha256-P6ux6UgbjeJW3lF4w696bZ73zumY8hEm1iM98IsKgTQ=",
     "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip": "sha256-iK3cy0Nf87rLV0m/t3LJv65Klij/9L5l9ad2UW9O00w=",
     "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip": "sha256-OFisV6Vs/xlbDvchxfrREDVgVh7wcfGnot+zUrgQU6M=",
+    "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip": "sha256-aG15ecfrsvNkpLjHclJEVKEW95GvBH+dEaqa+VCRkUo=",
+    "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip": "sha256-Boy61dRieXmWrnTMfqqYZbdG/DNQ24KdguKN2fcZ+eg=",
     "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip": "sha256-hR7hC2phDJnHXxPy80WlEDFAhZHtMCu7nqYvAb0VeTI=",
     "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip": "sha256-0c/2qbuu+M6z0gvpme+Mkv23JlQKNTUU+9GL9mh2IFw=",
     "https://plugins.jetbrains.com/files/9568/728728/go-plugin-251.25410.59.zip": "sha256-hBZozpcXPSsvSH5/8hJ2OhA3ukCsLXvXGlqYMv2GtFA=",


### PR DESCRIPTION
Manual backport of #410218 #413926 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.