### PR TITLE
gitea-actions-runner: 0.2.11 -> 0.2.12

### DIFF
--- a/pkgs/by-name/gi/gitea-actions-runner/package.nix
+++ b/pkgs/by-name/gi/gitea-actions-runner/package.nix
@@ -1,42 +1,42 @@
 {
   lib,
   fetchFromGitea,
-  buildGo123Module,
+  buildGoModule,
   testers,
   gitea-actions-runner,
 }:
 
-buildGo123Module rec {
+buildGoModule (finalAttrs: {
   pname = "gitea-actions-runner";
-  version = "0.2.11";
+  version = "0.2.12";
 
   src = fetchFromGitea {
     domain = "gitea.com";
     owner = "gitea";
     repo = "act_runner";
-    rev = "v${version}";
-    hash = "sha256-PmDa8XIe1uZ4SSrs9zh5HBmFaOuj+uuLm7jJ4O5V1dI=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-z/wEs110Y2IZ2Jm6bayxlD2sjyl2V/v+gP6l9pwGi5o=";
   };
 
-  vendorHash = "sha256-lYJFySGqkhT89vHDp1FcTiiC7DG4ziQ1DaBHLh/kXQc=";
+  vendorHash = "sha256-HuiL6OLShSeGtHb4dOeOFOpOgl55s3x18uYgM4X8G7M=";
 
   ldflags = [
     "-s"
     "-w"
-    "-X gitea.com/gitea/act_runner/internal/pkg/ver.version=v${version}"
+    "-X gitea.com/gitea/act_runner/internal/pkg/ver.version=v${finalAttrs.version}"
   ];
 
   passthru.tests.version = testers.testVersion {
     package = gitea-actions-runner;
-    version = "v${version}";
+    version = "v${finalAttrs.version}";
   };
 
   meta = {
     mainProgram = "act_runner";
     maintainers = with lib.maintainers; [ techknowlogick ];
     license = lib.licenses.mit;
-    changelog = "https://gitea.com/gitea/act_runner/releases/tag/v${version}";
+    changelog = "https://gitea.com/gitea/act_runner/releases/tag/v${finalAttrs.version}";
     homepage = "https://gitea.com/gitea/act_runner";
     description = "Runner for Gitea based on act";
   };
-}
+})


### PR DESCRIPTION
Updates to new release: https://gitea.com/gitea/act_runner/releases/tag/v0.2.12
Notable change
- [0d687268c7](https://gitea.com/gitea/act_runner/commit/0d687268c77e4e391f04d1685431734993600636) act_runner requires go 1.24 now

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
