### PR TITLE
firefox-unwrapped: 140.0.2 -> 140.0.4

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,2477 +1,2477 @@
 {
-  version = "140.0.2";
+  version = "140.0.4";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ach/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ach/firefox-140.0.4.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "e2c227089de992da5a02f95b106e5294a02ed4d25fc8de2bec09f6b71e97d66c";
+      sha256 = "f943c88e9137bac9d5ddfc60939ad2d29c1bd552a25940952cfc259594fed177";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/af/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/af/firefox-140.0.4.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "cf761d0ce70f84f5d58ee6258aac4a71abeaba884bb5270cdc66f63f3a232f08";
+      sha256 = "b99de59f6e9dc526de1a5b2ad32746e664644e1571808fc69afc8c4642c0e1e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/an/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/an/firefox-140.0.4.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "45376e155b125ad03b2d5c021d03a688271a267f2f454e46665d587661066b86";
+      sha256 = "c045273e667aeabc7be60f0086391bc36d90f2adfab92210ba1f9268e1d7c8ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ar/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ar/firefox-140.0.4.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "76311912ed9617e6268d07b4f966f569474c6e4afaa45ecbf41d46635d3bf61d";
+      sha256 = "82e951d31b07d9688937734621057a7619cf191fe752ba8ec727163917ae56cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ast/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ast/firefox-140.0.4.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "cddb8708c58ea8ede3144fbbe5d5ac75f6b31b7b458214e8861ada75ea8b71f0";
+      sha256 = "8dda2a1af36b2dca3de2c9f74bc0072f3be2d9b3214d39d710db03583d921b84";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/az/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/az/firefox-140.0.4.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "f302ae54f3505e58140cdc5e08ed11ceda66cbcbcc2c02121571dd43e841e5dc";
+      sha256 = "2807a17273842e0599a13dfe4fdea595f2f5949217e3a346b92839d15dea72e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/be/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/be/firefox-140.0.4.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "29bd46023ff9ec1e5e24a017290e58bf40ba0e653dfd6c90fe8cd1d902ec442c";
+      sha256 = "b8296455d8ece60bffb88e8202dc30c34bef5d7ec1ffab8af08239e70ab1046d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/bg/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/bg/firefox-140.0.4.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "4cc5d8b67eb7db41f12d8499fcb93599f15239d9b39356e7e79a6d6938978ed6";
+      sha256 = "7d3e2f5e04170c73008253f03b11fbe0c48c183faf6e10e2350e1836df60a475";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/bn/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/bn/firefox-140.0.4.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "4d03e63d210bee0966f276a1a52838fb79996279d60678848085b530d78851f1";
+      sha256 = "be32a5971fd9ec8b7a90ec14d36025501744bfd0fede998f7e3050529f84480d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/br/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/br/firefox-140.0.4.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "e6e28d37de7390c89cc4bdbb5e509f9897c27453d233c07ed4fac38780d06e0b";
+      sha256 = "fd4216ca595c6aeb3df8f65757f255ec19c3ec3a4efc189f247ff46266c0b49c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/bs/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/bs/firefox-140.0.4.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "82f9d85725ff479487fbad5dd214e4cef6ac768925d0a3d9f752d4b0e675568d";
+      sha256 = "81dd60942c9ff6756678076ecd7911bcdf3b7d4a5a8afbd7b30b18a6653ab542";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ca-valencia/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ca-valencia/firefox-140.0.4.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "3bac8a3d6d84a156d77b0f418df20f462a4fc7d6df4683b76ce8c09d66a2c21e";
+      sha256 = "033596fb9b446b4e83a05db4d3ca4bbedb4749fc306d2abf19aa18cd1ce56c7b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ca/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ca/firefox-140.0.4.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "7e7bf5b13622d91d6c7cd0fb2ce192ac65a2c3e85f6fa7d0f46cdcdbb10ef6a5";
+      sha256 = "8e0b32b4201d78fa0cdbe39358091f75823385bfef42202073b08fb89e855f1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/cak/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/cak/firefox-140.0.4.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "fde5d16b04bbfa8a873203b54076173b453d93b7ae72602fac3a2798d83f69d9";
+      sha256 = "80030af3faff215dd3a31a38ddf6300c25317c48d43cd6e368edb8260500b38c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/cs/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/cs/firefox-140.0.4.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "e24c51758acba74028dcb3eed2b09d622c5d5b9ad8ca1eaf7c66fcf9ab435558";
+      sha256 = "3268be2e344b28b4b29eb1e72cf998c08c03a4ec09b291c492c91e7ddd8ce527";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/cy/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/cy/firefox-140.0.4.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "8f9fda9a85a8bf1e33b78a6e41933668503b48a916cab51898302abe57fe1405";
+      sha256 = "ea30df26b853d0ac57d3e180469b31e8ab1ca9b2715159126254920934a553c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/da/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/da/firefox-140.0.4.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "fb3963cc112476ae647891d0b7e7d2d6c126d2a608fc91256bcabe685b3c6341";
+      sha256 = "1ab11a3de9e956f9409b0bb1bd63e93bca452dfee9af08b6146a48aec05360ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/de/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/de/firefox-140.0.4.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "165b4935290667d625e3083faa737ac9bef173e7c8d3811226ec9249e9bef3b0";
+      sha256 = "41238ec3f71f94994a5b4e0f8f853f37e118b525c236184f8252e5a8f3fd5fb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/dsb/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/dsb/firefox-140.0.4.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "af8eb29899fb648dad7c5089371351241a58644879a8973a8c9a96c114c23d5f";
+      sha256 = "9bc216214d2b946e1b6fd299650e7694936d40e8c42d1af495846846034b4e42";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/el/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/el/firefox-140.0.4.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "68a52eee4300145740575fadc8e0c82858ea7f7e021381e8467f72cfc80377a3";
+      sha256 = "eaf89ac946296670fdd03ff1a04b4e31415cf5a3aeea74136abe060aed5c1174";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/en-CA/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/en-CA/firefox-140.0.4.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "50896768c02b17501256c3289a346ed5d7874332dcf14e14390c2e6d20ce3357";
+      sha256 = "f3fc43e9a3cd80217021d16158f5a8788d0e79312b2d04f6506ef7b959be8f75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/en-GB/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/en-GB/firefox-140.0.4.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "a56a4df541984469906050eaa1a2585bb4b31db183f452bf8f57f78e13026757";
+      sha256 = "c0ad885a06a9c3544d26342ce750c8f77833af7bb07b58056b3766d8b39f9121";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/en-US/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/en-US/firefox-140.0.4.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "0de987e3065409d7feeba28e8b9c59c8270b917a293c140a5423579c7e70f8ce";
+      sha256 = "63e0033e6f4dd0576074de3cf1f70feec43359f923ed9055e554cf84b13856f6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/eo/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/eo/firefox-140.0.4.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "bc8515c4d88f75fa9241af9e21cf6748eec8859401dda872aa7f14993433a0d6";
+      sha256 = "9ba6978b7b93067906632f5ff5cc5176dcfa822b328bef47aeda12a2b80b772e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/es-AR/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/es-AR/firefox-140.0.4.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "dcb01e7b7071b9d29fc81205b5cd8c11d7c6802186e77aa656e0dfe3491523cc";
+      sha256 = "5f18c84a33a752113b605b7aa1190f861266d112bbd3bf11a02e398374f21793";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/es-CL/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/es-CL/firefox-140.0.4.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "d3918ab7c29edf8c61a4c69a863e1330f7e51039bd8a96038ad0d65db73f7d07";
+      sha256 = "3e50bdee8ba84836a5e473e7ae16a10a77c72ea00313ef747d481e456509d5cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/es-ES/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/es-ES/firefox-140.0.4.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "999de873f455860c8912e18401347f4156f91b0da3779122eee98473af400c9d";
+      sha256 = "c968ee5478d2d0d19345e3b2589c4ab59b920ea8d7362c9568894b01844b53ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/es-MX/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/es-MX/firefox-140.0.4.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "e4a0bcfbaecb78b99eb8f9c651b536b1db2189268e218c32408fd9db7dee7e93";
+      sha256 = "4b5cb4200ce1b0d03fa64c6548ac890ad728ba48f820cc57b646851a2b799906";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/et/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/et/firefox-140.0.4.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "3f48c7f1c94fcb7186a50ac344adf55ae3fc5b4e9538fc3c3a5bcc79794e6ea3";
+      sha256 = "cbc37f1164ae18c166304847ddaf77a2f41f80cfacffc621dd83ce49f58b396f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/eu/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/eu/firefox-140.0.4.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "8d0390f0d5daba9a5a94d2b6a617cfd779c4a94141a14772e9424fb1c50b42f8";
+      sha256 = "391084c38de7ec752b0127a2e094000428a1e14695be863ce9974a93bac68ca3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/fa/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/fa/firefox-140.0.4.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "368331431ed1825a3351889e7b9c50a9e22009f5d2310e787d15ea84e98d707a";
+      sha256 = "d4748949656408593c2a1b50cde8aaf793bc72949839757e0c876fd41103fbf6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ff/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ff/firefox-140.0.4.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "4984d768f622c23bd8f8daacdf5ccccd0b5e1bf02056df24e77d1a4c31e88ffd";
+      sha256 = "6936546f2b1ec30628566448d7ee1899bb2421aba7fe6216cffb188d1b37db30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/fi/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/fi/firefox-140.0.4.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "3fc303b3c69d6d1f6e359aef31fc045c477318533a2c468dfc35b675d545b54c";
+      sha256 = "b5fc0520a281b904effb0934de09d5aa181fe7e1e69097e5a210f171441cf8e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/fr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/fr/firefox-140.0.4.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "61f78b729cfab9c0de14946c9f9d792efcedf410efd771651ff819f6fe233903";
+      sha256 = "b09ae010df4e4532e8352b53d1e912063a7212d32a98b7c57d6b65ae8f69d2cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/fur/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/fur/firefox-140.0.4.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "2fa4e5b3dc3d402ffcce9eb0d39ec96fd15ad17534a61d8d8ebb54454cf637a3";
+      sha256 = "d22129ecdd21d576196314138c1ea95a3586e32597dfd7ec10ac521b1051f342";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/fy-NL/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/fy-NL/firefox-140.0.4.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "7c67c4eb2f2c1f7c2740a196036ebdd223e8ecf3502c36bd530383915bc9bc6a";
+      sha256 = "af31dd2af4fe4b189028c950a18aafb0c1c3929584c010eb7fbfd265f4d070ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ga-IE/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ga-IE/firefox-140.0.4.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "05b8aa663b4a42732af808270b473cacd331d3dc9bf62c6db2b58d0353cda961";
+      sha256 = "af7fec204caac40b39d53c32d4998e8d79d63852c20c814d452bff7242c3a203";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/gd/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/gd/firefox-140.0.4.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "1d5242d61ecf20c9808099be96fbc3f519afef972396f78d27bb95e13cea0563";
+      sha256 = "39557be86366b4af33ceba02999817cd9c924b71fa53c8ce8c5978db46540c03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/gl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/gl/firefox-140.0.4.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "62238f570bd7b6d04334042655a77e6e3f50e49f68a670d6a6de72239f2d13c4";
+      sha256 = "641d663a98e9cfb2d73851cd43690e5ba6558eb9a53293d82bc56317f13d304b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/gn/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/gn/firefox-140.0.4.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "72837ce7a4fa32d66574b08a62789d950f142c7dd4dc64e77c5fe1b4a1440e0c";
+      sha256 = "b31eae5285175df269e309669f7b388d5e0a6ba638bfeda93055332b50de7239";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/gu-IN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/gu-IN/firefox-140.0.4.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "437068e0a89843392e7fca35b7fd4bcd0fcf1cf4349773b96dac837b2fc444f6";
+      sha256 = "4005c93cc405fd87d657e48fe5d1fd4465138672fde4c99f52b473d6c0610c91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/he/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/he/firefox-140.0.4.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "e9e92af20871a0a54eb92b6cbf497e70e5c46aadbd1c7ce311f298cd712d1951";
+      sha256 = "c8be882c46896913f393dfa087aae2234a658aedd1fd40b95e6929fef4a09d89";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/hi-IN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/hi-IN/firefox-140.0.4.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "f2ca0ea65c92a60cf48c9edf573567ef42a74f11a48f75211d3ee08f20782107";
+      sha256 = "9635a5904731ff04829de5fe78006643bf95e66ced31cf408a391c840529ec57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/hr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/hr/firefox-140.0.4.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "31fa2fdd19478e38104916d30cb6979413730e15e05e67c848b883296eecbbf6";
+      sha256 = "fbb0266b9d44fa95ce0d836828c652931b95fb0788fc34677627f2f65154f0f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/hsb/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/hsb/firefox-140.0.4.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "d0c53d3b6f50f82d937ae1ebc136988e52b8d4fe4c1a856a270bead227e18168";
+      sha256 = "67b867edf6f8755462e6655a924ad814f2dec6773fb9f16a8fe7a2e99f5e162f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/hu/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/hu/firefox-140.0.4.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "d1a398d8f68b2802a23ecedc7b13af9ab15a95e29bdcce67b0faa5ddd74a23f3";
+      sha256 = "b2e5d9572e5c4a432b8724da8d93b1b2fc380aa17edb1bbc8e9404fc7aceb3fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/hy-AM/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/hy-AM/firefox-140.0.4.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "ed7d7d3b3afda6713a43616f3bb557109bf111c87000a28883498fab5fc97fe8";
+      sha256 = "2275107b5ce36130de9ed6a017b3eba161094d6d82795e14ec94f49c219e28e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ia/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ia/firefox-140.0.4.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "8d6d4b5bd8a58f09a116d4660cf8c11581dde9eaa3bbfba629dd75680802136f";
+      sha256 = "1e8da9c5524c7f110747be29b8d5dd0cf9dde3e688b69dc01b4f2ab9128ad998";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/id/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/id/firefox-140.0.4.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "ae6a44bba8aaf3c90ec7f2c1349e3a0d3dc40d71032f9cdd1766b88cb76c519b";
+      sha256 = "003534b48392817c8086008ece34ebc3841e46cfe542b2fcae85fa53f4e23328";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/is/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/is/firefox-140.0.4.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "1e3b8183d4a05f5046b5c3ee88a0d9b10c13a1abcb222d160674f2dc5a8ee644";
+      sha256 = "b4721a060e43541462752c7d32afd68dbbd31acc2b5a6ecf80a266e7e96f25ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/it/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/it/firefox-140.0.4.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "fb0037c8da022dbb4d850fbc8115e69e18b5d3abbadb00d99c175b752ea62e2a";
+      sha256 = "aacda149720a3b218a7bbc7e5f9b79f9b90f12a1c0e11d9c3cdc6ba73bdf4e1a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ja/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ja/firefox-140.0.4.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "0ff7873a842ee5ffb9199cdd8960c9e8e8139eb870c1d6eaeb08b93180ab3e7a";
+      sha256 = "4c3e0e5d946447466a14f65c94f27c11e5fb20b948da4d580ea069909b9babd5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ka/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ka/firefox-140.0.4.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "da87492318002a32f7be7dd0a79c9eb1ce2089ba87dc09768170b9ad8386cc7a";
+      sha256 = "58c5ba63cceaa864645f015148305b73dcc68ee15d30f65c38fd4a8c731f87e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/kab/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/kab/firefox-140.0.4.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "55a193ba40f44363456cb58fbbc4ffcb84c81249e793c9d3b9fb6ceaadc1c206";
+      sha256 = "8759cb4d63917b1a767eeef65fcedb63d56e5abaaa6fde80ceed66eac5daa76d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/kk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/kk/firefox-140.0.4.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "c84f5ab5051392f785946cc207ff44f3e76a4869de9867de69100ced2f293e05";
+      sha256 = "6f3d8d0872fad6b6d99842ed558e4585c55928d46abbadb8a5b9ecad41d98147";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/km/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/km/firefox-140.0.4.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "8d0430da0846291063e5e76a86ce1e5ce4badd15a29af532ee9093bc24c5e7c6";
+      sha256 = "599233b9a4a4e0d8bbb303df932830f5f48f05e6e8f6abc6a613b9cb65a3a08a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/kn/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/kn/firefox-140.0.4.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "a02a1353ae9d415819f8084a5909fe5dbedffac3e163a2d618b78b84b1eb0f17";
+      sha256 = "0fedef33ccdf32bb7d402ac10068c4710473acfc35daa75f0027364c61f37993";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ko/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ko/firefox-140.0.4.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "06e8914c37157eeaaf0e4ce0500965cd3f5c638b0f6a5dc6c5ecf176e8c0c1af";
+      sha256 = "afbe28ce7f201e9ff3910ea66780c9422ea8c2d6f86914fd35d3e12016039199";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/lij/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/lij/firefox-140.0.4.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "392a45592535eb509aaffc3d1d34462e3a716d4c76763b5432676fb168e1a719";
+      sha256 = "07b0ea91c23c6925bfa9ae4fb8778feaaaa9ed0b1dcab8f401fe438fb97440f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/lt/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/lt/firefox-140.0.4.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "8e3d915a0ab0e373ee992112d0dfa360ab8434d3e285097629fbf341a58aa156";
+      sha256 = "9baa71d8a7c20aca54c421b0aa89d7a5ccd47d81ae330b62f47d80645fbccc7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/lv/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/lv/firefox-140.0.4.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "041e89dce80beea445dd202466cd901e3ea756e09c88fdad9b8b5dea1fd22651";
+      sha256 = "09e19b4cbafa4eed3389bfb4d963ee336f20e1e7013d73302f6735fba0c83762";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/mk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/mk/firefox-140.0.4.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "3ab3afc5e292cd3cfa034944904ea040bde8ae800ac31a325ba8a29fd2e6f02d";
+      sha256 = "8863e0afc27e29630604ab9d5d46119233dc6dc1acdaa0411ddf546e51f25a90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/mr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/mr/firefox-140.0.4.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "e86a79c31c80a6807a7efa0f5ac5e8ec83a205395049b8f71acd24f86e07bf30";
+      sha256 = "f89cf49dd5a8119987c9824af141a610fafd35ecdad63efdda4566ef881b779e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ms/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ms/firefox-140.0.4.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "7bdcd7a59746930d8af534593e9cffa6b4ea7aa9c9f55e588a9b36848e16f9de";
+      sha256 = "16034026fa470345bda32ab6cf77855ad181a46450605c2f3a3da7b3e8459141";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/my/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/my/firefox-140.0.4.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "9a02d4654aea0a331254fae34ce63d19d32d776b8e7dd878ee739dc1269a288f";
+      sha256 = "80b62b63f5b85034ad85c08427e8b57d8ad7006c39398f1d53d5c1d371d52f58";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/nb-NO/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/nb-NO/firefox-140.0.4.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "56e556cf8febe6c07430845e42b830034a23bb4495e009446e44c4c589d1e49b";
+      sha256 = "822b4d14e399be6be9a7138eef6c3d4196df57c1af1bf397e57ceaf255f5005d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ne-NP/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ne-NP/firefox-140.0.4.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "fb30955d8124f7ac413520f977e4523aacaf68f6131a15a51681f3feec37c7db";
+      sha256 = "9835c9fcee863a72f405342b3b9e5ca8221640999f676071208b92e4f55a431b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/nl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/nl/firefox-140.0.4.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "e0c0a9fb70336038f1d69a63f7c76a4838b91799f474b98b4fbed33de37e676e";
+      sha256 = "321eabfeca0d23d1ca52f11f2385951ab493cf37e6fa0f2910c614b9cea50c5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/nn-NO/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/nn-NO/firefox-140.0.4.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "46cfd0576574902b949f4c8da49db68ef3c76020a11411609a40a82399e98f52";
+      sha256 = "b6d189494b498693635c773fb5508add490766a8e84a3434174aeb806fcae122";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/oc/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/oc/firefox-140.0.4.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "94b5918783376bd741fb383ce3bb8a311fd98d433ebfd147854283102bfd2f7d";
+      sha256 = "5e4c3b578f7be36ba60f0bea160384c3d51c975a78509e978229116409a0c2dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/pa-IN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/pa-IN/firefox-140.0.4.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "ed8bf829691da467f7826b4f94ca339908d75f9f5900006a8339591693e7356b";
+      sha256 = "9a2db5dda0332d2bc15319a2bd9827fe631b55e309874683c013f467e241560c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/pl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/pl/firefox-140.0.4.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "66e1410b13b95d86534122db96706822ecbc8fcaf0f58630289f732673963b61";
+      sha256 = "d1d2e2e5280de06eb8e5c4a5003427bd022a1fd75de781d9f1102a493f489728";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/pt-BR/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/pt-BR/firefox-140.0.4.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "d740579183cc64d4c295602730ab8a3c766774871a82c840498a30528db13183";
+      sha256 = "98b35b1f41e66e81bce4d73389537d5f65a62b26a541d11d7a777173ff80ace1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/pt-PT/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/pt-PT/firefox-140.0.4.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "0fcb53162dade58f21fda891c67b582dc54abbd230f5ff52731ee7441a14c40b";
+      sha256 = "3888619d2961ae318b80554a1a96d6a1217775b73fd420cab7c7550db213677d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/rm/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/rm/firefox-140.0.4.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "a9107f9abf695219c162c916f3a9b524833a56481e5601a8a991929a92c504ef";
+      sha256 = "454c0d5c4206dc40aa4d1466c68bfa34a14dffadc39b4f1389c08396cbfc6a2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ro/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ro/firefox-140.0.4.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "ac9d146306ff772630e69bf4401a1a4132768ce09a2d99d65cde404d57f4347a";
+      sha256 = "36e688a7fd8de7faa6137b8f18c529af29c1ddb4127f13522d1e764a96a0359f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ru/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ru/firefox-140.0.4.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "869e9d4bb40782997ca61117adefb2fff9fc65c88a3842a5ea427cbae34f7ab0";
+      sha256 = "b58eff8dd606fc072aec5d2a5c05aaf3f1be24df50ebe229f67ae470fc0de77e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/sat/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/sat/firefox-140.0.4.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "f3196ca979279dcce6a77cce8ea5a52bf59173ba739862abb72348601eede52e";
+      sha256 = "359ea9fa726ae7cf85e8c4e3b93ac229fd1eb1e6aadfcd80202f43261f230b2d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/sc/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/sc/firefox-140.0.4.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "7e4c790af8176f4402cfa5be91fc5235b917ee4e061a42e36141c907133f6289";
+      sha256 = "019e0c4b5efa01ccf11c648ea5926b06723b8347dc40a510dc8943d6f3f9398c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/sco/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/sco/firefox-140.0.4.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "2ed21bbbf843179dd49b6f45ec9d92cc71206ff883836bb91ea38e652259df2a";
+      sha256 = "579aa32bf96feaf1802661cb76ee71e2e86eab5eef165427ffd17221d930a424";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/si/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/si/firefox-140.0.4.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "913bd04c526982236f7b36722e9fb9c5e0efe001261dc51a9a458467d0b32cdc";
+      sha256 = "36bbcbf0c69c94dcaa5f7d83a210803e62aa4e7681ea265ff940b450809a8c9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/sk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/sk/firefox-140.0.4.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "23431f9be624313c735504839e57fe9d47a529f54e6d7f7b4b89c6d65dca46e1";
+      sha256 = "4c0d7fd27b2d6f13b9fbb46bc60d0d0fae3ccc0a48964d8b76fd755abb09b6c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/skr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/skr/firefox-140.0.4.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "2a55f81b4539d4ae3e67c3b38f908d7c89a0d21c679c9c1a66eff3fb132aeef2";
+      sha256 = "a36eb3eff2841cf74a826ecfdf5e9bba0f002dbfbdbd047efa666f017b4b8990";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/sl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/sl/firefox-140.0.4.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "83b3ed4227201fe2bb211a9220075e81a4e25ca474a270ff3dab3aede93f0bda";
+      sha256 = "94907dcffdcb458d689f07d44d593bebb626b8e33369f8430bb832af3ebbeb31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/son/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/son/firefox-140.0.4.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "bc6b2351357684f75284fe37afa3ea12ca671fa12d848fefc018e4bf7a28f29c";
+      sha256 = "2361e0fe70ce80a749202033a108cdd5f452bde4f6d1aabe93bac29f111099be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/sq/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/sq/firefox-140.0.4.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "7e4858b0ba7ffbe8070a1c87fbeb4a2478366ed4bf4f3ef14ed2604159c2834d";
+      sha256 = "0b10efa397b9374633f1e6cdd96e6c0db209fbbbecea9f5b2ace09387f0d0632";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/sr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/sr/firefox-140.0.4.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "9a6a1ca2d911b33b98941e1173004986f1bebc186e1a6a65dc6e99b2d27905f2";
+      sha256 = "d3d1ee2abed6d1f4a7141266dc91607f63e99050bb8604d42d57fb84ec4b0ad1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/sv-SE/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/sv-SE/firefox-140.0.4.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "34195b184fa6a8aad50e90786be62602544d2d468b8f4cd0fab941b6f2cfc376";
+      sha256 = "861ec995d3c583b3923bc3341eeef98798081efad4aed440c85db7d68c17e633";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/szl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/szl/firefox-140.0.4.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "72b8cfe0a99403d735d95efbba2c6e697703bb2fdbd1adbce0121374d6b90c79";
+      sha256 = "cf15037296dc5d8d12473c7d6b35d76212e18737e615bad47618544770689e30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ta/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ta/firefox-140.0.4.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "9c0d4011f1705ec2a87d64e6ac326be24a310a9f33a50731433b341a70bd924d";
+      sha256 = "b67ecba9a19f933c2119a360bc32155933bbf58880682e9a92d611413839e3f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/te/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/te/firefox-140.0.4.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "9f880735a73310bb3f8e09b8b80f3e36a57a4349c9ef9611956a87445ded12b2";
+      sha256 = "3a7f66d6301d732aa1f7a38b543af171217981752422adc8369bb0d2fa57960e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/tg/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/tg/firefox-140.0.4.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "a92a1c3cd36de8882d23a70c7191001f01846ef0deff1065568d59ccd924376e";
+      sha256 = "7f7d9279462f9258d34d5c244ee05f7b550c077783de99826f98c85c1b18a1de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/th/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/th/firefox-140.0.4.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "a3b38ae33a09730acfb862a3ec698f8efe87c42c7048ac0012fadf759c663de7";
+      sha256 = "7f66f1da57dcb7d66d01df6dde1a6164c2b67547de375f922f3b969da44b0c4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/tl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/tl/firefox-140.0.4.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "d5429936c9f02d9a9325a30daad2465df66f90e8c5a500b067b5b975cc7a69f9";
+      sha256 = "e5e537353c36f62fe81665e568b58a628cbded6e3878b6f7cd0a4c1595f66a7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/tr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/tr/firefox-140.0.4.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "1ad4d75abb9ce983dd053d9edcb3b910e3d8aa1694c493e64cf336685cdee44e";
+      sha256 = "1a1234f1d51aa51914e0a7b0691119f7db59e2fdec984ac7a050f6146165094c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/trs/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/trs/firefox-140.0.4.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "fbf0f946a55c741d8d93b0d7ec4c6acff39c11f7adaf53d0bb52b3abac7549f9";
+      sha256 = "f2daf710fca9ef775dacb674666248b263f17de8aafbe104057883b9cb8ab082";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/uk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/uk/firefox-140.0.4.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "f35e7cd88bc7a0d04e9d332e4e1d146087f3b1cd1e7823014c9be433e2b74919";
+      sha256 = "ccde5546dfffdf689266eb5d775e515788720e3ee9fd604040f5fa1159a13629";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/ur/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/ur/firefox-140.0.4.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "5e6a5ca058ebfe254c98871e2f0acc5023a3d71979c7610b56b8cd579ad796a9";
+      sha256 = "d341965dbe1d7b5e97a259616c656241d70b79475edb66f496eb12b847c7b8b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/uz/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/uz/firefox-140.0.4.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "b554070e63c7cce2e0e529262cb09028aa525f4a95a867456ab27b01d5bfd6a0";
+      sha256 = "10be44ae71670ff47a6a5d5770a66ae72f0de6c9f92b20ad5ba4e35c513c7c21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/vi/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/vi/firefox-140.0.4.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "18eba0e1d2825c49ca791a13b967cda18150811c4af7645a75eea193145f7a19";
+      sha256 = "0f62936990ed1b09fa802076f5a3fac6e0124abc7b00e2b21eb3d99f67b9a93c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/xh/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/xh/firefox-140.0.4.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "59650b315866f02f2d9fb5dfd3bce4099e6b4aa48653553a730a85cd30b5ff9e";
+      sha256 = "5a2b8e9bb73887c7bf67dcbdba8107276865c6acc5f068097762ea6423363b69";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/zh-CN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/zh-CN/firefox-140.0.4.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "8c9d65d9462b8982157355145989e7e249242830d1d759cfa48164de7f76d406";
+      sha256 = "7e9414f774c20db478855bda61ac92b4391b71b67926a3c0500ade8b02a50118";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-x86_64/zh-TW/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-x86_64/zh-TW/firefox-140.0.4.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "77e66e8fed62f2899cc25e39906736dfdbb3efb56b2f29ce208b01f2b46ea9e0";
+      sha256 = "91745033ba539697affd88bc38b907e8611366ab920e0368f7c32d58995ec38a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ach/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ach/firefox-140.0.4.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "85ebde10a333bab7282b175ff3ad2eaa519b91b0746a6e59e19a4677774c1a14";
+      sha256 = "1186084f9cb050042d78e286a31cf8638025a86323e35980646a7097117af318";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/af/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/af/firefox-140.0.4.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "ef4f11da9cefd5cccfb7ebeba2f6571fa69ecee0604e481d38bdb2c10e37cd43";
+      sha256 = "2a38b0c0ef06cee8b82618b1590a381c4aa986db7fb2a4c5c95e8c84ecaf7cb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/an/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/an/firefox-140.0.4.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "322c2ff75021e6033236c5af8952593bc11035d1b936391de0c6d7b8859caf97";
+      sha256 = "14be6b274071b90e28b31eaced6fb55c8aa802f812ee844895f05a6976a7b67c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ar/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ar/firefox-140.0.4.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e4b9b54bdc05614d209df3c5480539843eb7b832ba48e336d16846de63f7338b";
+      sha256 = "2fd0c0cb5059f4982c3b47350bd20e1a75c61e556b0624eb48e5842ed7651adb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ast/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ast/firefox-140.0.4.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "f83d9920819e2d7e4746ecada967c151dff1a010054f6994f52b211e1d39f2c6";
+      sha256 = "73d6547c8e24b39cf93f10f58f72198108967eb3f8b00bad07ffd62f01ffa528";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/az/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/az/firefox-140.0.4.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "8741405c7173581127bab43cd3bb12b89a5a5af2d0bd62326d0aa35aaf068b9b";
+      sha256 = "79fb1f46eae41d4bff468e72de977282c353936fcd8a3e3cf7503bc324284183";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/be/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/be/firefox-140.0.4.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "72402f8097dd729b430890de299ee3833eb7d9766837746f475c2caa094031d0";
+      sha256 = "dc68865f6e1946c94828eecf8f3d8f036e31a0e39628f15b68b434c05e6236e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/bg/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/bg/firefox-140.0.4.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "36a5940709aa5f0083f34eec767185d3774a7e17ccba12f50e92e7b3e52a05c7";
+      sha256 = "105a93713444c9e121945073ed075530ea8cf6de27304f51eda03d97fc390be1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/bn/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/bn/firefox-140.0.4.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "f5a74bc15c324e22eccff2e780be09622300c979ec2c817ae4795c063a3e97b1";
+      sha256 = "689007b39930b173756e9dd0f07db52dddd7af05ab75058103a22af1bdf2f243";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/br/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/br/firefox-140.0.4.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "8b212f1b1697eb31e0145858171e32c59e21d0af2a557b29f11f41ec8f964365";
+      sha256 = "f7f4fdddc29c097eba6d19cf9956c0e1e57a6319d8e8b595d75c818a5aeb2969";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/bs/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/bs/firefox-140.0.4.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "687ff1bbee0f71afb3a59c6287a9ecaee4bba60e670373e5d72b212d4a367a8b";
+      sha256 = "f03d2f78cee1bb7ff52191daf0aefa020051135876e93584705a576ceab2c000";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ca-valencia/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ca-valencia/firefox-140.0.4.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "3bdb6457717e87d4af1a59199dfca5983483a7e6af2b7e89114cd764d9e0ac26";
+      sha256 = "f374f49c3b99ef7a4ab5971476088e0a795f51b79c78bb107735736fb02608cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ca/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ca/firefox-140.0.4.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "6731d518a8550a2cf474fe3c661735bec5724d4774d84c0b2a56eaffe850bec9";
+      sha256 = "19ee5381f86227c2cece4d0bc17bb91a903d2d3f91ef426962ed4088fa420a5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/cak/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/cak/firefox-140.0.4.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "b6c74cf2cf12a738824aba735f8c975bb3d1f7f4f4fb3349c781d01425ef3244";
+      sha256 = "d2ee2f40482b9b2e38c30845ad2e81a22adeade19ac4d9bbd74c65457bc60372";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/cs/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/cs/firefox-140.0.4.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "ff68d28c13e14aa22e9162ebf7846e12ea9fa93e5dd486e862cab909d15ffc18";
+      sha256 = "e6d69d98553b603912cee8d1c4a34055b9ab1eacff80c7951bc171e792e760f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/cy/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/cy/firefox-140.0.4.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "69d45fdabca475a679dac82e5e9ff524a93219fa7472d859850b3e48b09bd77a";
+      sha256 = "eb66fd829f0c8824aa6b591e9a493ab09014c5a0ce1f6964228eda7ae55c78be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/da/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/da/firefox-140.0.4.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "13d854824d0a07aa091625e9a3fb558d5bc1f0cd495ca053aa259a089a7633e1";
+      sha256 = "01dd245a9277b95134001c1c96a1f3a82af274a76034e307695d8f1c1793bc26";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/de/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/de/firefox-140.0.4.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "f63a41183122ede2c0b3313fcdb5aad9a39ffa980fb99034c2fbfdf2f0139ee4";
+      sha256 = "31f6ead3bc8c4dd96a7f6f4471090f36a7783ba35aff21aa4809257d713f837c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/dsb/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/dsb/firefox-140.0.4.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "dc0bcf2150fb45189e99ed532420d6015a965394c8c57618329a2192dd7e5a21";
+      sha256 = "8e88de458d493f789912612b1c90f444eab638ad300db42142ed17683c4980ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/el/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/el/firefox-140.0.4.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "a74fd1c406a2f4960cbe3a800bd0e40466f0a001f0bd64a3dd30ce50af3c7ed0";
+      sha256 = "799de2a52b142ab9c506a839c7adb9d9c1bdc06a1ab59ba4713a8b950fe6173d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/en-CA/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/en-CA/firefox-140.0.4.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "9d96ba8a39774235137f6748c59895a3cf95380904d93a4891b521b3f2c692f9";
+      sha256 = "a5385017f0ac16e01be9f62034e1e598e52f0b89095538f060f52323e77364e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/en-GB/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/en-GB/firefox-140.0.4.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "b8fe905ea964649b0c4ca6703bdfa4e484974fb9717c8dd6d313c23c066261b0";
+      sha256 = "6ae767b1b34a59c7e0ef1df07367ad47a396f68c50577ae537d888ab6f7ae692";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/en-US/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/en-US/firefox-140.0.4.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "7237c46e28e15c58ab9c3d35a75cf32f669c0bea0224f66f7742fb30289faa53";
+      sha256 = "eafcda88f4a296ee1b67936cc6caf44650f3c109f208c86729ba029ba78378ab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/eo/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/eo/firefox-140.0.4.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "c9528279e1d2f61cfb397a969fc5f28ec0b046b02e76f8b0fe3940f65c0519b7";
+      sha256 = "92ada3e5fb02c36d2e8c1bfe8bac1adb522f5d528e355b368b887a07b44b764b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/es-AR/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/es-AR/firefox-140.0.4.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "6d387d863437f98a8a608a3236d1211c3650189c30449251d79fce0cde44db19";
+      sha256 = "838667df7f1454bb55f8c55cb92ea4feb0a4c6d7c85aa77670a8bdb607a3759f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/es-CL/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/es-CL/firefox-140.0.4.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "389faa055f1e16f3f8dab4ec2a734597cabfd11fb2c84d1cf9d5d9220bdffeeb";
+      sha256 = "2af8df8d4192e875c750c6689e44eb18c21dbae9e7db73f0def9df63c89e36f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/es-ES/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/es-ES/firefox-140.0.4.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "a72790c89cac16d0d072f8b2dfe95497b924c9fcdb9373cbc5a7f28d73f3d108";
+      sha256 = "76667eef65181a671dcf5624c60c13d529ebabd2fd3c541886ec568cef6d81c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/es-MX/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/es-MX/firefox-140.0.4.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "22370da2c4a6a72f82fe2f4134a890b2e5232095037a8f2d6ae2fa3578eb99dd";
+      sha256 = "9d92bab5185b98dd57da6c49f65a6f67937edb39027dae66f745a1292bd574f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/et/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/et/firefox-140.0.4.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "5a322b8185f8dc0aa940c0c4f00ded6db90a010f6a6680eda909fef8cb200674";
+      sha256 = "ac1b2e960d0d57d03b0e08afd7fe4426c4aedbc4bb9d24aef77182aa8480a8f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/eu/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/eu/firefox-140.0.4.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "784f3266156a739535e7a3c8734e700aa92f70c7dd620542598a47568f58941f";
+      sha256 = "bef2d01f49e73a81f0a59afcd3ac8709eb9918acf79fb47f7cdac6b09c4a1c3c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/fa/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/fa/firefox-140.0.4.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "02fb858bc7a2af197c80e01df0e182aef127d1d31eddd149d58eedc9e6e3b8a2";
+      sha256 = "bd1d3f8bcb2ba008f76c449a3661f42f45559faf047e1339143926e972b6cd21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ff/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ff/firefox-140.0.4.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "a260206f7e5330505204b328636152eb6becfcc5905298af859ca00c571f8f69";
+      sha256 = "5c3907a334848afbae90d52b643413dc9692ed76b60225ec71524867b40eae0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/fi/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/fi/firefox-140.0.4.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "be27347a1082f2769ffff328e968711649e42dd1ebb5046b7a548da204d45d06";
+      sha256 = "db125233d28993a07aba3b3920e99417d7bb1348c179cc2c9c20285aae72f1a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/fr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/fr/firefox-140.0.4.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "6a5c02ae5cbb1c4e8480ccd0654579ee4db322944a025f81c8bea85e7a1eb4a4";
+      sha256 = "cd75264af4230341e12cfd29c4561fb0c5b2871f63d2c6ba13dfbb8107e549e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/fur/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/fur/firefox-140.0.4.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "5ff8b09c2887e89ac62cd2a9363f77e72605622937a0914fe969fe9187ca02c5";
+      sha256 = "b8404633354613834a6d088b7f9ab77936c1535b7c30f87f8145e3f81bafd5dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/fy-NL/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/fy-NL/firefox-140.0.4.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "806cccaada32105c2386eb224d9378f954d32c124ee6217a48e49316a4c359b7";
+      sha256 = "2ff96697538281488c405648f9adbb378cb716a6946923ee616f29f3e647232d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ga-IE/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ga-IE/firefox-140.0.4.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "10dfe7240917e4ebed53e7bb820c7c08aeb8bc44aa3245eae8327433bb284edd";
+      sha256 = "767885a0c5e8e409be4918a534e3afba13697e3a97beab0832e9f1f47e26d2e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/gd/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/gd/firefox-140.0.4.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "3555779acd6c2de51ceadf4d8a51e3f907916739b4c2297bceccc69e2a0dccd4";
+      sha256 = "6d7de73fb8d3dc953d384ef7388b17d3df364fa3127f39ebb319b4fd1a443d11";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/gl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/gl/firefox-140.0.4.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "b29497c0a8f2b323a34724281e50ad16717475cd7e77969232f7385a1857c1e9";
+      sha256 = "90726dd9f6cf47601d11567f194a32f34db308d6ee0a63df97057bf7810c51f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/gn/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/gn/firefox-140.0.4.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "31fe81ed44e00539451fe909b74bce5993c6b2ce40a285acd1f65ace282fb858";
+      sha256 = "a93f279cfe4d256ed9065cbbad5fd619469723a4451a67a4427ccb8cb767af1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/gu-IN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/gu-IN/firefox-140.0.4.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "f6cfb98f513ef4b0b532dc29c456691ce8c7e149bb423f8b7dddd5c4cefb07e2";
+      sha256 = "591d5fc411d3da52b04ffec9a3a54e3952e512b9fe66527dd4145568145f7a4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/he/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/he/firefox-140.0.4.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "45a11a082020b36dc3abd727de1eff3f2bcd12657cde89e119a0c8d3c7974b58";
+      sha256 = "760e0ab517792425bfcf61c203cae2237dbda07141f468cfe7994ac0acf7802f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/hi-IN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/hi-IN/firefox-140.0.4.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "c781f6da36d194f730b61ef33080fea7dd13c82d85a4409c93a812198350b5bb";
+      sha256 = "26aaef2183370bcbc259109030aa2282d670a1fd53cbfb68897650c452417a79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/hr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/hr/firefox-140.0.4.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "d756e3bca4ce7779e6e116483f711ce94ad069ee2efbda29ec1724bf2b651c5f";
+      sha256 = "85091c7c9c80d1fb4e91129ce00185689c4c768ae7071c61a2350d5b43de4ff3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/hsb/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/hsb/firefox-140.0.4.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "de971db6126097ecdc2d0cb5613afed55e95260f2d3fa308541c863e8c59ef48";
+      sha256 = "00a7c57673ccf6dfd6cf1dc01681c7d75f150c0bd24eb06add8574779bd5099c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/hu/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/hu/firefox-140.0.4.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "8c5924dd3ef6fc2247399311962fd32ef1ad04b5c430ecb39abe37f17308f566";
+      sha256 = "78575993d3b84d8cebc2205ceef28866fdcc8bd5197df345c410132733b554f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/hy-AM/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/hy-AM/firefox-140.0.4.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "fd33dc0087f60780845a01ce0d8d973c3f8ced50979b636064e490ad5cc775e9";
+      sha256 = "410e925297b0084e9b727f931cc6701cde2e8fed7b824aa5b484c44ca69cefc6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ia/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ia/firefox-140.0.4.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "cb04a55dcf48ea791e9c536d43e682778b94a4107b3c51b40d0fc76831c0f62d";
+      sha256 = "5210d60588e6716e837d5910dbdf437cdcfce114281f4c3b040c162bda99d2b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/id/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/id/firefox-140.0.4.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "d2d9ef506a7516edc25f1ea008ef4537ab6f547a28d4cceaf3a13958cba947aa";
+      sha256 = "5730cdf18ca4724f3e198328431d393761efd46041bdabb65185e36dddfc781d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/is/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/is/firefox-140.0.4.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "8a1fe40b6482b61d6b50c5ee6508ec9bf08e530749ba8b9fc9b19155a5bd1eab";
+      sha256 = "19a6a3f928b4fbf9a5febad502227e00c919860a4f434bd2b9ddacaf96062708";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/it/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/it/firefox-140.0.4.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "7e183d66e34ff423e9d98490d48daea925663eb33ce517de5ae9642188169f16";
+      sha256 = "926d389543d9969e7820024ff536faacdeeb0382122300a6611f91d20e13325e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ja/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ja/firefox-140.0.4.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "d9ab0a72a334bda5713afc8f8aec8d40064a120e077fc09c38a0a515d544b353";
+      sha256 = "f6163a71d048e428e4fb0ad48467b53cef0e4f27b7145822e0ed3ca545ce288f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ka/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ka/firefox-140.0.4.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "6c04a099a03131009a4b9e3d495425633043e73419fca54a86b7069c64c288b0";
+      sha256 = "a24df85ab9592ee6d362b67e82707c12c77516021214734157082b33fe47abd1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/kab/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/kab/firefox-140.0.4.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "8520faecbbd2f59f4c8c1db31a012b9aaad6ed8ef68c680de34e8006ad73f150";
+      sha256 = "42333cd22e35b27212e08a183d464c54797926835314c98afc06ad863846a41f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/kk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/kk/firefox-140.0.4.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "2c14aa7d161cbbcc1b2e695659643c4516aa9fca487306b1953b7bdad8788c3b";
+      sha256 = "11cef3b82e42ddf4683da915a13da3561c140427bb40343b4192bfd0902f20d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/km/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/km/firefox-140.0.4.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "70162c50f48915b4a565ebd81aa4771e95e9d1bf5f7bbaf9b9a6af1a8f4062de";
+      sha256 = "3606f00c659d1ac9bde60a6311ab0c8c1d7a512219acec6597392f128c16c009";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/kn/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/kn/firefox-140.0.4.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "f3ae4c7500857c1717352acec3957555cc699ffb0853911b9bbe6eb56ca1a35c";
+      sha256 = "0d36b7260b717e6817821759b105fced8c0d3c08ebcefbc04aefc7bf9e49ab2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ko/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ko/firefox-140.0.4.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "c6de5457fb22ab505dc1628c268f140cec6d430629a3d66ef3d180efbe5a52f2";
+      sha256 = "f54e98158ab899e17ae495a9339154c564565fe0c4955b67dca57c5a454083e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/lij/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/lij/firefox-140.0.4.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ac00b942457f7a2a92f02a5880e54417aaae071c2c5a18420306e5646b10629a";
+      sha256 = "85411a183548f9dd3210a595fd84e3cb283dc5b4f42b9ab0f09f4c28397b14db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/lt/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/lt/firefox-140.0.4.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "713e673cc7699aa5106048ef7b8929d1618b257421ed1aea17a45836fa700b07";
+      sha256 = "d11ebfadbc6abb1768e5accd287ae8ec716b36e6f150e85b1d987c558aa6c0b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/lv/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/lv/firefox-140.0.4.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "c762ddb67927f1ca8bff6aac3d4f408a66cdbbd52eadd5337561e89fd797a55f";
+      sha256 = "84fffed5dc9c2e8daee302f1c13365dd7b9a1023d5844fff2fbd4096a192b020";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/mk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/mk/firefox-140.0.4.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "2d15047d1153b71ccf1a5c02bdd2cd00857e84d361300dfcc7f33e57b13a935d";
+      sha256 = "04c0cafa61498b0d6ec291fe3f96cb57e5b7706753d2d67ff569736da636239c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/mr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/mr/firefox-140.0.4.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "45e9333ef4c83983307f06d0dfccccba73d16e6c11507ef2a473e9d334abf335";
+      sha256 = "3f03d5b6dce578611e79991fbb414b7fda11a3ebaccb20115cc3574658332d99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ms/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ms/firefox-140.0.4.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "a24b36363b3b3793c2fa38210794593c65be50db46cde4944903a58be0819781";
+      sha256 = "4d9d5b55c7e39c440aa274f1b1fe7633c7b688ebe6bb49938d70908649de480e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/my/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/my/firefox-140.0.4.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "19169c4c48a7ca2aabbe1454e20c9648596872b52259538ed871079a6fbbe4c0";
+      sha256 = "8bef74e92c76779e82e7fa52179f9e34ddb4b3fd6151ea15113c0704ad498072";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/nb-NO/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/nb-NO/firefox-140.0.4.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "f606376495dd6da948f32ce13a5c6686e59e104ae88e0cc3d361326736b63f2a";
+      sha256 = "88d110b88ef70b57911f546cef221cac830ea2e636c5484dbeb61d885ebedf24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ne-NP/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ne-NP/firefox-140.0.4.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "10db0b50c509d650f942a4138536eddcd0d89afd100f8429453f02b9c1c857a4";
+      sha256 = "fb6712cacd82c6f02606dc4905dd23eef2476f7c418e5880f173ff10b5fa59c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/nl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/nl/firefox-140.0.4.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "498baf0a4a6e857e2ffaf8cc290435565f72aadf9fa16534cfd8b908230c575c";
+      sha256 = "8b90206da1f2b369efc854460d9ab281f965f39def4861c95b9ce760f2c360bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/nn-NO/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/nn-NO/firefox-140.0.4.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e089f5985b66f27e00b118bf993421958bb3201fa8969e7bb3db37192722eb4f";
+      sha256 = "e24a2b5e8c110d05bebdd3abe3ff4195eef879b24a30fb163f2d8871125ee56b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/oc/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/oc/firefox-140.0.4.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "8d427058e3773ac866af61624bbe47c468283fa39c60e9868a39f2589e0c641f";
+      sha256 = "0ae9de22a79c531978af028c44f8e10df180bcec26881e8f54a694849a46505a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/pa-IN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/pa-IN/firefox-140.0.4.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "55ed4c50b9294e10135636104a55694d4688356a8f0dc887028e97c41fc3f269";
+      sha256 = "517a43fa69a74781289432120f437cf376ef7ed048404fd56d5117868afe6d0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/pl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/pl/firefox-140.0.4.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "0aa99722a3b865fdefa65ed3c07bfba17c818adfa725216491924990d36499c0";
+      sha256 = "acf94affec7f47373fe85cfdd824513f3c3b6fb30179bf3d4fc7715de5691f8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/pt-BR/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/pt-BR/firefox-140.0.4.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "d9977eeeb32c29144528d4d9087c169da59e568a64e05812ed9f51ae0ac28d6f";
+      sha256 = "ad4fdc5a791b43f030ad93c2b4cfb4282dbc8f42a19b9d35a212ee8ee98b6074";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/pt-PT/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/pt-PT/firefox-140.0.4.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "098568fb1332dab5e2bf689ecec025d60d8310d5c8f62edad6f62c2d36f46bd6";
+      sha256 = "5cdac4fea8472a90f172d45a2d18f4647b93e1f2f8b2ac3c40fca62038644a4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/rm/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/rm/firefox-140.0.4.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "6e8c8c8c010d28a1762adbc19831cb479ef8842d29c8e75510d7594d6e963d95";
+      sha256 = "21241ffb36c656890a3237ef91dd77baff5d43281af40acba3417e8dc4a86214";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ro/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ro/firefox-140.0.4.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "d19ed5da96a3bb2761c0c38c07ea0b3b05f254c3faca359f36afe5a8c600ccfd";
+      sha256 = "c9dac36d52db35856e66499fc5173b98ccfd95be625d4e849877b764cdf80c9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ru/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ru/firefox-140.0.4.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "571fb47a5e0ef4e65105e7ba5cc31ab524bb10a79ab63963eb37cccf5cff406e";
+      sha256 = "ded83911dcf012854599b9f9d31c5f4a91ec58d9ae0253180d6ea6f1d75c1822";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/sat/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/sat/firefox-140.0.4.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "e3904ff0013252bc53e86915b40610edc4bffebfd62048427036c0aca608cab4";
+      sha256 = "059393952f1f7a02b548f2e449cff48607ffe6e06468b66859705da256735acf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/sc/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/sc/firefox-140.0.4.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "31de923d0836f7d89ef7ae55e1bdebeba88dfa86b1194cc2a973e5fea8b218bc";
+      sha256 = "5806b3f7a94555921c1c9531246cc4b94ec362843b91391b221d79fe808ad162";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/sco/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/sco/firefox-140.0.4.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "e933df74a19d15f59a6bd916c1cfc9b0fa223be3a6a18265158ba8c237b7346e";
+      sha256 = "d327e522393d3620051068217c194f45f5ed5f5940f5d1cdaaea7f2600015ecb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/si/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/si/firefox-140.0.4.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "1b6784ebcc66b1d95117aca4ceb532c7ac26497908911fd3a6f6e78093ca9041";
+      sha256 = "8815c0a8fba1b3d877f4ed563ee6b197ceac5eeb726acdb0d78a32dac7266ab1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/sk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/sk/firefox-140.0.4.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "1c131a544b091194c9a77cb3c974ecee03c04f6036b059ba47f960b77d2a05c2";
+      sha256 = "f177a066c7844baee30c7a36c409b32806f183006e2a31fa3ba004ab62fcfdc3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/skr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/skr/firefox-140.0.4.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "eb9f5fe584ce1a75897d81273412c9b7473a23588ffc42a0688fbab314a9662b";
+      sha256 = "cc6acfdd37ce3a9879dcf5ee9d5f38c429eaf249c4f7176c02380d71d0801791";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/sl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/sl/firefox-140.0.4.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "9d8bef2230d7b8d2eb352688ddb20cdf7017a824ae2e8d85ea28966a816025ef";
+      sha256 = "ba3d208c9c962823357250878e2f0009e3f58f4d1b30b2899ee2082a7a5ed3d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/son/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/son/firefox-140.0.4.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "6cac761c33d9ed8be1d9bcdcd2ba1bc93933349cf562b8e315365ed28910e346";
+      sha256 = "7bc3d7fad830deecb63ebb36fbc0d840370e4cb8c745912f7c6137a009754e5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/sq/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/sq/firefox-140.0.4.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "6ac69e3de447f6165b3a2e0f1cc613efec5f00e0fc894217b133cb15806d92f8";
+      sha256 = "27bbf9aa13ef2165309ec386115d79451db291ea8a248d8f8680092fbcbd1a8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/sr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/sr/firefox-140.0.4.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "457d061ceaa31c2705a1e909f656692fe64de9766fdbdaa364dd3379b4557cfa";
+      sha256 = "f90cfb58f79ae2550f847eb904861e5f7c86c2a6e098ea5f1454dc3e1f5a5306";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/sv-SE/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/sv-SE/firefox-140.0.4.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "7702db8cb5fb0896fc8a472174cfc6d661e13d732ca1090feaa3a5ae27aac214";
+      sha256 = "6d6e809c8883a51082fe1a3e6dfc2903904377c51bd103cfada00935c905daba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/szl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/szl/firefox-140.0.4.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "0cfc51cdbd12c31ee3c7b0fc2be864b5f087434e8840d5a6f0e77bb036e5194a";
+      sha256 = "29192ac2b94d1d96020ece1c6fc8b33e65eec9c2cdf7b438f0e5b7df0b851e09";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ta/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ta/firefox-140.0.4.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "f8a7ab5bed5c0f873b7efa4cb356ff3fcea5e7e5e9c21ffb56b0c2d14644a6b7";
+      sha256 = "979babaf05ebc2c16bf2da8d279f6f3828f048aac6d04e2dd86dc7f4fcc554d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/te/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/te/firefox-140.0.4.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "7dcae041f4c49f0383a312314226406887e5f8ef32231cc8e1ec5980e37eb932";
+      sha256 = "7c7da8dadec29b82e314d7912bda12fa293e11e94f7868063d4dd94407dc2bf5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/tg/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/tg/firefox-140.0.4.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "8124279f9c9549f3848d6c962833e3cf93fe5be31c1ef90c3662d410d0102c6c";
+      sha256 = "9115f96a39349f10579c2cde41913cdde6eecf04543caac8c6a35c52c4e5add4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/th/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/th/firefox-140.0.4.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "b474ef15d79135e281dee9cbb2b10f2fdc4679e9ac21fd860b027216fd153c73";
+      sha256 = "6c0b244c8a6ee15c8f5b0f0bf5ce0e31af2d99d20d734d21b6e6ce18ac567d84";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/tl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/tl/firefox-140.0.4.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "0b0546d631a63eec671a07f1880172b129f5b32e1e5ca80c253e384b9e5bd7fc";
+      sha256 = "1cd80d936cd748cb208c47e2f0b5f3f69f22fc24621b02c22cd53b60b9115583";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/tr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/tr/firefox-140.0.4.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "c323f43318cad08988eb3e822c8841ae99c3b85ad9159da6d22efdbe70f36b56";
+      sha256 = "60ed67df6ffea409dc5e4ac797377a6e70c209df5f75c7d973eadc4b01d64445";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/trs/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/trs/firefox-140.0.4.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "c21070795213316816e3cd45cc8f3643639b81117c9788ef4ef24bf5265e1ff8";
+      sha256 = "acd9b73c34d44f136fe10cc6fb02b2e61a0c0e4c1f0d7b90b69c1f2dd37e3cd2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/uk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/uk/firefox-140.0.4.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "579b97d4970488a9c8c0bf9a6e313e529fa4e9f4083da5d0b5c3fd20976d9a8d";
+      sha256 = "0317a19713592c74d4c63985343aa19c5bf4b5a03d888e2dd1f6f8e6df57c411";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/ur/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/ur/firefox-140.0.4.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "a55e11b54220367f01d4168d02f3a3cc529723a2f566b4583f12e875332457a3";
+      sha256 = "20a209284bf272b652bddec3c5e7ade62281b08c2d4cb9f64daad729bf68de41";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/uz/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/uz/firefox-140.0.4.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "4ccf80494d285d8e8b0761e885a78605b8fd393a1e846d66e93c7d35e6fa9b75";
+      sha256 = "f751e5ca2598227f47d947616f489f7f7d68dae18aab7d98723d840db3d3eed0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/vi/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/vi/firefox-140.0.4.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ac92738d2a8e5b29e6bc454a6fe26ddc5ed2d5b56f732c4ebefe03fc3a533786";
+      sha256 = "d4f49dda1cf6095b3efd018825c0a486e339685b5e036ec24839fb970cb64a9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/xh/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/xh/firefox-140.0.4.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "60727ffc393c38f927856ec094273fd4738884d2aa9eedbf3daf3f7741a9629f";
+      sha256 = "21c8dae0e3d167785cc6836d6e84b0002b3ecfd078026cecdfd56c4f78b4ad61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/zh-CN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/zh-CN/firefox-140.0.4.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "7be14d1553d6fcfa983b269fc313c6016b6ec9e1c170c34f9d85df211a5093b3";
+      sha256 = "ec63201dc79770db65338212096adb556bbd6dbfd4dd437f65828020f3c084ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-i686/zh-TW/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-i686/zh-TW/firefox-140.0.4.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "b52683c7ac05ba33f6edcad2730652709ea16152738845a10d87332b17601d8f";
+      sha256 = "880a92add3be7ef80e53906949732f5be0de4b5f8160b9573cbcd73b977f2918";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ach/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ach/firefox-140.0.4.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "93f2737be5fa33cf201efd4d8b7f7e96f6e1993ffb40c69cf2e804b8b751a9f5";
+      sha256 = "ee6a2f927fceac0a29b482d26196cb548d947533271c24b29be8e18f1bcb023e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/af/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/af/firefox-140.0.4.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "c9053eb18c562e260b2107989ebcca3009ab167b975b030b6c998a922a26c411";
+      sha256 = "3509f5a61f54ff9cf90323b6916ebbf0d090c79696fcf59c5b75c8b265307d57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/an/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/an/firefox-140.0.4.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "566b5b4f42ede2c3c1ade1eee56f7442c72b5b6d386e4236999911fa91317288";
+      sha256 = "7bba810d969a564349e6fec524735fa8b112baa736d6fb89c2e9408ecf9b6f3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ar/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ar/firefox-140.0.4.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "d1330f52cf1fe976a7ae5e64aebc0548cd56b13561fc3b8c0a2b6a264270c3d7";
+      sha256 = "3d894a428a8d21831ee740b08362cf5ee4f3e801dd79dfdeda5035e1744581b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ast/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ast/firefox-140.0.4.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "1423b6da41e1fb52fa7ca4f2cc425d59ce8f2a85f947159c3623a5be39bf8759";
+      sha256 = "b326e605e76a2ab98e76524a7f492b78e2a09d0780665966ca535d339fc9c1a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/az/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/az/firefox-140.0.4.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "10812ca634f32c6c08f51c2d5eb7d474d26784947dc5f36dc7ae2790e9c3e348";
+      sha256 = "0829bd77aa680c1fa46fbbd1ac8b198f3bf8eb05370a516e8ca45ae5cad1e7f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/be/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/be/firefox-140.0.4.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "1543013e7e43bcfab2f1020b541681bf38e27d824a80aa0bbee4ffd72eb5254c";
+      sha256 = "341ad96edc419e1f04124c9f64644f519d4dd0e5330b3cc7c09deb065cac724e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/bg/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/bg/firefox-140.0.4.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "06de6f2b82f4e6087708e4471a119bae4996b9ae9acb9e7803591330d7a6ba15";
+      sha256 = "fb3e054b853a1fc6405c6c1fa79a8ba85b90b91f2a5f002746a86116b27359fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/bn/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/bn/firefox-140.0.4.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "783d9510244245b2ed03f6bfc1ca51fb88e52d01ae311d594541214203c3b04b";
+      sha256 = "967d668fdd4d4b7c4400cd97fa5e6def893475f226fc87d3c16f760de2131e36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/br/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/br/firefox-140.0.4.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "920c463ada52add81a42fcda544b3a635cee8424d04f9bf1ebd2314e5b3c3d03";
+      sha256 = "fc5bf2eb28c833ce9327921d31361d689a95be25758decd739e40f9c95254ba1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/bs/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/bs/firefox-140.0.4.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "1063562c3bd8dbbee227979a77ee3a8f7eb24fd097caf8e7c998a16d6cfe4e7c";
+      sha256 = "4f1a924828e80324e0b2f11c7525b94d079cd68d1291f778bdecc8e705c0af90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ca-valencia/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ca-valencia/firefox-140.0.4.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "425b36e600980a43cdcbcfd715fd6cba78cfab2939218ec569742b56d7b01993";
+      sha256 = "5c5922151fcec6d24a4720df7d8990060055c0b959c313434018e8dd434527cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ca/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ca/firefox-140.0.4.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "1f31dc40cfd4aeb2bea1f3b0f5c9da5caa28f9366ef662cb751013232054d1aa";
+      sha256 = "c098f2b52b3b616c38065664d4f2e21c6a7a2dc5e4a7f95ea1f644cf0d9c53aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/cak/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/cak/firefox-140.0.4.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "5c4dddb13d44d84b05bac6c09c65f5e6d3c07040f301e8d84c88a1d5e0189101";
+      sha256 = "3dd00b15b3d6be7d58826da7f9aebbc9914c9b06bf5e99799cd7c59a0c5288a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/cs/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/cs/firefox-140.0.4.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "421edcb43470ef104c508b7247a8ebd846c8578ddff89ed3508fdb92ea079f72";
+      sha256 = "70556ad2f415e77a310f4665680a2b20bf0e775622ae2313c465e642dd18399a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/cy/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/cy/firefox-140.0.4.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "b357fff5e0268071ebf077f79650f054ae9ad428d5386192d71a2f3bd701c1d8";
+      sha256 = "e3bcfcb7bdafcdad35e44f2ec05597c1d369f7172c94e83654b6d51b70afbc03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/da/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/da/firefox-140.0.4.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "c99af654178e98426702cf6b058d497de10c8fc6daff54628dbd8c1a30b6dfa5";
+      sha256 = "20232efc4305599d6baeeb5dc408b910ff74758ba71a01db02b1dec386989065";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/de/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/de/firefox-140.0.4.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "44451ee98bf89ecb175d482cec2e9e00ef6a6ce0f9cd42ab48a9cc66cdd7f09e";
+      sha256 = "5efee132fa89ad0475752616afdd9ba2036c7571254829616430f53a34175300";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/dsb/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/dsb/firefox-140.0.4.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "2c87845146938dc90f155fa36d430dfc9033ee3dd551b2aecfaef5b90d8a63df";
+      sha256 = "a30c1efe29f33a855713fbf8063575f7d49dde6a2616b5fa3cf1c3cf487d37ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/el/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/el/firefox-140.0.4.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "b0c740891f16b8669db8975b615597e6b2bdd12a17c0fe15d0dbe27c3a91ab6c";
+      sha256 = "d4193f216d3b1ac5b40a2fa8c94b45f1ac4531cdf22f3a41c45b840d4d125f1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/en-CA/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/en-CA/firefox-140.0.4.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "e9d0a15751aef60fb29ee3ebf34f7f268e488c653da43a67eb1ea97112eca326";
+      sha256 = "227a921b8d40f111a0d0212fe5d44455f20297a210dbb05188f8ed0dda6cebab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/en-GB/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/en-GB/firefox-140.0.4.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "5ba47aad25a1196995e6a2bcff149d4eadefa11283c50c6cc5774b57492b3e61";
+      sha256 = "7240f66b1a87c0b796b254056ce7e8dc644f294fa5156cd7cbdec3f7d1a7792b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/en-US/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/en-US/firefox-140.0.4.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "da5c1ff12d2e7a3dab953964ce13e8382a8f6c38d3981ae31e1bea3b6903e34a";
+      sha256 = "49da44e2936ef9ce1f11da3630ded25d5c1b6335a8a7594ba448aa54777eefc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/eo/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/eo/firefox-140.0.4.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "e1768a196abf0dd038ac810b2825bd2bba889ebff1bdb1299038413f9a05ee7b";
+      sha256 = "0bae6d02e31658ce42e6abb42ed49ad1af39d8f16284bb9d28124182b35f357d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/es-AR/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/es-AR/firefox-140.0.4.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "1426c8e7dcb77b71fd3e1414b75cb49096d5705f417723392de082ae2b4228f9";
+      sha256 = "a2428221a38ddd566dfd4a594060d7aff353e671bce4d130a8f0a5e7bad46903";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/es-CL/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/es-CL/firefox-140.0.4.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "b8622eae2ad0a5431194b2ee2f13c67d49be7ce53be0548a417677b000677c84";
+      sha256 = "369938be0e9d55b11bf31112c7ab947953be1322c98522ebdd0c4885fb136912";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/es-ES/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/es-ES/firefox-140.0.4.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "f8e16795acdbe35259517d9fb56faeab513fbe28163e50eb0cd7362e953f38b9";
+      sha256 = "91bbd1ad46d76473d48a99ab32ad52aafc6bc4affdf4813309c96a10042dab62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/es-MX/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/es-MX/firefox-140.0.4.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "277b27023b06851cccc8f590b27b3bb48b05bac693f15c798b2a6aa560edaab0";
+      sha256 = "6f4314b2b0fabf30dbe4ad561c45287199159a03542991666fac5876ff69095e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/et/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/et/firefox-140.0.4.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "db1fdfbb1ac5c51fccee6142961508501ce6e1893a949d3009d67375d182d1c7";
+      sha256 = "f02a0088768be3728906b464b9fa7a5dbc29aca6d453e614954836d4a2a037d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/eu/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/eu/firefox-140.0.4.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "dddfd6538724b45e83b8a8a0ba786ea5c8655f0edc7c70caaafe16ca7c37b79c";
+      sha256 = "64fd3f22e97c514b90e40d21eccb3b60cf5e75bc5a1a5e439e32aad8846f0080";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/fa/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/fa/firefox-140.0.4.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "68e633772e2519d9a760195bfa2ad9e0b1994c267751b3d33d0cb6258362025d";
+      sha256 = "770254c4417f195e9bdad4de8428688bdc36f25bc3cbacf1f694427f3393d2f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ff/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ff/firefox-140.0.4.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "4bfb7ebdede857733e68421067827e93f33686e50588e5220ef007f462d1683a";
+      sha256 = "5b0375e73dedda5387f80033ced469c7f428096d316731674439cf6a7a049a23";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/fi/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/fi/firefox-140.0.4.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "f178366d85265e82fd1ad0dbcb1e6d483986947225524cf7e4c5ee335a2a6f2a";
+      sha256 = "50ca8051d24cb8876f1daae33082d4e7ba3c5e37d1a4dd6af8fb50e543365155";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/fr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/fr/firefox-140.0.4.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "6be69cd7174af0ff25dd43e83b6b3e1c39ccc55ce95d397352f3f8736297ca02";
+      sha256 = "7d08364316235d9709a3893efff19ec3b427c9bb2b42525ec9f4b8d3fa93c1b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/fur/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/fur/firefox-140.0.4.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "0bc3f68f88c0ae01f5145594aee75f8aa4b71cfd075b9f7f63307d295a12f6ab";
+      sha256 = "58d796e386371bac0f72e0b42f557dac7af26c4188cb97aee29a99de2f13c1be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/fy-NL/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/fy-NL/firefox-140.0.4.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "099ec6292ac3fbe9a4eb37649c14ba2014ce0c2e3386cceeb3bdc5d670312d11";
+      sha256 = "05f36abc1281d79bf70a83800945d939d7508d1a781f16dd6e89eef67189e1b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ga-IE/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ga-IE/firefox-140.0.4.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "80b8db2b3437f9569445a9e41d7731538e0162bc34dffbf6a84b746f66c1e323";
+      sha256 = "ea2561f9ad01e1fc9b92da91d855ff9a20d887989616d1bc89874383ce6cfd0a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/gd/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/gd/firefox-140.0.4.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "ef72ee0642597225a9fe41f2971465c2417a8a01c1120499c5be079c0bc14e0e";
+      sha256 = "bba853484a42bd14c86a647f1132e75f237f2ccb618b4f0e40a5183a8408c589";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/gl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/gl/firefox-140.0.4.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "ac72b92ff76018487fe472370f0f43ef6c32272db416db9c707f29e33de7539e";
+      sha256 = "bc333bfbd4c5a7f219d1f3f29418cca7472ffe1a7e01bd40a5eab8a33e8d492d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/gn/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/gn/firefox-140.0.4.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "c43f33a69dbf9834fba6bd5db60e7056269e0430f9f49255296d9df3babad078";
+      sha256 = "5c43fc318ebe73f0b9ee79ba24379f45c423d377ae35634839000080f69c2fb9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/gu-IN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/gu-IN/firefox-140.0.4.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "591034871a4d037e7d580893bbf5facbc8490df0b23820fe2059c42346771028";
+      sha256 = "d3ed9b516e2c020a3db99373ada5ebf47053954e6ddaa05b82d2235b0493d1ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/he/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/he/firefox-140.0.4.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "6c34b0624f703b75a1860e5e4fdc9e2ef4668404505b537806067546b3d2a5be";
+      sha256 = "a7766f63fd84e10f60cb9320e42b5a385436513addf5467415fed92a1ba98c4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/hi-IN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/hi-IN/firefox-140.0.4.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "e0e1ab49547cb0ad5901f9322dff8a8d1f00d998691c0c95d99d959ac71e6369";
+      sha256 = "21c799ade147e12f177ae9c63d0434ca845de3a75546017ae4bd7fe33984bff9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/hr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/hr/firefox-140.0.4.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "13204ea33f683ff9199909bb15f99d3ad51cd1d6c6c6676b6c0ec2a261e28ed4";
+      sha256 = "ef0ce05465362d699d95535a2c8af8e7a041dc959391d2a1e032cc043bf38d0f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/hsb/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/hsb/firefox-140.0.4.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "509074d795b75b94d7d1d5344cd12054b304a84d6bdd16f8714cc894f212ba53";
+      sha256 = "ace01688b2523329e5070a34672262c309fb27a96d7b9e33cedaeaac1d721581";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/hu/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/hu/firefox-140.0.4.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "4212c909bc9eb920d58af2c7ef161dbb78a911faec9e79aedf18dd55528fe8a6";
+      sha256 = "9e3147d01af92d36cd21b25a6461cc2c2c4ab7db5fdbebba1882fcdb37e98793";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/hy-AM/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/hy-AM/firefox-140.0.4.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "ef2c510da1e59113120d14acc5328eb1fa166b90b09bf18356cd876903c1e47e";
+      sha256 = "a51c68b72e7e26c24fe5131a3e8a1da32e3062d274b3aebf736013a4ce663647";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ia/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ia/firefox-140.0.4.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "1f41b1c3cb6e99b42aaf08422068d1ee8b29a715c6933f8af8d24f79ba8ffc61";
+      sha256 = "eaa04b180552fe5dc8eaa69147c6c844486086eb98dddb4c4bc5b0438b699ada";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/id/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/id/firefox-140.0.4.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "c3360028bac60165cc4b588dac35bd1eb3df5042348068147d56591206748d4d";
+      sha256 = "c8b724dc675ad34581a13492fa5fcdcb9e2033aa25a91cacec8f89d47d7ef802";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/is/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/is/firefox-140.0.4.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "a22dfaaa59104bd371d7f7d5ab082f39ef3c90b3d2228defdb20bd9693326fca";
+      sha256 = "654311b10195eed0fc13e7d0c3b347a8034fa8d075522f1c2a86020e3c5c9b7e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/it/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/it/firefox-140.0.4.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "30800d733eb2bc25b07a47a41fe0fc58f2d8898b956f9be0085237620d42d6fc";
+      sha256 = "ab14882c6ef15e534c416e5c7127aaaef2104885a933e71f1e26d97ba91eb836";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ja/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ja/firefox-140.0.4.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "9445d1d158e8ff00e9e91a953701e8b905f0d700764f468c9c4915b981afa30b";
+      sha256 = "76d761b485afaead9fd2eedcf7baba0a28b1889ae5c07937dc3f78403d3254c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ka/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ka/firefox-140.0.4.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "ec0547c3921d15d2ec6b4214d8e1dd16ff5b82cf20c4fff4a8f8135d29d5780b";
+      sha256 = "50cd042ed4e96900b12b2fd3e4c2948bae13f5b1ee9301f70fca772bacb5412a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/kab/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/kab/firefox-140.0.4.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "cc939b62ba033f6a3d17a11d14801dce7716dfdfeddb5eb5769caa764939e7cb";
+      sha256 = "277e8b2991d305221986ff6d7cfa104dd59918816fb90e4dc17f3933729efefc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/kk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/kk/firefox-140.0.4.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "4a4ed5cf84893e41d019cc91d5cef7e1698fcb9f05f864c5f4c188b299598659";
+      sha256 = "7adc1aaa752c9e6c7e249ea931d4a23dd7d3423eba3c2993fdf05f6ec63f7c48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/km/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/km/firefox-140.0.4.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "e3e73438fa30248f33a0a621111e631f29a55212beefe6beb4f2f384e23a81f1";
+      sha256 = "ed43eb8ebcdfa4edc5607a7a0ed6c4e063945f089e59b356cf9c724aaf252f16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/kn/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/kn/firefox-140.0.4.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "66a029df919aed8f4b53933026e1f93739c51be1f30e7cc81ea4590f1e39c298";
+      sha256 = "5f43e929dcb0b02deb0fc496d1111df5401fc9ec4ee80eceef87b2f3be1f3dd9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ko/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ko/firefox-140.0.4.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "f0f7d754973ec609b1470cf6dfe3a34f6bc7bd70462e84c7ef242545319d3f02";
+      sha256 = "7dc6e17515344497ab7ab7f6970ad019f19d1c3db716af10ab9db46b92fa335b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/lij/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/lij/firefox-140.0.4.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "be3bcc8f66c9f5122ff7dbcb938bbb37680ff8748e224f5eaff6d524a670b194";
+      sha256 = "6b18ed5bb0c37dc64120c2ac5cc15048215fca442da0da7929b09621ce2ed331";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/lt/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/lt/firefox-140.0.4.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "4b9c1f9a885a8d9da5beeeb0d6e4a0bd62b3f08489b917eb829a3c04b0531ece";
+      sha256 = "b6cf020bd8d89bc8d0e9bcfc733b975b46a0619cdbb4a4b50c695683959b8a45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/lv/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/lv/firefox-140.0.4.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "0247b0c0c095965b575c0dcc46b5edf736809898f7b9681b45de4fe942696a11";
+      sha256 = "9fe291e0cf50e1b62539f8a0660942140a3264c18424d5e9071019646065384d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/mk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/mk/firefox-140.0.4.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "206eaf35b9072a9d292ac23b56697fb51edfc2c7de1264a3c61c8a3cc7d5ce6b";
+      sha256 = "85f06e3c8ab85bb1474bc1e925641802723c5cd17beddce394da9abaa2c4ddb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/mr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/mr/firefox-140.0.4.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "3527c344bdae74ea526ef94ad754fb097ab58bc98fdc4d01edda40ddf18e5e4a";
+      sha256 = "b235154077ae5db0e322792f2fd486971586b5bbc900c37f452e094ca47ec640";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ms/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ms/firefox-140.0.4.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "768c930eb1c362fe12cc0c0e11b2e0795188062edb10ae40d910b45ad1a4a7b9";
+      sha256 = "14bff36ef998f00a29532795e69cd6f658341c37dc15e7c23081b6ce494382f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/my/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/my/firefox-140.0.4.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "d7a6ffa05d026edb92152e89cd211b3298b319ee463329209a2ee90912544f63";
+      sha256 = "a7001bd1cbb7284ee6385e3d3d615aa350adfb774daa3da914d5b934cd539b3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/nb-NO/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/nb-NO/firefox-140.0.4.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "72dbebb852bc552393c5d835db3e8e9bb4cf138b3808d71f5f7d0e1f5c13e189";
+      sha256 = "70a06afb3e9cdac1014335f85fe4dcd720a6777369a935e02d70024975448db3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ne-NP/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ne-NP/firefox-140.0.4.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "366eb396838b66a85265295cc32f164744de3e9ea00f4c14d25f9786376c975d";
+      sha256 = "a589a80bbc4246ebfe862722ecd954911afe0f531ce88c29214f022681d8ccdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/nl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/nl/firefox-140.0.4.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "cdd3ebe6b2a5edaaab379d9874348dc5a23d7a2181b53341e36ad35618a1e888";
+      sha256 = "31b8bcea4411543c6b9dd3861fcccbf952a995fa7b5c49b0155e1cf48d50a6a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/nn-NO/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/nn-NO/firefox-140.0.4.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "85384d922fd19490787094b01f3bbdeedc41a530d666d332b4c10de7656dc86d";
+      sha256 = "5b686f327debb1575111d0144a7e37f64569b6c404e4e432394ca340c900803d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/oc/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/oc/firefox-140.0.4.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "bd4e1f17b29088be579066bb0dcb1ff7ac8bfee3754c1c92cf52054eae099fba";
+      sha256 = "2b8c20c0aea4aa731b7571cbd0411fc28675daf0df7e3e178db00c01f8339287";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/pa-IN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/pa-IN/firefox-140.0.4.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "7313e0f2ff8a1ae98e0a039d34e82e44285124986b0e927e7980911680986bf7";
+      sha256 = "997a9c2fbc7618b6b94fb5094c6d7a5ffac8d0df30b44aa55c01e7034a412ad9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/pl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/pl/firefox-140.0.4.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "f826a02e8892a7b047801f2c71a3ab4cc075ae85094a539992b9e81cf2fe7937";
+      sha256 = "d15f725123515636ca8efc4fada37c777d33703652fa7fd78d424e074e5886fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/pt-BR/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/pt-BR/firefox-140.0.4.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "e63a251db1651962d1668c04bb8500202acc4b2f3ac7670cef753abad7b5a9cf";
+      sha256 = "ea6a30fa75d99b625e323155c6e6510dda6870e92c8945ee6ebe72ef80b95719";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/pt-PT/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/pt-PT/firefox-140.0.4.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "62ad73606fb65b1ff449458ce80a3cab5ec58e39c5a0d005084618ca048ba336";
+      sha256 = "101b96f5e866cbaae618d78c64c0756be0c1ddfbc0e34c33f26336fa59728845";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/rm/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/rm/firefox-140.0.4.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "13e46725dc1319390a0c13ac73ce168bbe7bdb503f922732e843d48bc7e9573a";
+      sha256 = "2cfd9e972f3ec29085b8fe745e92fbbab515a10abf9b7995b81ea5371d984b78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ro/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ro/firefox-140.0.4.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "550ee056c745731b9afb560da322f7140ebfca15668cb1b3e6f59157ef7c4832";
+      sha256 = "033d5537fc46f12e98dc691c17a2b76ba10829f496e6f5bd177ccb4da9bd00ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ru/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ru/firefox-140.0.4.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "109d09e5c113113f47fcffa95dbe81351560bd2eb294386f1674ce1dbf231a98";
+      sha256 = "c0e77abeb8b3c49007283fa7455005fdeb38ed5fd4a11822eab62e8ab38d26c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/sat/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/sat/firefox-140.0.4.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "9c3260546b5c817569d4432220c3275c2007b2e760205a51f81ad1433520d997";
+      sha256 = "7e31342df60c7d789da8e0d3bc2afbbb5dd088d7ff9be49306318eeaf4f4cff4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/sc/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/sc/firefox-140.0.4.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "eb3e73f36a65e63c8105eb29b061f921c9cbbed2c50aef516449e47362d6f9d1";
+      sha256 = "5cfe8e8b0b86848feb7711c0360c8b991e9d9b3dcb39676d10a3d40c9fc1b4a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/sco/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/sco/firefox-140.0.4.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "383b3243dfa89feb7dd4f5fdace236b4596f53ebed52a995c4d9054ae640cc39";
+      sha256 = "edf5dcce85c6f38d866a61acf0c0b9ef6cee8062c9ac5b856d70cc079eb2cfa2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/si/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/si/firefox-140.0.4.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "f366ec7b5caa7a4ee2e7923b2c8df9a189c79eb2106e119c12199b4896950e79";
+      sha256 = "ef5016a94479fc9914b722de0f686163d9ff0b6343c0a825877c1c095db872bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/sk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/sk/firefox-140.0.4.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "5708162af87f18029c6b3848863134757ea5c4fa535b826fab806c91e83cde96";
+      sha256 = "5dc50a12c14297db1f9f59e44870be390265693353d69fa1b31465cc0e08f79d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/skr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/skr/firefox-140.0.4.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "8c21d972204624475aa318317920ba97f126baa68597c392074f28db7b99481d";
+      sha256 = "f7b3dbd0386981995bb07a055b66eaa8d54b002a3562dd19497314cbda20e68f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/sl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/sl/firefox-140.0.4.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "fbf31ed1eb9123000cee497d0eeabb6b7606ce7192c4012599b48fdbe927a6d7";
+      sha256 = "a5fafb0df39613ef5c1670a36368fb73c66c4f8b853205669da9eec305a1ff02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/son/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/son/firefox-140.0.4.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "d34fa4727aab2968431b82689bc377ed4910a5705f90c1987c7a5162c048c18e";
+      sha256 = "612dc6eca9650fd96e0abae35efae626753928d575b5e420292854c164f5aa51";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/sq/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/sq/firefox-140.0.4.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "73e52de711ac363c7d57dcde927218a1b3ee7ecfcdd35ddc8401a179cc1f227a";
+      sha256 = "921e13d746eb17a421d97672273c886d924f773234694405f00395a65210aac0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/sr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/sr/firefox-140.0.4.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "caf52538031e6ede5ec3e2ccf49e1f5fe1290f983acbfef646a4bea4f5282a5a";
+      sha256 = "1025c259512e6aab613fb1543439b49101fc84b38e0124c8727f7a2007d62159";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/sv-SE/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/sv-SE/firefox-140.0.4.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "db5b48657124df020d908baf8cc109ca21106688e6f5bd3267d685f880a82771";
+      sha256 = "5cb05c6739b26128fb1f0dbbd18204a85da05c59f05ea093e20651eab09128de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/szl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/szl/firefox-140.0.4.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "7be844802660121db0839025adcd4e89bcc2b5aa6b370aae1ced4828354b0062";
+      sha256 = "ab55e0ea9ea39073330acbf8774b8e407a356ed97747eb7050692308a141bad2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ta/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ta/firefox-140.0.4.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "82a540f8815ba0b57c1de7e0b517a02a62f45082e459edc9b3826c49bf580fe4";
+      sha256 = "a9a084d97c19ebce2aa3939d4773c7afac89780c45da9654c316f0606aa1e55a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/te/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/te/firefox-140.0.4.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "e49a728c482bff5e228be569ca3e324d6cf474a46afe19108862bee644bf67ae";
+      sha256 = "d07ba7015244294d981cdf9f7bda120c76739eed7e8dbc698231bef19ab05c09";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/tg/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/tg/firefox-140.0.4.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "92f4c0c21b56171b5f363bea89b432e3b83c16ddb6616e51e7299de549fa9a2c";
+      sha256 = "ab89563040fa7561896cbac272e268067c893f60134f29e07524b9582d7f7f34";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/th/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/th/firefox-140.0.4.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "6792bf0e6b4eeec6f0f80471af31d6baec14062fd32e2ae72fcd5825068f8a1a";
+      sha256 = "b9b73ce1f8d6526663810b6fa21e3a0b57cd8e9558aeee50b499e7ea9ac3f0d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/tl/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/tl/firefox-140.0.4.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "2420037d652bdfb12d694d68e451718dea3ea258f3be4c486bd3316be35a2902";
+      sha256 = "a39396b454763f477019a8f537718a91e04ac7b699b1241e7e2e586e6d98f236";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/tr/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/tr/firefox-140.0.4.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "69b810b14fe46164284dc9602f2fb88ae622bb1ba4e03b0f1e7b4f89fd201146";
+      sha256 = "3b3cb24381bf0e3bbec6381624dfe892904446775624510f5b8f42f88407d7c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/trs/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/trs/firefox-140.0.4.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "c49e310f81d95bf37b7bb8152aeb1b8c535144b52a4919e3a2e61fbde8773754";
+      sha256 = "9fc80b0e716820b338a16a8a7c06cdb3ae0766ee7c0b38a563fa67d8f00fa1d3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/uk/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/uk/firefox-140.0.4.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "c1e445c804fe7b566e125adadb72dd55d2b08c9bc1ce28b678a24d624226aa9e";
+      sha256 = "f7a7dc5dec812f3eeecc5eb08b4e5e0b19d1e230f5e599539d49b8cbbe283f37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/ur/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/ur/firefox-140.0.4.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "efdda791f75069b2eb6fd737422838ade0fa18ca8aae5ab2f49e04dafb339ed2";
+      sha256 = "df2a6673417798160298d93f667c6f8cff6c6060b89b293e4553a4afb25ae426";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/uz/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/uz/firefox-140.0.4.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "0281f34c78b6b3d8a3e8fdc71b5b135561d596bd8180c18f43f0404d37d5a7d9";
+      sha256 = "ca5f4503c25ca5e1489c050e08914ad382f7a66bb734a7be0a4e85d9f8481834";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/vi/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/vi/firefox-140.0.4.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "5d5a845b80a0df049ce65906cb60551c553f9ab538f201a3eb7f0a822616a8ef";
+      sha256 = "a5246465d7fd30150c5a2516efe8defaf4efd5ba4b31620af1c6aed83ddd49c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/xh/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/xh/firefox-140.0.4.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "0ed1c80605c82f1511a4f5b6c892d88afa5e7f3bf095c6c374edc43ba3e103dd";
+      sha256 = "563095415dae63d07dc071988e8beca12683b5df044cac470c9dc70688605dc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/zh-CN/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/zh-CN/firefox-140.0.4.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "890869cf44d6740f0b0eba54fe2874ae10d388dde3df3770884bf8e66bca1658";
+      sha256 = "7d4dd6d7af3ae4ea0cdb340afbe83c44f2da2fbcfa6c324a2e5b6dd20a47ec6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/linux-aarch64/zh-TW/firefox-140.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/linux-aarch64/zh-TW/firefox-140.0.4.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "366b0dd0028f090bb1220cc49782cfc77fe661b82a2a8db63d1bcc6fd8039d24";
+      sha256 = "95320006e0a544120fa7d2ad27f0ef15b253f438a257b79c226e74dc8d26e1e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ach/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ach/Firefox%20140.0.4.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "9574083c5f10dea1715bdfc957afe01c57f4bfe6a3d0bd78e29a785aa3609836";
+      sha256 = "4c8286ccda8e88bcde5ed66c235fae7bdeb15c98a10990dd7f3eb6ef8e65ad85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/af/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/af/Firefox%20140.0.4.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "510deda8544c99cc97eb1255ab6e26e9ca3e4e06ff0ed97e7cf93ab56f3fb001";
+      sha256 = "e9f57d3a8e6e7e488f7fd54fae59f2be7b1233371079d898382fbd9c89acdef4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/an/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/an/Firefox%20140.0.4.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "53215a5f12b40b52e804f0a0b5c64a609f716666eaa39f22f946b8d4014b69c5";
+      sha256 = "cb2fcb694e47d16477445f63730fff81e2b38b24cb9d8eb94587b62f8210b31e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ar/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ar/Firefox%20140.0.4.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "d9e3f0f824e12631af03db167da0206035700e5e7b208946603b05b1ef249683";
+      sha256 = "0c040cd1637142090716a9537cf89b249d1c82d782cf1d7f3ff6f86eeb3d6db1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ast/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ast/Firefox%20140.0.4.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "05ed457716c070a24292ca555464b7ab440608d39d9924c943e1e8f8733cf358";
+      sha256 = "1d255ef5534eaf6183aa214bafb72b588299662f7fb7af1bc892e5f83972304d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/az/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/az/Firefox%20140.0.4.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "0a648dd41a97264cc682cf4550c5c19ae3c7ba0f0943cb946926b8af4fce0aec";
+      sha256 = "ecff452dfc9d0f42fbe2f2d7408d55648c45e92840010cfc7753f9ed5189624d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/be/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/be/Firefox%20140.0.4.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "bc161c0b3b4a7d05c17a980dad54bed45f7cb49f8bc9461eb6f8425da9c7e730";
+      sha256 = "405ea45bdf09994704affe968d6dcd2505b9450c1241105d0cec7cd849a0303d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/bg/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/bg/Firefox%20140.0.4.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "448e17c970925dbd6afd049817b09bc673ce112a9bef20345f2bab70a74b1471";
+      sha256 = "de85ca7b6d121e8e0a55f53d65803b7d5782fb7afb1a0a7ec7483a3a1c68ba2c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/bn/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/bn/Firefox%20140.0.4.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "4ba478b5d8b4590d1295da6372a39ce340930879c163d1bf02a5f8c43a7bd1a9";
+      sha256 = "a8b21d3ab4a3e3dccc30e8188e9e953d17cbdf52534ebf53f5cc1d252cce99b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/br/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/br/Firefox%20140.0.4.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "13f088c36316fb4bd41c241f1f7abfb547b050d84b697951dcb04d741906bee3";
+      sha256 = "536aca8e56e1990e329a23998db9628943ececa17a239eedb5f62f95a12494db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/bs/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/bs/Firefox%20140.0.4.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "902ef4030c43c578ac4b41e3d8a9c995d3ba751887f403a0cdcfc14cc4833fc0";
+      sha256 = "0a13b4c61bdfda6274358f3a58baffa15b2ba40ebfc9b8fa5ae5da7317d590af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ca-valencia/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ca-valencia/Firefox%20140.0.4.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "9ea267a5321a86a7fc96deb7fee2c12dece0a15cdb0f3d1809fe2e17ab90e901";
+      sha256 = "5d1f6569ac2b8c561334d5ada5245ef9aecf0814398e6d9ca89cd7c01f73cafb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ca/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ca/Firefox%20140.0.4.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "c38e4bb0fdcf8936f19edd35e5cbc70cd9c7d3372644c8403e2a8ce6aaad60a0";
+      sha256 = "a97bca2cd5de2dbcb6d04e14f45b5e9144bb5d035464a9a056fa8eb633de89be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/cak/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/cak/Firefox%20140.0.4.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "c9355d3e9688d45b1c5f588df14b96421d8d585cd7647ba4a1fd97ae56ff94d8";
+      sha256 = "e6b815c4631d3fc622b5912fa286ea0b626a9d2fc81595e7492c656a6b1e9111";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/cs/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/cs/Firefox%20140.0.4.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "f00c0f86ce41bfcca1a96021b04f74b9ec7c9faf56021dbe1d18f012c645f878";
+      sha256 = "e60d7c7f78d2178457c357bf89f4687c94a1fe1e8212626957823b1c13ab11c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/cy/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/cy/Firefox%20140.0.4.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "9883b5d63fbbcf8f1612db500c545b659000c3bf7c308fb4bf52615b744b5a2c";
+      sha256 = "6af60b846d8b7f0ba3eba2f3a6b3eb41f935d109ebe59cbbbc6948a2bae6eb2b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/da/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/da/Firefox%20140.0.4.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "86e87041eb527db3a4142b9149f371ab7d426a148136dd6e41759306c46e4648";
+      sha256 = "f8b04a2d2c4c966a5451d964b23b6c6136cdf2ad2a86f1f3e6820c63fc7d9940";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/de/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/de/Firefox%20140.0.4.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "a5a6447c8cdec9a7f06f05f9fbf1c2cc2af4cd079c2c1b015e1a74e457c9249e";
+      sha256 = "b51a3ba43c4a0afd4cdd78e44ab5795663fe07c49dc1fef3fccf5c5ba5049bda";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/dsb/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/dsb/Firefox%20140.0.4.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "939d44b66ae87d88343b1ce7a8a5a8726b902f7e0af6ba91155f96735d5fe792";
+      sha256 = "8fe058e953664730490b54d549825282458dd031087df0c3ee72838f88141005";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/el/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/el/Firefox%20140.0.4.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "0aa026d3fcb036120dee3acc268a98dc92ea9fe1e9cd2e3cf63f34e5f8edbbc1";
+      sha256 = "dd4f77a7d168a2dea9229a9a7fcde85fd33484242802ba3adf543133d1485ea9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/en-CA/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/en-CA/Firefox%20140.0.4.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "ad2885278e3ec165eadd239d8d58b989d4e0f4e1612ab576b1a6dc675a8989ff";
+      sha256 = "a6577b839347ca1dcb6fdc4e017ac277238f969fe567a2923ae1d19a02408600";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/en-GB/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/en-GB/Firefox%20140.0.4.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "721932e9f05a371830a8107ed3e31bf4a95fb51f71e56a04917e118d26f218d0";
+      sha256 = "027a7b1755d0a2a6dd1eddc1ca71f9dbb4d43b9f8c81fce32a18e2bd41550aca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/en-US/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/en-US/Firefox%20140.0.4.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "4584538f48fc104a83cd5b62b72f027e70bffb8cb6ea56dd24e3657347cfa979";
+      sha256 = "e97d88d6ac04766cc52963d0d8f567bd39464bfc612167cd81627e6bb22d1d8c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/eo/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/eo/Firefox%20140.0.4.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "406f580dfe154194e256a74e5d799f397ebe6cc3886aab76c5560610b1209f8c";
+      sha256 = "488e0a613dbb62ef53d244dac8c9ab1349c2ea6b4ccc84ab57836103502dfb65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/es-AR/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/es-AR/Firefox%20140.0.4.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "caf760c019ceb2b9e6d3f2648708ccf6fca8683d131e50124d7166a7379b819c";
+      sha256 = "da7725fb75155f96a0abc50cb503e32d17f8debb3002e010a3ebf59b5a2bbb99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/es-CL/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/es-CL/Firefox%20140.0.4.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "83e2d00d5aa4d8f3f1956199a9b5c858457ecb7dc850869c0e72433384ba2516";
+      sha256 = "650a8f2d8198eded9cf01ab44668c46b6c5100524478017e9a1a95332976146d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/es-ES/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/es-ES/Firefox%20140.0.4.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "5d89313084fe55ff8c71b62a48d850dc35f3bcf93fec0990274211a34dfe43c5";
+      sha256 = "aff48cbc6a8dab4c88a9ed40222e85c27d44c281e7d9b0f835e84820f8909fad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/es-MX/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/es-MX/Firefox%20140.0.4.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "bad4fd02555db02c5c368977340c2fef5bdf2035d0098642f6091217988263b9";
+      sha256 = "243d59d14008425a1c264713586cf13ffcc375b56de828f8cda5a4ae22b459bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/et/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/et/Firefox%20140.0.4.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "be7d3d8a83181a43701ac0454f9defa4bff86f91d9f12d44f4dda88c1ef380b8";
+      sha256 = "c3403c2475c259c1e775598814455c0954d0aa788993014a481355d71e38a9b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/eu/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/eu/Firefox%20140.0.4.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "e679afce833f49d23fcca2446bd30c3ec46c56340e7e2bf71b0fd789db1af3e8";
+      sha256 = "49cb5f48d63040c0bdaa236d12139ca3f04795c164813893128228ff2f23d944";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/fa/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/fa/Firefox%20140.0.4.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "3fa74b83b227f53e795e5db895c6b88c0f86f6a93d23727cabf9cd511208926e";
+      sha256 = "80807e3b049f0568492a67dd346a42cac86da5a07318d5dda2b7e596a6a20b5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ff/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ff/Firefox%20140.0.4.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "79a02b2f1e98fa754df19c0654a21c7a28d4b24b00e0be9b6496a7604632ce36";
+      sha256 = "cd75707ccad5392126b4f2e2059b226925b5762eb5ee5d9cc6f3d8be62d1dfdb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/fi/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/fi/Firefox%20140.0.4.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "1de412cf06b8f6e1c65ea1fd036b087c691857f88eb5f288ad0dc036752defd8";
+      sha256 = "51578245b8bd2eb40aeebca324940634c7fa735a2d1e313a58bee237bd708625";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/fr/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/fr/Firefox%20140.0.4.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "646df95e72ba0fb3d3a169c6e1baf5501edef4d8b4d3fdd9bbf872197b7bd3a3";
+      sha256 = "983937d9e3fe76aa0b90150ea43fc6ae9d4595a2cd5ad23fe0b7b441d742b5a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/fur/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/fur/Firefox%20140.0.4.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "3d62a2b8c396384a8c66c0d6dca42f3203570844a68c3a64fa40cdc104e28452";
+      sha256 = "c93f087be6cdc2c1ef2ffcc4f4fa5c23a768fa46a0cf089e37c102bf3722f92f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/fy-NL/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/fy-NL/Firefox%20140.0.4.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "0c637c0a70658d1fbceacdb381ff16c0fd28e157ef5fd58c4e95b5734cab9643";
+      sha256 = "5cab4a45193a8983fdfdaa39f96fc091d02360546b526a64fe15b2f66644a5af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ga-IE/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ga-IE/Firefox%20140.0.4.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "2ffc124e5ff486fcfb5910e7f9d97851edb2d6496259f6b2be6ed2d76f526ba1";
+      sha256 = "10d323fff09bb3cee2d99262a86726815ee36396ff0ad15a55213876b7b956e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/gd/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/gd/Firefox%20140.0.4.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "566efee6522c826d8811572457d185ae5898802436fceff1af008a6c31b430c7";
+      sha256 = "83ff0d14ae302cacef73c078f4d2a10c845376f928b4302e2dcb1a197db97190";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/gl/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/gl/Firefox%20140.0.4.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "e5fce126d4e60cf01cd2b4d9f032fe84a36bbc402cba5c7b3319d4603e0981d3";
+      sha256 = "96cb66a2829c0cc22157e0b53c782de7c281e96a5044bdc73f905c1140e4ff6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/gn/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/gn/Firefox%20140.0.4.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "e539ddf9eb7bf115560f81eee96680250f501d3bc66da36d999a5d5dc558c7a2";
+      sha256 = "7bcb00d87a9274aa154b3ca74272389180df0a1d399c7e9840a19f61c0714b21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/gu-IN/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/gu-IN/Firefox%20140.0.4.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "e9296b000ff84239cf71f5313239c294434001db340ce4504518de64f7dd30a2";
+      sha256 = "26d644391bf6e772c3cb5551eecddbfe1eb03d1f0acf3905071019e268151fee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/he/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/he/Firefox%20140.0.4.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "09be2afffa661784f0a1a44b20399437382d7dc343db256f27912a9c935a9cfa";
+      sha256 = "2fa8005f947b7af24fe8b2099b7c5a1b4ba0703271ef7b77aedc3d154c8dc35c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/hi-IN/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/hi-IN/Firefox%20140.0.4.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "933b56f7b344bc1eab2d7a80f3eab746ace77f272570df0ea3cffcf5892d0183";
+      sha256 = "656fc2cd7490d2da9ec61ddd4df9b9bf384e80cd87e718e2394e02de393837dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/hr/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/hr/Firefox%20140.0.4.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "64d5ddec4924716e077e4e1645486cf14cec3e029f307320457aeb6001b1fcc8";
+      sha256 = "37f3c1a7026e32fdf89eeaa19b9b77243eae301766ba6d2be42ac936d837fec2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/hsb/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/hsb/Firefox%20140.0.4.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "63f10cc6ed00a7bfed4b30566f0f6350941a664ed4b7258c63b73e48129b75b6";
+      sha256 = "a47e0bf57e7067b8c88e284b8b725ce860bc02800e25a4f47bfe6614355840b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/hu/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/hu/Firefox%20140.0.4.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "3645d1a9fc28ec718abbf9f730a0076c228d6feb188a5d31b029225df352ef01";
+      sha256 = "3b3b56a4da6934fb4945d8b386810503752104b0973e3ce20d826142e1c87f81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/hy-AM/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/hy-AM/Firefox%20140.0.4.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "033ea44236e95c8d5b74f6692a6ecdf6cc1a9927398c7ba5e81431fc4a82b3b6";
+      sha256 = "b3949d87e2eac12b715340590ccbbfd67382d40928a0a641f2c017d044e78049";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ia/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ia/Firefox%20140.0.4.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "15679c8e1bd89c75d3300cb3e033a17ae93f75cb22e8dd81b137fca751890b16";
+      sha256 = "443fca414194feb84e801baabe6592ed95858c96b2f8b4e569fcb701b579e822";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/id/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/id/Firefox%20140.0.4.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "87944600f3696c298cca9c5c5c4b46421a389bf83a5853f07bd0000503af4d83";
+      sha256 = "a3cb49eda1eb25f5099df6f82e5483f0b3be5f1c919c83950f5fdbac22f580e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/is/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/is/Firefox%20140.0.4.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "8a588b8b52257cf773da756c8b1c67742d5324f3a1c1f422a8bea670daff4e38";
+      sha256 = "7b70819e255261c0a0c1ae32ad69d2dce1da301fe9b3eda4b656f5d3a9c2c938";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/it/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/it/Firefox%20140.0.4.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "1b79852aa06196f7c9187931c5572638de5030df931841182558a224ade44c55";
+      sha256 = "b6f2be2b39f18483009de42a3da9f752b0564b55f56e1b00cd289db530e218a7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ja-JP-mac/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ja-JP-mac/Firefox%20140.0.4.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "ee6c52e01d969f68d2478f3a90a0b7b242a0ce6a2b83394425aa721892a2378f";
+      sha256 = "b24cc09f5bbff3f55aa28d4728ff347464891edb66219df9c6f2e44ed860107f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ka/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ka/Firefox%20140.0.4.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "5a450dc134bcba6d74dd967ce752089aebaba5991e531f055e0e495def44e904";
+      sha256 = "4260c25eeeda5198d62eedc945f26d488aff857365ee81088e52629035039f14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/kab/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/kab/Firefox%20140.0.4.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "9b39486547b6c3adc488e9d3943fc0140cc1c58a87fc6e64330e572b970e7633";
+      sha256 = "5d29fa67a92bd3447b8bdb7023d2979087427980ffe1128b1661d0b0615c1169";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/kk/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/kk/Firefox%20140.0.4.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "7c28577b7ce7a05ea16122f0190da573c363cddeef114ccfac7e39087ca71da2";
+      sha256 = "e746741ab8ff463985849f3b65a82a0105605bc689d3f27f9e9dfc26433d125a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/km/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/km/Firefox%20140.0.4.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "8debf1d1c3c2ab14c2419aa44237c3183a5e02fc55b857b5418bed98e24b8a94";
+      sha256 = "9c72595599c6943194bdf659b6d7a7d55f68be905f139a88ad511ab3e7c54863";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/kn/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/kn/Firefox%20140.0.4.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "84f278459d95a03ac61b94caa60e13bf92066a8592abdb0d2cf9a1c36e25b89d";
+      sha256 = "b7d63b5583d9f51c6fceb2f444a3dfcc79cd335e44566ad18166fd607833a571";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ko/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ko/Firefox%20140.0.4.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "5f1cfc0ed96ca290ec4823918eda334f7535237b31b94b5c0a9ed8aa12d4b2b4";
+      sha256 = "b8287ea7deedbf7350115dd1ac4358f9a9ed3a4670e5054c6058be2f47fb696b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/lij/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/lij/Firefox%20140.0.4.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "d06f9e94e04287e57bdf2f6991cc0e7434a7583c114206059c906b3b9474c9ff";
+      sha256 = "bf6907af6b823649b82d142bb953ac82678240d546c37d60729d53748fca2c01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/lt/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/lt/Firefox%20140.0.4.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "793ed5697bc878424749e605148776371c62b18bea4b024b84c5c37777341fc6";
+      sha256 = "a3c3dc1761732eed8dcef2f54d114b02d93c50d37b489cfa661c3df91ebe43e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/lv/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/lv/Firefox%20140.0.4.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "e0787c7c4b328bde6f6542b1c8a395a0edc8b046b350d9b41056d241cbd50689";
+      sha256 = "73e0108bd692e7a457de70c5c7e899c429fad8cd37721ce7370e66a525e707e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/mk/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/mk/Firefox%20140.0.4.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "570adea48da8641dce718764c0db3e6176686daed1aab6a04bbfe3f13dad348d";
+      sha256 = "ca46e88411ec1cd4ceddc672ace2919dc25727663612bb9bd27632ab9a2f5f03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/mr/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/mr/Firefox%20140.0.4.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "3f62f4a0dfbd706abefd8f96e2d9c5c3075e27506379e593c1aceeee2e97f056";
+      sha256 = "181c49b5d8c02e3909bd4f2061efb8ef3cb9ec55e9ff63403211e32be3130e55";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ms/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ms/Firefox%20140.0.4.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "b873c56548b4d7d5a5d4c39b8ed6569b72be8d7906cb4d06505fe4dcfa2da1a9";
+      sha256 = "17f855ce25ef1ac92944fb14b16d7ffb5fb679e03b7bfc37e6cab025fca35b22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/my/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/my/Firefox%20140.0.4.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "cf5980c02043dd9c24ad751f2d2ec58265e48389e57738e1889635bf6e760952";
+      sha256 = "cff7f16757123113d39b8fb5a56ab77757fe9d90e1f5ba62f12ec9ea6f29b3a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/nb-NO/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/nb-NO/Firefox%20140.0.4.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "1a550cbfa265e463d24937c6f43b919365444d9bc80c87b00fdb3e5d9d3e2dc5";
+      sha256 = "8d76da8da930c484a4f2f78be4679688cc29ca44f8a6b991df385399eefa85c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ne-NP/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ne-NP/Firefox%20140.0.4.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "c8341aa9a7add1d1cbc8fe5aeb68f6609225a813d9cbbe0922318d5e35990b48";
+      sha256 = "c4614af7cfbe822fe82e46a614af0882ae14110e2254d5aa06e8dff7657694cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/nl/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/nl/Firefox%20140.0.4.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "35b78801c12767d27d03173d4abf163a18b34400c92a54e011fa22c1fbd502f3";
+      sha256 = "e5f2094e8b3d9ca293616d962cbd1d99eef02b92dcc3b473feb0d13c292c7082";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/nn-NO/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/nn-NO/Firefox%20140.0.4.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "edcbc6f8f42b80ce8be269111341960dc0f743dc1a92c76e3eaf6620b30b4725";
+      sha256 = "c67f47d65d913bc8767df912a6d6f3e633b811f1fc0aec3545cad7b6bb7757fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/oc/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/oc/Firefox%20140.0.4.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "df7ccb109a92b5d73890b9c1d85022856d16e663d0aff3dbfbb83eae848b68a9";
+      sha256 = "b0a98bc8572ec911403bfe490dc504d313fcff081079c1c18c6a82e0d9eca984";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/pa-IN/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/pa-IN/Firefox%20140.0.4.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "7d47b3571c1ac08c302049995b22a89de1f202436e8ad3d1f99c5cb6887bd7e2";
+      sha256 = "1b307d5709181a0b250327d04fd9a2f127fce7e792c4a525540480d4039fbc9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/pl/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/pl/Firefox%20140.0.4.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "8a3c05cc3c97566a94b35696490eb69cb04fafa7e14cf8d5382d57021c72fb08";
+      sha256 = "83a51dc92c8aafea137f698eef0c7d7249d238c0d459f4d6f542f023532db44a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/pt-BR/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/pt-BR/Firefox%20140.0.4.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "2db965c8888438d753def07a8ffacdc5a409251b0c84981fa038aaa060de0bde";
+      sha256 = "62c4ca2b20346f0906d5b536aab92f661d6f88ab0222469d3212c58e9d6224f5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/pt-PT/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/pt-PT/Firefox%20140.0.4.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "dac8aab2c52fbc566f44a9a4830c01a314538c1d8a100e340bce2109636e4fb8";
+      sha256 = "fa7f410a5d63c69e6b89501f34ce96fb09e0ac78a2e787349ab2af8fa801f3a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/rm/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/rm/Firefox%20140.0.4.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "9f69b7b620fa1ca834ae1746ede5430443b7c647ebe345e2f16fc6eec04c32b8";
+      sha256 = "233e7a0967801897a1458d33f0e0d0e7ee3f1841d2e564a9f4c2e7f872f64710";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ro/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ro/Firefox%20140.0.4.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "4ff95a794e5256ffbed21a03b1023d6952d1e382b501dd631275021941162195";
+      sha256 = "a6cb37d19d21f59bf35893661f3bf14f290a51bf78860edb555e4af46ccb2e82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ru/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ru/Firefox%20140.0.4.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "11b26b444e7dc2dc18d608eda787d9012284ebc6626452e860fddd3e91c67bd2";
+      sha256 = "bea384a03df803d4d91e7a8d6330f538a7949e66bf03b0b6db4105c1e92411ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/sat/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/sat/Firefox%20140.0.4.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "d1d000ec25fa58d46cb85ce1f150ebde60ae9842225c67f914dab67ef9e9015f";
+      sha256 = "c262f58493dfd81e6691578550a2942a8f9456513e3c51ad4b3805b60e07bc4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/sc/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/sc/Firefox%20140.0.4.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "3198a395d6a262c3df48676b0785f90cc6c692b78ea0efeb23d49d1151f07c85";
+      sha256 = "991631ef16653fe21a34ec791da72a457c820f58ee6365b62a43aff47bf06245";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/sco/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/sco/Firefox%20140.0.4.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "277ce0994d14407d92677d9398e6626170246919b894220cf5c6a5791d44fcb9";
+      sha256 = "2ce73609d4aeb566f702446280a7512e9107585208129ac857d29ca04fdb135c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/si/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/si/Firefox%20140.0.4.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "f461ef04aac49aee48b2315d10525d692ce1fa7d61fc10e5c343cae75ad74a6a";
+      sha256 = "6f0ab9069c5cf18ad5c4c12e2933e8304d12c492de1dd480f4b7e0393b4f0f40";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/sk/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/sk/Firefox%20140.0.4.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "a27db1ebb4bf19d12793a8407aca4e130484547822ee867ccecb4e61c4915e44";
+      sha256 = "c6801c789af1374ffb94eed0ef9245579dc7af6205d5175d7f3795bd9a01355a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/skr/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/skr/Firefox%20140.0.4.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "8a2899690de3a0b58a20dbb7e3775f7e9a7d7494cccacf63e9f36e40df74a418";
+      sha256 = "b776c0cf15d02f16558af2587d44cb8dfeaa4756c67363d04e61a355176f3feb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/sl/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/sl/Firefox%20140.0.4.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "dad132f5e6406be11f20b42ddc663d226dd916a8f204d28fd6410bb10cdf2851";
+      sha256 = "cb7f05c8dd3099f7887dc6554a854281bcea7e4595e643609d67a8d72a5b6d9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/son/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/son/Firefox%20140.0.4.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "ad7325b35f63688ec790cb495f8f730261188422f50ab3dbef82f9113a1b4e58";
+      sha256 = "fd85af5542a3dedf92870e240c39f1826a30396d15ff8c8b75a8e07d3fff2cc2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/sq/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/sq/Firefox%20140.0.4.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "5ea4f0854edfdc16460981da4cbb5899276327e5c844ca62177b128847045cf8";
+      sha256 = "5773ffbc81b5d558ae2197a76cea792f49dd9fe48a47d2329c7cb01a6b85c9ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/sr/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/sr/Firefox%20140.0.4.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "3c7ff91c5567d6514df255fe480dae0fcf0605a337a8cf73bc7abed6119a6007";
+      sha256 = "47b78c97701e7a146a42e8ca849ffb5ffe1852d4a23bb5bd702cc265b6f5736d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/sv-SE/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/sv-SE/Firefox%20140.0.4.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "aaadc713dc8f8b4c7a8175d0f62f7646059ae3d288fb14246b9577a922505226";
+      sha256 = "170936262506ad970a17d46e3d2c5fb23ebfc3d3f8b3ac3438c0f80d25870814";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/szl/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/szl/Firefox%20140.0.4.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "d687fa834eaf76e11a8f6246d49b63e3a7a37716e3465d7b67959bba59fdaddb";
+      sha256 = "71828dcc2c4c020d9773714c0847b20c367f36d432088f267fa73d425faa5728";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ta/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ta/Firefox%20140.0.4.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "bee72e67e70e61e4a56b2cab4505778965e060ae7c29a075d83974479d986554";
+      sha256 = "d8d9a5a2d78d3218119d4e6edbb602651cfa4f3918a7181eba3e8a3c41667aea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/te/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/te/Firefox%20140.0.4.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "eab2cb53fdbafab7de48a1ce91827f7bac16448f308394378ab881dd5734aa57";
+      sha256 = "345d3ff94590419d82f9ec551ec909d80b4fc5d7fa34bc41c489849d84f04f4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/tg/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/tg/Firefox%20140.0.4.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "cae682c2a847c0e2df469b5f53387d3e0454894fd3b1eb89b6b5c1b0c9972be2";
+      sha256 = "07f8aad52582f034079de255d3753d4e754d8ea89f5988ed5326c5a728969617";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/th/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/th/Firefox%20140.0.4.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "35cf811242dbfb38b2369e15fe7454cce24ddfbc143346e3c0751a052d995c39";
+      sha256 = "8751a21cf8772835eb7a0da4981517dcd2607691ba46137ee89f76c2bbba3a79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/tl/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/tl/Firefox%20140.0.4.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "185ac69c1f1016c89967bb1d755a1d077aeb3807cd6e9a9b9d90cb4399f43178";
+      sha256 = "dade6f970bbd83d77c6ee56465bc605a539aaed2e9d69f3edb6f71637f94aab2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/tr/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/tr/Firefox%20140.0.4.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "8771f38c75fdba62a609a6111aecc11b252f458b0ff65e8811193e1acb985398";
+      sha256 = "a2bd26e7f458938dd4ceae8a145beb1fa735081c2b99a34a843d6ec349b1703b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/trs/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/trs/Firefox%20140.0.4.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "61c4320c6bd48d214aa4b1a8231095ecbda9f5aa6dce3cf5b9efd8270357ea3e";
+      sha256 = "0b3333f1f80ec5005266f8e1e7c5b98edde047c9cd617bf37ae0f536f4962ba2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/uk/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/uk/Firefox%20140.0.4.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "3bf21f03952d45c44d7b5c3b1d6907a72f9aaddc1673d666e466e5bd58b7322f";
+      sha256 = "842296fa529441cc2ec1939d813649a1c05682d3eae0369b0917137fd32f5fd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/ur/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/ur/Firefox%20140.0.4.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "218bd2094f7d3eaf8a864c92f0bc54def3939d89c09e7a9e7d5abf65ad15f6d4";
+      sha256 = "469fa87ab6c043aca07f8c9c864b2a1370cc18c64df735cc034f146b18a0bcd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/uz/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/uz/Firefox%20140.0.4.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "97ac483e0b8f96378e6887bf070f5038a3dcd14500ef9f752a88b99e6d6b1318";
+      sha256 = "97e4ef0e7c28f03b9bcaecdbe5af093e5c03d4e1b845669fbac3cafa973738a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/vi/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/vi/Firefox%20140.0.4.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "e4b0774f97ef8146fd20c8eb42039cc67530bd5f85cf44b5b0da71899a9a9081";
+      sha256 = "727c8192e65e94dfbdf8fe506abe8d6db550bba6d559ba8923ce37031a130d68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/xh/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/xh/Firefox%20140.0.4.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "54e1da40dfa6b34d501ce9090bc9c5057d326d297f2c4d2d37ebf381c5c2e893";
+      sha256 = "bb6a1b92642b51a82ba0d3d8f19e01d4952a62c36add5ccb86e4c15c4bcd7b83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/zh-CN/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/zh-CN/Firefox%20140.0.4.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "9190935d949f774068f58fd254e385480f28fa816772cb82a5f4438ed062209f";
+      sha256 = "fc739cd43d62b94132292e8fa3457da7cb65b23a7cdf19f451d4025094231ae5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.2/mac/zh-TW/Firefox%20140.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/140.0.4/mac/zh-TW/Firefox%20140.0.4.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "bcd1b803d8e6b92e321e4978feffe7975d4c2dad35c11736a95ae0a67fe10d2e";
+      sha256 = "3b88dc8fd0ed780c5cf8fb3c4fbaf18177bf06150c94c7ceb2a5a88f5fcd80be";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,10 +9,10 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "140.0.2";
+  version = "140.0.4";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "11d3295c82835668f43a888bd5aada22248776e033aecc7558348e6ee26626bf4b65bbaae2680f7285a6b2b6209ec5d4aea453f1e0603544cd48bf45c735b2ea";
+    sha512 = "3de7c0871b8a45683f5c226fb3e91e597e8f89ef154b208b2a57c4d3ea9f39cb5c69ecbd5eca3b6da68d3775688d2289c1360c7d110c67bb1be1cf26ef8cf36d";
   };
 
   meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/140.0.4/releasenotes/
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
