### PR TITLE
treewide: builtins.fromJSON (builtins.readFile X) -> lib.importJSON

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -75,7 +75,7 @@ let
   # Attrs
   # - keys: "added", "changed" and "removed"
   # - values: lists of `packagePlatformPath`s
-  diffAttrs = builtins.fromJSON (builtins.readFile "${combinedDir}/combined-diff.json");
+  diffAttrs = lib.importJSON "${combinedDir}/combined-diff.json";
 
   rebuilds = diffAttrs.added ++ diffAttrs.changed;
   rebuildsPackagePlatformAttrs = convertToPackagePlatformAttrs rebuilds;

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -14,7 +14,7 @@ let
     overlays = [ ];
   };
 
-  changedpaths = builtins.fromJSON (builtins.readFile changedpathsjson);
+  changedpaths = lib.importJSON changedpathsjson;
 
   anyMatchingFile =
     filename: builtins.any (changed: lib.strings.hasSuffix changed filename) changedpaths;

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -39,7 +39,7 @@ let
       );
     };
 
-  supportedSystems = builtins.fromJSON (builtins.readFile ../supportedSystems.json);
+  supportedSystems = lib.importJSON ../supportedSystems.json;
 
   attrpathsSuperset =
     {

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -21,14 +21,12 @@
   formats commits for you.
 */
 
-let
-  # Read ./recipes-archive-melpa.json in an outer let to make sure we only do this once.
-  defaultArchive = builtins.fromJSON (builtins.readFile ./recipes-archive-melpa.json);
-in
-
 { lib, pkgs }:
 variant: self:
 let
+  # Read ./recipes-archive-melpa.json in an outer let to make sure we only do this once.
+  defaultArchive = lib.importJSON ./recipes-archive-melpa.json;
+
   inherit (import ./lib-override-helper.nix pkgs lib)
     addPackageRequires
     addPackageRequiresIfOlder

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -1,10 +1,3 @@
-let
-  # `ides.json` is handwritten and contains information that doesn't change across updates, like maintainers and other metadata
-  # `versions.json` contains everything generated/needed by the update script version numbers, build numbers and tarball hashes
-  ideInfo = builtins.fromJSON (builtins.readFile ./bin/ides.json);
-  versions = builtins.fromJSON (builtins.readFile ./bin/versions.json);
-in
-
 {
   lib,
   stdenv,
@@ -40,6 +33,11 @@ in
 }:
 
 let
+  # `ides.json` is handwritten and contains information that doesn't change across updates, like maintainers and other metadata
+  # `versions.json` contains everything generated/needed by the update script version numbers, build numbers and tarball hashes
+  ideInfo = lib.importJSON ./bin/ides.json;
+  versions = lib.importJSON ./bin/versions.json;
+
   inherit (stdenv.hostPlatform) system;
 
   products = versions.${system} or (throw "Unsupported system: ${system}");

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  pluginsJson = builtins.fromJSON (builtins.readFile ./plugins.json);
+  pluginsJson = lib.importJSON ./plugins.json;
   specialPluginsInfo = callPackage ./specialPlugins.nix { };
   fetchPluginSrc =
     url: hash:

--- a/pkgs/applications/editors/jetbrains/plugins/tests.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/tests.nix
@@ -56,7 +56,7 @@ in
   # as compatible, but the build version is somehow not in the "builds" map (as that would indicate that something with update_plugins.py went wrong).
   all =
     let
-      plugins-json = builtins.fromJSON (builtins.readFile ./plugins.json);
+      plugins-json = lib.importJSON ./plugins.json;
       plugins-for =
         with lib.asserts;
         ide:
@@ -86,7 +86,7 @@ in
   # Test always succeeds on IDEs that the tested plugins don't support.
   stored-correctly =
     let
-      plugins-json = builtins.fromJSON (builtins.readFile ./plugins.json);
+      plugins-json = lib.importJSON ./plugins.json;
       plugin-ids = [
         # This is a "normal plugin", it's output must be linked into /${pname}/plugins.
         "8607" # nixidea

--- a/pkgs/applications/editors/jetbrains/source/default.nix
+++ b/pkgs/applications/editors/jetbrains/source/default.nix
@@ -1,9 +1,10 @@
-let
-  ides = builtins.fromJSON (builtins.readFile ./ides.json);
-in
 {
   callPackage,
+  lib,
 }:
+let
+  ides = lib.importJSON ./ides.json;
+in
 builtins.mapAttrs (
   _: info: callPackage ./build.nix (info // { mvnDeps = ./. + "/${info.mvnDeps}"; })
 ) ides

--- a/pkgs/build-support/build-nim-package.nix
+++ b/pkgs/build-support/build-nim-package.nix
@@ -86,7 +86,7 @@ let
       postPkg = baseAttrs // (asFunc ((asFunc buildNimPackageArgs) finalAttrs)) baseAttrs;
 
       lockAttrs = lib.attrsets.optionalAttrs (builtins.hasAttr "lockFile" postPkg) (
-        builtins.fromJSON (builtins.readFile postPkg.lockFile)
+        lib.importJSON postPkg.lockFile
       );
 
       lockDepends = lockAttrs.depends or [ ];

--- a/pkgs/build-support/build-nim-sbom.nix
+++ b/pkgs/build-support/build-nim-sbom.nix
@@ -199,7 +199,7 @@ let
 in
 callerArg: sbomArg:
 let
-  sbom = if builtins.isAttrs sbomArg then sbomArg else builtins.fromJSON (builtins.readFile sbomArg);
+  sbom = if builtins.isAttrs sbomArg then sbomArg else lib.importJSON sbomArg;
   overrideSbom = f: stdenv.mkDerivation (compose callerArg (sbom // (f sbom)));
 in
 (stdenv.mkDerivation (compose callerArg sbom)) // { inherit overrideSbom; }

--- a/pkgs/by-name/_1/_1password-gui/package.nix
+++ b/pkgs/by-name/_1/_1password-gui/package.nix
@@ -13,7 +13,7 @@ let
 
   hostOs = stdenv.hostPlatform.parsed.kernel.name;
   hostArch = stdenv.hostPlatform.parsed.cpu.name;
-  sources = builtins.fromJSON (builtins.readFile ./sources.json);
+  sources = lib.importJSON ./sources.json;
 
   sourcesChan = sources.${channel} or (throw "unsupported channel ${channel}");
   sourcesChanOs = sourcesChan.${hostOs} or (throw "unsupported OS ${hostOs}");

--- a/pkgs/by-name/ap/apple-sdk/common/passthru-source-release-files.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/passthru-source-release-files.nix
@@ -1,7 +1,3 @@
-let
-  lockfile = builtins.fromJSON (builtins.readFile ../metadata/apple-oss-lockfile.json);
-in
-
 {
   lib,
   fetchFromGitHub,
@@ -10,6 +6,7 @@ in
 }:
 
 let
+  lockfile = lib.importJSON ../metadata/apple-oss-lockfile.json;
   sdkinfo = lockfile.${sdkVersion};
 in
 self: super: {

--- a/pkgs/by-name/ap/apple-sdk/common/remove-disallowed-packages.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/remove-disallowed-packages.nix
@@ -1,13 +1,12 @@
-let
-  disallowedPackages = builtins.fromJSON (builtins.readFile ../metadata/disallowed-packages.json);
-in
-
 {
   lib,
   jq,
   stdenv,
 }:
 
+let
+  disallowedPackages = lib.importJSON ../metadata/disallowed-packages.json;
+in
 self: super: {
   # Remove headers and stubs for packages that are available in nixpkgs.
   buildPhase =

--- a/pkgs/by-name/ap/apple-sdk/package.nix
+++ b/pkgs/by-name/ap/apple-sdk/package.nix
@@ -1,7 +1,3 @@
-let
-  sdkVersions = builtins.fromJSON (builtins.readFile ./metadata/versions.json);
-in
-
 {
   lib,
   stdenv,
@@ -22,6 +18,7 @@ in
 }:
 
 let
+  sdkVersions = lib.importJSON ./metadata/versions.json;
   sdkInfo =
     sdkVersions.${darwinSdkMajorVersion}
       or (lib.throw "Unsupported SDK major version: ${darwinSdkMajorVersion}");

--- a/pkgs/by-name/au/audiobookshelf/package.nix
+++ b/pkgs/by-name/au/audiobookshelf/package.nix
@@ -14,7 +14,7 @@
 }:
 
 let
-  source = builtins.fromJSON (builtins.readFile ./source.json);
+  source = lib.importJSON ./source.json;
   pname = "audiobookshelf";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/az/azure-cli/package.nix
+++ b/pkgs/by-name/az/azure-cli/package.nix
@@ -111,7 +111,7 @@ let
 
   extensions-generated = lib.mapAttrs (
     name: ext: mkAzExtension (ext // { passthru.updateScript = [ ]; })
-  ) (builtins.fromJSON (builtins.readFile ./extensions-generated.json));
+  ) (lib.importJSON ./extensions-generated.json);
   extensions-manual = callPackages ./extensions-manual.nix {
     inherit mkAzExtension;
     python3Packages = python3.pkgs;

--- a/pkgs/by-name/ba/balls/package.nix
+++ b/pkgs/by-name/ba/balls/package.nix
@@ -35,7 +35,7 @@ buildNimPackage (finalAttrs: {
 
   postFixup =
     let
-      lockAttrs = builtins.fromJSON (builtins.readFile finalAttrs.lockFile);
+      lockAttrs = lib.importJSON finalAttrs.lockFile;
       pathFlagOfFod = { path, srcDir, ... }: ''"--path:${path}/${srcDir}"'';
       pathFlags = map pathFlagOfFod lockAttrs.depends;
     in

--- a/pkgs/by-name/bu/buck2/package.nix
+++ b/pkgs/by-name/bu/buck2/package.nix
@@ -41,7 +41,7 @@ let
   # build hashes, which correspond to the hashes of the precompiled binaries
   # procued by GitHub Actions. this also includes the hash for a download of a
   # compatible buck2-prelude
-  buildHashes = builtins.fromJSON (builtins.readFile ./hashes.json);
+  buildHashes = lib.importJSON ./hashes.json;
 
   # our version of buck2; this should be a git tag
   version = "2025-05-06";

--- a/pkgs/by-name/dr/draupnir/package.nix
+++ b/pkgs/by-name/dr/draupnir/package.nix
@@ -17,7 +17,7 @@
 
 # docs: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/javascript.section.md#yarn2nix-javascript-yarn2nix
 let
-  hashesFile = builtins.fromJSON (builtins.readFile ./hashes.json);
+  hashesFile = lib.importJSON ./hashes.json;
   nodeSources = srcOnly nodejs;
 in
 mkYarnPackage rec {

--- a/pkgs/by-name/os/osquery/package.nix
+++ b/pkgs/by-name/os/osquery/package.nix
@@ -20,7 +20,7 @@
 
 let
 
-  info = builtins.fromJSON (builtins.readFile ./info.json);
+  info = lib.importJSON ./info.json;
 
   opensslSrc = fetchurl info.openssl;
 

--- a/pkgs/by-name/pu/purescm/package.nix
+++ b/pkgs/by-name/pu/purescm/package.nix
@@ -8,7 +8,7 @@
 let
   inherit (lib) fileset;
 
-  packageLock = builtins.fromJSON (builtins.readFile ./manifests/package-lock.json);
+  packageLock = lib.importJSON ./manifests/package-lock.json;
 
   pname = "purescm";
   version = packageLock.packages."node_modules/${pname}".version;

--- a/pkgs/by-name/st/standardnotes/package.nix
+++ b/pkgs/by-name/st/standardnotes/package.nix
@@ -15,7 +15,7 @@
 
 let
 
-  srcjson = builtins.fromJSON (builtins.readFile ./src.json);
+  srcjson = lib.importJSON ./src.json;
 
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 

--- a/pkgs/by-name/st/stubby/package.nix
+++ b/pkgs/by-name/st/stubby/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
       > $stubbyExampleJson
   '';
 
-  passthru.settingsExample = builtins.fromJSON (builtins.readFile stubby.stubbyExampleJson);
+  passthru.settingsExample = lib.importJSON stubby.stubbyExampleJson;
 
   meta = getdns.meta // {
     description = "Local DNS Privacy stub resolver (using DNS-over-TLS)";

--- a/pkgs/by-name/ya/yandex-music/package.nix
+++ b/pkgs/by-name/ya/yandex-music/package.nix
@@ -50,7 +50,7 @@ stdenvNoCC.mkDerivation rec {
 
   ymExe =
     let
-      ym_info = builtins.fromJSON (builtins.readFile ./ym_info.json);
+      ym_info = lib.importJSON ./ym_info.json;
     in
     fetchurl {
       url = ym_info.exe_link;

--- a/pkgs/development/compilers/smlnj/default.nix
+++ b/pkgs/development/compilers/smlnj/default.nix
@@ -9,7 +9,7 @@ let
 
   arch = if stdenv.hostPlatform.is64bit then "64" else "32";
 
-  hashes = builtins.fromJSON (builtins.readFile ./hashes.json);
+  hashes = lib.importJSON ./hashes.json;
 
   fetchSource =
     name:

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1,14 +1,5 @@
 # This file defines the composition for R packages.
 
-let
-  importJSON = f: builtins.fromJSON (builtins.readFile f);
-
-  biocPackagesGenerated = importJSON ./bioc-packages.json;
-  biocAnnotationPackagesGenerated = importJSON ./bioc-annotation-packages.json;
-  biocExperimentPackagesGenerated = importJSON ./bioc-experiment-packages.json;
-  cranPackagesGenerated = importJSON ./cran-packages.json;
-in
-
 {
   R,
   pkgs,
@@ -16,6 +7,11 @@ in
 }:
 
 let
+  biocPackagesGenerated = lib.importJSON ./bioc-packages.json;
+  biocAnnotationPackagesGenerated = lib.importJSON ./bioc-annotation-packages.json;
+  biocExperimentPackagesGenerated = lib.importJSON ./bioc-experiment-packages.json;
+  cranPackagesGenerated = lib.importJSON ./cran-packages.json;
+
   inherit (pkgs)
     cacert
     fetchurl

--- a/pkgs/development/tools/electron/binary/default.nix
+++ b/pkgs/development/tools/electron/binary/default.nix
@@ -1,10 +1,7 @@
-let
-  infoJson = builtins.fromJSON (builtins.readFile ./info.json);
-in
-
 { lib, callPackage }:
 
 let
+  infoJson = lib.importJSON ./info.json;
   mkElectron = callPackage ./generic.nix { };
 in
 lib.mapAttrs' (

--- a/pkgs/development/tools/electron/chromedriver/default.nix
+++ b/pkgs/development/tools/electron/chromedriver/default.nix
@@ -1,10 +1,7 @@
-let
-  infoJson = builtins.fromJSON (builtins.readFile ./info.json);
-in
-
 { lib, callPackage }:
 
 let
+  infoJson = lib.importJSON ./info.json;
   mkElectronChromedriver = callPackage ./generic.nix { };
 in
 lib.mapAttrs' (

--- a/pkgs/development/tools/infisical/default.nix
+++ b/pkgs/development/tools/infisical/default.nix
@@ -18,7 +18,7 @@
 
 let
   # build hashes, which correspond to the hashes of the precompiled binaries procured by GitHub Actions.
-  buildHashes = builtins.fromJSON (builtins.readFile ./hashes.json);
+  buildHashes = lib.importJSON ./hashes.json;
 
   # the version of infisical
   version = "0.41.85";

--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -1,8 +1,6 @@
-let
-  versions = builtins.fromJSON (builtins.readFile ./versions.json);
-in
 { callPackage, lib, ... }:
 let
+  versions = lib.importJSON ./versions.json;
   latestVersion = lib.last (builtins.sort lib.versionOlder (builtins.attrNames versions));
   escapeVersion = builtins.replaceStrings [ "." ] [ "_" ];
   packages = lib.mapAttrs' (version: value: {

--- a/pkgs/misc/translatelocally-models/default.nix
+++ b/pkgs/misc/translatelocally-models/default.nix
@@ -1,7 +1,3 @@
-let
-  modelSpecs = (builtins.fromJSON (builtins.readFile ./models.json));
-in
-
 {
   lib,
   stdenvNoCC,
@@ -9,6 +5,7 @@ in
 }:
 
 let
+  modelSpecs = lib.importJSON ./models.json;
   withCodeAsKey = f: { code, ... }@attrs: lib.nameValuePair code (f attrs);
   mkModelPackage =
     {

--- a/pkgs/os-specific/darwin/apple-source-releases/mkAppleDerivation.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/mkAppleDerivation.nix
@@ -1,7 +1,3 @@
-let
-  versions = builtins.fromJSON (builtins.readFile ./versions.json);
-in
-
 {
   lib,
   bootstrapStdenv,
@@ -15,6 +11,7 @@ in
 
 let
   hasBasenamePrefix = prefix: file: lib.hasPrefix prefix (baseNameOf file);
+  versions = lib.importJSON ./versions.json;
 in
 lib.makeOverridable (
   attrs:

--- a/pkgs/os-specific/linux/kernel/mainline.nix
+++ b/pkgs/os-specific/linux/kernel/mainline.nix
@@ -1,7 +1,3 @@
-let
-  allKernels = builtins.fromJSON (builtins.readFile ./kernels-org.json);
-in
-
 {
   branch,
   lib,
@@ -12,6 +8,7 @@ in
 }@args:
 
 let
+  allKernels = lib.importJSON ./kernels-org.json;
   thisKernel = allKernels.${branch};
   inherit (thisKernel) version;
 

--- a/pkgs/servers/nextcloud/packages/default.nix
+++ b/pkgs/servers/nextcloud/packages/default.nix
@@ -19,7 +19,7 @@ let
       generatedJson = {
         inherit apps;
       };
-      appBaseDefs = builtins.fromJSON (builtins.readFile ./nextcloud-apps.json);
+      appBaseDefs = lib.importJSON ./nextcloud-apps.json;
 
     in
     {

--- a/pkgs/servers/web-apps/wordpress/packages/default.nix
+++ b/pkgs/servers/web-apps/wordpress/packages/default.nix
@@ -19,9 +19,9 @@ let
         inherit plugins themes languages;
       };
       sourceJson = {
-        plugins = builtins.fromJSON (builtins.readFile ./wordpress-plugins.json);
-        themes = builtins.fromJSON (builtins.readFile ./wordpress-themes.json);
-        languages = builtins.fromJSON (builtins.readFile ./wordpress-languages.json);
+        plugins = lib.importJSON ./wordpress-plugins.json;
+        themes = lib.importJSON ./wordpress-themes.json;
+        languages = lib.importJSON ./wordpress-languages.json;
       };
 
     in

--- a/pkgs/tools/networking/maubot/plugins/generated.nix
+++ b/pkgs/tools/networking/maubot/plugins/generated.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  json = builtins.fromJSON (builtins.readFile ./generated.json);
+  json = lib.importJSON ./generated.json;
 in
 
 lib.flip builtins.mapAttrs json (


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
