### PR TITLE
x32edit,m32edit: 4.3 -> 4.4

### DIFF
--- a/pkgs/applications/audio/midas/deps.nix
+++ b/pkgs/applications/audio/midas/deps.nix
@@ -1,5 +1,5 @@
 # This is a generated file.  Do not modify!
-# Following are the Debian packages constituting the closure of: libstdc++6 libcurl3-gnutls libfreetype6 libasound2 libx11-6 libxext6
+# Following are the Debian packages constituting the closure of: libstdc++6 libcurl4 libfreetype6 libasound2 libx11-6 libxext6
 
 { fetchurl }:
 
@@ -8,8 +8,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb";
-      sha256 = "be65535e94f95fbf04b104e8ab36790476f063374430f7dfc6c516cbe2d2cd1e";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gcc-12/gcc-12-base_12.2.0-14_amd64.deb";
+      sha256 = "1a03df5a57833d65b5bb08cfa19d50e76f29088dc9e64fb934af42d9023a0807";
     })
 
   ]
@@ -17,18 +17,13 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb";
-      sha256 = "e478f2709d8474165bb664de42e16950c391f30eaa55bc9b3573281d83a29daf";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gcc-12/libgcc-s1_12.2.0-14_amd64.deb";
+      sha256 = "f3d1d48c0599aea85b7f2077a01d285badc42998c1a1e7473935d5cf995c8141";
     })
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb";
-      sha256 = "f617952df0c57b4ee039448e3941bccd3f97bfff71e9b0f87ca6dae15cb3f5ef";
-    })
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/glibc/libc6_2.31-13+deb11u6_amd64.deb";
-      sha256 = "cb8771d39b068834197b2b75c6b06433685b6e6a23a315064fb7cb5ab80cc235";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/glibc/libc6_2.36-9+deb12u2_amd64.deb";
+      sha256 = "b50aac01737995d399b49fdfa213236c382e1dc1d402e61c8dcc669af3a41b19";
     })
 
   ]
@@ -36,8 +31,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb";
-      sha256 = "5c155c58935870bf3b4bfe769116841c0d286a74f59eccfd5645693ac23f06b1";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gcc-12/libstdc++6_12.2.0-14_amd64.deb";
+      sha256 = "9b1b269020cec6aced3b39f096f7b67edd1f0d4ab24f412cb6506d0800e19cbf";
     })
 
   ]
@@ -45,8 +40,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb";
-      sha256 = "65ca7d8b03e9dac09c5d544a89dd52d1aeb74f6a19583d32e4ff5f0c77624c24";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b6_amd64.deb";
+      sha256 = "563b4caec1aa5e876bd3355b36e7a38e1484baf5a293b48d1e8bd22db786e4d7";
     })
 
   ]
@@ -54,8 +49,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb";
-      sha256 = "fc117ccb084a98d25021f7e01e4dfedd414fa2118fdd1e27d2d801d7248aebbc";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2_amd64.deb";
+      sha256 = "8010e4285276bb344c05ae780deae2fffb45e237116c3a78481365c5954125ec";
     })
 
   ]
@@ -63,8 +58,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb";
-      sha256 = "e4f8ec31ed14518b241eb7b423ad5ed3f4a4e8ac50aae72c9fd475c569582764";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libkrb5support0_1.20.1-2+deb12u1_amd64.deb";
+      sha256 = "e489a9282c4b765c29d9eda7c4747e1cb58be71161012c3a57e2a8bc63dc0f5a";
     })
 
   ]
@@ -72,8 +67,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb";
-      sha256 = "6aab2e892cdb2dfba45707601bc6c3b19aa228f70ae5841017f14c3b0ca3d22f";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libk5crypto3_1.20.1-2+deb12u1_amd64.deb";
+      sha256 = "6a91eee690e6ad2207df3a355fc329a58d8e31bf5ca9a9dd4de8f7a1c812ddc5";
     })
 
   ]
@@ -81,8 +76,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb";
-      sha256 = "654433ad02d3a8b05c1683c6c29a224500bf343039c34dcec4e5e9515345e3d4";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/keyutils/libkeyutils1_1.6.3-2_amd64.deb";
+      sha256 = "cfac89e6a7a54ff3c6a4f843310e25efeddaa771baeae470bd98bd588c373563";
     })
 
   ]
@@ -90,8 +85,9 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb";
-      sha256 = "cb80cd769171537bafbb4a16c12ec427065795946b3415781bc9792e92d60b59";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/o/openssl/libssl3_3.0.11-1~deb12u1_amd64.deb";
+      sha256 = "e3348978d10f036948ecabbe540c4c581e79793070a8b7f480a46c34c381ac1f";
+      name = "libssl3_3.0.11-1deb12u1_amd64.deb";
     })
 
   ]
