### PR TITLE
nixos/tpm2: check kernel config if TCG_CRB is available

### DIFF
--- a/nixos/modules/system/boot/systemd/tpm2.nix
+++ b/nixos/modules/system/boot/systemd/tpm2.nix
@@ -67,9 +67,7 @@
         boot.initrd.availableKernelModules = [
           "tpm-tis"
         ]
-        ++ lib.optional (
-          !(pkgs.stdenv.hostPlatform.isRiscV64 || pkgs.stdenv.hostPlatform.isArmv7)
-        ) "tpm-crb";
+        ++ lib.optional (config.boot.kernelPackages.kernel.config.isEnabled "TCG_CRB") "tpm-crb";
         boot.initrd.systemd.storePaths = [
           pkgs.tpm2-tss
           "${cfg.package}/lib/systemd/systemd-tpm2-setup"


### PR DESCRIPTION
With the Raspberry Pi 4 kernel I got the following error:

```
linux-rpi> root module: tpm-tis
linux-rpi>   copying dependency: /nix/store/difr7fjwgg5dnl5zj3fv6g9hby2c4kyb-linux-rpi-6.6.51-stable_20241008-modules/lib/modules/6.6.51/kernel/drivers/char/tpm/tpm.ko.xz
linux-rpi>   copying dependency: /nix/store/difr7fjwgg5dnl5zj3fv6g9hby2c4kyb-linux-rpi-6.6.51-stable_20241008-modules/lib/modules/6.6.51/kernel/drivers/char/tpm/tpm_tis_core.ko.xz
linux-rpi>   copying dependency: /nix/store/difr7fjwgg5dnl5zj3fv6g9hby2c4kyb-linux-rpi-6.6.51-stable_20241008-modules/lib/modules/6.6.51/kernel/drivers/char/tpm/tpm_tis.ko.xz
linux-rpi> root module: tpm-crb
linux-rpi> modprobe: FATAL: Module tpm-crb not found in directory /nix/store/difr7fjwgg5dnl5zj3fv6g9hby2c4kyb-linux-rpi-6.6.51-stable_20241008-modules/lib/modules/6.6.51
```

Idea copied from https://github.com/NixOS/nixpkgs/pull/189676/files#r1020393709

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
