### PR TITLE
gogh: init at 361

### DIFF
--- a/pkgs/by-name/go/gogh/package.nix
+++ b/pkgs/by-name/go/gogh/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  ncurses,
+  bashNonInteractive,
+  python3,
+  rustpython,
+  nix-update-script,
+}:
+
+let
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      ruamel-yaml
+      unidecode
+      pyyaml
+      tomli
+      tomli-w
+      configobj
+    ]
+  );
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gogh";
+  version = "361";
+
+  src = fetchFromGitHub {
+    owner = "Gogh-Co";
+    repo = "Gogh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kzJiI1w8CYVYMcHo8mMqLseyFsU/PekjMkkk0gG+RH4=";
+  };
+
+  postPatch = ''
+    # Remove the `SCRIPT_PATH` variable definition from `gogh.sh`,
+    # see `makeWrapperArgs`: `--set SCRIPT_PATH "$out/lib"` in `postInstall`
+    sed -i '/^SCRIPT_PATH=/d' gogh.sh
+
+    patchShebangs .
+
+    substituteInPlace {gogh.sh,installs/*.sh} \
+      --replace-fail 'bash ' '${lib.getExe bashNonInteractive} '
+
+    substituteInPlace apply-colors.sh \
+      --replace-fail 'python3' '${lib.getExe' rustpython "rustpython"}'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir --parents $out/lib
+    cp --recursive {*.py,apply-colors.sh,installs,themes} $out/lib
+    install -Dm755 gogh.sh $out/bin/${finalAttrs.meta.mainProgram}
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/${finalAttrs.meta.mainProgram} \
+      --set SCRIPT_PATH "$out/lib" \
+      --prefix PATH : "${lib.getBin bashNonInteractive}/bin" \
+      --prefix PATH : "${lib.getBin rustpython}/bin" \
+      --prefix PATH : "${lib.getBin ncurses}/bin" \
+      --prefix PATH : "${pythonEnv}/bin" \
+      --prefix PYTHONPATH : "${pythonEnv}/${pythonEnv.sitePackages}"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Collection of color schemes for terminal emulators";
+    longDescription = ''
+      Gogh is a collection of color schemes for various terminal
+      emulators, including Gnome Terminal, Pantheon Terminal, Tilix
+      and XFCE4 Terminal. These schemes are designed to make your
+      terminal more visually appealing and improve your productivity
+      by providing a better contrast and color differentiation. (This
+      fork of Gogh includes a color scheme named "Vaombe".)
+
+      The inspiration for Gogh came from the clean and minimalistic
+      design of Elementary OS, but the project has since grown to
+      include a variety of unique and beautiful options. Not only does
+      Gogh work on Linux systems, but it's also compatible with iTerm
+      on macOS, providing a consistent and visually appealing
+      experience across platforms.
+    '';
+    homepage = "https://github.com/Gogh-Co/Gogh";
+    changelog = "https://github.com/Gogh-Co/Gogh/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "gogh";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Gogh is a collection of color schemes for various terminal
emulators, including Gnome Terminal, Pantheon Terminal, Tilix
and XFCE4 Terminal. These schemes are designed to make your
terminal more visually appealing and improve your productivity
by providing a better contrast and color differentiation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