@@ -99,8 +95,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb";
-      sha256 = "30ca89bfddae5fa6e0a2a044f22b6e50cd17c4bc6bc850c579819aeab7101f0f";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libkrb5-3_1.20.1-2+deb12u1_amd64.deb";
+      sha256 = "03ebdf235600f4a8a6d4fbc7080de0a776b1a701f43c4e9697944757591d7809";
     })
 
   ]
@@ -108,8 +104,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb";
-      sha256 = "bfef5f31ee1c730e56e16bb62cc5ff8372185106c75bf1ed1756c96703019457";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-2+deb12u1_amd64.deb";
+      sha256 = "6631304ce4b5b9ba0af3fdebf088a734aed2d28ffad2a03ba79e4fcb2e226dd6";
     })
 
   ]
@@ -117,8 +113,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb";
-      sha256 = "6ebb579337cdc9d6201237a66578425a7a221db622524354e27c0c1bcb6dd7ca";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libu/libunistring/libunistring2_1.0-2_amd64.deb";
+      sha256 = "d466bbfe011d764d793c1d9d777cad9c7cf65b938e11598f27408171ad95a951";
     })
 
   ]
@@ -126,8 +122,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u3_amd64.deb";
-      sha256 = "d7d504ff9d45a292a4af549014c9471b526a0dbc898ff9a606fe24e0319a2d8e";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libi/libidn2/libidn2-0_2.3.3-1+b1_amd64.deb";
+      sha256 = "d50716d5824083d667427817d506b45d3f59dc77e1ca52de000f3f62d4918afa";
     })
 
   ]
@@ -135,8 +131,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb";
-      sha256 = "d478f132871f4ab8352d39becf936d0ad74db905398bf98465d8fe3da6fb1126";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg1-1.1_amd64.deb";
+      sha256 = "187aedef2ed763f425c1e523753b9719677633c7eede660401739e9c893482bd";
     })
 
   ]
@@ -144,8 +140,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb";
-      sha256 = "da8d022e3dd7f4a72ea32e328b3ac382dbe6bdb91606c5738fe17a29f8ea8080";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/n/nettle/libnettle8_3.8.1-2_amd64.deb";
+      sha256 = "45922e6e289ffd92f0f92d2bb9159e84236ff202d552a461bf10e5335b3f0261";
     })
 
   ]
@@ -153,8 +149,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb";
-      sha256 = "f635062bcbfe2eef5a83fcba7d1a8ae343fc7c779cae88b11cae90fd6845a744";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/n/nettle/libhogweed6_3.8.1-2_amd64.deb";
+      sha256 = "ed8185c28b2cb519744a5a462dcd720d3b332c9b88a1d0002eac06dc8550cb94";
     })
 
   ]
@@ -162,8 +158,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb";
-      sha256 = "f01060b434d8cad3c58d5811d2082389f11b3db8152657d6c22c1d298953f2a5";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libf/libffi/libffi8_3.4.4-1_amd64.deb";
+      sha256 = "6d9f6c25c30efccce6d4bceaa48ea86c329a3432abb360a141f76ac223a4c34a";
     })
 
   ]
@@ -171,8 +167,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb";
-      sha256 = "aa18d721be8aea50fbdb32cd9a319cb18a3f111ea6ad17399aa4ba9324c8e26a";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/p/p11-kit/libp11-kit0_0.24.1-2_amd64.deb";
+      sha256 = "251330faddbf013f060fcdb41f4b0c037c8a6e89ba7c09b04bfcc4e3f0807b22";
     })
 
   ]
@@ -180,8 +176,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb";
-      sha256 = "ee192c8d22624eb9d0a2ae95056bad7fb371e5abc17e23e16b1de3ddb17a1064";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0-2_amd64.deb";
+      sha256 = "eec4dc9d949d2c666b1da3fa762a340e8ba10c3a04d3eed32749a97695c15641";
     })
 
   ]
@@ -189,8 +185,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb";
-      sha256 = "339f5ede10500c16dd7192d73169c31c4b27ab12130347275f23044ec8c7d897";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/g/gnutls28/libgnutls30_3.7.9-2_amd64.deb";
+      sha256 = "0c8dac5177d72fb9a38dfe28ae5f9fad3331c7c793abbb8e67362760c7ec5c76";
     })
 
   ]
