### PR TITLE
fetchhg: use `lib.extendMkDerivation` and support `<pkg>.overrideAttrs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -193,6 +193,9 @@ cffc27daf06c77c0d76bc35d24b929cb9d68c3c9
 # nixos/kanidm: inherit lib, nixfmt
 8f18393d380079904d072007fb19dc64baef0a3a
 
+# fetchhg: format after refactoring with lib.extendMkDerivation and make overridable (#423539)
+34a5b1eb23129f8fb62c677e3760903f6d43228f
+
 # fetchurl: nixfmt-rfc-style
 ce21e97a1f20dee15da85c084f9d1148d84f853b
 

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -840,7 +840,7 @@ Used with CVS. Expects `cvsRoot`, `tag`, and `hash`.
 
 ## `fetchhg` {#fetchhg}
 
-Used with Mercurial. Expects `url`, `rev`, and `hash`.
+Used with Mercurial. Expects `url`, `rev`, `hash`, overridable with [`<pkg>.overrideAttrs`](#sec-pkg-overrideAttrs).
 
 A number of fetcher functions wrap part of `fetchurl` and `fetchzip`. They are mainly convenience functions intended for commonly used destinations of source code in Nixpkgs. These wrapper fetchers are listed below.
 

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -13,9 +13,6 @@
   preferLocalBuild ? true,
 }:
 
-if hash != null && sha256 != null then
-  throw "Only one of sha256 or hash can be set"
-else
   # TODO: statically check if mercurial as the https support if the url starts with https.
   stdenvNoCC.mkDerivation {
     name = "hg-archive" + (lib.optionalString (name != null) "-${name}");
@@ -26,15 +23,20 @@ else
 
     subrepoClause = lib.optionalString fetchSubrepos "S";
 
-    outputHashAlgo = if hash != null then null else "sha256";
+    outputHashAlgo = if hash != null && hash != "" then null else "sha256";
     outputHashMode = "recursive";
     outputHash =
-      if hash != null then
-        hash
-      else if sha256 != null then
-        sha256
-      else
-        lib.fakeSha256;
+      lib.throwIf
+        (hash != null && sha256 != null)
+        "Only one of sha256 or hash can be set"
+        (
+          if hash != null then
+            hash
+          else if sha256 != null then
+            sha256
+          else
+            ""
+        );
 
     inherit url rev;
     inherit preferLocalBuild;

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -3,6 +3,12 @@
   stdenvNoCC,
   mercurial,
 }:
+
+lib.extendMkDerivation {
+  constructDrv = stdenvNoCC.mkDerivation;
+
+  extendDrvArgs =
+    finalAttrs:
 {
   name ? null,
   url,
@@ -12,9 +18,8 @@
   fetchSubrepos ? false,
   preferLocalBuild ? true,
 }:
-
   # TODO: statically check if mercurial as the https support if the url starts with https.
-  stdenvNoCC.mkDerivation {
+  {
     name = "hg-archive" + (lib.optionalString (name != null) "-${name}");
     builder = ./builder.sh;
     nativeBuildInputs = [ mercurial ];
@@ -40,4 +45,8 @@
 
     inherit url rev;
     inherit preferLocalBuild;
-  }
+  };
+
+  # No ellipsis
+  inheritFunctionArgs = false;
+}

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -9,43 +9,41 @@ lib.extendMkDerivation {
 
   extendDrvArgs =
     finalAttrs:
-{
-  name ? null,
-  url,
-  rev ? null,
-  sha256 ? null,
-  hash ? null,
-  fetchSubrepos ? false,
-  preferLocalBuild ? true,
-}:
-  # TODO: statically check if mercurial as the https support if the url starts with https.
-  {
-    name = "hg-archive" + (lib.optionalString (name != null) "-${name}");
-    builder = ./builder.sh;
-    nativeBuildInputs = [ mercurial ];
+    {
+      name ? null,
+      url,
+      rev ? null,
+      sha256 ? null,
+      hash ? null,
+      fetchSubrepos ? false,
+      preferLocalBuild ? true,
+    }:
+    # TODO: statically check if mercurial as the https support if the url starts with https.
+    {
+      name = "hg-archive" + (lib.optionalString (name != null) "-${name}");
+      builder = ./builder.sh;
+      nativeBuildInputs = [ mercurial ];
 
-    impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 
-    subrepoClause = lib.optionalString fetchSubrepos "S";
+      subrepoClause = lib.optionalString fetchSubrepos "S";
 
-    outputHashAlgo = if finalAttrs.hash != null && finalAttrs.hash != "" then null else "sha256";
-    outputHashMode = "recursive";
-    outputHash =
-      lib.throwIf
-        (finalAttrs.hash != null && sha256 != null)
-        "Only one of sha256 or hash can be set"
-        (
-          if finalAttrs.hash != null then
-            finalAttrs.hash
-          else if sha256 != null then
-            sha256
-          else
-            ""
-        );
+      outputHashAlgo = if finalAttrs.hash != null && finalAttrs.hash != "" then null else "sha256";
+      outputHashMode = "recursive";
+      outputHash =
+        lib.throwIf (finalAttrs.hash != null && sha256 != null) "Only one of sha256 or hash can be set"
+          (
+            if finalAttrs.hash != null then
+              finalAttrs.hash
+            else if sha256 != null then
+              sha256
+            else
+              ""
+          );
 
-    inherit url rev hash;
-    inherit preferLocalBuild;
-  };
+      inherit url rev hash;
+      inherit preferLocalBuild;
+    };
 
   # No ellipsis
   inheritFunctionArgs = false;

--- a/pkgs/build-support/fetchhg/default.nix
+++ b/pkgs/build-support/fetchhg/default.nix
@@ -28,22 +28,22 @@ lib.extendMkDerivation {
 
     subrepoClause = lib.optionalString fetchSubrepos "S";
 
-    outputHashAlgo = if hash != null && hash != "" then null else "sha256";
+    outputHashAlgo = if finalAttrs.hash != null && finalAttrs.hash != "" then null else "sha256";
     outputHashMode = "recursive";
     outputHash =
       lib.throwIf
-        (hash != null && sha256 != null)
+        (finalAttrs.hash != null && sha256 != null)
         "Only one of sha256 or hash can be set"
         (
-          if hash != null then
-            hash
+          if finalAttrs.hash != null then
+            finalAttrs.hash
           else if sha256 != null then
             sha256
           else
             ""
         );
 
-    inherit url rev;
+    inherit url rev hash;
     inherit preferLocalBuild;
   };
 

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  tests = tests-stdenv // test-extendMkDerivation // tests-go // tests-python;
+  tests = tests-stdenv // test-extendMkDerivation // tests-fetchhg // tests-go // tests-python;
 
   tests-stdenv =
     let
@@ -127,6 +127,51 @@ let
       };
       extendMkDerivation-helloLocal-specialArg = {
         expr = hiLocal.greeting == "Hi!";
+        expected = true;
+      };
+    };
+
+  tests-fetchhg =
+    let
+      ruamel_0_18_14-hash = "sha256-HDkPPp1xI3uoGYlS9mwPp1ZjG2gKvx6vog0Blj6tBuI=";
+      ruamel_0_18_14-src = pkgs.fetchhg {
+        url = "http://hg.code.sf.net/p/ruamel-yaml/code";
+        rev = "0.18.14";
+        hash = ruamel_0_18_14-hash;
+      };
+      ruamel_0_17_21-hash = "sha256-6PV0NyPQfd+4RBqoj5vJaOHShx+TJVHD2IamRinU0VU=";
+      ruamel_0_17_21-src = pkgs.fetchhg {
+        url = "http://hg.code.sf.net/p/ruamel-yaml/code";
+        rev = "0.17.21";
+        hash = ruamel_0_17_21-hash;
+      };
+      ruamel_0_17_21-src-by-overriding = ruamel_0_18_14-src.overrideAttrs {
+        rev = "0.17.21";
+        hash = ruamel_0_17_21-hash;
+      };
+    in
+    {
+      hash-outputHash-equivalence = {
+        expr = ruamel_0_17_21-src.outputHash == ruamel_0_17_21-hash;
+        expected = true;
+      };
+
+      hash-overridability-outputHash = {
+        expr = ruamel_0_17_21-src-by-overriding.outputHash == ruamel_0_17_21-hash;
+        expected = true;
+      };
+
+      hash-overridability-drvPath = {
+        expr =
+          lib.isString ruamel_0_17_21-src-by-overriding.drvPath
+          && ruamel_0_17_21-src-by-overriding.drvPath == ruamel_0_17_21-src.drvPath;
+        expected = true;
+      };
+
+      hash-overridability-outPath = {
+        expr =
+          lib.isString ruamel_0_17_21-src-by-overriding.outPath
+          && ruamel_0_17_21-src-by-overriding.outPath == ruamel_0_17_21-src.outPath;
         expected = true;
       };
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Refactor `fetchhg` with `lib.extendMkDerivation` and make supported arguments (including `hash`) overridable via `<pkg>.overrideAttrs`.

It would be easier to review commit-by-commit or hide white space changes when viewing the changes.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
