### PR TITLE
pylibfdt: Use the correct Python for tests

### DIFF
--- a/pkgs/by-name/dt/dtc/package.nix
+++ b/pkgs/by-name/dt/dtc/package.nix
@@ -11,6 +11,7 @@
   which,
   pythonSupport ? false,
   python ? null,
+  replaceVars,
   swig,
   libyaml,
 }:
@@ -38,7 +39,15 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/dgibson/dtc/commit/ce1d8588880aecd7af264e422a16a8b33617cef7.patch";
       hash = "sha256-t1CxKnbCXUArtVcniAIdNvahOGXPbYhPCZiTynGLvfo=";
     })
-  ];
+  ]
+  ++
+    lib.optional pythonSupport
+      # Make Meson use our Python version, not the one it was built with itself
+      (
+        replaceVars ./python-path.patch {
+          python_bin = lib.getExe python;
+        }
+      );
 
   env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
 

--- a/pkgs/by-name/dt/dtc/python-path.patch
+++ b/pkgs/by-name/dt/dtc/python-path.patch
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index 310699f..4e2b8a4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -48,7 +48,7 @@ if not valgrind.found()
+ endif
+ 
+ py = import('python')
+-py = py.find_installation(required: get_option('python'))
++py = py.find_installation('@python_bin@', required: get_option('python'))
+ swig = find_program('swig', required: get_option('python'))
+ pylibfdt_enabled = not meson.is_cross_build() and py.found() and swig.found() ? true : false


### PR DESCRIPTION
By default, Meson will find the version of Python that it itself is using, i.e. the default one in Nixpkgs.
However, when building libfdt for other Python package sets, we need to make sure we match the version of the Python used for tests – otherwise the interpreter will not find the compiled module.

Tweak meson.build to always use the Python interpreter that was passed to the expression, rather than the default one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

Ping maintainer: @dezgeg.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
