### PR TITLE
nixosTests.trilium-server: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1454,7 +1454,7 @@ in
   tracee = handleTestOn [ "x86_64-linux" ] ./tracee.nix { };
   trezord = runTest ./trezord.nix;
   trickster = runTest ./trickster.nix;
-  trilium-server = handleTestOn [ "x86_64-linux" ] ./trilium-server.nix { };
+  trilium-server = runTestOn [ "x86_64-linux" ] ./trilium-server.nix;
   tsm-client-gui = runTest ./tsm-client-gui.nix;
   ttyd = runTest ./web-servers/ttyd.nix;
   tt-rss = runTest ./web-apps/tt-rss.nix;

--- a/nixos/tests/trilium-server.nix
+++ b/nixos/tests/trilium-server.nix
@@ -1,55 +1,52 @@
-import ./make-test-python.nix (
-  { ... }:
-  {
-    name = "trilium-server";
-    nodes = {
-      default = {
-        services.trilium-server.enable = true;
-      };
-      configured = {
-        services.trilium-server = {
-          enable = true;
-          dataDir = "/data/trilium";
-        };
-      };
-
-      nginx = {
-        services.trilium-server = {
-          enable = true;
-          nginx.enable = true;
-          nginx.hostName = "trilium.example.com";
-        };
+{
+  name = "trilium-server";
+  nodes = {
+    default = {
+      services.trilium-server.enable = true;
+    };
+    configured = {
+      services.trilium-server = {
+        enable = true;
+        dataDir = "/data/trilium";
       };
     };
 
-    testScript = ''
-      start_all()
+    nginx = {
+      services.trilium-server = {
+        enable = true;
+        nginx.enable = true;
+        nginx.hostName = "trilium.example.com";
+      };
+    };
+  };
 
-      with subtest("by default works without configuration"):
-          default.wait_for_unit("trilium-server.service")
+  testScript = ''
+    start_all()
 
-      with subtest("by default available on port 8080"):
-          default.wait_for_unit("trilium-server.service")
-          default.wait_for_open_port(8080)
-          # we output to /dev/null here to avoid a python UTF-8 decode error
-          # but the check will still fail if the service doesn't respond
-          default.succeed("curl --fail -o /dev/null 127.0.0.1:8080")
+    with subtest("by default works without configuration"):
+        default.wait_for_unit("trilium-server.service")
 
-      with subtest("by default creates empty document"):
-          default.wait_for_unit("trilium-server.service")
-          default.succeed("test -f /var/lib/trilium/document.db")
+    with subtest("by default available on port 8080"):
+        default.wait_for_unit("trilium-server.service")
+        default.wait_for_open_port(8080)
+        # we output to /dev/null here to avoid a python UTF-8 decode error
+        # but the check will still fail if the service doesn't respond
+        default.succeed("curl --fail -o /dev/null 127.0.0.1:8080")
 
-      with subtest("configured with custom data store"):
-          configured.wait_for_unit("trilium-server.service")
-          configured.succeed("test -f /data/trilium/document.db")
+    with subtest("by default creates empty document"):
+        default.wait_for_unit("trilium-server.service")
+        default.succeed("test -f /var/lib/trilium/document.db")
 
-      with subtest("nginx with custom host name"):
-          nginx.wait_for_unit("trilium-server.service")
-          nginx.wait_for_unit("nginx.service")
+    with subtest("configured with custom data store"):
+        configured.wait_for_unit("trilium-server.service")
+        configured.succeed("test -f /data/trilium/document.db")
 
-          nginx.succeed(
-              "curl --resolve 'trilium.example.com:80:127.0.0.1' http://trilium.example.com/"
-          )
-    '';
-  }
-)
+    with subtest("nginx with custom host name"):
+        nginx.wait_for_unit("trilium-server.service")
+        nginx.wait_for_unit("nginx.service")
+
+        nginx.succeed(
+            "curl --resolve 'trilium.example.com:80:127.0.0.1' http://trilium.example.com/"
+        )
+  '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on a698ac12 (master) and 913252c5 (this PR) and compare outputs, note that the derivations are the same.

`nix eval --read-only .#nixosTests.trilium-server`

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
