### PR TITLE
nixos-rebuild-ng: Fix a typo and a few unbalanced curly quotes in the man page

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -190,9 +190,9 @@ It must be one of the following:
 	trusted user in the Nix daemon. This can be achieved by using the
 	_nix.settings.trusted-users_ NixOS option. Examples values for that
 	option are described in the “Remote builds” chapter in the Nix manual,
-	(i.e. ‘--builders "ssh://bigbrother x86_64-linux"‘). By specifying an
+	(i.e. ‘--builders "ssh://bigbrother x86_64-linux"’). By specifying an
 	empty string existing builders specified in /etc/nix/machines can be
-	ignored: ‘--builders ""‘ for example when they are not reachable due to
+	ignored: ‘--builders ""’ for example when they are not reachable due to
 	network connectivity.
 
 *--profile-name* _name_, *-p* _name_
@@ -200,7 +200,7 @@ It must be one of the following:
 	track of the current and previous system configurations, use
 	_/nix/var/nix/profiles/system-profiles/name_. When you use GRUB 2, for
 	every system profile created with this flag, NixOS will create a submenu
-	named “NixOS - Profile _name_“ in GRUB's boot menu, containing the
+	named “NixOS - Profile _name_” in GRUB's boot menu, containing the
 	current and previous configurations of this profile.
 
 	For instance, if you want to test a configuration file named _test.nix_
@@ -209,7 +209,7 @@ It must be one of the following:
 		$ nixos-rebuild switch -p test -I nixos-config=./test.nix
 
 	The new configuration will appear in the GRUB 2 submenu “NixOS - Profile
-	‘test’“.
+	‘test’”.
 
 *--specialisation* _name_, *-c* _name_
 	Activates given specialisation; when not specified, switching and testing

--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -306,7 +306,7 @@ Builder options:
 
 *--verbose,*  *-v*,  *--quiet*,  *--log-format*,  *--no-build-output*, *-Q*,
 *--max-jobs*, *-j*, *--cores*, *--keep-going*, *-k*, *--keep-failed*, *-K*,
-*--fallback*, *--incllude*, *-I*, *--option*, *--repair*, *--builders*,
+*--fallback*, *--include*, *-I*, *--option*, *--repair*, *--builders*,
 *--print-build-logs*, *-L*, *--show-trace*
 
 See the Nix manual, *nix flake lock --help* or *nix-build --help* for details.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
