### PR TITLE
opencommit: 3.2.7 -> 3.2.9

### DIFF
--- a/pkgs/by-name/op/opencommit/package.nix
+++ b/pkgs/by-name/op/opencommit/package.nix
@@ -3,20 +3,26 @@
   buildNpmPackage,
   fetchFromGitHub,
   nix-update-script,
+  npm-lockfile-fix,
 }:
 
 buildNpmPackage rec {
   pname = "opencommit";
-  version = "3.2.7";
+  version = "3.2.9";
 
   src = fetchFromGitHub {
     owner = "di-sukharev";
     repo = "opencommit";
     rev = "v${version}";
-    hash = "sha256-vmVOrNwUsgB3iBvO8QhpJfI2OO0Kb9ZthcAXVaQ2cBM=";
+    hash = "sha256-nn+Whjs3qLXhydrELXzogr66H6btY/TPbmWT/MH6w+M=";
+    postFetch = ''
+      cd $out
+      # Fix lockfile issues with bundled dependencies
+      ${lib.getExe npm-lockfile-fix} package-lock.json
+    '';
   };
 
-  npmDepsHash = "sha256-F19xbiZoIC2JA+3rLqJBbFZvs2XbAk94F2borp/7gMo=";
+  npmDepsHash = "sha256-1lUMtQFGlM1Z2oQ4nktsePyce/EwAu75BbkBiqBrdnQ=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Updates opencommit from 3.2.7 to 3.2.9

This is a minor version update for the opencommit package, an AI-powered commit message generator. The update includes refreshed source and npm dependency hashes to ensure package integrity.
https://github.com/di-sukharev/opencommit/commits/v3.2.9/

## Things done

- [x] Built on platform(s)
  - [] x86_64-linux
  - [ ] aarch64-linux  
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [ ] and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - [ ] made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

CC: @matteo-pacini