### PR TITLE
oku: avoid optimizations

### DIFF
--- a/pkgs/by-name/ok/oku/package.nix
+++ b/pkgs/by-name/ok/oku/package.nix
@@ -25,6 +25,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-utbey8DFXUWU6u2H2unNjCHE3/bwhPdrxAOApC+unGA=";
   };
 
+  # Avoiding optimizations for reproducibility
+  prePatch = ''
+    substituteInPlace .cargo/config.toml \
+      --replace-fail '"-C", "target-cpu=native", ' ""
+  '';
+
   cargoHash = "sha256-rwf9jdr+RDpUcTEG7Xhpph0zuyz6tdFx6hWEZRuxkTY=";
 
   nativeBuildInputs = [


### PR DESCRIPTION
This PR aims to generalize binary cache. It results in a coredump on my devices which are x86_64-linux but not supporting AVX-512.
It seems a similar problem described in https://github.com/NixOS/nixpkgs/pull/422588.

```console
> hydra-check oku
Build Status for nixpkgs.oku.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.oku.x86_64-linux
✔  oku-0.1.1  2025-07-05  https://hydra.nixos.org/build/301557563

> nix run 'github:NixOS/nixpkgs/104581ff2b10640635234a45fa278b344cc4543c#oku'
Illegal instruction (core dumped)

> lscpu | grep avx
Flags:                                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local clzero irperf xsaveerptr rdpru wbnoinvd cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif v_spec_ctrl umip rdpid overflow_recov succor smca

> coredumpctl list | tail -n 1
Wed 2025-07-09 15:28:30 JST  197251  1001   100 SIGILL  present  /nix/store/hxqav74nsmfnk3fpw9wllx5zj7n8iw9f-oku-0.1.1/bin/.oku-wrapped                                               2.9M

> coredumpctl dump 197251 --output oku.dump

> gdb "$(nix build --no-link --print-out-paths 'github:NixOS/nixpkgs/104581ff2b10640635234a45fa278b344cc4543c#oku')/bin/oku" oku.dump

> (gdb) disassemble $rip-32,$rip+32
Dump of assembler code from 0x55d5d0e95224 to 0x55d5d0e95264:
   0x000055d5d0e95224:  ret    $0x149
   0x000055d5d0e95227:  (bad)
   0x000055d5d0e95228:  mov    %r12,%rax
   0x000055d5d0e9522b:  sub    %rbx,%rax
   0x000055d5d0e9522e:  mov    %rax,%fs:0xfffffffffffffef8
   0x000055d5d0e95237:  mov    %r12,%fs:0xffffffffffffff00
   0x000055d5d0e95240:  vxorps %xmm0,%xmm0,%xmm0
=> 0x000055d5d0e95244:  vmovups %zmm0,-0x88(%rbp)
   0x000055d5d0e9524e:  vmovups %zmm0,-0xa0(%rbp)
   0x000055d5d0e95258:  vmovups %zmm0,-0xe0(%rbp)
   0x000055d5d0e95262:  lea    -0xe0(%rbp),%rdx
End of assembler dump.
(gdb)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
