### PR TITLE
Fix `legacyPackages` performance

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -209,11 +209,14 @@
       */
       legacyPackages = forAllSystems (
         system:
-        (import ./. { inherit system; }).extend (
-          final: prev: {
-            lib = prev.lib.extend libVersionInfoOverlay;
-          }
-        )
+        (import ./. {
+          inherit system;
+          overlays = import ./pkgs/top-level/impure-overlays.nix ++ [
+            (final: prev: {
+              lib = prev.lib.extend libVersionInfoOverlay;
+            })
+          ];
+        })
       );
 
       /**

--- a/pkgs/top-level/impure-overlays.nix
+++ b/pkgs/top-level/impure-overlays.nix
@@ -1,0 +1,61 @@
+/**
+  This file has as its value the list of overlays, as determined from the environment.
+  If Nix evaluation is [pure](https://nix.dev/manual/nix/latest/command-ref/conf-file.html?highlight=pure-eval#conf-pure-eval), then the list is empty.
+*/
+let
+  # Return ‘x’ if it evaluates, or ‘def’ if it throws an exception.
+  try =
+    x: def:
+    let
+      res = builtins.tryEval x;
+    in
+    if res.success then res.value else def;
+  homeDir = builtins.getEnv "HOME";
+
+  isDir = path: builtins.pathExists (path + "/.");
+  pathOverlays = try (toString <nixpkgs-overlays>) "";
+  homeOverlaysFile = homeDir + "/.config/nixpkgs/overlays.nix";
+  homeOverlaysDir = homeDir + "/.config/nixpkgs/overlays";
+  overlays =
+    path:
+    # check if the path is a directory or a file
+    if isDir path then
+      # it's a directory, so the set of overlays from the directory, ordered lexicographically
+      let
+        content = builtins.readDir path;
+      in
+      map (n: import (path + ("/" + n))) (
+        builtins.filter (
+          n:
+          (
+            builtins.match ".*\\.nix" n != null
+            &&
+              # ignore Emacs lock files (.#foo.nix)
+              builtins.match "\\.#.*" n == null
+          )
+          || builtins.pathExists (path + ("/" + n + "/default.nix"))
+        ) (builtins.attrNames content)
+      )
+    else
+      # it's a file, so the result is the contents of the file itself
+      import path;
+in
+if pathOverlays != "" && builtins.pathExists pathOverlays then
+  overlays pathOverlays
+else if builtins.pathExists homeOverlaysFile && builtins.pathExists homeOverlaysDir then
+  throw ''
+    Nixpkgs overlays can be specified with ${homeOverlaysFile} or ${homeOverlaysDir}, but not both.
+    Please remove one of them and try again.
+  ''
+else if builtins.pathExists homeOverlaysFile then
+  if isDir homeOverlaysFile then
+    throw (homeOverlaysFile + " should be a file")
+  else
+    overlays homeOverlaysFile
+else if builtins.pathExists homeOverlaysDir then
+  if !(isDir homeOverlaysDir) then
+    throw (homeOverlaysDir + " should be a directory")
+  else
+    overlays homeOverlaysDir
+else
+  [ ]

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -7,14 +7,6 @@ let
 
   homeDir = builtins.getEnv "HOME";
 
-  # Return ‘x’ if it evaluates, or ‘def’ if it throws an exception.
-  try =
-    x: def:
-    let
-      res = builtins.tryEval x;
-    in
-    if res.success then res.value else def;
-
 in
 
 {
@@ -50,55 +42,7 @@ in
   # Overlays are used to extend Nixpkgs collection with additional
   # collections of packages.  These collection of packages are part of the
   # fix-point made by Nixpkgs.
-  overlays ?
-    let
-      isDir = path: builtins.pathExists (path + "/.");
-      pathOverlays = try (toString <nixpkgs-overlays>) "";
-      homeOverlaysFile = homeDir + "/.config/nixpkgs/overlays.nix";
-      homeOverlaysDir = homeDir + "/.config/nixpkgs/overlays";
-      overlays =
-        path:
-        # check if the path is a directory or a file
-        if isDir path then
-          # it's a directory, so the set of overlays from the directory, ordered lexicographically
-          let
-            content = builtins.readDir path;
-          in
-          map (n: import (path + ("/" + n))) (
-            builtins.filter (
-              n:
-              (
-                builtins.match ".*\\.nix" n != null
-                &&
-                  # ignore Emacs lock files (.#foo.nix)
-                  builtins.match "\\.#.*" n == null
-              )
-              || builtins.pathExists (path + ("/" + n + "/default.nix"))
-            ) (builtins.attrNames content)
-          )
-        else
-          # it's a file, so the result is the contents of the file itself
-          import path;
-    in
-    if pathOverlays != "" && builtins.pathExists pathOverlays then
-      overlays pathOverlays
-    else if builtins.pathExists homeOverlaysFile && builtins.pathExists homeOverlaysDir then
-      throw ''
-        Nixpkgs overlays can be specified with ${homeOverlaysFile} or ${homeOverlaysDir}, but not both.
-        Please remove one of them and try again.
-      ''
-    else if builtins.pathExists homeOverlaysFile then
-      if isDir homeOverlaysFile then
-        throw (homeOverlaysFile + " should be a file")
-      else
-        overlays homeOverlaysFile
-    else if builtins.pathExists homeOverlaysDir then
-      if !(isDir homeOverlaysDir) then
-        throw (homeOverlaysDir + " should be a directory")
-      else
-        overlays homeOverlaysDir
-    else
-      [ ],
+  overlays ? import ./impure-overlays.nix,
 
   crossOverlays ? [ ],
 


### PR DESCRIPTION
Remove one `pkgs` construction.
This makes `.#hello.outPath` 1.24 ± 0.03 times faster to evaluate.
Larger closures will see a less dramatic effect. Expect a 100 to 300 ms improvement, depending on hardware etc.

(I don't like the impurities which are now more visible, but not they're not new; just preserved. Presumably they're used with `--impure`, and I'd like to call that OT because unchanged. I don't like the altered `lib` either.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
