### PR TITLE
nixos/testing: Add `onVMHost` attribute to all tests

### DIFF
--- a/nixos/lib/testing/alternate-vm-host.nix
+++ b/nixos/lib/testing/alternate-vm-host.nix
@@ -1,0 +1,36 @@
+{
+  extendModules,
+  hostPkgs,
+  lib,
+  ...
+}:
+let
+  # `meta.platforms` is not dependent on Nixpkgs configuration, so this should
+  # be constant (which is a stronger guarantee than we even need fwiw)
+  qemuPlatforms = hostPkgs.qemu.meta.platforms;
+
+  systemToPkgs =
+    system:
+    # This should instead be taken from a place where it's memoized,
+    # e.g. the flake (if this is consumed via the flake), or a file that
+    # contains something like `legacyPackages` as its only contents.
+    # That way we don't evaluate a new Nixpkgs for every test, when multiple
+    # tests are requested in the same Nix evaluation process.
+    import ../../../pkgs/top-level/default.nix {
+      localSystem = system;
+    };
+
+  useVMPlatform =
+    system:
+    let
+      hostPkgs = systemToPkgs system;
+      configuration = extendModules {
+        specialArgs = { inherit hostPkgs; };
+      };
+    in
+    configuration.config.test;
+
+in
+{
+  config.passthru.onVMHost = lib.genAttrs qemuPlatforms useVMPlatform;
+}

--- a/nixos/lib/testing/alternate-vm-host.nix
+++ b/nixos/lib/testing/alternate-vm-host.nix
@@ -32,5 +32,9 @@ let
 
 in
 {
-  config.passthru.onVMHost = lib.genAttrs qemuPlatforms useVMPlatform;
+  config.passthru.onVMHost =
+    lib.genAttrs qemuPlatforms useVMPlatform
+    // lib.optionalAttrs (builtins ? currentSystem) {
+      currentSystem = useVMPlatform builtins.currentSystem;
+    };
 }

--- a/nixos/lib/testing/default.nix
+++ b/nixos/lib/testing/default.nix
@@ -18,6 +18,7 @@ let
     )).config.result;
 
   testModules = [
+    ./alternate-vm-host.nix
     ./call-test.nix
     ./driver.nix
     ./interactive.nix


### PR DESCRIPTION
The interaction between `pkg.override*` and alternate VM hosts does not work.
Concretely, if I'm using Darwin, and I'm developing a patch to a linux package, I'd want to do `(pkg.overrideAttrs someFunction).tests`, but this does not work, because that will (have to) use the Linux version of the package, whereas we've added our patch (in `someFunction`) to a Darwin instantiation of the package.
The test framework can compensate for this.

Instead, with this PR, you could override the Linux package, and then build something like `(pkg.overrideAttrs someFunction).tests.nixos.onVMHost.aarch64-darwin` (where `pkg` is for Linux).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
