### PR TITLE
woomer: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/by-name/wo/woomer/package.nix
+++ b/pkgs/by-name/wo/woomer/package.nix
@@ -8,21 +8,22 @@
   pkg-config,
   rustPlatform,
   wayland,
+  libgbm,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "woomer";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "coffeeispower";
     repo = "woomer";
     tag = version;
-    hash = "sha256-puALhN54ma2KToXUF8ipaYysyayjaSp+ISZ3AgQvniw=";
+    hash = "sha256-LcL43Wq+5d7HPsm2bEK0vZsjP/dixtNhMKywXMi4ODw=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-VQee/2adBvJpJDihWuo22JNyDKLkZ9PrVqWPB/gJ9Sw=";
+  cargoHash = "sha256-xll/A0synEsXy9kPThA3bR8LRuAOQH0T6CAfIEoYJ0w=";
 
   strictDeps = true;
 
@@ -35,6 +36,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     glfw3
     wayland
+    libgbm
   ];
 
   # `raylib-sys` wants to compile examples that don't exist in its crate


### PR DESCRIPTION
- bumped version to [0.2.0](https://github.com/coffeeispower/woomer/releases/tag/0.2.0)
- added libgbm to `buildInputs` since its now needed for successful building

> [!NOTE]
> since this is a linux only package, sandboxing and darwin was not tested.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- For non-Linux: Is sandboxing enabled in nix.conf? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] ~~sandbox = relaxed~~
  - [ ] ~~sandbox = true~~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

(this is my first PR - sorry if i missed something)
