### PR TITLE
buildPgrxExtension: force pinning cargo-pgrx

### DIFF
--- a/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/buildPgrxExtension.nix
@@ -29,7 +29,6 @@
 
 {
   lib,
-  cargo-pgrx,
   pkg-config,
   rustPlatform,
   stdenv,
@@ -64,6 +63,8 @@ lib.extendMkDerivation {
       buildFeatures ? [ ],
       cargoBuildFlags ? [ ],
       cargoPgrxFlags ? [ ],
+      # pinned dependencies
+      cargo-pgrx,
       postgresql,
       # cargo-pgrx calls rustfmt on generated bindings, this is not strictly necessary, so we avoid the
       # dependency here. Set to false and provide rustfmt in nativeBuildInputs, if you need it, e.g.

--- a/pkgs/development/tools/rust/cargo-pgrx/default.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/default.nix
@@ -81,4 +81,13 @@ in
     hash = "sha256-oMToAhKkRiCyC8JYS0gmo/XX3QVcVtF5mUV0aQjd+p8=";
     cargoHash = "sha256-RawGAQGtG2QVDCMbwjmUEaH6rDeRiBvvJsGCY8wySw0=";
   };
+
+  # Default version for direct usage.
+  # Not to be used with buildPgrxExtension, where it should be pinned.
+  # When you make an extension use the latest version, *copy* this to a separate pinned attribute.
+  cargo-pgrx = generic {
+    version = "0.15.0";
+    hash = "sha256-sksRfNV6l8YbdI6fzrEtanpDVV4sh14JXLqYBydHwy0=";
+    cargoHash = "sha256-c+n1bJMO9254kT4e6exVNhlIouzkkzrRIOVzR9lZeg4=";
+  };
 }

--- a/pkgs/development/tools/rust/cargo-pgrx/default.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/default.nix
@@ -1,11 +1,9 @@
 {
-  lib,
-  darwin,
   fetchCrate,
+  lib,
   openssl,
   pkg-config,
   rustPlatform,
-  stdenv,
 }:
 
 let
@@ -15,16 +13,16 @@ let
       hash,
       cargoHash,
     }:
