### PR TITLE
python3Packages.filecheck: 0.0.24 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/filecheck/default.nix
+++ b/pkgs/development/python-modules/filecheck/default.nix
@@ -2,33 +2,33 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  hatchling,
+  poetry-core,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "filecheck";
-  version = "0.0.24";
-  format = "pyproject";
+  version = "1.0.2";
+  pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "mull-project";
-    repo = "FileCheck.py";
+    owner = "AntonLydike";
+    repo = "filecheck";
     tag = "v${version}";
-    hash = "sha256-VbMlCqGd3MVpj0jEKjSGC2L0s/3e/d53b+2eZcXZneo=";
+    hash = "sha256-73HQ8dGp52+SyuwacthCjSQsA5v3LU49sabI066wuwU=";
   };
 
-  nativeBuildInputs = [ hatchling ];
+  build-system = [ poetry-core ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "filecheck" ];
 
   meta = with lib; {
-    changelog = "https://github.com/mull-project/FileCheck.py/releases/tag/v${version}";
-    homepage = "https://github.com/mull-project/FileCheck.py";
+    changelog = "https://github.com/antonlydike/filecheck/releases/tag/v${version}";
+    homepage = "https://github.com/antonlydike/filecheck";
     license = licenses.asl20;
-    description = "Python port of LLVM's FileCheck, flexible pattern matching file verifier";
+    description = "Python-native clone of LLVMs FileCheck tool";
     mainProgram = "filecheck";
     maintainers = with maintainers; [ yorickvp ];
   };


### PR DESCRIPTION
Update the version of the `filecheck` python package. This package has seen a change in maintainers and project location, as documented [here](https://github.com/mull-project/FileCheck.py?tab=readme-ov-file#2024-07-10-status-update---project-discontinued) in the old project.

I don't have a ton of experience with packaging for nix, so this is a first attempt and will probably need some revisions. Happy to implement needed changes.

Continuation of #391568 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
