### PR TITLE
discord: remove libunity dependency

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -54,7 +54,6 @@
   pipewire,
   python3,
   runCommand,
-  libunity,
   speechd-minimal,
   wayland,
   branch,
@@ -142,7 +141,6 @@ stdenv.mkDerivation rec {
       libnotify
       libX11
       libXcomposite
-      libunity
       libuuid
       libXcursor
       libXdamage


### PR DESCRIPTION
Isn't used by Discord anymore apparently (checked ldd on the binary)

Currently libunity is broken on staging-next ( https://hydra.nixos.org/build/301838860 )

<summary>
ldd
<details>

```
	linux-vdso.so.1 (0x00007effbf7aa000)
	libffmpeg.so => /nix/store/55lkmgdn14j0wswgy39znb7yngzvkdj9-discord-0.0.98/opt/Discord/libffmpeg.so (0x00007effb4000000)
	libdl.so.2 => /nix/store/g2jzxk3s7cnkhh8yq55l4fbvf639zy37-glibc-2.40-66/lib/libdl.so.2 (0x00007effbf79b000)
	libpthread.so.0 => /nix/store/g2jzxk3s7cnkhh8yq55l4fbvf639zy37-glibc-2.40-66/lib/libpthread.so.0 (0x00007effbf796000)
	libgobject-2.0.so.0 => /nix/store/syzi2bpl8j599spgvs20xjkjzcw758as-glib-2.84.3/lib/libgobject-2.0.so.0 (0x00007effb459b000)
	libglib-2.0.so.0 => /nix/store/syzi2bpl8j599spgvs20xjkjzcw758as-glib-2.84.3/lib/libglib-2.0.so.0 (0x00007effb3ea1000)
	libgio-2.0.so.0 => /nix/store/syzi2bpl8j599spgvs20xjkjzcw758as-glib-2.84.3/lib/libgio-2.0.so.0 (0x00007effb3c00000)
	libnss3.so => /nix/store/rvdnjd0dkw0ywhr8vvlhsc6krsz5h68x-nss-3.101.2/lib/libnss3.so (0x00007effb3abe000)
	libnssutil3.so => /nix/store/rvdnjd0dkw0ywhr8vvlhsc6krsz5h68x-nss-3.101.2/lib/libnssutil3.so (0x00007effb4566000)
	libsmime3.so => /nix/store/rvdnjd0dkw0ywhr8vvlhsc6krsz5h68x-nss-3.101.2/lib/libsmime3.so (0x00007effb4538000)
	libnspr4.so => /nix/store/xxrlf334l7bvgmxv9yrgyks46rjbafly-nspr-4.36/lib/libnspr4.so (0x00007effb3e5b000)
	libdbus-1.so.3 => /nix/store/7b2abh5dbx4yr23fqs0xjkws6br9kz94-dbus-1.14.10-lib/lib/libdbus-1.so.3 (0x00007effb3e02000)
	libatk-1.0.so.0 => /nix/store/pz3kcrcicssx56mw876q68b4gdgl8mz3-at-spi2-core-2.56.2/lib/libatk-1.0.so.0 (0x00007effb450e000)
	libatk-bridge-2.0.so.0 => /nix/store/pz3kcrcicssx56mw876q68b4gdgl8mz3-at-spi2-core-2.56.2/lib/libatk-bridge-2.0.so.0 (0x00007effb3a7f000)
	libgtk-3.so.0 => /nix/store/jyyijm438kvbx1425hw00wx965jsgd9g-gtk+3-3.24.49/lib/libgtk-3.so.0 (0x00007effb3200000)
	libpango-1.0.so.0 => /nix/store/p2imx8gg3rb6p0b60sr0gf3m65drr7i1-pango-1.56.3/lib/libpango-1.0.so.0 (0x00007effb318d000)
	libcairo.so.2 => /nix/store/09raz8qnv2n16794rmsnm9n93zs55p11-cairo-1.18.4/lib/libcairo.so.2 (0x00007effb3040000)
	libX11.so.6 => /nix/store/pahwl2rq51dmwrn8czks27yy3sa3byg9-libX11-1.8.12/lib/libX11.so.6 (0x00007effb2ef2000)
	libXcomposite.so.1 => /nix/store/0j0g1zi101flk6xbixmnws1jyagyhqdr-libXcomposite-0.4.6/lib/libXcomposite.so.1 (0x00007effbf78b000)
	libXdamage.so.1 => /nix/store/cc25qpjfpcar2ar63pcmsrz60dalbm9r-libXdamage-1.1.6/lib/libXdamage.so.1 (0x00007effbf786000)
	libXext.so.6 => /nix/store/844cgxkyzi1nrilvamxr08gs9l278gx9-libXext-1.3.6/lib/libXext.so.6 (0x00007effbf771000)
	libXfixes.so.3 => /nix/store/ksi1cmprh96psxs72y786w3m30l6x7wm-libXfixes-6.0.1/lib/libXfixes.so.3 (0x00007effb4506000)
	libXrandr.so.2 => /nix/store/yp7hylmnidn1mr91xsdn2dj5glhqmk7a-libXrandr-1.5.4/lib/libXrandr.so.2 (0x00007effb44f7000)
	libgbm.so.1 => /nix/store/d6a8ckgb953nqr2qamidqzz1i7v473pm-mesa-libgbm-25.1.0/lib/libgbm.so.1 (0x00007effb3a78000)
	libexpat.so.1 => /nix/store/4ciq67pdwyc43a5y1h63wcipl54f938w-expat-2.7.1/lib/libexpat.so.1 (0x00007effb3a4a000)
	libxcb.so.1 => /nix/store/rcm8ry0f10l80h5l26s74p4ik5wsbzas-libxcb-1.17.0/lib/libxcb.so.1 (0x00007effb3a1e000)
	libxkbcommon.so.0 => /nix/store/dc49la2pfdzf93inii1icqj7rfiar2cr-libxkbcommon-1.10.0/lib/libxkbcommon.so.0 (0x00007effb2e9c000)
	libudev.so.1 => /nix/store/pbqih0cmbc4xilscj36m80ardhg6kawp-systemd-minimal-257.6/lib/libudev.so.1 (0x00007effb2e40000)
	libasound.so.2 => /nix/store/7p8rmrv6hy8lx90a52nk94fdm4av51pl-alsa-lib-1.2.14/lib/libasound.so.2 (0x00007effb2d21000)
	libatspi.so.0 => /nix/store/pz3kcrcicssx56mw876q68b4gdgl8mz3-at-spi2-core-2.56.2/lib/libatspi.so.0 (0x00007effb2ce1000)
	libm.so.6 => /nix/store/g2jzxk3s7cnkhh8yq55l4fbvf639zy37-glibc-2.40-66/lib/libm.so.6 (0x00007effb2bf9000)
	libgcc_s.so.1 => /nix/store/fxwmabprl1nyxskbrygqlaps5kwg3fjv-gcc-14.3.0-libgcc/lib/libgcc_s.so.1 (0x00007effb2bcb000)
	libc.so.6 => /nix/store/g2jzxk3s7cnkhh8yq55l4fbvf639zy37-glibc-2.40-66/lib/libc.so.6 (0x00007effb2800000)
	/nix/store/g2jzxk3s7cnkhh8yq55l4fbvf639zy37-glibc-2.40-66/lib/ld-linux-x86-64.so.2 => /nix/store/g2jzxk3s7cnkhh8yq55l4fbvf639zy37-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007effbf7ac000)
	libffi.so.8 => /nix/store/v4vqyvb5gq799b1v3qf5lyyij7pnjfiz-libffi-3.4.8/lib/libffi.so.8 (0x00007effb2bba000)
	libpcre2-8.so.0 => /nix/store/39hdlpl2586k2m75wgmydnrj5rzyhsnh-pcre2-10.44/lib/libpcre2-8.so.0 (0x00007effb2b18000)
	libgmodule-2.0.so.0 => /nix/store/syzi2bpl8j599spgvs20xjkjzcw758as-glib-2.84.3/lib/libgmodule-2.0.so.0 (0x00007effb3a15000)
	libz.so.1 => /nix/store/abch1r0gnbpikbp9n4x6mm8dwqwfrib6-zlib-1.3.1/lib/libz.so.1 (0x00007effb2af8000)
	libmount.so.1 => /nix/store/fi10kgdpl0nzj7viccd633a711apfni7-util-linux-minimal-2.41-lib/lib/libmount.so.1 (0x00007effb2a7c000)
	libselinux.so.1 => /nix/store/qkzhykx2hn8k7zwrgmfzx2cqi4vpwxr0-libselinux-3.8.1/lib/libselinux.so.1 (0x00007effb2a46000)
	libplds4.so => /nix/store/xxrlf334l7bvgmxv9yrgyks46rjbafly-nspr-4.36/lib/libplds4.so (0x00007effb2a41000)
	libplc4.so => /nix/store/xxrlf334l7bvgmxv9yrgyks46rjbafly-nspr-4.36/lib/libplc4.so (0x00007effb2a3a000)
	librt.so.1 => /nix/store/g2jzxk3s7cnkhh8yq55l4fbvf639zy37-glibc-2.40-66/lib/librt.so.1 (0x00007effb2a33000)
	libsystemd.so.0 => /nix/store/pbqih0cmbc4xilscj36m80ardhg6kawp-systemd-minimal-257.6/lib/libsystemd.so.0 (0x00007effb26af000)
	libgdk-3.so.0 => /nix/store/jyyijm438kvbx1425hw00wx965jsgd9g-gtk+3-3.24.49/lib/libgdk-3.so.0 (0x00007effb259a000)
	libpangocairo-1.0.so.0 => /nix/store/p2imx8gg3rb6p0b60sr0gf3m65drr7i1-pango-1.56.3/lib/libpangocairo-1.0.so.0 (0x00007effb2a20000)
	libharfbuzz.so.0 => /nix/store/4grh04r663f9dsa8pahh6r7d40dnkff1-harfbuzz-11.2.1/lib/libharfbuzz.so.0 (0x00007effb2441000)
	libpangoft2-1.0.so.0 => /nix/store/p2imx8gg3rb6p0b60sr0gf3m65drr7i1-pango-1.56.3/lib/libpangoft2-1.0.so.0 (0x00007effb2425000)
	libfontconfig.so.1 => /nix/store/543757pg6b05fhmqk6xcfahah86i9srp-fontconfig-2.16.2-lib/lib/libfontconfig.so.1 (0x00007effb23d5000)
	libfribidi.so.0 => /nix/store/wp3v93f6d8bd87af0hn7vc9ril4ayvqc-fribidi-1.0.16/lib/libfribidi.so.0 (0x00007effb23b4000)
	libcairo-gobject.so.2 => /nix/store/09raz8qnv2n16794rmsnm9n93zs55p11-cairo-1.18.4/lib/libcairo-gobject.so.2 (0x00007effb2a13000)
	libgdk_pixbuf-2.0.so.0 => /nix/store/56lrk83ayp4x9dm7i94nz59f6gzhqghk-gdk-pixbuf-2.42.12/lib/libgdk_pixbuf-2.0.so.0 (0x00007effb2386000)
	libepoxy.so.0 => /nix/store/szj803rapssxl0wiyjnb1v4djpacvmla-libepoxy-1.5.10/lib/libepoxy.so.0 (0x00007effb2260000)
	libXi.so.6 => /nix/store/474ia8w6cpw6vmhbsvbf5zx7bx5md4bv-libXi-1.8.2/lib/libXi.so.6 (0x00007effb224c000)
	libtinysparql-3.0.so.0 => /nix/store/0hykqvs20ii9ngmi855s7dxr8988f3l8-tinysparql-3.9.2/lib/libtinysparql-3.0.so.0 (0x00007effb2175000)
	libthai.so.0 => /nix/store/x2ida0d5yvxx51042yjyx0sfizi8y3za-libthai-0.1.29/lib/libthai.so.0 (0x00007effb2168000)
	libpng16.so.16 => /nix/store/4h3bvqsxa229qdqrw7z9spdzsqahs2hn-libpng-apng-1.6.47/lib/libpng16.so.16 (0x00007effb212c000)
	libfreetype.so.6 => /nix/store/ba8c3gyj3np25v6azfmfivh6bdi60zr0-freetype-2.13.3/lib/libfreetype.so.6 (0x00007effb2056000)
	libXrender.so.1 => /nix/store/sczkw2z74zm3niylbfgxh211b3cs9k9f-libXrender-0.9.12/lib/libXrender.so.1 (0x00007effb204a000)
	libxcb-render.so.0 => /nix/store/rcm8ry0f10l80h5l26s74p4ik5wsbzas-libxcb-1.17.0/lib/libxcb-render.so.0 (0x00007effb2039000)
	libxcb-shm.so.0 => /nix/store/rcm8ry0f10l80h5l26s74p4ik5wsbzas-libxcb-1.17.0/lib/libxcb-shm.so.0 (0x00007effb2a0a000)
	libpixman-1.so.0 => /nix/store/6h3khw669m4vw175lvgvvrwcb0df45rq-pixman-0.46.2/lib/libpixman-1.so.0 (0x00007effb1f80000)
	libdrm.so.2 => /nix/store/r99pbih59a8yp73f1cgcb63iwg55m3zb-libdrm-2.4.124/lib/libdrm.so.2 (0x00007effb1f67000)
	libXau.so.6 => /nix/store/zv8s9b9vq8b2shavwq7s8j5inw34d9sy-libXau-1.0.12/lib/libXau.so.6 (0x00007effb1f60000)
	libXdmcp.so.6 => /nix/store/28ywdnr6d9s0z1q6c22v84pi1ffwy50y-libXdmcp-1.1.5/lib/libXdmcp.so.6 (0x00007effb1f58000)
	libcap.so.2 => /nix/store/x18cljzn90cdmja42xy4aqry1s3qi2c1-libcap-2.76-lib/lib/libcap.so.2 (0x00007effb1f4b000)
	libblkid.so.1 => /nix/store/fi10kgdpl0nzj7viccd633a711apfni7-util-linux-minimal-2.41-lib/lib/libblkid.so.1 (0x00007effb1ee9000)
	libwayland-client.so.0 => /nix/store/h36c7mikp5l9yjxqrygrqgx69ha308q8-wayland-1.23.1/lib/libwayland-client.so.0 (0x00007effb1ed4000)
	libwayland-cursor.so.0 => /nix/store/h36c7mikp5l9yjxqrygrqgx69ha308q8-wayland-1.23.1/lib/libwayland-cursor.so.0 (0x00007effb1eca000)
	libwayland-egl.so.1 => /nix/store/h36c7mikp5l9yjxqrygrqgx69ha308q8-wayland-1.23.1/lib/libwayland-egl.so.1 (0x00007effb1ec5000)
	libXcursor.so.1 => /nix/store/zgpm3jjfsfs1ljdzm1xjq502mkvxck3m-libXcursor-1.2.3/lib/libXcursor.so.1 (0x00007effb1eb8000)
	libXinerama.so.1 => /nix/store/1ar5dnd5hqiyaxi6whj52vkd2bf0h7n8-libXinerama-1.1.5/lib/libXinerama.so.1 (0x00007effb1eb1000)
	libgraphite2.so.3 => /nix/store/yhrz0aid2gc7543cydwf9p7kqsx2c639-graphite2-1.3.14/lib/libgraphite2.so.3 (0x00007effb1e87000)
	libbz2.so.1 => /nix/store/5zz0lpl9pfb72vcal9hzr8d6lnv0n2ny-bzip2-1.0.8/lib/libbz2.so.1 (0x00007effb1e73000)
	libbrotlidec.so.1 => /nix/store/pazhpyf2g67czh2g7za2vbx20jg6fgpd-brotli-1.1.0-lib/lib/libbrotlidec.so.1 (0x00007effb1e62000)
	libjpeg.so.62 => /nix/store/15rkcy8rnhnv4cbai5q7dgsmhpj7nznj-libjpeg-turbo-3.1.1/lib/libjpeg.so.62 (0x00007effb1d95000)
	libjson-glib-1.0.so.0 => /nix/store/p86zzvv81ak84f63q60v5n8slik0a3d2-json-glib-1.10.6/lib/libjson-glib-1.0.so.0 (0x00007effb1d69000)
	libxml2.so.16 => /nix/store/ii6cjlj3fjbz4zvygf0f3c4yvi37h56x-libxml2-2.14.4-unstable-2025-06-20/lib/libxml2.so.16 (0x00007effb1c1c000)
	/nix/store/5x3inxk2l78ygb75kbhim3g2w67fra2r-sqlite-3.50.1/lib/libsqlite3.so (0x00007effb1a85000)
	libdatrie.so.1 => /nix/store/qw150nv8bp8x8x0w28z008b7s7kwdjv1-libdatrie-2019-12-20-lib/lib/libdatrie.so.1 (0x00007effb1a79000)
	libbrotlicommon.so.1 => /nix/store/pazhpyf2g67czh2g7za2vbx20jg6fgpd-brotli-1.1.0-lib/lib/libbrotlicommon.so.1 (0x00007effb1a56000)
```

</details>
</summary>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