@@ -198,8 +194,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/t/tar/tar_1.34+dfsg-1_amd64.deb";
-      sha256 = "bd8e963c6edcf1c806df97cd73560794c347aa94b9aaaf3b88eea585bb2d2f3c";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg2-1_amd64.deb";
+      sha256 = "7dc5127b8dd0da80e992ba594954c005ae4359d839a24eb65d0d8129b5235c84";
     })
 
   ]
@@ -207,8 +203,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb";
-      sha256 = "16e27c3ebd97981e70db3733f899963362748f178a62644df69d1f247e741379";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg-10_amd64.deb";
+      sha256 = "3ac4fd6cbe3b3b06e68d24b931bf3eb9385b42f15604a37ed25310e948ca0ee6";
     })
 
   ]
@@ -216,9 +212,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb";
-      sha256 = "1c79a02415ca5ee7234ac60502fb33ee94fa70b02d1c329a6a14178f8329c435";
-      name = "liblzma5_5.2.5-2.1deb11u1_amd64.deb";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg-10_amd64.deb";
+      sha256 = "11ee190ad39f8d7af441d2c8347388b9449434c73acc67b4b372445ac4152efa";
     })
 
   ]
@@ -226,8 +221,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb";
-      sha256 = "03d2ab2174af76df6f517b854b77460fbdafc3dac0dca979317da67538159a3e";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_amd64.deb";
+      sha256 = "4b6c30f6554149c594628d945edc6003f0eea8d0cc1341638c0e71375db147ed";
     })
 
   ]
@@ -235,8 +230,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb";
-      sha256 = "eb2b7ba3a3c4e905a380045a2d1cd219d2d45755aba5966d6c804b79400beb05";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/n/nghttp2/libnghttp2-14_1.52.0-1_amd64.deb";
+      sha256 = "faf52ab52cc91e5ca1fec230a51b2b25634409d8fbcbff5c9c8d128bea755b2d";
     })
 
   ]
@@ -244,8 +239,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u2_amd64.deb";
-      sha256 = "018a3e48e58cbc478d3a4365090fb1daa151769f90f9b45984ec9d056ef96adc";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libp/libpsl/libpsl5_0.21.2-1_amd64.deb";
+      sha256 = "4f0d35610204e4e754b057748719744114621f2f6f4202d846c314860a981afb";
     })
 
   ]
@@ -253,89 +248,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/d/debconf/debconf_1.5.77_all.deb";
-      sha256 = "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb";
-      sha256 = "aadf8b4b197335645b230c2839b4517aa444fd2e8f434e5438c48a18857988f7";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb";
-      sha256 = "b785fa324cf27e6bf7f97fc0279470e6ce8a8cc54f8ccc6c9b24c8111ba5c952";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb";
-      sha256 = "037cc4bb34a6cd0d7a6e83bdcae6d68e0d0f9218eb7dedafc8099c8c0be491a2";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb";
-      sha256 = "00b9e63e287f45300d4a4f59b6b88e25918443c932ae3e5845d5761ae193c530";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.27+dfsg-2.1+deb11u1_amd64.deb";
-      sha256 = "122bf3de4ca0ec873bc35bdde1f21ec9d91ace4f5245c3b1240e077f866e1ae9";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.27+dfsg-2.1+deb11u1_amd64.deb";
-      sha256 = "2e86ab7a3329aad4b7350a9b067fe8f80b680302f2f82d94f73f9bf075404460";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/o/openldap/libldap-2.4-2_2.4.57+dfsg-3+deb11u1_amd64.deb";
-      sha256 = "3d79ee84c42c1d1b58a6e0d7debc7e3c8444147b84412b8248a7789809bc3163";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/n/nghttp2/libnghttp2-14_1.43.0-1_amd64.deb";
-      sha256 = "a1a8aae24ced43025c94a9cb0c0eabfb3fc070785de9ee51c9a3a4fe86f0d11e";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_amd64.deb";
-      sha256 = "d716f5b4346ec85bb728f4530abeb1da4a79f696c72d7f774c59ba127c202fa7";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/z/zlib/zlib1g_1.2.13.dfsg-1_amd64.deb";
+      sha256 = "d7dd1d1411fedf27f5e27650a6eff20ef294077b568f4c8c5e51466dc7c08ce4";
     })
 
   ]
@@ -352,8 +266,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb";
-      sha256 = "16a507fb20cc58b5a524a0dc254a9cb1df02e1ce758a2d8abde0bc4a3c9b7c26";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libs/libssh2/libssh2-1_1.10.0-3+b1_amd64.deb";
+      sha256 = "d20a3ee34fa84ad8bd381e8be6e9c2c2ea32347cff5e1169c10e978d43f54f24";
     })
 
   ]
