### PR TITLE
nixosTests.victoriametrics: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1511,7 +1511,7 @@ in
   velocity = runTest ./velocity.nix;
   vengi-tools = runTest ./vengi-tools.nix;
   victorialogs = runTest ./victorialogs.nix;
-  victoriametrics = handleTest ./victoriametrics { };
+  victoriametrics = import ./victoriametrics { inherit runTest; };
   vikunja = runTest ./vikunja.nix;
   virtualbox = handleTestOn [ "x86_64-linux" ] ./virtualbox.nix { };
   vm-variant = handleTest ./vm-variant.nix { };

--- a/nixos/tests/victoriametrics/default.nix
+++ b/nixos/tests/victoriametrics/default.nix
@@ -1,11 +1,6 @@
+{ runTest }:
 {
-  system ? builtins.currentSystem,
-  config ? { },
-  pkgs ? import ../../.. { inherit system config; },
-}:
-
-{
-  remote-write = import ./remote-write.nix { inherit system pkgs; };
-  vmalert = import ./vmalert.nix { inherit system pkgs; };
-  external-promscrape-config = import ./external-promscrape-config.nix { inherit system pkgs; };
+  remote-write = runTest ./remote-write.nix;
+  vmalert = runTest ./vmalert.nix;
+  external-promscrape-config = runTest ./external-promscrape-config.nix;
 }

