### PR TITLE
phpactor: explicitly list required php extensions

### DIFF
--- a/pkgs/by-name/ph/phpactor/package.nix
+++ b/pkgs/by-name/ph/phpactor/package.nix
@@ -21,6 +21,8 @@ php.buildComposerProject2 (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  php = php.withExtensions ({ all, ... }: with all; [ mbstring ]);
+
   postInstall = ''
     installShellCompletion --cmd phpactor \
     --bash <(php $out/bin/phpactor completion bash)


### PR DESCRIPTION
Together with #423266 I achieved this on my otherwise php free system:

```
bison: 3.8.2 → ∅, -3271.7 KiB
dav1d: 1.5.1 → ∅, -2624.6 KiB
flex: 2.6.4 → ∅, -1170.4 KiB
gd: 2.3.3 → ∅, -457.6 KiB
gdk-pixbuf: 2.42.12 → ∅, -2851.4 KiB
gnum4: 1.4.19 → ∅, -827.2 KiB
icu4c: 73.2 → ∅, -38768.0 KiB
libXpm: 3.5.17 → ∅, -88.6 KiB
libaom: 3.11.0 → ∅, -10239.1 KiB
libavif: 1.3.0 → ∅, -1102.6 KiB
libvmaf: 3.0.0 → ∅, -2711.3 KiB
libwebp: -1715.7 KiB
libyuv: 1908 → ∅, -4253.8 KiB
libzip: 1.11.4 → ∅, -242.3 KiB
ncompress: 5.0 → ∅, -74.6 KiB
php: -518.2 KiB
php-bcmath: 8.4.10 → ∅, -89.5 KiB
php-calendar: 8.4.10 → ∅, -47.7 KiB
php-ctype: 8.4.10 → ∅, -21.9 KiB
php-curl: 8.4.10 → ∅, -157.8 KiB
php-dom: 8.4.10 → ∅, -3774.3 KiB
php-exif: 8.4.10 → ∅, -102.1 KiB
php-fileinfo: 8.4.10 → ∅, -8478.0 KiB
php-filter: 8.4.10 → ∅, -62.2 KiB
php-ftp: 8.4.10 → ∅, -81.7 KiB
php-gd: 8.4.10 → ∅, -180.0 KiB
php-gettext: 8.4.10 → ∅, -26.1 KiB
php-gmp: 8.4.10 → ∅, -92.3 KiB
php-iconv: 8.4.10 → ∅, -58.2 KiB
php-intl: 8.4.10 → ∅, -761.9 KiB
php-ldap: 8.4.10 → ∅, -124.2 KiB
php-mysqli: 8.4.10 → ∅, -207.0 KiB
php-mysqlnd: 8.4.10 → ∅, -263.1 KiB
php-opcache: 8.4.10 → ∅, -1273.3 KiB
php-openssl: 8.4.10 → ∅, -271.1 KiB
php-pcntl: 8.4.10 → ∅, -68.2 KiB
php-pdo: 8.4.10 → ∅, -157.8 KiB
php-pdo_mysql: 8.4.10 → ∅, -49.2 KiB
php-pdo_odbc: 8.4.10 → ∅, -49.5 KiB
php-pdo_pgsql: 8.4.10 → ∅, -79.5 KiB
php-pdo_sqlite: 8.4.10 → ∅, -65.9 KiB
php-pgsql: 8.4.10 → ∅, -211.8 KiB
php-posix: 8.4.10 → ∅, -56.7 KiB
php-readline: 8.4.10 → ∅, -51.4 KiB
php-session: 8.4.10 → ∅, -131.4 KiB
php-simplexml: 8.4.10 → ∅, -75.8 KiB
php-soap: 8.4.10 → ∅, -383.9 KiB
php-sockets: 8.4.10 → ∅, -140.6 KiB
php-sodium: 8.4.10 → ∅, -156.4 KiB
php-sqlite3: 8.4.10 → ∅, -95.0 KiB
php-sysvsem: 8.4.10 → ∅, -21.8 KiB
php-tokenizer: 8.4.10 → ∅, -39.9 KiB
php-xmlreader: 8.4.10 → ∅, -67.7 KiB
php-xmlwriter: 8.4.10 → ∅, -71.4 KiB
php-zip: 8.4.10 → ∅, -130.8 KiB
php-zlib: 8.4.10 → ∅, -74.2 KiB
unixODBC: 2.3.12 → ∅, -1088.9 KiB
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
