### PR TITLE
lazylibrarian: init at 0-unstable-2025-07-08

### DIFF
--- a/pkgs/by-name/la/lazylibrarian/fix-setup.diff
+++ b/pkgs/by-name/la/lazylibrarian/fix-setup.diff
@@ -1,0 +1,40 @@
+diff --git a/MANIFEST.in b/MANIFEST.in
+new file mode 100644
+index 00000000..bec3e4d2
+--- /dev/null
++++ b/MANIFEST.in
+@@ -0,0 +1 @@
++recursive-include src/data *
+diff --git a/pyproject.toml b/pyproject.toml
+index b415e8cb..252f761e 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -2,9 +2,6 @@
+ requires = ["setuptools", "ez_setup"]
+ build-backend = "setuptools.build_meta"
+ 
+-[tool.setuptools.packages.find]
+-where = ["lazylibrarian"]
+-
+ [project]
+ name = "LazyLibrarian"
+ version = "2025.01.09"
+@@ -16,7 +13,7 @@ classifiers = [
+ ]
+ 
+ dependencies = [
+-    'bs4',
++    'beautifulsoup4',
+     'html5lib',
+     'webencodings',
+     'requests[use_chardet_on_py3]',
+@@ -44,6 +41,9 @@ dependencies = [
+ "Documentation" = "https://lazylibrarian.gitlab.io/"
+ "Issue Tracker" = "https://gitlab.com/LazyLibrarian/LazyLibrarian/-/issues"
+ 
++[project.scripts]
++lazylibrarian = "LazyLibrarian:main"
++
+ # Config file for pytest
+ [tool.pytest.ini_options]
+ pythonpath = "."

--- a/pkgs/by-name/la/lazylibrarian/package.nix
+++ b/pkgs/by-name/la/lazylibrarian/package.nix
@@ -1,0 +1,89 @@
+{
+  calibre,
+  fetchFromGitLab,
+  ffmpeg-headless,
+  lib,
+  nix-update-script,
+  python3Packages,
+  calibreSupport ? true,
+  ffmpegSupport ? true,
+}:
+python3Packages.buildPythonApplication {
+  pname = "lazylibrarian";
+  version = "2025.09.16-unstable-2026-04-30";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "LazyLibrarian";
+    repo = "LazyLibrarian";
+    rev = "322dba1ebc323274fb4a2a615597dad71d7856af";
+    hash = "sha256-Kr6fOkIbQffxH1KDNuYzwB1ZgI8i/tc08gvyyNWRRW4=";
+  };
+
+  patches = [
+    ./fix-setup.diff
+  ];
+
+  postPatch = ''
+    mkdir -p src
+    mv LazyLibrarian.py lazylibrarian lib data src
+  '';
+
+  build-system = with python3Packages; [
+    ez-setup
+    setuptools
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      apprise
+      apscheduler
+      beautifulsoup4
+      cherrypy
+      cherrypy-cors
+      deluge-client
+      html5lib
+      httpagentparser
+      httplib2
+      irc
+      iso639-lang
+      lxml
+      mako
+      pillow
+      pyopenssl
+      pyparsing
+      pypdf
+      python-magic
+      rapidfuzz
+      requests
+      slskd-api
+      tzdata
+      urllib3
+      webencodings
+      xmltodict
+    ]
+    ++ lib.optionals calibreSupport [ calibre ]
+    ++ lib.optionals ffmpegSupport [ ffmpeg-headless ];
+
+  pythonImportsCheck = [
+    "lazylibrarian"
+  ];
+
+  makeWrapperArgs = [
+    # Avoid automatic updates.
+    "--set DOCKER 1"
+    # Avoid `datadir` being on `/nix/store` by default.
+    "--add-flags --datadir=\\$XDG_DATA_HOME/lazylibrarian"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Usenet/BitTorrent ebook, audiobook and magazine downloader";
+    homepage = "https://lazylibrarian.gitlab.io/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ xelden ];
+    mainProgram = "lazylibrarian";
+  };
+}

--- a/pkgs/by-name/la/lazylibrarian/package.nix
+++ b/pkgs/by-name/la/lazylibrarian/package.nix
@@ -1,0 +1,94 @@
+{
+  calibre,
+  fetchFromGitLab,
+  ffmpeg-headless,
+  lib,
+  nix-update-script,
+  python3Packages,
+  calibreSupport ? true,
+  ffmpegSupport ? true,
+}:
+python3Packages.buildPythonApplication {
+  pname = "lazylibrarian";
+  version = "2025.09.16-unstable-2026-04-30";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "LazyLibrarian";
+    repo = "LazyLibrarian";
+    rev = "322dba1ebc323274fb4a2a615597dad71d7856af";
+    hash = "sha256-Kr6fOkIbQffxH1KDNuYzwB1ZgI8i/tc08gvyyNWRRW4=";
+  };
+
+  patches = [
+    ./fix-setup.diff
+  ];
+
+  postPatch = ''
+    mkdir -p src
+    mv LazyLibrarian.py lazylibrarian lib data src
+  '';
+
+  build-system = with python3Packages; [
+    ez-setup
+    setuptools
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      apprise
+      apscheduler
+      beautifulsoup4
+      cherrypy
+      cherrypy-cors
+      deluge-client
+      html5lib
+      httpagentparser
+      httplib2
+      irc
+      iso639-lang
+      lxml
+      mako
+      pillow
+      pyopenssl
+      pyparsing
+      pypdf
+      python-magic
+      rapidfuzz
+      requests
+      slskd-api
+      tzdata
+      urllib3
+      webencodings
+      xmltodict
+    ]
+    ++ lib.optionals calibreSupport [ calibre ]
+    ++ lib.optionals ffmpegSupport [ ffmpeg-headless ];
+
+  pythonImportsCheck = [
+    "lazylibrarian"
+  ];
+
+  makeWrapperArgs = [
+    # Avoid automatic updates.
+    "--set"
+    "DOCKER"
+    "1"
+    # Avoid `datadir` being on `/nix/store` by default.
+    "--add-flags"
+    "--datadir=\\$XDG_DATA_HOME/lazylibrarian"
+  ];
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Usenet/BitTorrent ebook, audiobook and magazine downloader";
+    homepage = "https://lazylibrarian.gitlab.io/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ xelden ];
+    mainProgram = "lazylibrarian";
+  };
+}

