### PR TITLE
mir: 2.20.2 -> 2.21.1

### DIFF
--- a/pkgs/by-name/mi/miracle-wm/package.nix
+++ b/pkgs/by-name/mi/miracle-wm/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  unstableGitUpdater,
   nixosTests,
   boost,
   cmake,
@@ -30,13 +30,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "miracle-wm";
-  version = "0.5.2";
+  version = "0.5.2-unstable-2025-07-06";
 
   src = fetchFromGitHub {
     owner = "miracle-wm-org";
     repo = "miracle-wm";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-nmDFmj3DawgjRB0+vlcvPX+kj6lzAu14HySFc2NsJss=";
+    rev = "859c1e4c97db78872ee799ceb0316c612841ee37";
+    hash = "sha256-1AZLxD/VyBt60ZHXVN/OpKNigN9NdEBJ9svOOVI0JCI=";
   };
 
   postPatch =
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
   checkPhase = ''
     runHook preCheck
 
-    ./bin/miracle-wm-tests
+    ./tests/miracle-wm-tests
 
     runHook postCheck
   '';
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = gitUpdater { rev-prefix = "v"; };
+    updateScript = unstableGitUpdater { tagPrefix = "v"; };
     providedSessions = [ "miracle-wm" ];
     tests.vm = nixosTests.miracle-wm;
   };

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -26,6 +26,7 @@
   lttng-ust,
   libgbm,
   nettle,
+  pixman,
   udev,
   wayland,
   wayland-scanner,
@@ -105,32 +106,39 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-scanner
   ];
 
-  buildInputs = [
-    boost
-    egl-wayland
-    freetype
-    glib
-    glm
-    libdrm
-    libepoxy
-    libevdev
-    libglvnd
-    libinput
-    libuuid
-    libxcb
-    libxkbcommon
-    libxmlxx
-    yaml-cpp
-    lttng-ust
-    libgbm
-    nettle
-    udev
-    wayland
-    xorg.libX11
-    xorg.libXcursor
-    xorg.xorgproto
-    xwayland
-  ] ++ lib.optionals (lib.strings.versionAtLeast version "2.18.0") [ libapparmor ];
+  buildInputs =
+    [
+      boost
+      egl-wayland
+      freetype
+      glib
+      glm
+      libdrm
+      libepoxy
+      libevdev
+      libglvnd
+      libinput
+      libuuid
+      libxcb
+      libxkbcommon
+      libxmlxx
+      yaml-cpp
+      lttng-ust
+      libgbm
+      nettle
+      udev
+      wayland
+      xorg.libX11
+      xorg.libXcursor
+      xorg.xorgproto
+      xwayland
+    ]
+    ++ lib.optionals (lib.strings.versionAtLeast version "2.18.0") [
+      libapparmor
+    ]
+    ++ lib.optionals (lib.strings.versionAtLeast version "2.21.0") [
+      pixman
+    ];
 
   nativeCheckInputs = [
     dbus

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -7,6 +7,13 @@ in
   mir = common {
     version = "2.21.1";
     hash = "sha256-FDZ40LiuvMuyWQQGjgOHTm+J3i7yczKMzL3dZ1jsz/E=";
+    patches = [
+      (fetchpatch {
+        name = "0001-Fix-gtest-nodiscard-error.patch";
+        url = "https://github.com/canonical/mir/commit/60dab2b197deb159087e44865e7314ad2865b79d.patch";
+        hash = "sha256-fB49E+Wjm2zJnie9Ws+tP0d6lxcG3V/C/UDfy/4iuFU=";
+      })
+    ];
   };
 
   mir_2_15 = common {

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,8 +5,8 @@ let
 in
 {
   mir = common {
-    version = "2.20.2";
-    hash = "sha256-kxXPRIvgvpWqos8l/fJyHvfJBNi0jOZfV5inY3SBavM=";
+    version = "2.21.0";
+    hash = "sha256-WCVh1163ZmT8tHe60AOxSg7AEDXsSekNb7UpbojyIXU=";
   };
 
   mir_2_15 = common {

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,8 +5,8 @@ let
 in
 {
   mir = common {
-    version = "2.21.0";
-    hash = "sha256-WCVh1163ZmT8tHe60AOxSg7AEDXsSekNb7UpbojyIXU=";
+    version = "2.21.1";
+    hash = "sha256-FDZ40LiuvMuyWQQGjgOHTm+J3i7yczKMzL3dZ1jsz/E=";
   };
 
   mir_2_15 = common {


### PR DESCRIPTION
https://github.com/canonical/mir/releases/tag/v2.21.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
