### PR TITLE
nixosTests.nagios: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -912,7 +912,7 @@ in
   mysql-backup = handleTest ./mysql/mysql-backup.nix { };
   mysql-replication = handleTest ./mysql/mysql-replication.nix { };
   n8n = runTest ./n8n.nix;
-  nagios = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./nagios.nix { };
+  nagios = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./nagios.nix;
   nar-serve = runTest ./nar-serve.nix;
   nat.firewall = handleTest ./nat.nix { withFirewall = true; };
   nat.standalone = handleTest ./nat.nix { withFirewall = false; };

--- a/nixos/tests/nagios.nix
+++ b/nixos/tests/nagios.nix
@@ -1,124 +1,120 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "nagios";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ symphorien ];
+{ lib, ... }:
+{
+  name = "nagios";
+  meta = with lib.maintainers; {
+    maintainers = [ symphorien ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    let
+      writer = pkgs.writeShellScript "write" ''
+        set -x
+        echo "$@"  >> /tmp/notifications
+      '';
+    in
+    {
+      # tested service
+      services.sshd.enable = true;
+      # nagios
+      services.nagios = {
+        enable = true;
+        # make state transitions faster
+        extraConfig.interval_length = "5";
+        objectDefs =
+          (map (x: "${pkgs.nagios}/etc/objects/${x}.cfg") [
+            "templates"
+            "timeperiods"
+            "commands"
+          ])
+          ++ [
+            (pkgs.writeText "objects.cfg" ''
+              # notifications are written to /tmp/notifications
+              define command {
+              command_name notify-host-by-file
+              command_line ${writer} "$HOSTNAME is $HOSTSTATE$"
+              }
+              define command {
+              command_name notify-service-by-file
+              command_line ${writer} "$SERVICEDESC$ is $SERVICESTATE$"
+              }
+
+              # nagios boilerplate
+              define contact {
+              contact_name                    alice
+              alias                           alice
+              host_notifications_enabled      1
+              service_notifications_enabled   1
+              service_notification_period     24x7
+              host_notification_period        24x7
+              service_notification_options    w,u,c,r,f,s
+              host_notification_options       d,u,r,f,s
+              service_notification_commands   notify-service-by-file
+              host_notification_commands      notify-host-by-file
+              email                           foo@example.com
+              }
+              define contactgroup {
+              contactgroup_name   admins
+              alias               Admins
+              members alice
+              }
+              define hostgroup{
+              hostgroup_name  allhosts
+              alias  All hosts
+              }
+
+              # monitored objects
+              define host {
+              use         generic-host
+              host_name   localhost
+              alias       localhost
+              address     localhost
+              hostgroups  allhosts
+              contact_groups admins
+              # make state transitions faster.
+              max_check_attempts 2
+              check_interval 1
+              retry_interval 1
+              }
+              define service {
+              use                 generic-service
+              host_name           localhost
+              service_description ssh
+              check_command       check_ssh
+              # make state transitions faster.
+              max_check_attempts 2
+              check_interval 1
+              retry_interval 1
+              }
+            '')
+          ];
+      };
     };
 
-    nodes.machine =
-      { lib, ... }:
-      let
-        writer = pkgs.writeShellScript "write" ''
-          set -x
-          echo "$@"  >> /tmp/notifications
-        '';
-      in
-      {
-        # tested service
-        services.sshd.enable = true;
-        # nagios
-        services.nagios = {
-          enable = true;
-          # make state transitions faster
-          extraConfig.interval_length = "5";
-          objectDefs =
-            (map (x: "${pkgs.nagios}/etc/objects/${x}.cfg") [
-              "templates"
-              "timeperiods"
-              "commands"
-            ])
-            ++ [
-              (pkgs.writeText "objects.cfg" ''
-                # notifications are written to /tmp/notifications
-                define command {
-                command_name notify-host-by-file
-                command_line ${writer} "$HOSTNAME is $HOSTSTATE$"
-                }
-                define command {
-                command_name notify-service-by-file
-                command_line ${writer} "$SERVICEDESC$ is $SERVICESTATE$"
-                }
-
-                # nagios boilerplate
-                define contact {
-                contact_name                    alice
-                alias                           alice
-                host_notifications_enabled      1
-                service_notifications_enabled   1
-                service_notification_period     24x7
-                host_notification_period        24x7
-                service_notification_options    w,u,c,r,f,s
-                host_notification_options       d,u,r,f,s
-                service_notification_commands   notify-service-by-file
-                host_notification_commands      notify-host-by-file
-                email                           foo@example.com
-                }
-                define contactgroup {
-                contactgroup_name   admins
-                alias               Admins
-                members alice
-                }
-                define hostgroup{
-                hostgroup_name  allhosts
-                alias  All hosts
-                }
-
-                # monitored objects
-                define host {
-                use         generic-host
-                host_name   localhost
-                alias       localhost
-                address     localhost
-                hostgroups  allhosts
-                contact_groups admins
-                # make state transitions faster.
-                max_check_attempts 2
-                check_interval 1
-                retry_interval 1
-                }
-                define service {
-                use                 generic-service
-                host_name           localhost
-                service_description ssh
-                check_command       check_ssh
-                # make state transitions faster.
-                max_check_attempts 2
-                check_interval 1
-                retry_interval 1
-                }
-              '')
-            ];
-        };
-      };
-
-    testScript =
-      { ... }:
-      ''
-        with subtest("ensure sshd starts"):
-            machine.wait_for_unit("sshd.service")
+  testScript = ''
+    with subtest("ensure sshd starts"):
+        machine.wait_for_unit("sshd.service")
 
 
-        with subtest("ensure nagios starts"):
-            machine.wait_for_file("/var/log/nagios/current")
+    with subtest("ensure nagios starts"):
+        machine.wait_for_file("/var/log/nagios/current")
 
 
-        def assert_notify(text):
-            machine.wait_for_file("/tmp/notifications")
-            real = machine.succeed("cat /tmp/notifications").strip()
-            print(f"got {real!r}, expected {text!r}")
-            assert text == real
+    def assert_notify(text):
+        machine.wait_for_file("/tmp/notifications")
+        real = machine.succeed("cat /tmp/notifications").strip()
+        print(f"got {real!r}, expected {text!r}")
+        assert text == real
 
 
-        with subtest("ensure we get a notification when sshd is down"):
-            machine.succeed("systemctl stop sshd")
-            assert_notify("ssh is CRITICAL")
+    with subtest("ensure we get a notification when sshd is down"):
+        machine.succeed("systemctl stop sshd")
+        assert_notify("ssh is CRITICAL")
 
 
-        with subtest("ensure tests can succeed"):
-            machine.succeed("systemctl start sshd")
-            machine.succeed("rm /tmp/notifications")
-            assert_notify("ssh is OK")
-      '';
-  }
-)
+    with subtest("ensure tests can succeed"):
+        machine.succeed("systemctl start sshd")
+        machine.succeed("rm /tmp/notifications")
+        assert_notify("ssh is OK")
+  '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on 7b09056b (master) and dfa61b2622eeb1226e92ae72d2b85e904752c885 (this PR) and compare outputs, note that the derivations are the same.

`nix eval --read-only .#nixosTests.nagios`

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
