### PR TITLE
nixos-install-tools: enable flakes when using nixos-generate-config --flake

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -652,8 +652,14 @@ if ($showHardwareConfig) {
     mkpath($outDir, 0, 0755);
     write_file($fn, $hwConfig);
 
+    my $nixConfig = "";
     $fn = "$outDir/flake.nix";
     if ($flake) {
+        $nixConfig = <<EOF;
+  # Enable flakes to allow rebuilding the system.
+  nix.settings.experimental-features = [ "flakes" "nix-command" ];
+
+EOF
         if ($force || ! -e $fn) {
             print STDERR "writing $fn...\n";
             mkpath($outDir, 0, 0755);

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -106,6 +106,7 @@ let
           ./hardware-configuration.nix
         ];
 
+    $nixConfig
     $bootLoaderConfig
       # networking.hostName = "nixos"; # Define your hostname.
 

--- a/nixos/tests/nixos-generate-config.nix
+++ b/nixos/tests/nixos-generate-config.nix
@@ -7,8 +7,9 @@
       # OVERRIDDEN
       { config, pkgs, ... }: {
         imports = [ ./hardware-configuration.nix ];
-      $bootLoaderConfig
+
       $nixConfig
+      $bootLoaderConfig
       $desktopConfiguration
       }
     '';

--- a/nixos/tests/nixos-generate-config.nix
+++ b/nixos/tests/nixos-generate-config.nix
@@ -43,9 +43,19 @@
         "grep 'services\\.desktopManager\\.gnome\\.enable = true;' /etc/nixos/configuration.nix"
     )
 
+    # Ensure flakes are not enabled by default.
+    machine.fail(
+        "grep -F 'nix.settings.experimental-features = [ \"flakes\" \"nix-command\" ];' /etc/nixos/configuration.nix"
+    )
+
     machine.succeed("rm -rf /etc/nixos")
     machine.succeed("nixos-generate-config --flake")
     machine.succeed("nix-instantiate --parse /etc/nixos/flake.nix /etc/nixos/configuration.nix /etc/nixos/hardware-configuration.nix")
+
+    # Ensure flakes are enabled when `--flake` was passed.
+    machine.succeed(
+        "grep -F 'nix.settings.experimental-features = [ \"flakes\" \"nix-command\" ];' /etc/nixos/configuration.nix"
+    )
 
     machine.succeed("mv /etc/nixos /etc/nixos-with-flake-arg")
     machine.succeed("printf '[Defaults]\nFlake = 1\n' > /etc/nixos-generate-config.conf")

--- a/nixos/tests/nixos-generate-config.nix
+++ b/nixos/tests/nixos-generate-config.nix
@@ -8,6 +8,7 @@
       { config, pkgs, ... }: {
         imports = [ ./hardware-configuration.nix ];
       $bootLoaderConfig
+      $nixConfig
       $desktopConfiguration
       }
     '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Using n-g-c with --flake option will generate a config that is effectively _unbuildable_ with nixos-rebuild (#181471) unless additional options are passed explicitly.
This _will_ cause confusion for new users who aren't aware of what those additional options would be, and in any case, using `--flake` is an explicit statement that the system should support flakes.
Hence, we should enable said features in the config of those who are opting in in this manner.
 
Relevant:
* https://github.com/NixOS/nixpkgs/pull/383033
* https://github.com/NixOS/nixpkgs/issues/181471

This is a continuation of @eclairevoyant's work on #422717 and replaces #387594



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