@@ -361,8 +275,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb";
-      sha256 = "7a2e0eef8e0c37f03f3a5fcf7102a2e3dc70ba987f696ab71949f9abf36f35ef";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libz/libzstd/libzstd1_1.5.4+dfsg2-5_amd64.deb";
+      sha256 = "6315b5ac38b724a710fb96bf1042019398cb656718b1522279a5185ed39318fa";
     })
 
   ]
@@ -370,8 +284,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libs/libssh2/libssh2-1_1.9.0-2_amd64.deb";
-      sha256 = "f730fe45716a206003597819ececeeffe0fff754bdbbd0105425a177aa20a2de";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/c/curl/libcurl4_7.88.1-10+deb12u3_amd64.deb";
+      sha256 = "c4d2cbd54d6cb0a6a0ede613090b1eb6e28cdc05912ac11d617fb0d8dc493cdc";
     })
 
   ]
@@ -379,8 +293,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/c/curl/libcurl3-gnutls_7.74.0-1.3+deb11u9_amd64.deb";
-      sha256 = "bfaffacec95713a1486b20f24219952a0d56db041d43ece1768b732d859be885";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libp/libpng1.6/libpng16-16_1.6.39-2_amd64.deb";
+      sha256 = "dc32727dca9a87ba317da7989572011669f568d10159b9d8675ed7aedd26d686";
     })
 
   ]
@@ -388,8 +302,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb";
-      sha256 = "7d5336af395d1f658d0e66d74d0e1f4c632028750e7e04314d1a650e0317f3d6";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/f/freetype/libfreetype6_2.12.1+dfsg-5_amd64.deb";
+      sha256 = "72ef03236f1936e72a0faf86a547425b0eff3c5fd0b43f8669012182cf376354";
     })
 
   ]
@@ -397,8 +311,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb";
-      sha256 = "b21cfdd12adf6cac4af320c2485fb62a8a5edc6f9768bc2288fd686f4fa6dfdf";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/a/alsa-lib/libasound2-data_1.2.8-1_all.deb";
+      sha256 = "fe0780d2d3674b2977e0acb0d48b448ad72ba1642564b7dc537f55e839984c2d";
     })
 
   ]
@@ -406,17 +320,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/a/alsa-lib/libasound2-data_1.2.4-1.1_all.deb";
-      sha256 = "76211f5f201ad1069b95d047863e0c1b51d8400c874b59e00f24f31f972b4036";
-    })
-
-  ]
-
-  [
-
-    (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/a/alsa-lib/libasound2_1.2.4-1.1_amd64.deb";
-      sha256 = "d8c9b5182768db2a7c5c73f1eed0b1be1431ae4f41084d502b325d06d5b0f648";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/a/alsa-lib/libasound2_1.2.8-1+b1_amd64.deb";
+      sha256 = "44c77b076a7b11ae99712439022d822245b1994c435da564ebd320bb676faf4c";
     })
 
   ]
@@ -433,8 +338,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb";
-      sha256 = "9e425b3c128b69126d95e61998e1b5ef74e862dd1fc953d91eebcc315aea62ea";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libm/libmd/libmd0_1.0.4-2_amd64.deb";
+      sha256 = "03539fd30c509e27101d13a56e52eda9062bdf1aefe337c07ab56def25a13eab";
     })
 
   ]
@@ -442,8 +347,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb";
-      sha256 = "6ec5a08a4bb32c0dc316617f4bbefa8654c472d1cd4412ab8995f3955491f4a8";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libb/libbsd/libbsd0_0.11.7-2_amd64.deb";
+      sha256 = "bb31cc8b40f962a85b2cec970f7f79cc704a1ae4bad24257a822055404b2c60b";
     })
 
   ]
@@ -460,8 +365,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb";
-      sha256 = "d5e0f047ed766f45eb7473947b70f9e8fddbe45ef22ecfd92ab712c0671a93ac";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxcb/libxcb1_1.15-1_amd64.deb";
+      sha256 = "fdc61332a3892168f3cc9cfa1fe9cf11a91dc3e0acacbc47cbc50ebaa234cc71";
     })
 
   ]
@@ -469,8 +374,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libx11/libx11-data_1.7.2-1+deb11u1_all.deb";
-      sha256 = "457db358e1d77cfe4f8af5e6efa7a1b262848b65192589932c38a589a4b6976b";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libx11/libx11-data_1.8.4-2+deb12u1_all.deb";
+      sha256 = "30dc02bd10805d159a19676de17dbbf3330ec0139a92f7e5b7e5e5453d63832c";
     })
 
   ]
