### PR TITLE
nixosTests.mycelium: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -905,7 +905,7 @@ in
   music-assistant = runTest ./music-assistant.nix;
   munin = runTest ./munin.nix;
   mutableUsers = runTest ./mutable-users.nix;
-  mycelium = handleTest ./mycelium { };
+  mycelium = runTest ./mycelium;
   mympd = runTest ./mympd.nix;
   mysql = handleTest ./mysql/mysql.nix { };
   mysql-autobackup = handleTest ./mysql/mysql-autobackup.nix { };

--- a/nixos/tests/mycelium/default.nix
+++ b/nixos/tests/mycelium/default.nix
@@ -1,73 +1,66 @@
-import ../make-test-python.nix (
-  { lib, ... }:
-  let
-    peer1-ip = "538:f40f:1c51:9bd9:9569:d3f6:d0a1:b2df";
-    peer2-ip = "5b6:6776:fee0:c1f3:db00:b6a8:d013:d38f";
-  in
-  {
-    name = "mycelium";
-    meta.maintainers = with lib.maintainers; [ lassulus ];
+{ lib, ... }:
+let
+  peer1-ip = "538:f40f:1c51:9bd9:9569:d3f6:d0a1:b2df";
+  peer2-ip = "5b6:6776:fee0:c1f3:db00:b6a8:d013:d38f";
+in
+{
+  name = "mycelium";
+  meta.maintainers = with lib.maintainers; [ lassulus ];
 
-    nodes = {
-
-      peer1 =
-        { config, pkgs, ... }:
+  nodes = {
+    peer1 = {
+      virtualisation.vlans = [ 1 ];
+      networking.interfaces.eth1.ipv4.addresses = [
         {
-          virtualisation.vlans = [ 1 ];
-          networking.interfaces.eth1.ipv4.addresses = [
-            {
-              address = "192.168.1.11";
-              prefixLength = 24;
-            }
-          ];
+          address = "192.168.1.11";
+          prefixLength = 24;
+        }
+      ];
 
-          services.mycelium = {
-            enable = true;
-            addHostedPublicNodes = false;
-            openFirewall = true;
-            keyFile = ./peer1.key;
-            peers = [
-              "quic://192.168.1.12:9651"
-              "tcp://192.168.1.12:9651"
-            ];
-          };
-        };
-
-      peer2 =
-        { config, pkgs, ... }:
-        {
-          virtualisation.vlans = [ 1 ];
-          networking.interfaces.eth1.ipv4.addresses = [
-            {
-              address = "192.168.1.12";
-              prefixLength = 24;
-            }
-          ];
-
-          services.mycelium = {
-            enable = true;
-            addHostedPublicNodes = false;
-            openFirewall = true;
-            keyFile = ./peer2.key;
-          };
-        };
+      services.mycelium = {
+        enable = true;
+        addHostedPublicNodes = false;
+        openFirewall = true;
+        keyFile = ./peer1.key;
+        peers = [
+          "quic://192.168.1.12:9651"
+          "tcp://192.168.1.12:9651"
+        ];
+      };
     };
 
-    testScript = ''
-      start_all()
+    peer2 = {
+      virtualisation.vlans = [ 1 ];
+      networking.interfaces.eth1.ipv4.addresses = [
+        {
+          address = "192.168.1.12";
+          prefixLength = 24;
+        }
+      ];
 
-      peer1.wait_for_unit("network-online.target")
-      peer2.wait_for_unit("network-online.target")
-      peer1.wait_for_unit("mycelium.service")
-      peer2.wait_for_unit("mycelium.service")
+      services.mycelium = {
+        enable = true;
+        addHostedPublicNodes = false;
+        openFirewall = true;
+        keyFile = ./peer2.key;
+      };
+    };
+  };
 
-      # Give mycelium some time to discover the other peer
-      peer1.wait_until_succeeds("ping -c1 ${peer2-ip}", timeout=10)
-      peer2.succeed("ping -c1 ${peer1-ip}")
+  testScript = ''
+    start_all()
 
-      peer1.succeed("mycelium peers list | grep 192.168.1.12")
-      peer2.succeed("mycelium peers list | grep 192.168.1.11")
+    peer1.wait_for_unit("network-online.target")
+    peer2.wait_for_unit("network-online.target")
+    peer1.wait_for_unit("mycelium.service")
+    peer2.wait_for_unit("mycelium.service")
 
-    '';
-  }
-)
+    # Give mycelium some time to discover the other peer
+    peer1.wait_until_succeeds("ping -c1 ${peer2-ip}", timeout=10)
+    peer2.succeed("ping -c1 ${peer1-ip}")
+
+    peer1.succeed("mycelium peers list | grep 192.168.1.12")
+    peer2.succeed("mycelium peers list | grep 192.168.1.11")
+
+  '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on 7b09056b (master) and 2eb3f817 (this PR) and compare outputs, note that the derivations are the same.

`nix eval --read-only .#nixosTests.mycelium`

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
