### PR TITLE
Run0

### DIFF
--- a/nixos/modules/security/run0.nix
+++ b/nixos/modules/security/run0.nix
@@ -1,0 +1,71 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+let
+
+  cfg = config.security.run0;
+  run0-wrapper = pkgs.writeShellScriptBin "run0" ''
+    #!${pkgs.bash}/bin/bash
+    exec -a run0 ${pkgs.systemd}/bin/systemd-run "$@"
+  '';
+
+in
+
+{
+
+  ###### interface
+
+  options.security.run0 = {
+
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable the {command}`run0` command, a non-setuid
+        sudo alternative from systemd.
+      '';
+    };
+
+    pamCfg = lib.mkOption {
+      type = options.security.pam.services.type;
+      default = {};
+      description = ''
+        Extra settings to add to systemd-run0 pam service.
+      '';
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.security.polkit.enable;
+        message = ''
+                The `run0` program needs polkit for authorization.
+        '';
+      }
+    ];
+
+    security.wrappers.run0 = {
+        owner = "root";
+        group = "root";
+        permissions = "a+x";
+        setuid = false;
+        setgid = false;
+        source = "${run0-wrapper}/bin/run0";
+    };
+
+
+
+    security.pam.services.run0 = cfg.pamCfg;
+
+  };
+
+}

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -151,7 +151,7 @@
   withQrencode ? true,
   withRemote ? !stdenv.hostPlatform.isMusl,
   withResolved ? true,
-  withRun0 ? true,
+  withRun0 ? false,
   withShellCompletions ? true,
   withSysusers ? true,
   withSysupdate ? true,

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -151,6 +151,7 @@
   withQrencode ? true,
   withRemote ? !stdenv.hostPlatform.isMusl,
   withResolved ? true,
+  withRun0 ? true,
   withShellCompletions ? true,
   withSysusers ? true,
   withSysupdate ? true,
@@ -834,6 +835,11 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     + lib.optionalString withSysusers ''
       mv $out/lib/sysusers.d $out/example
+    ''
+    + lib.optionalString (!withRun0) ''
+      if test -f $out/bin/run0; then
+         unlink $out/bin/run0
+      fi
     '';
 
   doInstallCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Proof of concept for discussion in https://github.com/NixOS/nixpkgs/pull/419588 and https://github.com/NixOS/nixpkgs/issues/361592

## Things done
- Unlink bin/run0 from systemd output by default
- Add security.run0
- Add wrapper for run0
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
