### PR TITLE
nixosTests.sddm: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1265,7 +1265,7 @@ in
   scion-freestanding-deployment = handleTest ./scion/freestanding-deployment { };
   scrutiny = runTest ./scrutiny.nix;
   scx = runTest ./scx/default.nix;
-  sddm = handleTest ./sddm.nix { };
+  sddm = import ./sddm.nix { inherit runTest; };
   sdl3 = runTest ./sdl3.nix;
   seafile = runTest ./seafile.nix;
   searx = runTest ./searx.nix;

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -1,77 +1,62 @@
+{ runTest }:
 {
-  system ? builtins.currentSystem,
-  config ? { },
-  pkgs ? import ../.. { inherit system config; },
-}:
+  default = runTest {
+    name = "sddm";
 
-with import ../lib/testing-python.nix { inherit system pkgs; };
-
-let
-  inherit (pkgs) lib;
-
-  tests = {
-    default = {
-      name = "sddm";
-
-      nodes.machine =
-        { ... }:
-        {
-          imports = [ ./common/user-account.nix ];
-          services.xserver.enable = true;
-          services.displayManager.sddm.enable = true;
-          services.displayManager.defaultSession = "none+icewm";
-          services.xserver.windowManager.icewm.enable = true;
-        };
-
-      enableOCR = true;
-
-      testScript =
-        { nodes, ... }:
-        let
-          user = nodes.machine.users.users.alice;
-        in
-        ''
-          start_all()
-          machine.wait_for_text("(?i)select your user")
-          machine.screenshot("sddm")
-          machine.send_chars("${user.password}\n")
-          machine.wait_for_file("/tmp/xauth_*")
-          machine.succeed("xauth merge /tmp/xauth_*")
-          machine.wait_for_window("^IceWM ")
-        '';
+    nodes.machine = {
+      imports = [ ./common/user-account.nix ];
+      services.xserver.enable = true;
+      services.displayManager.sddm.enable = true;
+      services.displayManager.defaultSession = "none+icewm";
+      services.xserver.windowManager.icewm.enable = true;
     };
 
-    autoLogin = {
+    enableOCR = true;
+
+    testScript =
+      { nodes, ... }:
+      let
+        user = nodes.machine.users.users.alice;
+      in
+      ''
+        start_all()
+        machine.wait_for_text("(?i)select your user")
+        machine.screenshot("sddm")
+        machine.send_chars("${user.password}\n")
+        machine.wait_for_file("/tmp/xauth_*")
+        machine.succeed("xauth merge /tmp/xauth_*")
+        machine.wait_for_window("^IceWM ")
+      '';
+  };
+
+  autoLogin = runTest (
+    { lib, ... }:
+    {
       name = "sddm-autologin";
-      meta = with pkgs.lib.maintainers; {
+      meta = with lib.maintainers; {
         maintainers = [ ttuegel ];
       };
 
-      nodes.machine =
-        { ... }:
-        {
-          imports = [ ./common/user-account.nix ];
-          services.xserver.enable = true;
-          services.displayManager = {
-            sddm.enable = true;
-            autoLogin = {
-              enable = true;
-              user = "alice";
-            };
+      nodes.machine = {
+        imports = [ ./common/user-account.nix ];
+        services.xserver.enable = true;
+        services.displayManager = {
+          sddm.enable = true;
+          autoLogin = {
+            enable = true;
+            user = "alice";
           };
-          services.displayManager.defaultSession = "none+icewm";
-          services.xserver.windowManager.icewm.enable = true;
         };
+        services.displayManager.defaultSession = "none+icewm";
+        services.xserver.windowManager.icewm.enable = true;
+      };
 
-      testScript =
-        { nodes, ... }:
-        ''
-          start_all()
-          machine.wait_for_file("/tmp/xauth_*")
-          machine.succeed("xauth merge /tmp/xauth_*")
-          machine.wait_for_window("^IceWM ")
-        '';
-    };
-  };
-in
-lib.mapAttrs (lib.const makeTest) tests
+      testScript = ''
+        start_all()
+        machine.wait_for_file("/tmp/xauth_*")
+        machine.succeed("xauth merge /tmp/xauth_*")
+        machine.wait_for_window("^IceWM ")
+      '';
+    }
+  );
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on a698ac12 (master) and 447c8559 (this PR) and compare outputs, note that the derivations are the same.

```
nix eval --read-only .#nixosTests.sddm
```

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
