### PR TITLE
seppo: 0-unstable-2025-06-03 -> 0-unstable-2025-07-06 & add updateScript and NGI team

### DIFF
--- a/pkgs/by-name/se/seppo/package.nix
+++ b/pkgs/by-name/se/seppo/package.nix
@@ -4,6 +4,7 @@
   ocaml-crunch,
   seppo,
   lib,
+  nix-update-script,
 }:
 
 let
@@ -58,6 +59,10 @@ ocamlPackages.buildDunePackage {
     x509
     xmlm
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     homepage = "https://seppo.mro.name";

--- a/pkgs/by-name/se/seppo/package.nix
+++ b/pkgs/by-name/se/seppo/package.nix
@@ -13,14 +13,14 @@ in
 
 ocamlPackages.buildDunePackage {
   pname = "seppo";
-  version = "0-unstable-2025-06-03";
+  version = "0-unstable-2025-07-06";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "seppo";
     repo = "seppo";
-    rev = "33ae3e9f61d596fb91d3ab1a91fc26ae80981a93";
-    hash = "sha256-tOIIfYBLcZqQzoPxAVkE8RGX0sugUmDGpxIhIZ5Wy+w=";
+    rev = "500f712be07076f70341f423e883ade576ee708c";
+    hash = "sha256-wq2QPIJ3+/udzY8TvkSyMwqTL0RnKk0nKkQ/3sd/FKQ=";
   };
 
   # Provide git sha to avoid git dependency

--- a/pkgs/by-name/se/seppo/package.nix
+++ b/pkgs/by-name/se/seppo/package.nix
@@ -69,6 +69,7 @@ ocamlPackages.buildDunePackage {
     description = "Personal Social Web";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ infinidoge ];
+    teams = with lib.teams; [ ngi ];
     mainProgram = "seppo";
   };
 }


### PR DESCRIPTION
Related-to:
- https://github.com/ngi-nix/ngipkgs/issues/1047

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
