### PR TITLE
[DRAFT] wpaperd: added dependencies for AVIF support

### DIFF
--- a/pkgs/by-name/wp/wpaperd/package.nix
+++ b/pkgs/by-name/wp/wpaperd/package.nix
@@ -29,6 +29,11 @@ rustPlatform.buildRustPackage rec {
     wayland
     libGL
     libxkbcommon
+    dav1d
+  ];
+
+  buildFeatures = [
+    "avif"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
added **dav1d** _build dependency_ and **avif** _build flag_ to allow _wpaper_ to support avif image as input.
sources:
https://github.com/danyspin97/wpaperd?tab=readme-ov-file#dependencies
https://github.com/danyspin97/wpaperd?tab=readme-ov-file#image-formats-support
https://github.com/image-rs/image/blob/main/README.md#supported-image-formats
