### PR TITLE
turborepo-remote-cache: init at 2.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10795,6 +10795,12 @@
     githubId = 51334444;
     name = "Akshat Agarwal";
   };
+  humemm = {
+    email = "nixpkgs.scabbed988@passinbox.com";
+    github = "humemm";
+    githubId = 75555696;
+    name = "humemm";
+  };
   hummeltech = {
     email = "hummeltech@sherpaguru.com";
     github = "hummeltech";

--- a/pkgs/by-name/tu/turborepo-remote-cache/package.nix
+++ b/pkgs/by-name/tu/turborepo-remote-cache/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenvNoCC,
+  nodejs-slim_24,
+  pnpm_10,
+  pnpmConfigHook,
+  jq,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  makeWrapper,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "turborepo-remote-cache";
+  version = "2.7.0";
+
+  src = fetchFromGitHub {
+    owner = "ducktors";
+    repo = "turborepo-remote-cache";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ySMZZ9rhVNkoJzz9g1ZxfnL67xGjN2WbirINJMKQqN4=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-i8kXC9bRit9S1TPV9uixCkkn3KahRu/hhBeDyHm6MBc=";
+  };
+
+  nativeBuildInputs = [
+    nodejs-slim_24
+    pnpmConfigHook
+    pnpm_10
+    jq
+    makeWrapper
+  ];
+
+  postPatch = ''
+    # Replace build script to skip linting
+    jq '.scripts.build = "tsc -p ./tsconfig.json"' package.json > package.json.tmp
+    mv package.json.tmp package.json
+
+    # Remove prepare script since we don't need git hooks
+    jq 'del(.scripts.prepare)' package.json > package.json.tmp
+    mv package.json.tmp package.json
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm build
+    pnpm prune --prod
+    # Clean up broken symlinks left behind by `pnpm prune`
+    # https://github.com/pnpm/pnpm/issues/3645
+    find node_modules -xtype l -delete
+     # Remove non-deterministic files
+    rm node_modules/.modules.yaml
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    appdir="$out/lib/turborepo-remote-cache"
+    mkdir -p "$appdir" "$out/bin"
+
+    cp -r dist node_modules "$appdir"/
+
+    makeWrapper ${nodejs-slim_24}/bin/node "$out/bin/turborepo-remote-cache" \
+      --add-flags "$appdir/dist/index.js" \
+      --set NODE_PATH "$appdir/node_modules"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/ducktors/turborepo-remote-cache";
+    description = "This project is an open-source implementation of the Turborepo custom remote cache server.";
+    license = lib.licenses.mit;
+    mainProgram = "turborepo-remote-cache";
+    maintainers = with lib.maintainers; [ humemm ];
+  };
+})


### PR DESCRIPTION
<!--
turborepo-remote-cache: init at 2.6.0

Add turborepo-remote-cache 2.6.0, an open-source implementation of the Turborepo custom remote cache server supporting multiple storage backends (S3, GCS, Azure, HTTP) for self-hosted CI and team caching.
Homepage: https://github.com/ducktors/turborepo-remote-cache
-->

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`?  
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [ ] NixOS test(s)
  - [x] package tests
  - [ ] lib/tests or pkgs/test
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [x] Tested basic functionality of all binary files (e.g. `./result/bin/turborepo-remote-cache --help` and a basic cache round-trip)
- [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [ ] (Module updates) Added a release notes entry if significant
- [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.
