### PR TITLE
postgresql18Packages: mark as broken without available source

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -6,31 +6,34 @@
 }:
 
 let
+  sources = {
+    "17" = {
+      version = "1.7.0";
+      hash = "sha256-MNQMePDmGxC8OFIJuVJrhfgU566vkng00+tjeGpGKvs=";
+    };
+    "16" = {
+      version = "1.6.0";
+      hash = "sha256-lg7N0QblluTgtNo1tGZjirNJSyQXtcAEs9Jqd3zx0Sg=";
+    };
+    "15" = {
+      version = "1.5.1";
+      hash = "sha256-o8Hepf/Mc1ClRTLZ6PBdqU4jSdlz+ijVgl2vJKmIc6M=";
+    };
+    "14" = {
+      version = "1.4.2";
+      hash = "sha256-nGyKcNY57RdQdZKSaBPk2/YbT0Annz1ZevH0lKswdhA=";
+    };
+    "13" = {
+      version = "1.3.9";
+      hash = "sha256-KGcHDwk8CgNHPZARfLBfS8r7TRCP9LPjT+m4fNSnnW0=";
+    };
+  };
+
   source =
-    {
-      "17" = {
-        version = "1.7.0";
-        hash = "sha256-MNQMePDmGxC8OFIJuVJrhfgU566vkng00+tjeGpGKvs=";
-      };
-      "16" = {
-        version = "1.6.0";
-        hash = "sha256-lg7N0QblluTgtNo1tGZjirNJSyQXtcAEs9Jqd3zx0Sg=";
-      };
-      "15" = {
-        version = "1.5.1";
-        hash = "sha256-o8Hepf/Mc1ClRTLZ6PBdqU4jSdlz+ijVgl2vJKmIc6M=";
-      };
-      "14" = {
-        version = "1.4.2";
-        hash = "sha256-nGyKcNY57RdQdZKSaBPk2/YbT0Annz1ZevH0lKswdhA=";
-      };
-      "13" = {
-        version = "1.3.9";
-        hash = "sha256-KGcHDwk8CgNHPZARfLBfS8r7TRCP9LPjT+m4fNSnnW0=";
-      };
-    }
-    .${lib.versions.major postgresql.version}
-    or (throw "Source for pg_hint_plan is not available for ${postgresql.version}");
+    sources.${lib.versions.major postgresql.version} or {
+      version = "";
+      hash = throw "Source for pg_hint_plan is not available for ${postgresql.version}";
+    };
 in
 postgresqlBuildExtension {
   pname = "pg_hint_plan";
@@ -53,6 +56,7 @@ postgresqlBuildExtension {
   enableUpdateScript = false;
 
   meta = {
+    broken = !builtins.elem (lib.versions.major postgresql.version) (builtins.attrNames sources);
     description = "Extension to tweak PostgreSQL execution plans using so-called 'hints' in SQL comments";
     homepage = "https://github.com/ossc-db/pg_hint_plan";
     maintainers = with lib.maintainers; [ _1000101 ];

--- a/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hint_plan.nix
@@ -7,6 +7,7 @@
 
 let
   sources = {
+    # For v18, see https://github.com/ossc-db/pg_hint_plan/issues/224
     "17" = {
       version = "1.7.0";
       hash = "sha256-MNQMePDmGxC8OFIJuVJrhfgU566vkng00+tjeGpGKvs=";

--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -27,6 +27,10 @@ let
       version = "1.5";
       hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
     };
+    "18" = {
+      version = "1.5";
+      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
+    };
   };
 
   source =

--- a/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_safeupdate.nix
@@ -5,46 +5,53 @@
   postgresqlBuildExtension,
 }:
 
-with {
-  "13" = {
-    version = "1.4";
-    hash = "sha256-1cyvVEC9MQGMr7Tg6EUbsVBrMc8ahdFS3+CmDkmAq4Y=";
+let
+  sources = {
+    "13" = {
+      version = "1.4";
+      hash = "sha256-1cyvVEC9MQGMr7Tg6EUbsVBrMc8ahdFS3+CmDkmAq4Y=";
+    };
+    "14" = {
+      version = "1.5";
+      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
+    };
+    "15" = {
+      version = "1.5";
+      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
+    };
+    "16" = {
+      version = "1.5";
+      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
+    };
+    "17" = {
+      version = "1.5";
+      hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
+    };
   };
-  "14" = {
-    version = "1.5";
-    hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
-  };
-  "15" = {
-    version = "1.5";
-    hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
-  };
-  "16" = {
-    version = "1.5";
-    hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
-  };
-  "17" = {
-    version = "1.5";
-    hash = "sha256-RRSpkWLFuif+6RCncnsb1NnjKnIIRY9KgebKkjCN5cs=";
-  };
-}
-."${lib.versions.major postgresql.version}"
-  or (throw "pg_safeupdate: version specification for pg ${postgresql.version} missing.");
 
-postgresqlBuildExtension rec {
+  source =
+    sources."${lib.versions.major postgresql.version}" or {
+      version = "";
+      hash = throw "pg_safeupdate: version specification for pg ${postgresql.version} missing.";
+    };
+in
+
+postgresqlBuildExtension {
   pname = "pg-safeupdate";
-  inherit version;
+  inherit (source) version;
 
   src = fetchFromGitHub {
     owner = "eradman";
     repo = "pg-safeupdate";
-    tag = version;
-    inherit hash;
+    tag = source.version;
+    inherit (source) hash;
   };
 
   meta = {
+    broken = !builtins.elem (lib.versions.major postgresql.version) (builtins.attrNames sources);
     description = "Simple extension to PostgreSQL that requires criteria for UPDATE and DELETE";
     homepage = "https://github.com/eradman/pg-safeupdate";
-    changelog = "https://github.com/eradman/pg-safeupdate/raw/${src.rev}/NEWS";
+    changelog = "https://github.com/eradman/pg-safeupdate/raw/${source.version}/NEWS";
     platforms = postgresql.meta.platforms;
     maintainers = with lib.maintainers; [ wolfgangwalther ];
     license = lib.licenses.postgresql;

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -8,31 +8,34 @@
 }:
 
 let
+  sources = {
+    "17" = {
+      version = "17.0";
+      hash = "sha256-3ksq09wiudQPuBQI3dhEQi8IkXKLVIsPFgBnwLiicro=";
+    };
+    "16" = {
+      version = "16.0";
+      hash = "sha256-8+tGOl1U5y9Zgu+9O5UDDE4bec4B0JC/BQ6GLhHzQzc=";
+    };
+    "15" = {
+      version = "1.7.0";
+      hash = "sha256-8pShPr4HJaJQPjW1iPJIpj3CutTx8Tgr+rOqoXtgCcw=";
+    };
+    "14" = {
+      version = "1.6.2";
+      hash = "sha256-Bl7Jk2B0deZUDiI391vk4nilwuVGHd1wuaQRSCoA3Mk=";
+    };
+    "13" = {
+      version = "1.5.2";
+      hash = "sha256-fyf2Ym0fAAXjc28iFCGDEftPAyDLXmEgi/0DaTJJiIg=";
+    };
+  };
+
   source =
-    {
-      "17" = {
-        version = "17.0";
-        hash = "sha256-3ksq09wiudQPuBQI3dhEQi8IkXKLVIsPFgBnwLiicro=";
-      };
-      "16" = {
-        version = "16.0";
-        hash = "sha256-8+tGOl1U5y9Zgu+9O5UDDE4bec4B0JC/BQ6GLhHzQzc=";
-      };
-      "15" = {
-        version = "1.7.0";
-        hash = "sha256-8pShPr4HJaJQPjW1iPJIpj3CutTx8Tgr+rOqoXtgCcw=";
-      };
-      "14" = {
-        version = "1.6.2";
-        hash = "sha256-Bl7Jk2B0deZUDiI391vk4nilwuVGHd1wuaQRSCoA3Mk=";
-      };
-      "13" = {
-        version = "1.5.2";
-        hash = "sha256-fyf2Ym0fAAXjc28iFCGDEftPAyDLXmEgi/0DaTJJiIg=";
-      };
-    }
-    .${lib.versions.major postgresql.version}
-    or (throw "Source for pgaudit is not available for ${postgresql.version}");
+    sources.${lib.versions.major postgresql.version} or {
+      version = "";
+      hash = throw "Source for pgaudit is not available for ${postgresql.version}";
+    };
 in
 postgresqlBuildExtension {
   pname = "pgaudit";
@@ -42,7 +45,7 @@ postgresqlBuildExtension {
     owner = "pgaudit";
     repo = "pgaudit";
     tag = source.version;
-    hash = source.hash;
+    inherit (source) hash;
   };
 
   buildInputs = [
@@ -55,6 +58,7 @@ postgresqlBuildExtension {
   enableUpdateScript = false;
 
   meta = {
+    broken = !builtins.elem (lib.versions.major postgresql.version) (builtins.attrNames sources);
     description = "Open Source PostgreSQL Audit Logging";
     homepage = "https://github.com/pgaudit/pgaudit";
     changelog = "https://github.com/pgaudit/pgaudit/releases/tag/${source.version}";

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -23,8 +23,8 @@ let
       hash = "sha256-emwoTowT7WKFX0RQDqJXjIblrzqaUIUkzqSqBCHVKQ8=";
     };
     "14" = {
-      version = "1.6.2";
-      hash = "sha256-Bl7Jk2B0deZUDiI391vk4nilwuVGHd1wuaQRSCoA3Mk=";
+      version = "1.6.3";
+      hash = "sha256-KgLidJHjUK9BTp6ffmGUj1chcwIe6IzlcadRpGCfNdM=";
     };
     "13" = {
       version = "1.5.2";

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -19,8 +19,8 @@ let
       hash = "sha256-fzoAcXEKmA+xD4HtcHZgcduh1XmSgL8ZS4R72og7RGQ=";
     };
     "15" = {
-      version = "1.7.0";
-      hash = "sha256-8pShPr4HJaJQPjW1iPJIpj3CutTx8Tgr+rOqoXtgCcw=";
+      version = "1.7.1";
+      hash = "sha256-emwoTowT7WKFX0RQDqJXjIblrzqaUIUkzqSqBCHVKQ8=";
     };
     "14" = {
       version = "1.6.2";

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -15,8 +15,8 @@ let
       hash = "sha256-9St/ESPiFq2NiPKqbwHLwkIyATKUkOGxFcUrWgT+Iqo=";
     };
     "16" = {
-      version = "16.0";
-      hash = "sha256-8+tGOl1U5y9Zgu+9O5UDDE4bec4B0JC/BQ6GLhHzQzc=";
+      version = "16.1";
+      hash = "sha256-fzoAcXEKmA+xD4HtcHZgcduh1XmSgL8ZS4R72og7RGQ=";
     };
     "15" = {
       version = "1.7.0";

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -27,8 +27,8 @@ let
       hash = "sha256-KgLidJHjUK9BTp6ffmGUj1chcwIe6IzlcadRpGCfNdM=";
     };
     "13" = {
-      version = "1.5.2";
-      hash = "sha256-fyf2Ym0fAAXjc28iFCGDEftPAyDLXmEgi/0DaTJJiIg=";
+      version = "1.5.3";
+      hash = "sha256-IU4Clec3DkKWT7+kw0VtQNybt94i7M2rSSgJG/XdcRs=";
     };
   };
 

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -9,6 +9,7 @@
 
 let
   sources = {
+    # v18: No upstream ticket, yet (2025-07-07)
     "17" = {
       version = "17.0";
       hash = "sha256-3ksq09wiudQPuBQI3dhEQi8IkXKLVIsPFgBnwLiicro=";

--- a/pkgs/servers/sql/postgresql/ext/pgaudit.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgaudit.nix
@@ -11,8 +11,8 @@ let
   sources = {
     # v18: No upstream ticket, yet (2025-07-07)
     "17" = {
-      version = "17.0";
-      hash = "sha256-3ksq09wiudQPuBQI3dhEQi8IkXKLVIsPFgBnwLiicro=";
+      version = "17.1";
+      hash = "sha256-9St/ESPiFq2NiPKqbwHLwkIyATKUkOGxFcUrWgT+Iqo=";
     };
     "16" = {
       version = "16.0";


### PR DESCRIPTION
Should fix https://github.com/NixOS/nixpkgs/pull/411958#issuecomment-3044332093

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
