### PR TITLE
nixosTests.easytier: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -445,7 +445,7 @@ in
   fscrypt = runTest ./fscrypt.nix;
   fastnetmon-advanced = runTest ./fastnetmon-advanced.nix;
   lauti = runTest ./lauti.nix;
-  easytier = handleTest ./easytier.nix { };
+  easytier = runTest ./easytier.nix;
   ejabberd = runTest ./xmpp/ejabberd.nix;
   elk = handleTestOn [ "x86_64-linux" ] ./elk.nix { };
   emacs-daemon = runTest ./emacs-daemon.nix;

--- a/nixos/tests/easytier.nix
+++ b/nixos/tests/easytier.nix
@@ -1,121 +1,119 @@
-import ./make-test-python.nix (
-  { lib, ... }:
-  {
-    name = "easytier";
-    meta.maintainers = with lib.maintainers; [ ltrump ];
+{ lib, ... }:
+{
+  name = "easytier";
+  meta.maintainers = with lib.maintainers; [ ltrump ];
 
-    nodes =
-      let
-        genPeer =
-          hostConfig: settings:
-          lib.mkMerge [
-            {
-              services.easytier = {
-                enable = true;
-                instances.default = {
-                  settings = {
-                    network_name = "easytier_test";
-                    network_secret = "easytier_test_secret";
-                  } // settings;
-                };
+  nodes =
+    let
+      genPeer =
+        hostConfig: settings:
+        lib.mkMerge [
+          {
+            services.easytier = {
+              enable = true;
+              instances.default = {
+                settings = {
+                  network_name = "easytier_test";
+                  network_secret = "easytier_test_secret";
+                } // settings;
               };
-
-              networking.useDHCP = false;
-              networking.firewall.allowedTCPPorts = [
-                11010
-                11011
-              ];
-              networking.firewall.allowedUDPPorts = [
-                11010
-                11011
-              ];
-            }
-            hostConfig
-          ];
-      in
-      {
-        relay =
-          genPeer
-            {
-              virtualisation.vlans = [
-                1
-                2
-              ];
-
-              networking.interfaces.eth1.ipv4.addresses = [
-                {
-                  address = "192.168.1.11";
-                  prefixLength = 24;
-                }
-              ];
-
-              networking.interfaces.eth2.ipv4.addresses = [
-                {
-                  address = "192.168.2.11";
-                  prefixLength = 24;
-                }
-              ];
-            }
-            {
-              ipv4 = "10.144.144.1";
-              listeners = [
-                "tcp://0.0.0.0:11010"
-                "wss://0.0.0.0:11011"
-              ];
             };
 
-        peer1 =
-          genPeer
-            {
-              virtualisation.vlans = [ 1 ];
-            }
-            {
-              ipv4 = "10.144.144.2";
-              peers = [ "tcp://192.168.1.11:11010" ];
-            };
+            networking.useDHCP = false;
+            networking.firewall.allowedTCPPorts = [
+              11010
+              11011
+            ];
+            networking.firewall.allowedUDPPorts = [
+              11010
+              11011
+            ];
+          }
+          hostConfig
+        ];
+    in
+    {
+      relay =
+        genPeer
+          {
+            virtualisation.vlans = [
+              1
+              2
+            ];
 
-        peer2 =
-          genPeer
-            {
-              virtualisation.vlans = [ 2 ];
-            }
-            {
-              ipv4 = "10.144.144.3";
-              peers = [ "wss://192.168.2.11:11011" ];
-            };
-      };
+            networking.interfaces.eth1.ipv4.addresses = [
+              {
+                address = "192.168.1.11";
+                prefixLength = 24;
+              }
+            ];
 
-    testScript = ''
-      start_all()
+            networking.interfaces.eth2.ipv4.addresses = [
+              {
+                address = "192.168.2.11";
+                prefixLength = 24;
+              }
+            ];
+          }
+          {
+            ipv4 = "10.144.144.1";
+            listeners = [
+              "tcp://0.0.0.0:11010"
+              "wss://0.0.0.0:11011"
+            ];
+          };
 
-      relay.wait_for_unit("easytier-default.service")
-      peer1.wait_for_unit("easytier-default.service")
-      peer2.wait_for_unit("easytier-default.service")
+      peer1 =
+        genPeer
+          {
+            virtualisation.vlans = [ 1 ];
+          }
+          {
+            ipv4 = "10.144.144.2";
+            peers = [ "tcp://192.168.1.11:11010" ];
+          };
 
-      # relay is accessible by the other hosts
-      peer1.succeed("ping -c5 192.168.1.11")
-      peer2.succeed("ping -c5 192.168.2.11")
+      peer2 =
+        genPeer
+          {
+            virtualisation.vlans = [ 2 ];
+          }
+          {
+            ipv4 = "10.144.144.3";
+            peers = [ "wss://192.168.2.11:11011" ];
+          };
+    };
 
-      # The other hosts are in separate vlans
-      peer1.fail("ping -c5 192.168.2.11")
-      peer2.fail("ping -c5 192.168.1.11")
+  testScript = ''
+    start_all()
 
-      # Each host can ping themselves through EasyTier
-      relay.succeed("ping -c5 10.144.144.1")
-      peer1.succeed("ping -c5 10.144.144.2")
-      peer2.succeed("ping -c5 10.144.144.3")
+    relay.wait_for_unit("easytier-default.service")
+    peer1.wait_for_unit("easytier-default.service")
+    peer2.wait_for_unit("easytier-default.service")
 
-      # Relay is accessible by the other hosts through EasyTier
-      peer1.succeed("ping -c5 10.144.144.1")
-      peer2.succeed("ping -c5 10.144.144.1")
+    # relay is accessible by the other hosts
+    peer1.succeed("ping -c5 192.168.1.11")
+    peer2.succeed("ping -c5 192.168.2.11")
 
-      # Relay can access the other hosts through EasyTier
-      relay.succeed("ping -c5 10.144.144.2")
-      relay.succeed("ping -c5 10.144.144.3")
+    # The other hosts are in separate vlans
+    peer1.fail("ping -c5 192.168.2.11")
+    peer2.fail("ping -c5 192.168.1.11")
 
-      # The other hosts in separate vlans can access each other through EasyTier
-      peer1.succeed("ping -c5 10.144.144.3")
-      peer2.succeed("ping -c5 10.144.144.2")
-    '';
-  }
-)
+    # Each host can ping themselves through EasyTier
+    relay.succeed("ping -c5 10.144.144.1")
+    peer1.succeed("ping -c5 10.144.144.2")
+    peer2.succeed("ping -c5 10.144.144.3")
+
+    # Relay is accessible by the other hosts through EasyTier
+    peer1.succeed("ping -c5 10.144.144.1")
+    peer2.succeed("ping -c5 10.144.144.1")
+
+    # Relay can access the other hosts through EasyTier
+    relay.succeed("ping -c5 10.144.144.2")
+    relay.succeed("ping -c5 10.144.144.3")
+
+    # The other hosts in separate vlans can access each other through EasyTier
+    peer1.succeed("ping -c5 10.144.144.3")
+    peer2.succeed("ping -c5 10.144.144.2")
+  '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on 7b09056b (master) and 67256809 (this PR) and compare outputs, note that the derivations are the same.

`nix eval --read-only .#nixosTests.easytier`

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
