### PR TITLE
gemini-cli-nightly: init at 0.1.9-unstable-2025-07-08

### DIFF
--- a/pkgs/by-name/ge/gemini-cli-nightly/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-nightly/package.nix
@@ -31,9 +31,9 @@ buildNpmPackage (finalAttrs: {
   };
 
   postPatch = ''
-    sed -i 's/"version": "0.1.5"/"version": "${finalAttrs.version}"/' package.json
-    sed -i 's/"version": "0.1.5"/"version": "${finalAttrs.version}"/' packages/cli/package.json
-    sed -i 's/"version": "0.1.5"/"version": "${finalAttrs.version}"/' packages/core/package.json
+    for file in {,packages/cli,packages/core}package.json; do
+      substituteInPlace $file --replace-fail '"version": "0.1.5"' "version": "${finalAttrs.version}"'
+    done
   '';
 
   preBuild = ''

--- a/pkgs/by-name/ge/gemini-cli-nightly/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-nightly/package.nix
@@ -56,6 +56,7 @@ buildNpmPackage (finalAttrs: {
     cp -r packages/core $out/share/gemini-cli/node_modules/@google/gemini-cli-core
 
     ln -s $out/share/gemini-cli/node_modules/@google/gemini-cli/dist/index.js $out/bin/gemini
+    chmod +x $out/bin/gemini
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ge/gemini-cli-nightly/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-nightly/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  writeShellApplication,
+  cacert,
+  curl,
+  gnused,
+  jq,
+  nix-prefetch-github,
+  prefetch-npm-deps,
+  gitUpdater,
+  ...
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "gemini-cli";
+  version = "0.1.9-nightly.250708.137ffec3";
+
+  src = fetchFromGitHub {
+    owner = "google-gemini";
+    repo = "gemini-cli";
+    rev = "821abfc456cb4664f8e7cfdc5856b1dd6564fecd";
+    hash = "sha256-2w28N6Fhm6k3wdTYtKH4uLPBIOdELd/aRFDs8UMWMmU=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-yoUAOo8OwUWG0gyI5AdwfRFzSZvSCd3HYzzpJRvdbiM=";
+  };
+
+  postPatch = ''
+    sed -i 's/"version": "0.1.5"/"version": "${finalAttrs.version}"/' package.json
+    sed -i 's/"version": "0.1.5"/"version": "${finalAttrs.version}"/' packages/cli/package.json
+    sed -i 's/"version": "0.1.5"/"version": "${finalAttrs.version}"/' packages/core/package.json
+  '';
+
+  preBuild = ''
+    mkdir -p packages/cli/src/generated
+    # The TypeScript source file
+    echo "export const GIT_COMMIT_INFO = { commitHash: '${finalAttrs.src.rev}' };" > packages/cli/src/generated/git-commit.ts
+    # The TypeScript declaration file to satisfy the strict compiler
+    echo "export const GIT_COMMIT_INFO: { commitHash: string };" > packages/cli/src/generated/git-commit.d.ts
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,share/gemini-cli}
+
+    cp -r node_modules $out/share/gemini-cli/
+
+    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli
+    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-core
+    cp -r packages/cli $out/share/gemini-cli/node_modules/@google/gemini-cli
+    cp -r packages/core $out/share/gemini-cli/node_modules/@google/gemini-cli-core
+
+    ln -s $out/share/gemini-cli/node_modules/@google/gemini-cli/dist/index.js $out/bin/gemini
+    runHook postInstall
+  '';
+
+
+   postInstall = ''
+     chmod +x "$out/bin/gemini"
+   '';
+
+
+   passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "AI agent that brings the power of Gemini directly into your terminal";
+    homepage = "https://github.com/google-gemini/gemini-cli";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ donteatoreo ];
+    platforms = lib.platforms.all;
+    mainProgram = "gemini";
+  };
+})