@@ -478,8 +383,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libx11/libx11-6_1.7.2-1+deb11u1_amd64.deb";
-      sha256 = "23385ffd6d2e3e507a7532fb24dc48176dada9c861e5d43853e18179a08bf861";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libx11/libx11-6_1.8.4-2+deb12u1_amd64.deb";
+      sha256 = "6314d111fca4bf6f9aedd504b4daa534ec9b5607e840b67bfdd278a37ec5e506";
     })
 
   ]
@@ -487,8 +392,8 @@
   [
 
     (fetchurl {
-      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxext/libxext6_1.3.3-1.1_amd64.deb";
-      sha256 = "dc1ff8a2b60c7dd3c8917ffb9aa65ee6cda52648d9150608683c47319d1c0c8c";
+      url = "https://snapshot.debian.org/archive/debian/20231124T031419Z/pool/main/libx/libxext/libxext6_1.3.4-1+b1_amd64.deb";
+      sha256 = "504b7be9d7df4f6f4519e8dd4d6f9d03a9fb911a78530fa23a692fba3058cba6";
     })
 
   ]

--- a/pkgs/applications/audio/midas/generic.nix
+++ b/pkgs/applications/audio/midas/generic.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
   passthru.deps =
     let
-      distro = vmTools.debDistros.debian11x86_64;
+      distro = vmTools.debDistros.debian12x86_64;
     in
     vmTools.debClosureGenerator {
       name = "x32edit-dependencies";
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
       packagesLists = [ distro.packagesList ];
       packages = [
         "libstdc++6"
-        "libcurl3-gnutls"
+        "libcurl4"
         "libfreetype6"
         "libasound2"
         "libx11-6"

--- a/pkgs/applications/audio/midas/m32edit.nix
+++ b/pkgs/applications/audio/midas/m32edit.nix
@@ -5,9 +5,9 @@ callPackage ./generic.nix (
   // rec {
     brand = "Midas";
     type = "M32";
-    version = "4.3";
-    url = "https://mediadl.musictribe.com/download/software/midas_${type}/${type}-Edit_LINUX_${version}.tar.gz";
-    hash = "sha256-1+7xGmSqIPn5NGOnk2VvPJxkI2y1em/kjeldXU0M35w=";
+    version = "4.4";
+    url = "https://cdn.mediavalet.com/aunsw/musictribe/bpXmqFLKmkCfv8Xfp2fzGA/p_73LRnDKUyTLCRF8SiAhg/Original/${type}-Edit_LINUX_${version}.tar.gz";
+    hash = "sha256-/rzTIRYP982upiyPlg1B5L+ggSFb5jfmGKAQGhKghaA=";
     homepage = "https://midasconsoles.com/midas/product?modelCode=P0B3I";
   }
 )

--- a/pkgs/applications/audio/midas/x32edit.nix
+++ b/pkgs/applications/audio/midas/x32edit.nix
@@ -5,9 +5,9 @@ callPackage ./generic.nix (
   // rec {
     brand = "Behringer";
     type = "X32";
-    version = "4.3";
-    url = "https://mediadl.musictribe.com/download/software/behringer/${type}/${type}-Edit_LINUX_${version}.tar.gz";
-    hash = "sha256-iVBBW6qVtEGlNXqKRZxObB9WfbOEjXMA1Nsp1CTFOH4=";
+    version = "4.4";
+    url = "https://cdn.mediavalet.com/aunsw/musictribe/or9fQ8syH0ShGn-Pei63wQ/POJZwJV4MkWLkgr0ex3f6Q/Original/${type}-Edit_LINUX_${version}.tar.gz";
+    hash = "sha256-OOh0UnaKes8U2vNkavsCQF9021lFMPLX1gU1ENaWZHs=";
     homepage = "https://www.behringer.com/behringer/product?modelCode=P0ASF";
   }
 )


### PR DESCRIPTION
The existing packages are broken as the download URLs for version 4.3 now return a 404. This PR updates x32edit and m32edit to the latest version, 4.4 (released 23 May 2025).

Changes:
  - 4.4 has a dependency on libcurl4 instead of libcurl3.
  - 4.4 requires a newer glibc than 4.3, which required updating the FHS environment from Debian 11 to 12.
  - The upstream URL changed from `mediadl.musictribe.com` to `cdn.mediavalet.com`. These were the links provided when following vendor docs to download the software. Old link structure did not seem to work for either 4.3 or 4.4.

Testing:
Both applications launch successfully on NixOS. I have not yet tested this against physical hardware, but will validate against an X32 when I next have access. I do not have a M32 for hardware testing. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc