### PR TITLE
victorialogs: 1.24.0 -> 1.25.0

### DIFF
--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.24.0";
+  version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
-    repo = "VictoriaMetrics";
-    tag = "v${finalAttrs.version}-victorialogs";
-    hash = "sha256-E52hvxazzbz9FcPFZFcRHs2vVg6fJJQ8HsieQovQSi4=";
+    repo = "VictoriaLogs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KhXB+37uK08dDYXtnaPDS7gP/gBGZ0gqyR0u572QOx8=";
   };
 
   vendorHash = null;
@@ -28,30 +28,11 @@ buildGoModule (finalAttrs: {
     "app/vlogscli"
   ];
 
-  postPatch = ''
-    # main module (github.com/VictoriaMetrics/VictoriaMetrics) does not contain package
-    # github.com/VictoriaMetrics/VictoriaMetrics/app/vmui/packages/vmui/web
-    #
-    # This appears to be some kind of test server for development purposes only.
-    # rm -f app/vmui/packages/vmui/web/{go.mod,main.go}
-
-    # Increase timeouts in tests to prevent failure on heavily loaded builders
-    substituteInPlace lib/storage/storage_test.go \
-      --replace-fail "time.After(10 " "time.After(120 " \
-      --replace-fail "time.NewTimer(30 " "time.NewTimer(120 " \
-      --replace-fail "time.NewTimer(time.Second * 10)" "time.NewTimer(time.Second * 120)" \
-  '';
-
   ldflags = [
     "-s"
     "-w"
     "-X github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo.Version=${finalAttrs.version}"
   ];
-
-  preCheck = ''
-    # `lib/querytracer/tracer_test.go` expects `buildinfo.Version` to be unset
-    export ldflags=''${ldflags//=${finalAttrs.version}/=}
-  '';
 
   __darwinAllowLocalNetworking = true;
 
@@ -61,9 +42,7 @@ buildGoModule (finalAttrs: {
         victorialogs
         ;
     };
-    updateScript = nix-update-script {
-      extraArgs = [ "--version-regex=(.*)-victorialogs" ];
-    };
+    updateScript = nix-update-script { };
   };
 
   meta = {
@@ -71,7 +50,7 @@ buildGoModule (finalAttrs: {
     description = "User friendly log database from VictoriaMetrics";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ marie ];
-    changelog = "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "victoria-logs";
   };
 })


### PR DESCRIPTION
also migrate to new repository they have created 

see release notes

https://github.com/VictoriaMetrics/VictoriaLogs/releases/tag/v1.25.0

i combined update  and repo switch in one commit, as the new repo does not contain old(er) releases, and the old one no newer, thus a inbetween commit would render in a not buildable commit for vlogs. 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