--- a/pkgs/by-name/ge/gemini-cli-nightly/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-nightly/package.nix
@@ -15,7 +15,7 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "gemini-cli";
-  version = "0.1.9-unstable-25-07-08";
+  version = "0.1.9-unstable-2025-07-08";
 
   src = fetchFromGitHub {
     owner = "google-gemini";

--- a/pkgs/by-name/ge/gemini-cli-nightly/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-nightly/package.nix
@@ -60,9 +60,6 @@ buildNpmPackage (finalAttrs: {
   '';
 
 
-   postInstall = ''
-     chmod +x "$out/bin/gemini"
-   '';
 
 
    passthru.updateScript = gitUpdater { };

--- a/pkgs/by-name/ge/gemini-cli-nightly/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-nightly/package.nix
@@ -13,10 +13,9 @@
   gitUpdater,
   ...
 }:
-
 buildNpmPackage (finalAttrs: {
   pname = "gemini-cli";
-  version = "0.1.9-nightly.250708.137ffec3";
+  version = "0.1.9-unstable-25-07-08";
 
   src = fetchFromGitHub {
     owner = "google-gemini";
@@ -60,16 +59,13 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
-
-
-
-   passthru.updateScript = gitUpdater { };
+  passthru.updateScript = gitUpdater {};
 
   meta = {
     description = "AI agent that brings the power of Gemini directly into your terminal";
     homepage = "https://github.com/google-gemini/gemini-cli";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ donteatoreo ];
+    maintainers = with lib.maintainers; [donteatoreo];
     platforms = lib.platforms.all;
     mainProgram = "gemini";
   };

--- a/pkgs/by-name/ge/gemini-cli-nightly/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-nightly/package.nix
@@ -30,10 +30,11 @@ buildNpmPackage (finalAttrs: {
   };
 
   postPatch = ''
-    for file in {,packages/cli,packages/core}package.json; do
-      substituteInPlace $file --replace-fail '"version": "0.1.5"' "version": "${finalAttrs.version}"'
+    for file in package.json packages/cli/package.json packages/core/package.json; do
+      substituteInPlace $file --replace-fail '"version": "0.1.5"' '"version": "${finalAttrs.version}"'
     done
   '';
+
 
   preBuild = ''
     mkdir -p packages/cli/src/generated


### PR DESCRIPTION
This PR introduces the gemini-cli-nightly package.

The build process for the latest commits on the gemini-cli main branch has changed significantly from the last tagged release (v0.1.7), making a simple update of the existing gemini-cli package difficult. The new build process uses a stricter TypeScript compiler which requires explicit type declarations for all imported modules.

This package provides the necessary fixes to build the current main branch, which include:

    Patching the version numbers in the monorepo's package.json files.

    Creating a mock git-commit.ts and its corresponding type declaration file (git-commit.d.ts) during the build to satisfy the strict TypeScript compiler without needing git in the sandbox.

This allows users to install and test the latest development version.

Homepage: [https://github.com/google-gemini/gemini-cli](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2Fgoogle-gemini%2Fgemini-cli)
Things done


    Built on platform(s)

      [X]  x86_64-linux

      []  aarch64-linux

       [] x86_64-darwin

       [] aarch64-darwin

    For non-Linux: Is sandboxing enabled in nix.conf? (See [Nix manual](https://www.google.com/url?sa=E&q=https%3A%2F%2Fnixos.org%2Fmanual%2Fnix%2Fstable%2Fcommand-ref%2Fconf-file.html))

        sandbox = relaxed

        sandbox = true

    Tested, as applicable:

        [NixOS test(s)](https://www.google.com/url?sa=E&q=https%3A%2F%2Fnixos.org%2Fmanual%2Fnixos%2Funstable%2Findex.html%23sec-nixos-tests) (look inside [nixos/tests](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fnixos%2Ftests))

        and/or [package tests](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fpkgs%2FREADME.md%23package-tests)

        or, for functions and "core" functionality, tests in [lib/tests](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Flib%2Ftests) or [pkgs/test](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fpkgs%2Ftest)

        made sure NixOS tests are [linked](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fpkgs%2FREADME.md%23linking-nixos-module-tests-to-a-package) to the relevant packages

    Tested compilation of all packages that depend on this change using nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD". Note: all changes have to be committed, also see [nixpkgs-review usage](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FMic92%2Fnixpkgs-review%23usage)

    Tested basic functionality of all binary files (usually in ./result/bin/)

    [Nixpkgs 25.11 Release Notes](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fdoc%2Frelease-notes%2Frl-2511.section.md) (or backporting [25.05](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fdoc%2Fmanual%2Frelease-notes%2Frl-2505.section.md) Nixpkgs Release notes)

        (Package updates) Added a release notes entry if the change is major or breaking

    [NixOS 25.11 Release Notes](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fnixos%2Fdoc%2Fmanual%2Frelease-notes%2Frl-2511.section.md) (or backporting [25.05](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fnixos%2Fdoc%2Fmanual%2Frelease-notes%2Frl-2505.section.md) NixOS Release notes)

        (Module updates) Added a release notes entry if the change is significant

        (Module addition) Added a release notes entry if adding a new NixOS module

    Fits [CONTRIBUTING.md](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2FCONTRIBUTING.md), [pkgs/README.md](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fpkgs%2FREADME.md), [maintainers/README.md](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Fblob%2Fmaster%2Fmaintainers%2FREADME.md) and other contributing documentation in corresponding paths.