### PR TITLE
kryoflux: init at 3.50

### DIFF
--- a/nixos/modules/hardware/kryoflux.nix
+++ b/nixos/modules/hardware/kryoflux.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.kryoflux;
+
+in
+{
+  options.programs.kryoflux = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enables kryoflux udev rules, ensures 'floppy' group exists. This is a
+        prerequisite to using devices supported by kryoflux without being root,
+        since kryoflux device descriptors will be owned by floppy through udev.
+      '';
+    };
+    package = lib.mkPackageOption pkgs "kryoflux" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.udev.packages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
+    users.groups.floppy = { };
+  };
+
+  meta.maintainers = with lib.maintainers; [ matthewcroughan ];
+}

--- a/pkgs/by-name/kr/kryoflux/package.nix
+++ b/pkgs/by-name/kr/kryoflux/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  lib,
+  autoPatchelfHook,
+  fetchurl,
+  makeWrapper,
+  jre,
+  fmt_9,
+  libusb1,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "kryoflux";
+  version = "3.50";
+  src = fetchurl {
+    url = "https://www.kryoflux.com/download/kryoflux_${finalAttrs.version}_linux_r2.tar.gz";
+    hash = "sha256-qGFXu0FkmCB7cffOqNiOluDUww19MA/UuEVElgmSd3o=";
+  };
+  nativeBuildInputs = [
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    fmt_9
+    libusb1
+  ];
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/java
+    cp -r {docs,testimages,schematics} $out/share
+    cp dtc/kryoflux-ui.jar $out/share/java
+    makeWrapper ${jre}/bin/java $out/bin/kryoflux-ui \
+      --add-flags "-jar $out/share/java/kryoflux-ui.jar" \
+      --set PATH "$out/bin"
+    tar -C $out -xf dtc/${stdenv.hostPlatform.linuxArch}/kryoflux-dtc*.tar.gz \
+      --strip-components=1 \
+      --wildcards '*/bin/*' '*/lib/*' '*/share/*'
+
+    mkdir -p $out/etc/udev/rules.d
+    echo 'ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="6124", GROUP="floppy", MODE="0660"' > 80-kryoflux.rules
+
+    runHook postInstall
+  '';
+  meta = {
+    description = "Software UI to accompany KryoFlux, the renowned forensic floppy controller";
+    homepage = "https://kryoflux.com";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    mainProgram = "kryoflux-ui";
+    platforms = with lib.platforms; lib.intersectLists linux (x86_64 ++ aarch64);
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This one is a bit esoteric, but thought I'd better put here since the derivation didn't turn out too bad.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
