### PR TITLE
bats: fix build with procps without systemd

### DIFF
--- a/pkgs/by-name/ba/bats/package.nix
+++ b/pkgs/by-name/ba/bats/package.nix
@@ -123,6 +123,8 @@ resholve.mkDerivation rec {
           "cannot:libexec/bats-core/bats-exec-file"
           "cannot:libexec/bats-core/bats-exec-suite"
           "cannot:libexec/bats-core/bats-gather-tests"
+
+          "cannot:${procps}/bin/ps"
         ]
         ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
           # checked invocations for exec


### PR DESCRIPTION
bats does not build in case a procps without systemd support is used. Please backport to 25.05 as well, thank you!

```
nixpkgs = legacyPackages.x86_64-linux;
legacyPackages.x86_64-linux.bats.override(rec {
  parallel = nixpkgs.parallel.override({ procps = nixpkgs.procps.override({ withSystemd = false; }); });
  procps = nixpkgs.procps.override({ withSystemd = false; });
});
```

```
[resholve context] /nix/store/kxivaxnr6rwyidxi56gwijd56wdlyqh6-resholve-0.10.5/bin/resholve --overwrite bin/bats libexec/bats-core/bats libexec/bats-core/bats-exec-file libexec/bats-core/bats-exec-suite libexec/bats-core/bats-exec-test libexec/bats-core/bats-format-cat libexec/bats-core/bats-format-junit libexec/bats-core/bats-format-pretty libexec/bats-core/bats-format-tap libexec/bats-core/bats-format-tap13 libexec/bats-core/bats-gather-tests libexec/bats-core/bats-preprocess lib/bats-core/common.bash lib/bats-core/formatter.bash lib/bats-core/preprocessing.bash lib/bats-core/semaphore.bash lib/bats-core/test_functions.bash lib/bats-core/tracing.bash lib/bats-core/validator.bash lib/bats-core/warnings.bash
    } < <(ps -ef "$parent_pid")
          ^~
/nix/store/vdr0cwqd6bz4h2wd7735nsv60n7a0pc3-bats-1.11.1/libexec/bats-core/bats-exec-test:241: 'ps' _might_ be able to execute its arguments, and I don't have any command-specific rules for figuring out if this specific invocation does or not.
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
