### PR TITLE
rocmPackages.rocdbgapi: fix build

### DIFF
--- a/pkgs/development/rocm-modules/6/rocdbgapi/default.nix
+++ b/pkgs/development/rocm-modules/6/rocdbgapi/default.nix
@@ -37,6 +37,15 @@ let
         helvetic
         wasy
         courier
+        # FIXME: The following packages are used in the Doxygen table
+        # workaround, can be removed once
+        # https://github.com/doxygen/doxygen/issues/11634 is fixed, depending
+        # on what the fix is
+        tabularray
+        ninecolors
+        codehigh
+        catchfile
+        environ
       ]
     )
   );
@@ -58,6 +67,16 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "rocm-${finalAttrs.version}";
     hash = "sha256-6itfBrWVspobU47aiJAOQoxT8chwrq9scRn0or3bXto=";
   };
+
+  # FIXME: remove once https://github.com/doxygen/doxygen/issues/11634 is resolved
+  # Applies workaround based on what was suggested in
+  # https://github.com/doxygen/doxygen/issues/11634#issuecomment-3027000655,
+  # but rewritten to use the `tabularray` LaTeX package. Unfortunately,
+  # verbatim code snippets in the documentation are not formatted very nicely
+  # with this workaround.
+  postPatch = ''
+    substituteInPlace doc/Doxyfile.in --replace 'LATEX_EXTRA_STYLESHEET =' 'LATEX_EXTRA_STYLESHEET = ${./override_doxygen_tables.sty}'
+  '';
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/rocm-modules/6/rocdbgapi/override_doxygen_tables.sty
+++ b/pkgs/development/rocm-modules/6/rocdbgapi/override_doxygen_tables.sty
@@ -1,0 +1,89 @@
+\NeedsTeXFormat{LaTeX2e}
+
+% Packages used by this style file
+\RequirePackage{doxygen}
+\RequirePackage{tabularray}
+\UseTblrLibrary{varwidth}
+\RequirePackage{codehigh}
+\RequirePackage{environ}
+
+% Used by parameter lists
+\renewenvironment{DoxyParams}[2][]{%
+    \par%
+    \ifthenelse{\equal{#1}{}}%
+      {\begin{longtblr}[l]{rowhead=1,measure=vbox,colspec={|X[-1,l]|X[-1,l]|}}}% name + description
+    {\ifthenelse{\equal{#1}{1}}%
+      {\begin{longtblr}[l]{rowhead=1,measure=vbox,colspec={|X[-1,l]|X[-1,l]|X[-1,l]|}}}% in/out + name + desc
+      {\begin{longtblr}[l]{rowhead=1,measure=vbox,colspec={|X[-1,l]|X[-1,l]|X[-1,l]|X[-1,l]|}}}% in/out + type + name + desc
+    }
+    \SetCell[c=2]{l} \hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #2 \\[1ex]%
+    \hline%
+}{%
+    \end{longtblr}%
+    \vspace{6pt}%
+}
+
+% Used for fields of simple structs
+\renewenvironment{DoxyFields}[1]{%
+    \par%
+    \begin{longtblr}[l]{rowhead=1,measure=vbox,colspec={|X[-1,r]|X[-1,l]|X[-1,l]|}}%
+    \SetCell[c=3]{l} \hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #1 \\[1ex]%
+    \hline%
+}{%
+    \end{longtblr}%
+    \vspace{6pt}%
+}
+
+% Used for fields simple class style enums
+\renewenvironment{DoxyEnumFields}[2][]{%
+    \par%
+    \ifthenelse{\equal{#1}{2}}%
+      {\begin{longtblr}[l]{rowhead=1,measure=vbox,colspec={|X[-1,r]|X[-1,l]|}}}%
+      {\begin{longtblr}[l]{rowhead=1,measure=vbox,colspec={|X[-1,l]|X[-1,r]|X[-1,l]|}}}% with init value
+    \SetCell[c=2]{l} \hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #2 \\[1ex]%
+    \hline%
+}{%
+    \end{longtblr}%
+    \vspace{6pt}%
+}
+
+% Used by return value lists
+\renewenvironment{DoxyRetVals}[1]{%
+    \par%
+    \begin{longtblr}[l]{rowhead=1,measure=vbox,colspec={|X[-1,r]|X[-1,l]|}}%
+    \SetCell[c=2]{l} \hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #1 \\[1ex]%
+    \hline%
+}{%
+    \end{longtblr}%
+    \vspace{6pt}%
+}
+
+% Used by exception lists
+\renewenvironment{DoxyExceptions}[1]{%
+    \par%
+    \begin{longtblr}[l]{rowhead=1,measure=vbox,colspec={|l[-1,r]|l[-1,l]|}}%
+    \SetCell[c=2]{l} \hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #1 \\[1ex]%
+    \hline%
+}{%
+    \end{longtblr}%
+    \vspace{6pt}%
+}
+
+% Used by template parameter lists
+\renewenvironment{DoxyTemplParams}[1]{%
+    \par%
+    \begin{longtblr}[l]{rowhead=1,measure=vbox,colspec={|X[-1,r]|X[-1,l]|}}%
+    \SetCell[c=2]{l} \hspace{-6pt}\bfseries\fontseries{bc}\selectfont\color{darkgray} #1 \\[1ex]%
+    \hline%
+}{%
+    \end{longtblr}%
+    \vspace{6pt}%
+}
+
+% NOTE: this is not a perfect workaround, and known to loose linebreaks, repeated spaces, etc
+\RenewEnviron{DoxyVerb}{%
+  \par%
+  \footnotesize%
+  \ExpandArgs{o}\fakeverb{\BODY}%
+  \normalsize%
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This works around https://github.com/doxygen/doxygen/issues/11634 in building the documentation for `rocdbgapi` (appearing with the newest LaTeX kernel), by patching how Doxygen formats tables in LaTeX.
One known limitation of this fix is that verbatim (code) text in tables isn't formatted very nicely. This seems to appear 3 times in the documentation in question.

resolves #421822

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
