### PR TITLE
[Backport release-25.05] librecast: 0.10.0 -> 0.11.2; clean up & add updateScript and NGI team

### DIFF
--- a/pkgs/by-name/li/librecast/package.nix
+++ b/pkgs/by-name/li/librecast/package.nix
@@ -7,14 +7,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "librecast";
-  version = "0.10.0";
+  version = "0.11.2";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "librecast";
     repo = "librecast";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-uM7S7EBoLd49+JFZjX/Pq8WbTPN25alLY5slCeqHBxI=";
+    hash = "sha256-FFumVHTobvcty3x26IAMHP8M3fYrnfLtxt/RJ/4vKBg=";
   };
   buildInputs = [
     lcrq

--- a/pkgs/by-name/li/librecast/package.nix
+++ b/pkgs/by-name/li/librecast/package.nix
@@ -29,9 +29,9 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://codeberg.org/librecast/librecast/src/tag/v${finalAttrs.version}/CHANGELOG.md";
     description = "IPv6 multicast library";
     homepage = "https://librecast.net/librecast.html";
-    license = [
-      lib.licenses.gpl2
-      lib.licenses.gpl3
+    license = with lib.licenses; [
+      gpl2Only
+      gpl3Only
     ];
     maintainers = with lib.maintainers; [
       albertchae

--- a/pkgs/by-name/li/librecast/package.nix
+++ b/pkgs/by-name/li/librecast/package.nix
@@ -4,6 +4,7 @@
   lcrq,
   lib,
   libsodium,
+  nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "librecast";
@@ -21,6 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
     libsodium
   ];
   installFlags = [ "PREFIX=$(out)" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://codeberg.org/librecast/librecast/src/tag/v${finalAttrs.version}/CHANGELOG.md";

--- a/pkgs/by-name/li/librecast/package.nix
+++ b/pkgs/by-name/li/librecast/package.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       jasonodoom
       jleightcap
     ];
+    teams = with lib.teams; [ ngi ];
     platforms = lib.platforms.gnu;
   };
 })

--- a/pkgs/by-name/li/librecast/package.nix
+++ b/pkgs/by-name/li/librecast/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "codeberg.org";
     owner = "librecast";
     repo = "librecast";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-FFumVHTobvcty3x26IAMHP8M3fYrnfLtxt/RJ/4vKBg=";
   };
   buildInputs = [


### PR DESCRIPTION
Manual backport of #418570 #423145 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.