### PR TITLE
[25.05] xen: 4.19.2 -> 4.19.3-unstable-2025-07-09

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -1,46 +1,12 @@
 {
   buildXenPackage,
   python3Packages,
-  fetchpatch,
 }:
 
 buildXenPackage.override { inherit python3Packages; } {
   pname = "xen";
-  version = "4.19.2";
-  patches = [
-    (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-01.patch";
-      hash = "sha256-YUcp9QI49RM/7WCxYzpzppv+vKtyl/NvLy6rIX5hVMw=";
-    })
-    (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-02.patch";
-      hash = "sha256-FTtEGAPFYxsun38hLhVMKJ1TFJOsTMK3WWPkO0R/OHg=";
-    })
-    (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-03.patch";
-      hash = "sha256-UkYMSpUgFvr4GJPXLgQsCyppGkNbeiFMyCZORK5tfmA=";
-    })
-    (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-04.patch";
-      hash = "sha256-lpiDPSHi+v2VfaWE9kp4+hveZKTzojD1F+RHsOtKE3A=";
-    })
-    (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-05.patch";
-      hash = "sha256-EKo9a5STX0mTRopoThe3+6gCWat+3XbguLr9QgMheZs=";
-    })
-    (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-06.patch";
-      hash = "sha256-HU+4apyTZNIFZ9cySOEtNh0JBJDG3LjDLwMvQYq0src=";
-    })
-    (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-07.patch";
-      hash = "sha256-9S85nkQ9Nn0cMzyRe4KGrFUaLggVxXBeKhoFF4R0y78=";
-    })
-    (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa470.patch";
-      hash = "sha256-zhMZ6pCZtt0ocgsMFVqthMaof46lMMTaYmlepMXVJqM=";
-    })
-  ];
-  rev = "f3362182e028119e5ca2ab37e5628b9fa6d21254";
-  hash = "sha256-c6LXYJ61umJb/r5/utwBWLAfy+tIvpK7QLjI3zKfr6Y=";
+  version = "4.19.3-unstable-2025-07-09";
+  upstreamVersion = "4.19.3-pre";
+  rev = "b026848daf3cca7a4e1d234c8a3b91ebed270e65";
+  hash = "sha256-ThlKeS8SgrcXJvwSIQIE+GvSd5WmTskw+S9JowwFVHg=";
 }


### PR DESCRIPTION
https://xenbits.xen.org/xsa/advisory-471.html

Researchers from Microsoft and ETH Zurich have discovered several new speculative sidechannel attacks which bypass current protections.  They are detailed in a paper titled "Enter, Exit, Page Fault, Leak: Testing Isolation Boundaries for Microarchitectural Leaks".

Two issues, which AMD have named Transitive Scheduler Attacks, utilise timing information from instruction execution.  These are:

  * CVE-2024-36350: TSA-SQ (TSA in the Store Queues)
  * CVE-2024-36357: TSA-L1 (TSA in the L1 data cache)

For more information, see:
  https://www.amd.com/content/dam/amd/en/documents/resources/bulletin/technical-guidance-for-mitigating-transient-scheduler-attacks.pdf
  https://www.amd.com/en/resources/product-security/bulletin/amd-sb-7029.html
  https://aka.ms/enter-exit-leak

This security patch required a rebase to the HEAD of `staging-4.19`, which upgrades Xen to 4.19.3-pre. We should not expect a new release for the 4.19 branch anytime soon.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
