### PR TITLE
Update Nvidia/Mellanox Packages 2025-06-07

### DIFF
--- a/pkgs/by-name/bf/bfscripts/package.nix
+++ b/pkgs/by-name/bf/bfscripts/package.nix
@@ -1,8 +1,10 @@
 {
-  stdenv,
   fetchFromGitHub,
+  git,
   lib,
   python3,
+  rpm,
+  stdenv,
 }:
 
 let
@@ -36,17 +38,22 @@ let
 in
 stdenv.mkDerivation {
   pname = "bfscripts";
-  version = "unstable-2023-05-15";
+  version = "unstable-2025-06-27";
 
   src = fetchFromGitHub {
     owner = "Mellanox";
     repo = "bfscripts";
-    rev = "1da79f3ece7cdf99b2571c00e8b14d2e112504a4";
-    hash = "sha256-pTubrnZKEFmtAj/omycFYeYwrCog39zBDEszoCrsQNQ=";
+    rev = "ed8ede79fa002a2d83719a1bef6fbe0f7dcf37a4";
+    hash = "sha256-x+hpH6D5HTl39zD0vYj6wRFw881M4AcfM+ePcgXMst8=";
   };
 
   buildInputs = [
     python3
+  ];
+
+  nativeBuildInputs = [
+    git
+    rpm
   ];
 
   installPhase = ''
@@ -58,6 +65,9 @@ stdenv.mkDerivation {
     homepage = "https://github.com/Mellanox/bfscripts";
     license = licenses.bsd2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ nikstur ];
+    maintainers = with maintainers; [
+      nikstur
+      thillux
+    ];
   };
 }

--- a/pkgs/by-name/ml/mlxbf-bootctl/package.nix
+++ b/pkgs/by-name/ml/mlxbf-bootctl/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mlxbf-bootctl";
-  version = "1.1-6";
+  version = "unstable-2025-01-16";
 
   src = fetchFromGitHub {
     owner = "Mellanox";
     repo = "mlxbf-bootctl";
-    rev = "mlxbf-bootctl-${version}";
-    hash = "sha256-F49ZZtty+NARXA/doAFLhsQn4XkPW6GWLXGy4waIaM0=";
+    rev = "278160ca8e08251cff5e7989e5a1010bd247a6ae";
+    hash = "sha256-qS35wCb8zvuF2Zs/5hPZkoZAapr7fwKQ/0ZOBPtrkRQ=";
   };
 
   installPhase = ''
@@ -27,6 +27,9 @@ stdenv.mkDerivation rec {
     # This package is supposed to only run on a BlueField. Thus aarch64-linux
     # is the only relevant platform.
     platforms = [ "aarch64-linux" ];
-    maintainers = with lib.maintainers; [ nikstur ];
+    maintainers = with lib.maintainers; [
+      nikstur
+      thillux
+    ];
   };
 }

--- a/pkgs/by-name/ml/mlxbf-bootimages/package.nix
+++ b/pkgs/by-name/ml/mlxbf-bootimages/package.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mlxbf-bootimages";
-  version = "4.10.0-13520";
+  version = "4.11.0-13611";
 
   src = fetchurl {
     url = "https://linux.mellanox.com/public/repo/bluefield/${version}/bootimages/prod/${pname}-signed_${version}_arm64.deb";
-    hash = "sha256-lPclxhKmn1hvGXWI1A+Q1yXK7FZzKUcOtBoXG6KRsCA=";
+    hash = "sha256-bZpZ6qnC3Q/BuOngS4ZoU6vjeekPjVom0KdDoJF5iko=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/rs/rshim-user-space/package.nix
+++ b/pkgs/by-name/rs/rshim-user-space/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rshim-user-space";
-  version = "2.2.4";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "Mellanox";
     repo = "rshim-user-space";
     rev = "rshim-${version}";
-    hash = "sha256-z0Uk520vsBERbeVtxBqXPXSWhO0sLD5GCQy1dQsJdEg=";
+    hash = "sha256-J/gCACqpUY+KraVOLWpd+UVyZ1f2o77EfpAgUVtZL9w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/mstflint_access/default.nix
+++ b/pkgs/os-specific/linux/mstflint_access/default.nix
@@ -26,13 +26,13 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D ${pname}.ko $out/lib/modules/${kernel.modDirVersion}/extra/${pname}.ko
-
-    runHook postInstall
-  '';
+  installTargets = [ "modules_install" ];
+  installFlags = [
+    "-C"
+    "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+    "M=$(PWD)"
+  ] ++ makeFlags;
 
   meta = with lib; {
     description = "Kernel module for Nvidia NIC firmware update";


### PR DESCRIPTION
Updates for Mellanox/Nvidia packages. mstflint had build errors, therefore I skipped this update and opened an issue upstream.
 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