--- a/pkgs/development/python-modules/ez-setup/default.nix
+++ b/pkgs/development/python-modules/ez-setup/default.nix
@@ -1,0 +1,32 @@
+{
+  fetchPypi,
+  lib,
+  python3Packages,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "ez_setup";
+  version = "0.9";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-MDxbF9VS0eP7BQXYBUn4V59VfhPY3JDl7O88B9f1hkI=";
+  };
+
+  build-system = with python3Packages; [
+    distutils
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "ez_setup"
+  ];
+
+  meta = {
+    description = "Ez_setup.py and distribute_setup.py";
+    homepage = "https://github.com/ActiveState/ez_setup";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xelden ];
+  };
+}
+

--- a/pkgs/development/python-modules/ez-setup/default.nix
+++ b/pkgs/development/python-modules/ez-setup/default.nix
@@ -1,0 +1,31 @@
+{
+  fetchPypi,
+  lib,
+  python3Packages,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "ez_setup";
+  version = "0.9";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-MDxbF9VS0eP7BQXYBUn4V59VfhPY3JDl7O88B9f1hkI=";
+  };
+
+  build-system = with python3Packages; [
+    distutils
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "ez_setup"
+  ];
+
+  meta = {
+    description = "Ez_setup.py and distribute_setup.py";
+    homepage = "https://github.com/ActiveState/ez_setup";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xelden ];
+  };
+}

--- a/pkgs/development/python-modules/iso639-lang/default.nix
+++ b/pkgs/development/python-modules/iso639-lang/default.nix
@@ -1,0 +1,33 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "iso639-lang";
+  version = "2.6.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LBeaudoux";
+    repo = "iso639";
+    rev = "v${version}";
+    hash = "sha256-ORqSrf84b/ddpCUi9e43ur6C+XcJjQGM+fmJ8e/wFus=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "iso639"
+  ];
+
+  meta = {
+    description = "A fast, comprehensive, ISO 639 library";
+    homepage = "https://github.com/LBeaudoux/iso639";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xelden ];
+    mainProgram = "iso639";
+  };
+}

--- a/pkgs/development/python-modules/iso639-lang/default.nix
+++ b/pkgs/development/python-modules/iso639-lang/default.nix
@@ -1,0 +1,32 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "iso639-lang";
+  version = "2.6.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LBeaudoux";
+    repo = "iso639";
+    rev = "v${version}";
+    hash = "sha256-ORqSrf84b/ddpCUi9e43ur6C+XcJjQGM+fmJ8e/wFus=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "iso639"
+  ];
+
+  meta = {
+    description = "A fast, comprehensive, ISO 639 library";
+    homepage = "https://github.com/LBeaudoux/iso639";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xelden ];
+  };
+}

--- a/pkgs/development/python-modules/slskd-api/default.nix
+++ b/pkgs/development/python-modules/slskd-api/default.nix
@@ -1,0 +1,37 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "slskd-api";
+  version = "0.2.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bigoulours";
+    repo = "slskd-python-api";
+    rev = "v${version}";
+    hash = "sha256-rEfBT13NutwCfrWcxQf67rhtmxlB8Ws6RY8fObidSs8=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-git-versioning
+  ];
+
+  dependencies = with python3Packages; [
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "slskd_api"
+  ];
+
+  meta = {
+    description = "A python wrapper for the slskd api";
+    homepage = "https://github.com/bigoulours/slskd-python-api";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ xelden ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15039,6 +15039,8 @@ self: super: with self; {
 
   slpp = callPackage ../development/python-modules/slpp { };
 
+  slskd-api = callPackage ../development/python-modules/slskd-api { };
+
   slugid = callPackage ../development/python-modules/slugid { };
 
   py-slvs = callPackage ../development/python-modules/py-slvs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4401,6 +4401,8 @@ self: super: with self; {
 
   eyed3 = callPackage ../development/python-modules/eyed3 { };
 
+  ez-setup = callPackage ../development/python-modules/ez-setup { };
+
   ezdxf = callPackage ../development/python-modules/ezdxf { };
 
   ezyrb = callPackage ../development/python-modules/ezyrb { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6509,6 +6509,8 @@ self: super: with self; {
 
   iso4217 = callPackage ../development/python-modules/iso4217 { };
 
+  iso639-lang = callPackage ../development/python-modules/iso639-lang { };
+
   iso8601 = callPackage ../development/python-modules/iso8601 { };
 
   isodate = callPackage ../development/python-modules/isodate { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add `LazyLibrarian`, a Usenet/BitTorrent ebook, audiobook and magazine downloader.

Main repo: https://gitlab.com/LazyLibrarian/LazyLibrarian

Closes https://github.com/NixOS/nixpkgs/issues/179940

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
