### PR TITLE
nixosTests.go-camo: handleTest -> runTest, go-camo: link nixos test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -605,7 +605,7 @@ in
   gns3-server = runTest ./gns3-server.nix;
   gnupg = runTest ./gnupg.nix;
   goatcounter = runTest ./goatcounter.nix;
-  go-camo = handleTest ./go-camo.nix { };
+  go-camo = runTest ./go-camo.nix;
   go-neb = runTest ./go-neb.nix;
   gobgpd = runTest ./gobgpd.nix;
   gocd-agent = runTest ./gocd-agent.nix;

--- a/nixos/tests/go-camo.nix
+++ b/nixos/tests/go-camo.nix
@@ -1,36 +1,26 @@
+{ lib, ... }:
+let
+  key_val = "12345678";
+in
 {
-  system ? builtins.currentSystem,
-  config ? { },
-  pkgs ? import ../.. { inherit system config; },
-}:
+  name = "go-camo-file-key";
+  meta = {
+    maintainers = [ lib.maintainers.viraptor ];
+  };
 
-with import ../lib/testing-python.nix { inherit system pkgs; };
-
-{
-  gocamo_file_key =
-    let
-      key_val = "12345678";
-    in
-    makeTest {
-      name = "go-camo-file-key";
-      meta = {
-        maintainers = [ pkgs.lib.maintainers.viraptor ];
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.go-camo = {
+        enable = true;
+        keyFile = pkgs.writeText "foo" key_val;
       };
-
-      nodes.machine =
-        { config, pkgs, ... }:
-        {
-          services.go-camo = {
-            enable = true;
-            keyFile = pkgs.writeText "foo" key_val;
-          };
-        };
-
-      # go-camo responds to http requests
-      testScript = ''
-        machine.wait_for_unit("go-camo.service")
-        machine.wait_for_open_port(8080)
-        machine.succeed("curl http://localhost:8080")
-      '';
     };
+
+  # go-camo responds to http requests
+  testScript = ''
+    machine.wait_for_unit("go-camo.service")
+    machine.wait_for_open_port(8080)
+    machine.succeed("curl http://localhost:8080")
+  '';
 }

--- a/pkgs/by-name/go/go-camo/package.nix
+++ b/pkgs/by-name/go/go-camo/package.nix
@@ -3,6 +3,7 @@
   buildGo124Module,
   fetchFromGitHub,
   installShellFiles,
+  nixosTests,
   scdoc,
 }:
 
@@ -42,6 +43,10 @@ buildGo124Module rec {
     # requires network access
     rm pkg/camo/proxy_{,filter_}test.go
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) go-camo;
+  };
 
   meta = {
     description = "Camo server is a special type of image proxy that proxies non-secure images over SSL/TLS";


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on a698ac12 (master) and eafdc22a84a500f9ab4c2b2e1c4ab50f9653d520 (this PR) and compare outputs, note that the derivations are the same.

```
nix eval --read-only .#nixosTests.go-camo
```

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
