### PR TITLE
Add gtk3 to lib.makeLibraryPath

### DIFF
--- a/pkgs/applications/audio/reaper/default.nix
+++ b/pkgs/applications/audio/reaper/default.nix
@@ -117,6 +117,7 @@ stdenv.mkDerivation rec {
           --prefix LD_LIBRARY_PATH : "${
             lib.makeLibraryPath [
               curl
+              gtk3
               lame
               libxml2
               ffmpeg


### PR DESCRIPTION
Some plugins (for example ReaImGui) when installed give this error upon Reaper startup:
```
swell: dlopen() failed: libgtk-3.so.0: cannot open shared object file: No such file or directory
```

The problem is that the built reaper package does not include gtk3 in the lib.makeLibraryPath function and reaper cannot find the libgtk library.

Here is the strace output i used to figure out what was going on:
```
432295 openat(AT_FDCWD, "/nix/store/frlckg2m2sf0gs8g5pqkryddbpy6qcz1-curl-8.14.1/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/yajsqhqwdh7x87p6q15q6iz6g7ras1hp-lame-3.100-lib/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/izqbxvpsxw8b4r4arhlbkm48s3ghbddg-libxml2-2.14.3/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/m7cdk27sbksg0j8kn360b9pclpqyrg18-ffmpeg-headless-4.4.6-lib/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/x85wy0npd3h5ypqr1hnc7x5paxklrhgw-vlc-3.0.21/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/3a5vm74hj6sl5inzr03wvabf15wlw1qm-xdotool-3.20211022.1/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/l7d6vwajpfvgsd3j4cr25imd1mzb7d1d-gcc-14.3.0-lib/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/zkf2by751khwdihlia1ygw3r4iasagns-pipewire-1.4.5-jack/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/q4wq65gl3r8fy746v9bbwgx4gzn0r2kl-glibc-2.40-66/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/j4kybm2h5l6ing0i494zwdswp672pmgv-xgcc-14.3.0-libgcc/lib/glibc-hwcaps/x86-64-v4/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/j4kybm2h5l6ing0i494zwdswp672pmgv-xgcc-14.3.0-libgcc/lib/glibc-hwcaps/x86-64-v3/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/j4kybm2h5l6ing0i494zwdswp672pmgv-xgcc-14.3.0-libgcc/lib/glibc-hwcaps/x86-64-v2/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 openat(AT_FDCWD, "/nix/store/j4kybm2h5l6ing0i494zwdswp672pmgv-xgcc-14.3.0-libgcc/lib/libgtk-3.so.0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
432295 write(2, "swell: dlopen() failed: libgtk-3"..., 97) = 97
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
