### PR TITLE
[25.05] yeahwm: mark broken on Linux

### DIFF
--- a/pkgs/by-name/ye/yeahwm/package.nix
+++ b/pkgs/by-name/ye/yeahwm/package.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.isc;
     mainProgram = "yeahwm";
     maintainers = with lib.maintainers; [ ];
+    broken = stdenv.hostPlatform.isLinux; # Does not build with GCC 14.
     inherit (libX11.meta) platforms;
   };
 })


### PR DESCRIPTION
Does not build on GCC 14.

Related: #416319