### PR TITLE
[staging-next] opentype-sanitizer: build with C++17 stdlib

### DIFF
--- a/pkgs/by-name/op/opentype-sanitizer/package.nix
+++ b/pkgs/by-name/op/opentype-sanitizer/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-QRbF2GUDQsp8i6qVYlafSb9HaaozRuJ8dn1mhMMLeLc=";
   };
 
-  mesonFlags = [ "-Dcpp_std=c++14" ];
+  mesonFlags = [ "-Dcpp_std=c++17" ]; # required by gtest
 
   buildInputs = [
     freetype


### PR DESCRIPTION
staging-next cycle: https://github.com/NixOS/nixpkgs/pull/422427

gtest enforces C++17 now: https://github.com/NixOS/nixpkgs/pull/403142

```
opentype-sanitizer> [49/60] Compiling C++ object cff_charstring.p/tests_cff_charstring_test.cc.o
opentype-sanitizer> FAILED: cff_charstring.p/tests_cff_charstring_test.cc.o 
opentype-sanitizer> clang++ -Icff_charstring.p -I. -I.. -I../include -I../src -I/nix/store/a4jhc69r85dn5b9bgcm86lr8gfz2v1ln-gtest-1.17.0-dev/include -fdiagnostics-color=always -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -Wall -Winvalid-pch -Wextra -std=c++14 -DGTEST_HAS_PTHREAD=1 -MD -MQ cff_charstring.p/tests_cff_charstring_test.cc.o -MF cff_charstring.p/tests_cff_charstring_test.cc.o.d -o cff_charstring.p/tests_cff_charstring_test.cc.o -c ../tests/cff_charstring_test.cc
opentype-sanitizer> In file included from ../tests/cff_charstring_test.cc:7:
opentype-sanitizer> In file included from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gtest-1.17.0-dev/include/gtest/gtest.h:63:
opentype-sanitizer> In file included from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gtest-1.17.0-dev/include/gtest/gtest-assertion-result.h:46:
opentype-sanitizer> In file included from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gtest-1.17.0-dev/include/gtest/gtest-message.h:57:
opentype-sanitizer> /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gtest-1.17.0-dev/include/gtest/internal/gtest-port.h:273:2: error: C++ versions less than C++17 are not supported.
opentype-sanitizer>   273 | #error C++ versions less than C++17 are not supported.
opentype-sanitizer>       |  ^
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
