### PR TITLE
conda-build: init at 25.5.0 

### DIFF
--- a/pkgs/development/python-modules/conda-build/default.nix
+++ b/pkgs/development/python-modules/conda-build/default.nix
@@ -1,0 +1,245 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
+  bash,
+  beautifulsoup4,
+  chardet,
+  conda,
+  conda-index,
+  conda-package-handling,
+  distutils,
+  evalidate,
+  filelock,
+  frozendict,
+  git,
+  jinja2,
+  jsonschema,
+  libarchive-c,
+  libmambapy,
+  pkginfo,
+  psutil,
+  pytz,
+  pyyaml,
+  requests,
+  tqdm,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-mock,
+  pytest-rerunfailures,
+  pytest-xdist,
+}:
+
+buildPythonPackage rec {
+  pname = "conda-build";
+  version = "25.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "conda";
+    repo = "conda-build";
+    tag = version;
+    hash = "sha256-bQ34uoyjccpnx9ICOknhBHsO0NueLlMDoAiNIWccpi4=";
+  };
+
+  postPatch = ''
+    find . -type f -exec sed -i 's|/bin/bash|${lib.getExe bash}|g' {} +
+  '';
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+  dependencies = [
+    beautifulsoup4
+    chardet
+    conda-package-handling
+    conda
+    evalidate
+    filelock
+    frozendict
+    jinja2
+    jsonschema
+    libarchive-c
+    libmambapy
+    pkginfo
+    psutil
+    pytz
+    pyyaml
+    requests
+    tqdm
+    conda-index
+  ];
+  nativeCheckInputs = [
+    distutils # Required by tests/"test_variants.py::"test_variants_in_versions_with_setup_py_data
+    git # Some tests subprocess.run git (yikes)
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-mock
+    pytest-rerunfailures # TODO: is it worth it to disable the flaky tests?
+    pytest-xdist
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+  # Issue opened to track offline testing support: https://github.com/conda/conda-build/issues/5749
+  disabledTestPaths = [
+    # Networking (and seemingly has an API token in the test file!?)
+    # https://github.com/conda/conda-build/blob/fa742ca312cde5617c69c56e4c18ce5458b2e040/tests/test_api_build.py#L210-L214
+    "tests/test_api_build.py"
+    # Networking (almost all tests try to use conda.gateways.connection.download.download)
+    # NOTE: This should be possible to get rid of with a patch, it just uses it to fetch the same zip over and over
+    "tests/test_api_convert.py"
+    # Networking (tries to talk to PyPI)
+    "tests/test_api_skeleton.py"
+  ];
+  disabledTests = [
+    # Networking (attempted git clone)
+    "test_build_empty_sections"
+    "test_build_skip_existing"
+    "test_build_skip_existing_croot"
+    "test_git_in_output_version"
+    "test_git_repo_with_single_subdir_does_not_enter_subdir"
+    "test_multiple_different_sources"
+    "test_package_with_jinja2_does_not_redownload_source"
+    "test_recipe_builds"
+    "test_relative_path_croot"
+    "test_relative_path_test_artifact"
+    "test_check_recipe"
+    "test_render_need_download"
+    "test_render_yaml_output"
+    # Networking (conda.gateways.connection.download.download)
+    "test_develop"
+    # Networking (HTTP request to https://fastapi.metacpan.org/v1/download_url/Sub::Identify)
+    "test_xs_needs_c_compiler"
+    # FAILED tests/iforgetthename.py::"test_different_git_vars - conda_build.exceptions.CondaBuildUserError: Failed to render jinja template in /build/source/tests/test-recipes/variants/29_different_git_vars/meta.yaml:
+    # 'GIT_DESCRIBE_TAG' is undefined
+    "test_different_git_vars"
+    # FAILED tests/"test_variants.py::"test_git_variables_with_variants - AssertionError: assert 'None' == '1.20.2'
+    "test_git_variables_with_variants"
+    # FAILED tests/"test_utils.py::"test_subprocess_stats_call - FileNotFoundError: [Errno 2] No such file or directory: 'hostname'
+    "test_subprocess_stats_call"
+    # FAILED tests/"test_published_examples.py::"test_skeleton_pypi - FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/sd81bvmch7njdpwx3lkjslixcbj5mivz-python3-3.13.4/bin/conda'
+    # (WTF? Why is it looking *there*?)
+    "test_skeleton_pypi"
+    # Networking (HTTP request to https://repo.anaconda.com/pkgs/main/linux-64/repodata.json)
+    # nix log /nix/store/<...>.drv | grep repodata.json | sed s/^.*WARNING.*$// | sed s/^.*::// | sed "s/-.*$//" | sed "s/\[.*\].*$//" | grep "test_" | uniq
+    # I could disable whole test files, but the problem is these are interspersed with kind of crucial tests that work just fine offline
+    "test_debug"
+    "test_no_filename_hash"
+    "test_api_extra_dep"
+    "test_core_modules"
+    "test_build_script_and_script_env"
+    "test_test_extra_dep"
+    "test_build_output_folder"
+    "test_subpackage_recipes"
+    "test_build_multiple_recipes"
+    "test_python_variants"
+    "test_per_output_tests"
+    "test_python_line_up_with_compiled_lib" # win-64 here not linux-64 but whatever
+    "test_subpackage_script_and_files"
+    "test_no_force_upload"
+    "test_conda_py_no_period"
+    "test_inspect_installable"
+    "test_rewrite_output"
+    "test_conda_pkg_format"
+    "test_output_without_jinja_does_not_download"
+    "test_build_add_channel"
+    "test_metapackage_metadata"
+    "test_package_test"
+    "test_inspect_prefix_length"
+    "test_pin_compatible_semver"
+    "test_build_without_channel_fails"
+    "test_render_add_channel"
+    "test_inspect_hash_input"
+    "test_transitive_subpackage_dependency"
+    "test_render_output_build_path_set_python"
+    "test_recipe_build"
+    "test_metapackage"
+    "test_resolved_packages_recipe"
+    "test_render_with_python_arg_reduces_subspace"
+    "test_resolved_packages"
+    "test_slash_in_recipe_arg_keeps_build_id"
+    "test_build_preserves_PATH"
+    "test_metapackage_build_number"
+    "test_host_entries_finalized"
+    "test_render_with_python_arg_CLI_reduces_subspace"
+    "test_pypi_installer_metadata"
+    "test_build_long_test_prefix_default_enabled"
+    "test_channel_installable"
+    "test_metapackage_build_string"
+    "test_hash_no_apply_to_custom_build_string"
+    "test_build_no_build_id"
+    "test_file_hash"
+    "test_pin_depends"
+    "test_rpath_symlink"
+    "test_noarch_with_platform_deps"
+    "test_subpackage_independent_hash"
+    "test_autodetect_raises_on_invalid_extension"
+    "test_intradep_with_templated_output_name"
+    "test_noarch_with_no_platform_deps"
+    "test_run_exports_in_subpackage"
+    "test_rm_rf_does_not_remove_relative_source_package_files"
+    "test_toplevel_entry_points_do_not_apply_to_subpackages"
+    "test_run_exports_with_pin_compatible_in_subpackages"
+    "test_subpackage_variant_override"
+    "test_subpackage_order_natural"
+    "test_subpackage_hash_inputs"
+    "test_merge_build_host_build_key"
+    "test_build_source"
+    "test_intradependencies"
+    "test_subpackage_order_bad"
+    "test_overlapping_files"
+    "test_merge_build_host_empty_host_section"
+    "test_build_string_does_not_incorrectly_add_hash"
+    "test_activation_in_output_scripts"
+    "test_pinning_in_build_requirements"
+    "test_ensure_valid_spec_on_run_and_test"
+    "test_conda_py_no_period"
+    "test_circular_deps_cross"
+    "test_build_run_exports_act_on_host"
+    "test_merge_build_host_applies_in_outputs"
+    "test_no_satisfiable_variants_raises_error"
+    "test_serial_builds_have_independent_configs"
+    "test_inner_python_loop_with_output"
+    "test_loops_do_not_remove_earlier_packages"
+    "test_top_level_finalized"
+    "test_numpy_used_variable_looping"
+    "test_activate_scripts_not_included"
+    "test_variant_as_dependency_name"
+    "test_variant_subkeys_retained"
+    # Tries to access GitHub
+    "test_get_output_file_paths_jinja2"
+    # Fails to find the conda binary
+    "test_build_bootstrap_env_by_name"
+    "test_build_bootstrap_env_by_path"
+    # "conda_build.exceptions.CondaBuildUserError: Package python is not installed in /build/tmp.mQC6jfXZDO/.conda"
+    "test_inspect_linkages"
+    # Tries to access CRAN
+    "test_cran_no_comments"
+    # Tries to do something conda-related (idk)
+    # requests.exceptions.ConnectionError: HTTPSConnectionPool(host='schemas.conda.org', port=443): Max retries exceeded with url: /menuinst/menuinst-1-1-0.schema.json
+    "test_menuinst_validation_ok"
+    "test_menuinst_validation_fails_bad_input"
+    # Tries to fetch https://repo.anaconda.com/pkgs/free/win-64/affine-2.0.0-py27_0.tar.bz2
+    "test_convert"
+    # I don't know why these are failing but it's probably fiiiine
+    "test_build_output_build_path"
+    "test_render_output_build_path"
+  ];
+  # NOTE: xdist seemingly respects NIX_BUILD_CORES, neat!
+  pytestFlagsArray = [ "-n auto" ];
+
+  pythonImportsCheck = [ "conda_build" ];
+
+  meta = {
+    description = "Commands and tools for building conda packages";
+    homepage = "https://docs.conda.io/projects/conda-build/";
+    changelog = "https://docs.conda.io/projects/conda-build/en/stable/release-notes.html";
+    maintainers = with lib.maintainers; [ pandapip1 ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/conda-index/default.nix
+++ b/pkgs/development/python-modules/conda-index/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
+  conda-package-streaming,
+  filelock,
+  jinja2,
+  ruamel-yaml,
+  zstandard,
+  click,
+  msgpack,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "conda-build";
+  version = "0.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "conda";
+    repo = "conda-index";
+    tag = version;
+    hash = "sha256-ATM6cQ6JpHAAOxUwikuRtUF5yfPe4xn1leGgSNX4LN8=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+  dependencies = [
+    conda-package-streaming
+    filelock
+    jinja2
+    ruamel-yaml
+    zstandard
+    click
+    msgpack
+  ];
+  # TODO: Do pytest in passthru.tests (circular dependency w/ conda-build)
+  # nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "conda_index" ];
+
+  meta = {
+    description = "Create channels from collections of packages";
+    homepage = "https://conda.github.io/conda-index/";
+    changelog = "https://conda.github.io/conda-index/changelog.html";
+    maintainers = with lib.maintainers; [ pandapip1 ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/evalidate/default.nix
+++ b/pkgs/development/python-modules/evalidate/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  conda,
+  jsonschema,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "evalidate";
+  version = "2.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "yaroslaff";
+    repo = "evalidate";
+    tag = "v${version}";
+    hash = "sha256-2WsvLHbzwHBRyrGCU6eGPl4psAlu8Ko4hRSFr5C+upw=";
+  };
+
+  build-system = [ hatchling ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "evalidate" ];
+
+  meta = {
+    description = "Safe and fast evaluation of untrusted user-supplied python expressions";
+    homepage = "https://github.com/yaroslaff/evalidate";
+    changelog = "https://github.com/yaroslaff/evalidate/releases";
+    maintainers = with lib.maintainers; [ pandapip1 ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2837,6 +2837,8 @@ self: super: with self; {
 
   conda = callPackage ../development/python-modules/conda { };
 
+  conda-index = callPackage ../development/python-modules/conda-index { };
+
   conda-inject = callPackage ../development/python-modules/conda-inject { };
 
   conda-libmamba-solver = callPackage ../development/python-modules/conda-libmamba-solver { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4739,6 +4739,8 @@ self: super: with self; {
 
   eval-type-backport = callPackage ../development/python-modules/eval-type-backport { };
 
+  evalidate = callPackage ../development/python-modules/evalidate { };
+
   evaluate = callPackage ../development/python-modules/evaluate { };
 
   evdev = callPackage ../development/python-modules/evdev { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2837,6 +2837,8 @@ self: super: with self; {
 
   conda = callPackage ../development/python-modules/conda { };
 
+  conda-build = callPackage ../development/python-modules/conda-build { };
+
   conda-index = callPackage ../development/python-modules/conda-index { };
 
   conda-inject = callPackage ../development/python-modules/conda-inject { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/355340

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