--- a/nixos/tests/victoriametrics/external-promscrape-config.nix
+++ b/nixos/tests/victoriametrics/external-promscrape-config.nix
@@ -1,82 +1,70 @@
-import ../make-test-python.nix (
-  {
-    lib,
-    pkgs,
-    ...
-  }:
-  let
-    nodeExporterPort = 9100;
-    promscrapeConfig = {
-      global = {
-        scrape_interval = "2s";
-      };
-      scrape_configs = [
-        {
-          job_name = "node";
-          static_configs = [
-            {
-              targets = [
-                "node:${toString nodeExporterPort}"
-              ];
-            }
-          ];
-        }
-      ];
+{ lib, pkgs, ... }:
+let
+  nodeExporterPort = 9100;
+  promscrapeConfig = {
+    global = {
+      scrape_interval = "2s";
     };
-    settingsFormat = pkgs.formats.yaml { };
-    promscrapeConfigYaml = settingsFormat.generate "prometheusConfig.yaml" promscrapeConfig;
-  in
-  {
-    name = "victoriametrics-external-promscrape-config";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [
-        ryan4yin
-      ];
-    };
-
-    nodes = {
-      victoriametrics =
-        {
-          config,
-          pkgs,
-          ...
-        }:
-        {
-          environment.systemPackages = [ pkgs.jq ];
-          networking.firewall.allowedTCPPorts = [ 8428 ];
-          services.victoriametrics = {
-            enable = true;
-            extraOptions = [
-              "-promscrape.config=${toString promscrapeConfigYaml}"
+    scrape_configs = [
+      {
+        job_name = "node";
+        static_configs = [
+          {
+            targets = [
+              "node:${toString nodeExporterPort}"
             ];
-          };
-        };
+          }
+        ];
+      }
+    ];
+  };
+  settingsFormat = pkgs.formats.yaml { };
+  promscrapeConfigYaml = settingsFormat.generate "prometheusConfig.yaml" promscrapeConfig;
+in
+{
+  name = "victoriametrics-external-promscrape-config";
+  meta = with lib.maintainers; {
+    maintainers = [
+      ryan4yin
+    ];
+  };
 
-      node =
-        { ... }:
-        {
-          services.prometheus.exporters.node = {
-            enable = true;
-            openFirewall = true;
-          };
+  nodes = {
+    victoriametrics =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.jq ];
+        networking.firewall.allowedTCPPorts = [ 8428 ];
+        services.victoriametrics = {
+          enable = true;
+          extraOptions = [
+            "-promscrape.config=${toString promscrapeConfigYaml}"
+          ];
         };
+      };
+
+    node = {
+      services.prometheus.exporters.node = {
+        enable = true;
+        openFirewall = true;
+      };
     };
+  };
 
-    testScript = ''
-      node.wait_for_unit("prometheus-node-exporter")
-      node.wait_for_open_port(${toString nodeExporterPort})
+  testScript = ''
+    node.wait_for_unit("prometheus-node-exporter")
+    node.wait_for_open_port(${toString nodeExporterPort})
 
-      victoriametrics.wait_for_unit("victoriametrics")
-      victoriametrics.wait_for_open_port(8428)
+    victoriametrics.wait_for_unit("victoriametrics")
+    victoriametrics.wait_for_open_port(8428)
 
 
-      promscrape_config = victoriametrics.succeed("journalctl -u victoriametrics -o cat | grep 'promscrape.config'")
-      assert '${toString promscrapeConfigYaml}' in promscrape_config
+    promscrape_config = victoriametrics.succeed("journalctl -u victoriametrics -o cat | grep 'promscrape.config'")
+    assert '${toString promscrapeConfigYaml}' in promscrape_config
 
-      victoriametrics.wait_until_succeeds(
-        "curl -sf 'http://localhost:8428/api/v1/query?query=node_exporter_build_info\{instance=\"node:9100\"\}' | "
-        + "jq '.data.result[0].value[1]' | grep '\"1\"'"
-      )
-    '';
-  }
-)
+    victoriametrics.wait_until_succeeds(
+      "curl -sf 'http://localhost:8428/api/v1/query?query=node_exporter_build_info\{instance=\"node:9100\"\}' | "
+      + "jq '.data.result[0].value[1]' | grep '\"1\"'"
+    )
+  '';
+}

--- a/nixos/tests/victoriametrics/remote-write.nix
+++ b/nixos/tests/victoriametrics/remote-write.nix
@@ -1,103 +1,87 @@
 # Primarily reference the implementation of <nixos/tests/prometheus/remote-write.nix>
-import ../make-test-python.nix (
-  {
-    lib,
-    pkgs,
-    ...
-  }:
-  let
-    username = "vmtest";
-    password = "fsddfy8233rb"; # random string
-    passwordFile = pkgs.writeText "password-file" password;
-  in
-  {
-    name = "victoriametrics-remote-write";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [
-        yorickvp
-        ryan4yin
-      ];
-    };
+{ lib, pkgs, ... }:
+let
+  username = "vmtest";
+  password = "fsddfy8233rb"; # random string
+  passwordFile = pkgs.writeText "password-file" password;
+in
+{
+  name = "victoriametrics-remote-write";
+  meta = with lib.maintainers; {
+    maintainers = [
+      yorickvp
+      ryan4yin
+    ];
+  };
 
-    nodes = {
-      victoriametrics =
-        {
-          config,
-          pkgs,
-          ...
-        }:
-        {
-          environment.systemPackages = [ pkgs.jq ];
-          networking.firewall.allowedTCPPorts = [ 8428 ];
-          services.victoriametrics = {
-            enable = true;
-            extraOptions = [
-              "-httpAuth.username=${username}"
-              "-httpAuth.password=file://${toString passwordFile}"
+  nodes = {
+    victoriametrics =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.jq ];
+        networking.firewall.allowedTCPPorts = [ 8428 ];
+        services.victoriametrics = {
+          enable = true;
+          extraOptions = [
+            "-httpAuth.username=${username}"
+            "-httpAuth.password=file://${toString passwordFile}"
+          ];
+        };
+      };
+
+    vmagent =
+      { config, pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.jq ];
+        services.vmagent = {
+          enable = true;
+          remoteWrite = {
+            url = "http://victoriametrics:8428/api/v1/write";
+            basicAuthUsername = username;
+            basicAuthPasswordFile = toString passwordFile;
+          };
+
+          prometheusConfig = {
+            global = {
+              scrape_interval = "2s";
+            };
+            scrape_configs = [
+              {
+                job_name = "node";
+                static_configs = [
+                  {
+                    targets = [
+                      "node:${toString config.services.prometheus.exporters.node.port}"
+                    ];
+                  }
+                ];
+              }
             ];
           };
         };
+      };
 
-      vmagent =
-        {
-          config,
-          pkgs,
-          ...
-        }:
-        {
-          environment.systemPackages = [ pkgs.jq ];
-          services.vmagent = {
-            enable = true;
-            remoteWrite = {
-              url = "http://victoriametrics:8428/api/v1/write";
-              basicAuthUsername = username;
-              basicAuthPasswordFile = toString passwordFile;
-            };
-
-            prometheusConfig = {
-              global = {
-                scrape_interval = "2s";
-              };
-              scrape_configs = [
-                {
-                  job_name = "node";
-                  static_configs = [
-                    {
-                      targets = [
-                        "node:${toString config.services.prometheus.exporters.node.port}"
-                      ];
-                    }
-                  ];
-                }
-              ];
-            };
-          };
-        };
-
-      node =
-        { ... }:
-        {
-          services.prometheus.exporters.node = {
-            enable = true;
-            openFirewall = true;
-          };
-        };
+    node = {
+      services.prometheus.exporters.node = {
+        enable = true;
+        openFirewall = true;
+      };
     };
+  };
 
-    testScript = ''
-      node.wait_for_unit("prometheus-node-exporter")
-      node.wait_for_open_port(9100)
+  testScript = ''
+    node.wait_for_unit("prometheus-node-exporter")
+    node.wait_for_open_port(9100)
 
-      victoriametrics.wait_for_unit("victoriametrics")
-      victoriametrics.wait_for_open_port(8428)
+    victoriametrics.wait_for_unit("victoriametrics")
+    victoriametrics.wait_for_open_port(8428)
 
-      vmagent.wait_for_unit("vmagent")
+    vmagent.wait_for_unit("vmagent")
 
-      # check remote write
-      victoriametrics.wait_until_succeeds(
-        "curl --user '${username}:${password}' -sf 'http://localhost:8428/api/v1/query?query=node_exporter_build_info\{instance=\"node:9100\"\}' | "
-        + "jq '.data.result[0].value[1]' | grep '\"1\"'"
-      )
-    '';
-  }
-)
+    # check remote write
+    victoriametrics.wait_until_succeeds(
+      "curl --user '${username}:${password}' -sf 'http://localhost:8428/api/v1/query?query=node_exporter_build_info\{instance=\"node:9100\"\}' | "
+      + "jq '.data.result[0].value[1]' | grep '\"1\"'"
+    )
+  '';
+}

--- a/nixos/tests/victoriametrics/vmalert.nix
+++ b/nixos/tests/victoriametrics/vmalert.nix
@@ -1,179 +1,157 @@
 # Primarily reference the implementation of <nixos/tests/prometheus/alertmanager.nix>
-import ../make-test-python.nix (
-  {
-    lib,
-    pkgs,
-    ...
-  }:
-  {
-    name = "victoriametrics-vmalert";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [
-        yorickvp
-        ryan4yin
-      ];
+{ lib, pkgs, ... }:
+{
+  name = "victoriametrics-vmalert";
+  meta = with lib.maintainers; {
+    maintainers = [
+      yorickvp
+      ryan4yin
+    ];
+  };
+
+  nodes = {
+    victoriametrics =
+      { config, pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.jq ];
+        networking.firewall.allowedTCPPorts = [ 8428 ];
+        services.victoriametrics = {
+          enable = true;
+          prometheusConfig = {
+            global = {
+              scrape_interval = "2s";
+            };
+            scrape_configs = [
+              {
+                job_name = "alertmanager";
+                static_configs = [
+                  {
+                    targets = [
+                      "alertmanager:${toString config.services.prometheus.alertmanager.port}"
+                    ];
+                  }
+                ];
+              }
+              {
+                job_name = "node";
+                static_configs = [
+                  {
+                    targets = [
+                      "node:${toString config.services.prometheus.exporters.node.port}"
+                    ];
+                  }
+                ];
+              }
+            ];
+          };
+        };
+
+        services.vmalert.instances."" = {
+          enable = true;
+          settings = {
+            "datasource.url" = "http://localhost:8428"; # victoriametrics' api
+            "notifier.url" = [
+              "http://alertmanager:${toString config.services.prometheus.alertmanager.port}"
+            ]; # alertmanager's api
+            rule = [
+              (pkgs.writeText "instance-down.yml" ''
+                groups:
+                  - name: test
+                    rules:
+                      - alert: InstanceDown
+                        expr: up == 0
+                        for: 5s
+                        labels:
+                          severity: page
+                        annotations:
+                          summary: "Instance {{ $labels.instance }} down"
+              '')
+            ];
+          };
+        };
+      };
+
+    alertmanager = {
+      services.prometheus.alertmanager = {
+        enable = true;
+        openFirewall = true;
+
+        configuration = {
+          global = {
+            resolve_timeout = "1m";
+          };
+
+          route = {
+            # Root route node
+            receiver = "test";
+            group_by = [ "..." ];
+            continue = false;
+            group_wait = "1s";
+            group_interval = "15s";
+            repeat_interval = "24h";
+          };
+
+          receivers = [
+            {
+              name = "test";
+              webhook_configs = [
+                {
+                  url = "http://logger:6725";
+                  send_resolved = true;
+                  max_alerts = 0;
+                }
+              ];
+            }
+          ];
+        };
+      };
     };
 
-    nodes = {
-      victoriametrics =
-        {
-          config,
-          pkgs,
-          ...
-        }:
-        {
-          environment.systemPackages = [ pkgs.jq ];
-          networking.firewall.allowedTCPPorts = [ 8428 ];
-          services.victoriametrics = {
-            enable = true;
-            prometheusConfig = {
-              global = {
-                scrape_interval = "2s";
-              };
-              scrape_configs = [
-                {
-                  job_name = "alertmanager";
-                  static_configs = [
-                    {
-                      targets = [
-                        "alertmanager:${toString config.services.prometheus.alertmanager.port}"
-                      ];
-                    }
-                  ];
-                }
-                {
-                  job_name = "node";
-                  static_configs = [
-                    {
-                      targets = [
-                        "node:${toString config.services.prometheus.exporters.node.port}"
-                      ];
-                    }
-                  ];
-                }
-              ];
-            };
-          };
+    logger = {
+      networking.firewall.allowedTCPPorts = [ 6725 ];
 
-          services.vmalert.instances."" = {
-            enable = true;
-            settings = {
-              "datasource.url" = "http://localhost:8428"; # victoriametrics' api
-              "notifier.url" = [
-                "http://alertmanager:${toString config.services.prometheus.alertmanager.port}"
-              ]; # alertmanager's api
-              rule = [
-                (pkgs.writeText "instance-down.yml" ''
-                  groups:
-                    - name: test
-                      rules:
-                        - alert: InstanceDown
-                          expr: up == 0
-                          for: 5s
-                          labels:
-                            severity: page
-                          annotations:
-                            summary: "Instance {{ $labels.instance }} down"
-                '')
-              ];
-            };
-          };
-        };
-
-      alertmanager =
-        {
-          config,
-          pkgs,
-          ...
-        }:
-        {
-          services.prometheus.alertmanager = {
-            enable = true;
-            openFirewall = true;
-
-            configuration = {
-              global = {
-                resolve_timeout = "1m";
-              };
-
-              route = {
-                # Root route node
-                receiver = "test";
-                group_by = [ "..." ];
-                continue = false;
-                group_wait = "1s";
-                group_interval = "15s";
-                repeat_interval = "24h";
-              };
-
-              receivers = [
-                {
-                  name = "test";
-                  webhook_configs = [
-                    {
-                      url = "http://logger:6725";
-                      send_resolved = true;
-                      max_alerts = 0;
-                    }
-                  ];
-                }
-              ];
-            };
-          };
-        };
-
-      logger =
-        {
-          config,
-          pkgs,
-          ...
-        }:
-        {
-          networking.firewall.allowedTCPPorts = [ 6725 ];
-
-          services.prometheus.alertmanagerWebhookLogger.enable = true;
-        };
+      services.prometheus.alertmanagerWebhookLogger.enable = true;
     };
+  };
 
-    testScript = ''
-      alertmanager.wait_for_unit("alertmanager")
-      alertmanager.wait_for_open_port(9093)
-      alertmanager.wait_until_succeeds("curl -s http://127.0.0.1:9093/-/ready")
+  testScript = ''
+    alertmanager.wait_for_unit("alertmanager")
+    alertmanager.wait_for_open_port(9093)
+    alertmanager.wait_until_succeeds("curl -s http://127.0.0.1:9093/-/ready")
 
-      logger.wait_for_unit("alertmanager-webhook-logger")
-      logger.wait_for_open_port(6725)
+    logger.wait_for_unit("alertmanager-webhook-logger")
+    logger.wait_for_open_port(6725)
 
-      victoriametrics.wait_for_unit("victoriametrics")
-      victoriametrics.wait_for_unit("vmalert")
-      victoriametrics.wait_for_open_port(8428)
+    victoriametrics.wait_for_unit("victoriametrics")
+    victoriametrics.wait_for_unit("vmalert")
+    victoriametrics.wait_for_open_port(8428)
 
-      victoriametrics.wait_until_succeeds(
-        "curl -sf 'http://127.0.0.1:8428/api/v1/query?query=count(up\{job=\"alertmanager\"\}==1)' | "
-        + "jq '.data.result[0].value[1]' | grep '\"1\"'"
-      )
+    victoriametrics.wait_until_succeeds(
+      "curl -sf 'http://127.0.0.1:8428/api/v1/query?query=count(up\{job=\"alertmanager\"\}==1)' | "
+      + "jq '.data.result[0].value[1]' | grep '\"1\"'"
+    )
 
-      victoriametrics.wait_until_succeeds(
-        "curl -sf 'http://127.0.0.1:8428/api/v1/query?query=sum(alertmanager_build_info)%20by%20(version)' | "
-        + "jq '.data.result[0].metric.version' | grep '\"${pkgs.prometheus-alertmanager.version}\"'"
-      )
+    victoriametrics.wait_until_succeeds(
+      "curl -sf 'http://127.0.0.1:8428/api/v1/query?query=sum(alertmanager_build_info)%20by%20(version)' | "
+      + "jq '.data.result[0].metric.version' | grep '\"${pkgs.prometheus-alertmanager.version}\"'"
+    )
 
-      victoriametrics.wait_until_succeeds(
-        "curl -sf 'http://127.0.0.1:8428/api/v1/query?query=count(up\{job=\"node\"\}!=1)' | "
-        + "jq '.data.result[0].value[1]' | grep '\"1\"'"
-      )
+    victoriametrics.wait_until_succeeds(
+      "curl -sf 'http://127.0.0.1:8428/api/v1/query?query=count(up\{job=\"node\"\}!=1)' | "
+      + "jq '.data.result[0].value[1]' | grep '\"1\"'"
+    )
 
-      victoriametrics.wait_until_succeeds(
-        "curl -sf 'http://127.0.0.1:8428/api/v1/query?query=alertmanager_notifications_total\{integration=\"webhook\"\}' | "
-        + "jq '.data.result[0].value[1]' | grep -v '\"0\"'"
-      )
+    victoriametrics.wait_until_succeeds(
+      "curl -sf 'http://127.0.0.1:8428/api/v1/query?query=alertmanager_notifications_total\{integration=\"webhook\"\}' | "
+      + "jq '.data.result[0].value[1]' | grep -v '\"0\"'"
+    )
 
-      logger.wait_until_succeeds(
-        "journalctl -o cat -u alertmanager-webhook-logger.service | grep '\"alertname\":\"InstanceDown\"'"
-      )
+    logger.wait_until_succeeds(
+      "journalctl -o cat -u alertmanager-webhook-logger.service | grep '\"alertname\":\"InstanceDown\"'"
+    )
 
-      logger.log(logger.succeed("systemd-analyze security alertmanager-webhook-logger.service | grep -v '✓'"))
+    logger.log(logger.succeed("systemd-analyze security alertmanager-webhook-logger.service | grep -v '✓'"))
 
-      alertmanager.log(alertmanager.succeed("systemd-analyze security alertmanager.service | grep -v '✓'"))
-    '';
-  }
-)
+    alertmanager.log(alertmanager.succeed("systemd-analyze security alertmanager.service | grep -v '✓'"))
+  '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on a698ac12 (master) and c8df6153 (this PR) and compare outputs, note that the derivations are the same.

`nix eval --read-only .#nixosTests.victoriametrics`

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
