### PR TITLE
clink: init at 2024.12.07

### DIFF
--- a/pkgs/by-name/cl/clink/package.nix
+++ b/pkgs/by-name/cl/clink/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  coreutils,
+  rustpython,
+  cmake,
+  xxd,
+  libllvm,
+  libclang,
+  sqlite,
+  python3,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "clink";
+  version = "2024.12.07";
+
+  src = fetchFromGitHub {
+    owner = "Smattr";
+    repo = "clink";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BfKmipoc/dxa7ZYErV+DNV5sIRCvApZdNcIbHYlCwck=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace clink/src/{clink-repl,*.py} \
+      --replace-fail '#!/usr/bin/env python3' '#!${lib.getExe rustpython}'
+
+    find . -type f -name 'CMakeLists.txt' \
+      -exec sed -i "s|/usr/bin/env|${lib.getExe' coreutils "env"}|g" {} \;
+
+    find . -type f -name '*.py' \
+      -exec sed -i "s|#!/usr/bin/env python3|#!${lib.getExe rustpython}|" {} \;
+  '';
+
+  strctDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    xxd
+    libllvm
+    libclang
+    rustpython
+    (python3.withPackages (ps: with ps; [ pytest ]))
+  ];
+
+  buildInputs = [ sqlite ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern re-implementation of Cscope";
+    longDescription = ''
+      When working in a large, complex C/C++ code base, an invaluable
+      navigation tool is Cscope. However, Cscope is showing its age
+      and has some issues that prevent it from being the perfect
+      assistant. Clink aims to bring the Cscope experience into the
+      twenty-first century.
+    '';
+    homepage = "https://github.com/Smattr/clink";
+    changelog = "https://github.com/Smattr/clink/blob/${finalAttrs.version}/CHANGELOG.rst";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "clink";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
When working in a large, complex C/C++ code base, an invaluable navigation tool is [Cscope](http://cscope.sourceforge.net/). However, Cscope is showing its age and has some issues that prevent it from being the perfect assistant. [Clink](https://github.com/Smattr/clink) aims to bring the Cscope experience into the twenty-first century.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc