### PR TITLE
[Backport release-25.05] nixos/amdgpu: add overdrive and ppfeaturemask option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -541,6 +541,9 @@ Alongside many enhancements to NixOS modules and general system improvements, th
 
 - A toggle has been added under `users.users.<name>.enable` to allow toggling individual users conditionally. If set to false, the user account will not be created.
 
+- `amdgpu` kernel driver overdrive mode can now be enabled by setting [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable) and customized through [hardware.amdgpu.overdrive.ppfeaturemask](#opt-hardware.amdgpu.overdrive.ppfeaturemask).
+  This allows for fine-grained control over the GPU's performance and maybe required by overclocking softwares like Corectrl and Lact. These new options replace old options such as {option}`programs.corectrl.gpuOverclock.enable` and {option}`programs.tuxclocker.enableAMD`.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## NixOS Wiki {#sec-release-25.05-wiki}

--- a/nixos/modules/services/hardware/amdgpu.nix
+++ b/nixos/modules/services/hardware/amdgpu.nix
@@ -16,21 +16,44 @@ in
       series cards. Note: this removes support for analog video outputs,
       which is only available in the `radeon` driver
     '';
+
     initrd.enable = lib.mkEnableOption ''
       loading `amdgpu` kernelModule in stage 1.
       Can fix lower resolution in boot screen during initramfs phase
     '';
+
+    overdrive = {
+      enable = lib.mkEnableOption ''`amdgpu` overdrive mode for overclocking'';
+
+      ppfeaturemask = lib.mkOption {
+        type = lib.types.str;
+        default = "0xfffd7fff";
+        example = "0xffffffff";
+        description = ''
+          Sets the `amdgpu.ppfeaturemask` kernel option. It can be used to enable the overdrive bit.
+          Default is `0xfffd7fff` as it is less likely to cause flicker issues. Setting it to
+          `0xffffffff` enables all features, but also can be unstable. See
+          [the kernel documentation](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/gpu/drm/amd/include/amd_shared.h#n169)
+          for more information.
+        '';
+      };
+    };
+
     opencl.enable = lib.mkEnableOption ''OpenCL support using ROCM runtime library'';
     # cfg.amdvlk option is defined in ./amdvlk.nix module
   };
 
   config = {
-    boot.kernelParams = lib.optionals cfg.legacySupport.enable [
-      "amdgpu.si_support=1"
-      "amdgpu.cik_support=1"
-      "radeon.si_support=0"
-      "radeon.cik_support=0"
-    ];
+    boot.kernelParams =
+      lib.optionals cfg.legacySupport.enable [
+        "amdgpu.si_support=1"
+        "amdgpu.cik_support=1"
+        "radeon.si_support=0"
+        "radeon.cik_support=0"
+      ]
+      ++ lib.optionals cfg.overdrive.enable [
+        "amdgpu.ppfeaturemask=${cfg.overdrive.ppfeaturemask}"
+      ];
 
     boot.initrd.kernelModules = lib.optionals cfg.initrd.enable [ "amdgpu" ];
 

--- a/nixos/modules/services/misc/tuxclocker.nix
+++ b/nixos/modules/services/misc/tuxclocker.nix
@@ -8,14 +8,16 @@ let
   cfg = config.programs.tuxclocker;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "tuxclocker" "enableAMD" ]
+      [ "hardware" "amdgpu" "overdrive" "enable" ]
+    )
+  ];
+
   options.programs.tuxclocker = {
     enable = lib.mkEnableOption ''
       TuxClocker, a hardware control and monitoring program
-    '';
-
-    enableAMD = lib.mkEnableOption ''
-      AMD GPU controls.
-      Sets the `amdgpu.ppfeaturemask` kernel parameter to 0xfffd7fff to enable all TuxClocker controls
     '';
 
     enabledNVIDIADevices = lib.mkOption {
@@ -72,9 +74,5 @@ in
           );
         in
         lib.concatStrings (map configSection cfg.enabledNVIDIADevices);
-
-      # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/gpu/drm/amd/include/amd_shared.h#n207
-      # Enable everything modifiable in TuxClocker
-      boot.kernelParams = lib.mkIf cfg.enableAMD [ "amdgpu.ppfeaturemask=0xfffd7fff" ];
     };
 }


### PR DESCRIPTION
Manual backport of #411155 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.