### PR TITLE
nixosTests.musescore: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -901,7 +901,7 @@ in
   mumble = runTest ./mumble.nix;
   # Fails on aarch64-linux at the PDF creation step - need to debug this on an
   # aarch64 machine..
-  musescore = handleTestOn [ "x86_64-linux" ] ./musescore.nix { };
+  musescore = runTestOn [ "x86_64-linux" ] ./musescore.nix;
   music-assistant = runTest ./music-assistant.nix;
   munin = runTest ./munin.nix;
   mutableUsers = runTest ./mutable-users.nix;

--- a/nixos/tests/musescore.nix
+++ b/nixos/tests/musescore.nix
@@ -1,98 +1,95 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
+{ lib, hostPkgs, ... }:
 
-  let
-    # Make sure we don't have to go through the startup tutorial
-    customMuseScoreConfig = pkgs.writeText "MuseScore4.ini" ''
-      [application]
-      hasCompletedFirstLaunchSetup=true
+let
+  # Make sure we don't have to go through the startup tutorial
+  customMuseScoreConfig = hostPkgs.writeText "MuseScore4.ini" ''
+    [application]
+    hasCompletedFirstLaunchSetup=true
 
-      [project]
-      preferredScoreCreationMode=1
-    '';
-  in
-  {
-    name = "musescore";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ turion ];
+    [project]
+    preferredScoreCreationMode=1
+  '';
+in
+{
+  name = "musescore";
+  meta = with lib.maintainers; {
+    maintainers = [ turion ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [
+        ./common/x11.nix
+      ];
+
+      services.xserver.enable = true;
+      environment.systemPackages = with pkgs; [
+        musescore
+        pdfgrep
+      ];
     };
 
-    nodes.machine =
-      { ... }:
+  enableOCR = true;
 
-      {
-        imports = [
-          ./common/x11.nix
-        ];
+  testScript =
+    { ... }:
+    ''
+      start_all()
+      machine.wait_for_x()
 
-        services.xserver.enable = true;
-        environment.systemPackages = with pkgs; [
-          musescore
-          pdfgrep
-        ];
-      };
+      # Inject custom settings
+      machine.succeed("mkdir -p /root/.config/MuseScore/")
+      machine.succeed(
+          "cp ${customMuseScoreConfig} /root/.config/MuseScore/MuseScore4.ini"
+      )
 
-    enableOCR = true;
+      # Start MuseScore window
+      machine.execute("env XDG_RUNTIME_DIR=$PWD DISPLAY=:0.0 mscore >&2 &")
 
-    testScript =
-      { ... }:
-      ''
-        start_all()
-        machine.wait_for_x()
+      # Wait until MuseScore has launched
+      machine.wait_for_window("MuseScore Studio")
 
-        # Inject custom settings
-        machine.succeed("mkdir -p /root/.config/MuseScore/")
-        machine.succeed(
-            "cp ${customMuseScoreConfig} /root/.config/MuseScore/MuseScore4.ini"
-        )
+      machine.screenshot("MuseScore0")
 
-        # Start MuseScore window
-        machine.execute("env XDG_RUNTIME_DIR=$PWD DISPLAY=:0.0 mscore >&2 &")
+      # Create a new score
+      machine.send_key("ctrl-n")
 
-        # Wait until MuseScore has launched
-        machine.wait_for_window("MuseScore Studio")
+      # Wait until the creation wizard appears
+      machine.wait_for_window("New score")
 
-        machine.screenshot("MuseScore0")
+      machine.screenshot("MuseScore1")
 
-        # Create a new score
-        machine.send_key("ctrl-n")
+      machine.send_key("tab")
+      machine.send_key("tab")
+      machine.send_key("ret")
 
-        # Wait until the creation wizard appears
-        machine.wait_for_window("New score")
+      machine.sleep(2)
 
-        machine.screenshot("MuseScore1")
+      machine.send_key("tab")
+      # Type the beginning of https://de.wikipedia.org/wiki/Alle_meine_Entchen
+      machine.send_chars("cdef6gg5aaaa7g")
+      machine.sleep(1)
 
-        machine.send_key("tab")
-        machine.send_key("tab")
-        machine.send_key("ret")
+      machine.screenshot("MuseScore2")
 
-        machine.sleep(2)
+      # Go to the export dialogue and create a PDF
+      machine.send_key("ctrl-p")
 
-        machine.send_key("tab")
-        # Type the beginning of https://de.wikipedia.org/wiki/Alle_meine_Entchen
-        machine.send_chars("cdef6gg5aaaa7g")
-        machine.sleep(1)
+      # Wait until the Print dialogue appears.
+      machine.wait_for_window("Print")
 
-        machine.screenshot("MuseScore2")
+      machine.screenshot("MuseScore4")
+      machine.send_key("alt-p")
+      machine.sleep(1)
 
-        # Go to the export dialogue and create a PDF
-        machine.send_key("ctrl-p")
+      machine.screenshot("MuseScore5")
 
-        # Wait until the Print dialogue appears.
-        machine.wait_for_window("Print")
+      # Wait until PDF is exported
+      machine.wait_for_file('"/root/Untitled score.pdf"')
 
-        machine.screenshot("MuseScore4")
-        machine.send_key("alt-p")
-        machine.sleep(1)
-
-        machine.screenshot("MuseScore5")
-
-        # Wait until PDF is exported
-        machine.wait_for_file('"/root/Untitled score.pdf"')
-
-        ## Check that it contains the title of the score
-        machine.succeed('pdfgrep "Untitled score" "/root/Untitled score.pdf"')
-        machine.copy_from_vm("/root/Untitled score.pdf")
-      '';
-  }
-)
+      ## Check that it contains the title of the score
+      machine.succeed('pdfgrep "Untitled score" "/root/Untitled score.pdf"')
+      machine.copy_from_vm("/root/Untitled score.pdf")
+    '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on 7b09056b (master) and 7e1baf82 (this PR) and compare outputs, note that the derivations are the same.

`nix eval --read-only .#nixosTests.musescore`

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
