### PR TITLE
nekoray: 4.3.5 -> 4.3.7

### DIFF
--- a/pkgs/by-name/ne/nekoray/package.nix
+++ b/pkgs/by-name/ne/nekoray/package.nix
@@ -4,17 +4,15 @@
 
   buildGoModule,
   fetchFromGitHub,
+  fetchpatch,
   makeDesktopItem,
 
   cmake,
   copyDesktopItems,
   ninja,
 
-  libcpr,
   protobuf,
   qt6Packages,
-  yaml-cpp,
-  zxing-cpp,
 
   sing-geoip,
   sing-geosite,
@@ -22,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nekoray";
-  version = "4.3.5";
+  version = "4.3.7";
 
   src = fetchFromGitHub {
     owner = "Mahdi-zarei";
     repo = "nekoray";
     tag = finalAttrs.version;
-    hash = "sha256-dq3rBvCFEs+4+UadFObMnHhIiYeFlpvvLjTo0lcG8rE=";
+    hash = "sha256-oRoHu9mt4LiGJFe2OEATbPQ8buYT/6o9395BxYg1qKI=";
   };
 
   strictDeps = true;
@@ -41,12 +39,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    libcpr
     protobuf
     qt6Packages.qtbase
     qt6Packages.qttools
-    yaml-cpp
-    zxing-cpp
   ];
 
   cmakeFlags = [
@@ -106,9 +101,18 @@ stdenv.mkDerivation (finalAttrs: {
     patches = [
       # also check cap_net_admin so we don't have to set suid
       ./core-also-check-capabilities.patch
+
+      # adds missing entries to the lockfile
+      # can be removed next update
+      (fetchpatch {
+        name = "fix-lockfile.patch";
+        url = "https://github.com/Mahdi-zarei/nekoray/commit/6f9b2c69e21b0b86242fcc5731f21561373d0963.patch";
+        stripLen = 2;
+        hash = "sha256-LDLgCQUXOqaV++6Z4/8r2IaBM+Kz/LckjVsvZn/0lLM=";
+      })
     ];
 
-    vendorHash = "sha256-hZiEIJ4/TcLUfT+pkqs6WfzjqppSTjKXEtQC+DS26Ug=";
+    vendorHash = "sha256-6Q6Qi3QQOmuLBaV4t/CEER6s1MUvL7ER6Hfm44sQk4M=";
 
     # ldflags and tags are taken from script/build_go.sh
     ldflags = [


### PR DESCRIPTION
https://github.com/Mahdi-zarei/nekoray/releases/tag/4.3.6
https://github.com/Mahdi-zarei/nekoray/releases/tag/4.3.7

There was an issue with the lockfile which I'll try upstreaming:
- https://github.com/Mahdi-zarei/nekoray/pull/490

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
