### PR TITLE
nixosTests.scion-freestanding-deployment: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1262,7 +1262,7 @@ in
   saunafs = runTest ./saunafs.nix;
   scaphandre = handleTest ./scaphandre.nix { };
   schleuder = runTest ./schleuder.nix;
-  scion-freestanding-deployment = handleTest ./scion/freestanding-deployment { };
+  scion-freestanding-deployment = runTest ./scion/freestanding-deployment;
   scrutiny = runTest ./scrutiny.nix;
   scx = runTest ./scx/default.nix;
   sddm = import ./sddm.nix { inherit runTest; };

--- a/nixos/tests/scion/freestanding-deployment/default.nix
+++ b/nixos/tests/scion/freestanding-deployment/default.nix
@@ -1,211 +1,199 @@
 # implements https://github.com/scionproto/scion/blob/27983125bccac6b84d1f96f406853aab0e460405/doc/tutorials/deploy.rst
-import ../../make-test-python.nix (
-  { pkgs, ... }:
-  let
-    trust-root-configuration-keys = pkgs.runCommand "generate-trc-keys.sh" {
-      buildInputs = [
+{ pkgs, ... }:
+let
+  trust-root-configuration-keys = pkgs.runCommand "generate-trc-keys.sh" {
+    buildInputs = [
+      pkgs.scion
+    ];
+  } (builtins.readFile ./bootstrap.sh);
+
+  imports = hostId: [
+    {
+      services.scion = {
+        enable = true;
+        bypassBootstrapWarning = true;
+      };
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+      };
+      systemd.network.networks."01-eth1" = {
+        name = "eth1";
+        networkConfig.Address = "192.168.1.${toString hostId}/24";
+      };
+      environment.etc = {
+        "scion/topology.json".source = ./topology + "${toString hostId}.json";
+        "scion/crypto/as".source = trust-root-configuration-keys + "/AS${toString hostId}";
+        "scion/certs/ISD42-B1-S1.trc".source = trust-root-configuration-keys + "/ISD42-B1-S1.trc";
+        "scion/keys/master0.key".text = "U${toString hostId}v4k23ZXjGDwDofg/Eevw==";
+        "scion/keys/master1.key".text = "dBMko${toString hostId}qMS8DfrN/zP2OUdA==";
+      };
+      environment.systemPackages = [
         pkgs.scion
       ];
-    } (builtins.readFile ./bootstrap.sh);
-
-    imports = hostId: [
-      ({
-        services.scion = {
-          enable = true;
-          bypassBootstrapWarning = true;
-        };
-        networking = {
-          useNetworkd = true;
-          useDHCP = false;
-        };
-        systemd.network.networks."01-eth1" = {
-          name = "eth1";
-          networkConfig.Address = "192.168.1.${toString hostId}/24";
-        };
-        environment.etc = {
-          "scion/topology.json".source = ./topology + "${toString hostId}.json";
-          "scion/crypto/as".source = trust-root-configuration-keys + "/AS${toString hostId}";
-          "scion/certs/ISD42-B1-S1.trc".source = trust-root-configuration-keys + "/ISD42-B1-S1.trc";
-          "scion/keys/master0.key".text = "U${toString hostId}v4k23ZXjGDwDofg/Eevw==";
-          "scion/keys/master1.key".text = "dBMko${toString hostId}qMS8DfrN/zP2OUdA==";
-        };
-        environment.systemPackages = [
-          pkgs.scion
-        ];
-      })
-    ];
-  in
-  {
-    name = "scion-test";
-    nodes = {
-      scion01 =
-        { ... }:
-        {
-          imports = (imports 1);
-        };
-      scion02 =
-        { ... }:
-        {
-          imports = (imports 2);
-        };
-      scion03 =
-        { ... }:
-        {
-          imports = (imports 3);
-        };
-      scion04 =
-        { ... }:
-        {
-          imports = (imports 4);
-          networking.interfaces."lo".ipv4.addresses = [
-            {
-              address = "172.16.1.1";
-              prefixLength = 32;
-            }
-          ];
-          services.scion.scion-ip-gateway = {
-            enable = true;
-            config = {
-              tunnel = {
-                src_ipv4 = "172.16.1.1";
-              };
-            };
-            trafficConfig = {
-              ASes = {
-                "42-ffaa:1:5" = {
-                  Nets = [
-                    "172.16.100.0/24"
-                  ];
-                };
-              };
-              ConfigVersion = 9001;
-            };
-          };
-        };
-      scion05 =
-        { ... }:
-        {
-          imports = (imports 5);
-          networking.interfaces."lo".ipv4.addresses = [
-            {
-              address = "172.16.100.1";
-              prefixLength = 32;
-            }
-          ];
-          services.scion.scion-ip-gateway = {
-            enable = true;
-            config = {
-              tunnel = {
-                src_ipv4 = "172.16.100.1";
-              };
-            };
-            trafficConfig = {
-              ASes = {
-                "42-ffaa:1:4" = {
-                  Nets = [
-                    "172.16.1.0/24"
-                  ];
-                };
-              };
-              ConfigVersion = 9001;
-            };
-          };
-        };
+    }
+  ];
+in
+{
+  name = "scion-test";
+  nodes = {
+    scion01 = {
+      imports = (imports 1);
     };
-    testScript =
-      let
-        pingAll = pkgs.writeShellScript "ping-all-scion.sh" ''
-          addresses="42-ffaa:1:1 42-ffaa:1:2 42-ffaa:1:3 42-ffaa:1:4 42-ffaa:1:5"
-          timeout=100
-          wait_for_all() {
-            ret=0
-            for as in "$@"
-            do
-              scion showpaths $as --no-probe > /dev/null
-              ret=$?
-              if [ "$ret" -ne "0" ]; then
-                break
-              fi
-            done
-            return $ret
-          }
-          ping_all() {
-            ret=0
-            for as in "$@"
-            do
-              scion ping "$as,127.0.0.1" -c 3
-              ret=$?
-              if [ "$ret" -ne "0" ]; then
-                break
-              fi
-            done
-            return $ret
-          }
-          for i in $(seq 0 $timeout); do
-            sleep 1
-            wait_for_all $addresses || continue
-            ping_all $addresses && exit 0
+    scion02 = {
+      imports = (imports 2);
+    };
+    scion03 = {
+      imports = (imports 3);
+    };
+    scion04 = {
+      imports = (imports 4);
+      networking.interfaces."lo".ipv4.addresses = [
+        {
+          address = "172.16.1.1";
+          prefixLength = 32;
+        }
+      ];
+      services.scion.scion-ip-gateway = {
+        enable = true;
+        config = {
+          tunnel = {
+            src_ipv4 = "172.16.1.1";
+          };
+        };
+        trafficConfig = {
+          ASes = {
+            "42-ffaa:1:5" = {
+              Nets = [
+                "172.16.100.0/24"
+              ];
+            };
+          };
+          ConfigVersion = 9001;
+        };
+      };
+    };
+    scion05 = {
+      imports = (imports 5);
+      networking.interfaces."lo".ipv4.addresses = [
+        {
+          address = "172.16.100.1";
+          prefixLength = 32;
+        }
+      ];
+      services.scion.scion-ip-gateway = {
+        enable = true;
+        config = {
+          tunnel = {
+            src_ipv4 = "172.16.100.1";
+          };
+        };
+        trafficConfig = {
+          ASes = {
+            "42-ffaa:1:4" = {
+              Nets = [
+                "172.16.1.0/24"
+              ];
+            };
+          };
+          ConfigVersion = 9001;
+        };
+      };
+    };
+  };
+  testScript =
+    let
+      pingAll = pkgs.writeShellScript "ping-all-scion.sh" ''
+        addresses="42-ffaa:1:1 42-ffaa:1:2 42-ffaa:1:3 42-ffaa:1:4 42-ffaa:1:5"
+        timeout=100
+        wait_for_all() {
+          ret=0
+          for as in "$@"
+          do
+            scion showpaths $as --no-probe > /dev/null
+            ret=$?
+            if [ "$ret" -ne "0" ]; then
+              break
+            fi
           done
-          exit 1
-        '';
-      in
-      ''
-        # List of AS instances
-        machines = [scion01, scion02, scion03, scion04, scion05]
-
-        # Functions to avoid many for loops
-        def start(allow_reboot=False):
-            for i in machines:
-                i.start(allow_reboot=allow_reboot)
-
-        def wait_for_unit(service_name):
-            for i in machines:
-                i.wait_for_unit(service_name)
-
-        def succeed(command):
-            for i in machines:
-                i.succeed(command)
-
-        def reboot():
-            for i in machines:
-                i.reboot()
-
-        def crash():
-            for i in machines:
-                i.crash()
-
-        # Start all machines, allowing reboot for later
-        start(allow_reboot=True)
-
-        # Wait for scion-control.service on all instances
-        wait_for_unit("scion-control.service")
-
-        # Ensure cert is valid against TRC
-        succeed("scion-pki certificate verify --trc /etc/scion/certs/*.trc /etc/scion/crypto/as/*.pem >&2")
-
-        # Execute pingAll command on all instances
-        succeed("${pingAll} >&2")
-
-        # Execute ICMP pings across scion-ip-gateway
-        scion04.succeed("ping -c 3 172.16.100.1 >&2")
-        scion05.succeed("ping -c 3 172.16.1.1 >&2")
-
-        # Restart all scion services and ping again to test robustness
-        succeed("systemctl restart scion-* >&2")
-        succeed("${pingAll} >&2")
-
-        # Reboot machines, wait for service, and ping again
-        reboot()
-        wait_for_unit("scion-control.service")
-        succeed("${pingAll} >&2")
-
-        # Crash, start, wait for service, and ping again
-        crash()
-        start()
-        wait_for_unit("scion-control.service")
-        succeed("pkill -9 scion-* >&2")
-        wait_for_unit("scion-control.service")
-        succeed("${pingAll} >&2")
+          return $ret
+        }
+        ping_all() {
+          ret=0
+          for as in "$@"
+          do
+            scion ping "$as,127.0.0.1" -c 3
+            ret=$?
+            if [ "$ret" -ne "0" ]; then
+              break
+            fi
+          done
+          return $ret
+        }
+        for i in $(seq 0 $timeout); do
+          sleep 1
+          wait_for_all $addresses || continue
+          ping_all $addresses && exit 0
+        done
+        exit 1
       '';
-  }
-)
+    in
+    ''
+      # List of AS instances
+      machines = [scion01, scion02, scion03, scion04, scion05]
+
+      # Functions to avoid many for loops
+      def start(allow_reboot=False):
+          for i in machines:
+              i.start(allow_reboot=allow_reboot)
+
+      def wait_for_unit(service_name):
+          for i in machines:
+              i.wait_for_unit(service_name)
+
+      def succeed(command):
+          for i in machines:
+              i.succeed(command)
+
+      def reboot():
+          for i in machines:
+              i.reboot()
+
+      def crash():
+          for i in machines:
+              i.crash()
+
+      # Start all machines, allowing reboot for later
+      start(allow_reboot=True)
+
+      # Wait for scion-control.service on all instances
+      wait_for_unit("scion-control.service")
+
+      # Ensure cert is valid against TRC
+      succeed("scion-pki certificate verify --trc /etc/scion/certs/*.trc /etc/scion/crypto/as/*.pem >&2")
+
+      # Execute pingAll command on all instances
+      succeed("${pingAll} >&2")
+
+      # Execute ICMP pings across scion-ip-gateway
+      scion04.succeed("ping -c 3 172.16.100.1 >&2")
+      scion05.succeed("ping -c 3 172.16.1.1 >&2")
+
+      # Restart all scion services and ping again to test robustness
+      succeed("systemctl restart scion-* >&2")
+      succeed("${pingAll} >&2")
+
+      # Reboot machines, wait for service, and ping again
+      reboot()
+      wait_for_unit("scion-control.service")
+      succeed("${pingAll} >&2")
+
+      # Crash, start, wait for service, and ping again
+      crash()
+      start()
+      wait_for_unit("scion-control.service")
+      succeed("pkill -9 scion-* >&2")
+      wait_for_unit("scion-control.service")
+      succeed("${pingAll} >&2")
+    '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on a698ac12 (master) and e4fd50e0 (this PR) and compare outputs, note that the derivations are the same.

```
nix eval --read-only .#nixosTests.scion-freestanding-deployment
```

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