-    rustPlatform.buildRustPackage rec {
+    rustPlatform.buildRustPackage {
       pname = "cargo-pgrx";
 
       inherit version;
 
       src = fetchCrate {
-        inherit version pname hash;
+        inherit version hash;
+        pname = "cargo-pgrx";
       };
 
-      useFetchCargoVendor = true;
       inherit cargoHash;
 
       nativeBuildInputs = [
@@ -44,12 +42,12 @@ let
         "--skip=command::schema::tests::test_parse_managed_postmasters"
       ];
 
-      meta = with lib; {
+      meta = {
         description = "Build Postgres Extensions with Rust";
         homepage = "https://github.com/pgcentralfoundation/pgrx";
         changelog = "https://github.com/pgcentralfoundation/pgrx/releases/tag/v${version}";
-        license = licenses.mit;
-        maintainers = with maintainers; [
+        license = lib.licenses.mit;
+        maintainers = with lib.maintainers; [
           happysalada
           matthiasbeyer
         ];

--- a/pkgs/development/tools/rust/cargo-pgrx/default.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/default.nix
@@ -64,12 +64,6 @@ in
     cargoHash = "sha256-zYjqE7LZLnTaVxWAPWC1ncEjCMlrhy4THtgecB7wBYY=";
   };
 
-  cargo-pgrx_0_12_5 = generic {
-    version = "0.12.5";
-    hash = "sha256-U2kF+qjQwMTaocv5f4p5y3qmPUsTzdvAp8mz9cn/COw=";
-    cargoHash = "sha256-CycwWvxYrHj7lmTiiNC1WdbFgrdlGr/M3qTN/N+7xQA=";
-  };
-
   cargo-pgrx_0_12_6 = generic {
     version = "0.12.6";
     hash = "sha256-7aQkrApALZe6EoQGVShGBj0UIATnfOy2DytFj9IWdEA=";

--- a/pkgs/servers/sql/postgresql/ext/pgvecto-rs/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvecto-rs/package.nix
@@ -23,112 +23,106 @@ let
   };
 
 in
-(buildPgrxExtension.override {
-  # Upstream only works with a fixed version of cargo-pgrx for each release,
-  # so we're pinning it here to avoid future incompatibility.
-  # See https://docs.vectorchord.ai/developers/development.html#set-up-development-environment, step 5
+(buildPgrxExtension.override { rustPlatform = rustPlatform'; }) (finalAttrs: {
+  inherit postgresql;
   cargo-pgrx = cargo-pgrx_0_12_0_alpha_1;
-  rustPlatform = rustPlatform';
-})
-  (finalAttrs: {
-    inherit postgresql;
 
-    pname = "pgvecto-rs";
-    version = "0.3.0";
+  pname = "pgvecto-rs";
+  version = "0.3.0";
 
-    buildInputs = [ openssl ];
-    nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [ pkg-config ];
 
-    patches = [
-      # Tell the `c` crate to use the flags from the rust bindgen hook
-      (replaceVars ./0001-read-clang-flags-from-environment.diff {
-        clang = lib.getExe clang;
-      })
-    ];
+  patches = [
+    # Tell the `c` crate to use the flags from the rust bindgen hook
+    (replaceVars ./0001-read-clang-flags-from-environment.diff {
+      clang = lib.getExe clang;
+    })
+  ];
 
-    src = fetchFromGitHub {
-      owner = "tensorchord";
-      repo = "pgvecto.rs";
-      tag = "v${finalAttrs.version}";
-      hash = "sha256-X7BY2Exv0xQNhsS/GA7GNvj9OeVDqVCd/k3lUkXtfgE=";
-    };
+  src = fetchFromGitHub {
+    owner = "tensorchord";
+    repo = "pgvecto.rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-X7BY2Exv0xQNhsS/GA7GNvj9OeVDqVCd/k3lUkXtfgE=";
+  };
 
-    useFetchCargoVendor = true;
-    cargoHash = "sha256-8otJ1uqGrCmlxAqvfAL3OjhBI4I6dAu6EoajstO46Sw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-8otJ1uqGrCmlxAqvfAL3OjhBI4I6dAu6EoajstO46Sw=";
 
-    # Set appropriate version on vectors.control, otherwise it won't show up on PostgreSQL
-    postPatch = ''
-      substituteInPlace ./vectors.control --subst-var-by CARGO_VERSION ${finalAttrs.version}
-    '';
+  # Set appropriate version on vectors.control, otherwise it won't show up on PostgreSQL
+  postPatch = ''
+    substituteInPlace ./vectors.control --subst-var-by CARGO_VERSION ${finalAttrs.version}
+  '';
 
-    # Include upgrade scripts in the final package
-    # https://github.com/tensorchord/pgvecto.rs/blob/v0.2.0/scripts/ci_package.sh#L6-L8
-    postInstall = ''
-      cp sql/upgrade/* $out/share/postgresql/extension/
-    '';
+  # Include upgrade scripts in the final package
+  # https://github.com/tensorchord/pgvecto.rs/blob/v0.2.0/scripts/ci_package.sh#L6-L8
+  postInstall = ''
+    cp sql/upgrade/* $out/share/postgresql/extension/
+  '';
 
-    env = {
-      # Needed to get openssl-sys to use pkg-config.
-      OPENSSL_NO_VENDOR = 1;
+  env = {
+    # Needed to get openssl-sys to use pkg-config.
+    OPENSSL_NO_VENDOR = 1;
 
-      # Bypass rust nightly features not being available on rust stable
-      RUSTC_BOOTSTRAP = 1;
-    };
+    # Bypass rust nightly features not being available on rust stable
+    RUSTC_BOOTSTRAP = 1;
+  };
 
-    # This crate does not have the "pg_test" feature
-    usePgTestCheckFeature = false;
+  # This crate does not have the "pg_test" feature
+  usePgTestCheckFeature = false;
 
-    passthru = {
-      updateScript = nix-update-script { };
-      tests.extension = postgresqlTestExtension {
-        inherit (finalAttrs) finalPackage;
-        postgresqlExtraSettings = ''
-          shared_preload_libraries='vectors'
-        '';
-        sql = ''
-          CREATE EXTENSION vectors;
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.extension = postgresqlTestExtension {
+      inherit (finalAttrs) finalPackage;
+      postgresqlExtraSettings = ''
+        shared_preload_libraries='vectors'
+      '';
+      sql = ''
+        CREATE EXTENSION vectors;
 
-          CREATE TABLE items (
-            id bigserial PRIMARY KEY,
-            content text NOT NULL,
-            embedding vectors.vector(3) NOT NULL -- 3 dimensions
-          );
+        CREATE TABLE items (
+          id bigserial PRIMARY KEY,
+          content text NOT NULL,
+          embedding vectors.vector(3) NOT NULL -- 3 dimensions
+        );
 
-          INSERT INTO items (content, embedding) VALUES
-            ('a fat cat sat on a mat and ate a fat rat', '[1, 2, 3]'),
-            ('a fat dog sat on a mat and ate a fat rat', '[4, 5, 6]'),
-            ('a thin cat sat on a mat and ate a thin rat', '[7, 8, 9]'),
-            ('a thin dog sat on a mat and ate a thin rat', '[10, 11, 12]');
-        '';
-        asserts = [
-          {
-            query = "SELECT default_version FROM pg_available_extensions WHERE name = 'vectors'";
-            expected = "'${finalAttrs.version}'";
-            description = "Extension vectors has correct version.";
-          }
-          {
-            query = "SELECT COUNT(embedding) FROM items WHERE to_tsvector('english', content) @@ 'cat & rat'::tsquery";
-            expected = "2";
-            description = "Stores and returns vectors.";
-          }
-        ];
-      };
-    };
-
-    meta = {
-      # Upstream removed support for PostgreSQL 13 on 0.3.0: https://github.com/tensorchord/pgvecto.rs/issues/343
-      broken =
-        (lib.versionOlder postgresql.version "14")
-        ||
-          # PostgreSQL 17 support issue upstream: https://github.com/tensorchord/pgvecto.rs/issues/607
-          # Check after next package update.
-          lib.versionAtLeast postgresql.version "17" && finalAttrs.version == "0.3.0";
-      description = "Scalable, Low-latency and Hybrid-enabled Vector Search in Postgres";
-      homepage = "https://github.com/tensorchord/pgvecto.rs";
-      license = lib.licenses.asl20;
-      maintainers = with lib.maintainers; [
-        diogotcorreia
-        esclear
+        INSERT INTO items (content, embedding) VALUES
+          ('a fat cat sat on a mat and ate a fat rat', '[1, 2, 3]'),
+          ('a fat dog sat on a mat and ate a fat rat', '[4, 5, 6]'),
+          ('a thin cat sat on a mat and ate a thin rat', '[7, 8, 9]'),
+          ('a thin dog sat on a mat and ate a thin rat', '[10, 11, 12]');
+      '';
+      asserts = [
+        {
+          query = "SELECT default_version FROM pg_available_extensions WHERE name = 'vectors'";
+          expected = "'${finalAttrs.version}'";
+          description = "Extension vectors has correct version.";
+        }
+        {
+          query = "SELECT COUNT(embedding) FROM items WHERE to_tsvector('english', content) @@ 'cat & rat'::tsquery";
+          expected = "2";
+          description = "Stores and returns vectors.";
+        }
       ];
     };
-  })
+  };
+
+  meta = {
+    # Upstream removed support for PostgreSQL 13 on 0.3.0: https://github.com/tensorchord/pgvecto.rs/issues/343
+    broken =
+      (lib.versionOlder postgresql.version "14")
+      ||
+        # PostgreSQL 17 support issue upstream: https://github.com/tensorchord/pgvecto.rs/issues/607
+        # Check after next package update.
+        lib.versionAtLeast postgresql.version "17" && finalAttrs.version == "0.3.0";
+    description = "Scalable, Low-latency and Hybrid-enabled Vector Search in Postgres";
+    homepage = "https://github.com/tensorchord/pgvecto.rs";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      diogotcorreia
+      esclear
+    ];
+  };
+})

--- a/pkgs/servers/sql/postgresql/ext/pgvectorscale/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvectorscale/package.nix
@@ -7,13 +7,7 @@
   postgresqlTestExtension,
 }:
 
-let
-  buildPgrxExtension' = buildPgrxExtension.override {
-    # Upstream only works with a fixed minor version of cargo-pgrx for each release.
-    cargo-pgrx = cargo-pgrx_0_12_6;
-  };
-in
-buildPgrxExtension' (finalAttrs: {
+buildPgrxExtension (finalAttrs: {
   pname = "pgvectorscale";
   version = "0.7.0";
 
@@ -38,6 +32,7 @@ buildPgrxExtension' (finalAttrs: {
   ];
 
   inherit postgresql;
+  cargo-pgrx = cargo-pgrx_0_12_6;
 
   passthru.tests.extension = postgresqlTestExtension {
     inherit (finalAttrs) finalPackage;

--- a/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
@@ -7,14 +7,9 @@
   postgresql,
   util-linux,
 }:
-let
-  buildPgrxExtension' = buildPgrxExtension.override {
-    # Upstream only works with a fixed minor version of cargo-pgrx for each release.
-    cargo-pgrx = cargo-pgrx_0_12_6;
-  };
-in
-buildPgrxExtension' (finalAttrs: {
+buildPgrxExtension (finalAttrs: {
   inherit postgresql;
+  cargo-pgrx = cargo-pgrx_0_12_6;
 
   pname = "pgx_ulid";
   version = "0.2.0";

--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -7,8 +7,9 @@
   postgresql,
 }:
 
-(buildPgrxExtension.override { cargo-pgrx = cargo-pgrx_0_12_6; }) (finalAttrs: {
+buildPgrxExtension (finalAttrs: {
   inherit postgresql;
+  cargo-pgrx = cargo-pgrx_0_12_6;
 
   pname = "timescaledb_toolkit";
   version = "1.21.0";

--- a/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
@@ -12,12 +12,6 @@
   stdenv,
 }:
 let
-  buildPgrxExtension' = buildPgrxExtension.override {
-    # Upstream only works with a fixed version of cargo-pgrx for each release,
-    # so we're pinning it here to avoid future incompatibility.
-    cargo-pgrx = cargo-pgrx_0_14_1;
-  };
-
   # Follow upstream and use rust-jemalloc-sys on linux aarch64 and x86_64
   # Additionally, disable init exec TLS, since it causes issues with postgres.
   # https://github.com/tensorchord/VectorChord/blob/0.4.2/Cargo.toml#L43-L44
@@ -29,8 +23,9 @@ let
     })
   );
 in
-buildPgrxExtension' (finalAttrs: {
+buildPgrxExtension (finalAttrs: {
   inherit postgresql;
+  cargo-pgrx = cargo-pgrx_0_14_1;
 
   pname = "vectorchord";
   version = "0.4.2";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5984,8 +5984,8 @@ with pkgs;
     cargo-pgrx_0_12_5
     cargo-pgrx_0_12_6
     cargo-pgrx_0_14_1
+    cargo-pgrx
     ;
-  cargo-pgrx = cargo-pgrx_0_14_1;
 
   buildPgrxExtension = callPackage ../development/tools/rust/cargo-pgrx/buildPgrxExtension.nix { };
   opensmalltalk-vm = callPackage ../development/compilers/opensmalltalk-vm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5981,7 +5981,6 @@ with pkgs;
 
   inherit (callPackages ../development/tools/rust/cargo-pgrx { })
     cargo-pgrx_0_12_0_alpha_1
-    cargo-pgrx_0_12_5
     cargo-pgrx_0_12_6
     cargo-pgrx_0_14_1
     cargo-pgrx


### PR DESCRIPTION
As discussed in https://github.com/NixOS/nixpkgs/pull/392710#discussion_r2161407976 and https://github.com/NixOS/nixpkgs/pull/407527#issuecomment-3038590257.

Fixes #407527 as well.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
