### PR TITLE
nixos/testing: Add test attribute to please discoverTests

### DIFF
--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -106,6 +106,11 @@ in
     # useful for inspection (debugging / exploration)
     passthru.config = config;
 
+    /**
+      For discoverTests only. Deprecated. Will be removed when discoverTests can be removed from NixOS all-tests.nix.
+    */
+    passthru.test = config.test;
+
     # Docs: nixos/doc/manual/development/writing-nixos-tests.section.md
     /**
       See https://nixos.org/manual/nixos/unstable#sec-override-nixos-test

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -21,7 +21,7 @@ let
   discoverTests =
     val:
     if isAttrs val then
-      if hasAttr "test" val then
+      if (val ? test) then
         callTest val
       else
         mapAttrs (n: s: if n == "passthru" then s else discoverTests s) val

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -18,6 +18,8 @@
 with pkgs.lib;
 
 let
+  # TODO: remove when handleTest is gone (make sure nixosTests and nixos/release.nix#tests are unaffected)
+  # TODO: when removing, also deprecate `test` attribute in ../lib/testing/run.nix
   discoverTests =
     val:
     if isAttrs val then


### PR DESCRIPTION
- `discoverTests` is bankrupt in tech debt, so we work around it until https://github.com/NixOS/nixpkgs/issues/386873 is done.

- This is in response to https://github.com/NixOS/nixpkgs/pull/421480#issuecomment-3045722604

This makes it a happy lambda again:

```console
$ nix eval --impure --expr 'with import ./. {}; bind.tests.kubernetes-dns-multi-node.extend'
«lambda extend @ /home/user/src/nixpkgs-master/nixos/lib/testing/call-test.nix:31:7»
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
