### PR TITLE
nixosTests.google-oslogin: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -613,7 +613,7 @@ in
   gokapi = runTest ./gokapi.nix;
   gollum = runTest ./gollum.nix;
   gonic = runTest ./gonic.nix;
-  google-oslogin = handleTest ./google-oslogin { };
+  google-oslogin = runTest ./google-oslogin;
   gopro-tool = runTest ./gopro-tool.nix;
   goss = runTest ./goss.nix;
   gotenberg = runTest ./gotenberg.nix;

--- a/nixos/tests/google-oslogin/default.nix
+++ b/nixos/tests/google-oslogin/default.nix
@@ -1,78 +1,81 @@
-import ../make-test-python.nix (
-  { pkgs, ... }:
-  let
-    inherit (import ./../ssh-keys.nix pkgs)
-      snakeOilPrivateKey
-      snakeOilPublicKey
-      ;
+{
+  lib,
+  pkgs,
+  hostPkgs,
+  ...
+}:
+let
+  inherit (import ./../ssh-keys.nix hostPkgs)
+    snakeOilPrivateKey
+    snakeOilPublicKey
+    ;
 
-    # don't check host keys or known hosts, use the snakeoil ssh key
-    ssh-config = builtins.toFile "ssh.conf" ''
-      UserKnownHostsFile=/dev/null
-      StrictHostKeyChecking=no
-      IdentityFile=~/.ssh/id_snakeoil
-    '';
-  in
-  {
-    name = "google-oslogin";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ ];
-    };
+  # don't check host keys or known hosts, use the snakeoil ssh key
+  ssh-config = builtins.toFile "ssh.conf" ''
+    UserKnownHostsFile=/dev/null
+    StrictHostKeyChecking=no
+    IdentityFile=~/.ssh/id_snakeoil
+  '';
+in
+{
+  name = "google-oslogin";
+  meta = with lib.maintainers; {
+    maintainers = [ ];
+  };
 
-    nodes = {
-      # the server provides both the the mocked google metadata server and the ssh server
-      server = (import ./server.nix pkgs);
+  nodes = {
+    # the server provides both the the mocked google metadata server and the ssh server
+    server = ./server.nix;
 
-      client = { ... }: { };
-    };
-    testScript = ''
-      MOCKUSER = "mockuser_nixos_org"
-      MOCKADMIN = "mockadmin_nixos_org"
-      start_all()
+    client = { ... }: { };
+  };
+  testScript = ''
+    MOCKUSER = "mockuser_nixos_org"
+    MOCKADMIN = "mockadmin_nixos_org"
+    start_all()
 
-      server.wait_for_unit("mock-google-metadata.service")
-      server.wait_for_open_port(80)
+    server.wait_for_unit("mock-google-metadata.service")
+    server.wait_for_open_port(80)
 
-      # mockserver should return a non-expired ssh key for both mockuser and mockadmin
-      server.succeed(
-          f'${pkgs.google-guest-oslogin}/bin/google_authorized_keys {MOCKUSER} | grep -q "${snakeOilPublicKey}"'
-      )
-      server.succeed(
-          f'${pkgs.google-guest-oslogin}/bin/google_authorized_keys {MOCKADMIN} | grep -q "${snakeOilPublicKey}"'
-      )
+    # mockserver should return a non-expired ssh key for both mockuser and mockadmin
+    server.succeed(
+        f'${pkgs.google-guest-oslogin}/bin/google_authorized_keys {MOCKUSER} | grep -q "${snakeOilPublicKey}"'
+    )
+    server.succeed(
+        f'${pkgs.google-guest-oslogin}/bin/google_authorized_keys {MOCKADMIN} | grep -q "${snakeOilPublicKey}"'
+    )
 
-      # install snakeoil ssh key on the client, and provision .ssh/config file
-      client.succeed("mkdir -p ~/.ssh")
-      client.succeed(
-          "cat ${snakeOilPrivateKey} > ~/.ssh/id_snakeoil"
-      )
-      client.succeed("chmod 600 ~/.ssh/id_snakeoil")
-      client.succeed("cp ${ssh-config} ~/.ssh/config")
+    # install snakeoil ssh key on the client, and provision .ssh/config file
+    client.succeed("mkdir -p ~/.ssh")
+    client.succeed(
+        "cat ${snakeOilPrivateKey} > ~/.ssh/id_snakeoil"
+    )
+    client.succeed("chmod 600 ~/.ssh/id_snakeoil")
+    client.succeed("cp ${ssh-config} ~/.ssh/config")
 
-      client.wait_for_unit("network.target")
-      server.wait_for_unit("sshd.service")
+    client.wait_for_unit("network.target")
+    server.wait_for_unit("sshd.service")
 
-      # we should not be able to connect as non-existing user
-      client.fail("ssh ghost@server 'true'")
+    # we should not be able to connect as non-existing user
+    client.fail("ssh ghost@server 'true'")
 
-      # we should be able to connect as mockuser
-      client.succeed(f"ssh {MOCKUSER}@server 'true'")
-      # but we shouldn't be able to sudo
-      client.fail(
-          f"ssh {MOCKUSER}@server '/run/wrappers/bin/sudo /run/current-system/sw/bin/id' | grep -q 'root'"
-      )
+    # we should be able to connect as mockuser
+    client.succeed(f"ssh {MOCKUSER}@server 'true'")
+    # but we shouldn't be able to sudo
+    client.fail(
+        f"ssh {MOCKUSER}@server '/run/wrappers/bin/sudo /run/current-system/sw/bin/id' | grep -q 'root'"
+    )
 
-      # we should also be able to log in as mockadmin
-      client.succeed(f"ssh {MOCKADMIN}@server 'true'")
-      # pam_oslogin_admin.so should now have generated a sudoers file
-      server.succeed(
-          f"find /run/google-sudoers.d | grep -q '/run/google-sudoers.d/{MOCKADMIN}'"
-      )
+    # we should also be able to log in as mockadmin
+    client.succeed(f"ssh {MOCKADMIN}@server 'true'")
+    # pam_oslogin_admin.so should now have generated a sudoers file
+    server.succeed(
+        f"find /run/google-sudoers.d | grep -q '/run/google-sudoers.d/{MOCKADMIN}'"
+    )
 
-      # and we should be able to sudo
-      client.succeed(
-          f"ssh {MOCKADMIN}@server '/run/wrappers/bin/sudo /run/current-system/sw/bin/id' | grep -q 'root'"
-      )
-    '';
-  }
-)
+    # and we should be able to sudo
+    client.succeed(
+        f"ssh {MOCKADMIN}@server '/run/wrappers/bin/sudo /run/current-system/sw/bin/id' | grep -q 'root'"
+    )
+  '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on 7b09056b (master) and cdab66d5b896347e796c009878f75a0930e28d85 (this PR) and compare outputs, note that the derivations are the same.

`nix eval --read-only .#nixosTests.google-oslogin`

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
