### PR TITLE
gettext: backport upstream memory safety fix

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     # fix reproducibile output, in particular in the grub2 build
     # https://savannah.gnu.org/bugs/index.php?59658
     ./0001-msginit-Do-not-use-POT-Creation-Date.patch
+    ./memory-safety.patch
   ];
 
   outputs = [

--- a/pkgs/development/libraries/gettext/memory-safety.patch
+++ b/pkgs/development/libraries/gettext/memory-safety.patch
@@ -1,0 +1,44 @@
+From: Bruno Haible <bruno@clisp.org>
+Date: Mon, 7 Jul 2025 07:02:41 +0000 (+0200)
+Subject: xgettext: Perl: Fix bug with comment lines longer than 1024 (regr. 2024-09-26).
+X-Git-Url: https://gitweb.git.savannah.gnu.org/gitweb/?p=gettext.git;a=commitdiff_plain;h=f98de965a08d1883a46ba5411922b54cc5125f14
+
+xgettext: Perl: Fix bug with comment lines longer than 1024 (regr. 2024-09-26).
+
+Reported by Alyssa Ross <hi@alyssa.is> in
+<https://lists.gnu.org/archive/html/bug-gettext/2025-07/msg00009.html>.
+
+* gettext-tools/src/x-perl.c (phase2_getc): Move the sb_free call until after
+the savable_comment_add call.
+---
+
+diff --git a/gettext-tools/src/x-perl.c b/gettext-tools/src/x-perl.c
+index d3aa50476..312fef371 100644
+--- a/gettext-tools/src/x-perl.c
++++ b/gettext-tools/src/x-perl.c
+@@ -558,7 +558,6 @@ phase2_getc (struct perl_extractor *xp)
+ {
+   int lineno;
+   int c;
+-  char *utf8_string;
+ 
+   c = phase1_getc (xp);
+   if (c == '#')
+@@ -587,12 +586,13 @@ phase2_getc (struct perl_extractor *xp)
+           sb_xappend1 (&buffer, c);
+         }
+       /* Convert it to UTF-8.  */
+-      utf8_string =
+-        from_current_source_encoding (sb_xcontents_c (&buffer), lc_comment,
++      const char *contents = sb_xcontents_c (&buffer);
++      char *utf8_contents =
++        from_current_source_encoding (contents, lc_comment,
+                                       logical_file_name, lineno);
+-      sb_free (&buffer);
+       /* Save it until we encounter the corresponding string.  */
+-      savable_comment_add (utf8_string);
++      savable_comment_add (utf8_contents);
++      sb_free (&buffer);
+       xp->last_comment_line = lineno;
+     }
+   return c;


### PR DESCRIPTION
This fixes building perlPackages.Po4a on musl.  While we haven't seen it with Glibc, I have no reason to believe the bug is musl-specific.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
