### PR TITLE
sheep_net: init

### DIFF
--- a/nixos/modules/hardware/sheep-net.nix
+++ b/nixos/modules/hardware/sheep-net.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 

--- a/nixos/modules/hardware/sheep-net.nix
+++ b/nixos/modules/hardware/sheep-net.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.hardware.sheep_net;
+in
+{
+  options.hardware.sheep_net = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enables sheep_net udev rules, ensures 'sheep_net' group exists, and adds
+        sheep-net to boot.kernelModules and boot.extraModulePackages
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    services.udev.extraRules = ''
+      KERNEL=="sheep_net", GROUP="sheep_net"
+    '';
+    boot.kernelModules = [
+      "sheep_net"
+    ];
+    boot.extraModulePackages = [
+      config.boot.kernelPackages.sheep-net
+    ];
+    users.groups.sheep_net = { };
+  };
+  meta.maintainers = with lib.maintainers; [ matthewcroughan ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -103,6 +103,7 @@
   ./hardware/sata.nix
   ./hardware/sensor/hddtemp.nix
   ./hardware/sensor/iio.nix
+  ./hardware/sheep-net.nix
   ./hardware/steam-hardware.nix
   ./hardware/system-76.nix
   ./hardware/tuxedo-drivers.nix

--- a/pkgs/by-name/ba/basiliskii/package.nix
+++ b/pkgs/by-name/ba/basiliskii/package.nix
@@ -11,15 +11,15 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "basiliskii";
-  version = "unstable-2022-09-30";
+  version = "unstable-2025-07-16";
 
   # This src is also used to build pkgs/os-specific/linux/sheep-net
   # Therefore changes to it may effect the sheep-net package
   src = fetchFromGitHub {
     owner = "kanjitalk755";
     repo = "macemu";
-    rev = "2fa17a0783cf36ae60b77b5ed930cda4dc1824af";
-    sha256 = "+jkns6H2YjlewbUzgoteGSQYWJL+OWVu178aM+BtABM=";
+    rev = "030599cf8d31cb80afae0e1b086b5706dbdd2eea";
+    sha256 = "sha256-gxaj+2ymelH6uWmjMLXi64xMNrToo6HZcJ7RW7sVMzo=";
   };
   sourceRoot = "${finalAttrs.src.name}/BasiliskII/src/Unix";
   patches = [ ./remove-redhat-6-workaround-for-scsi-sg.h.patch ];

--- a/pkgs/by-name/ba/basiliskii/package.nix
+++ b/pkgs/by-name/ba/basiliskii/package.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "basiliskii";
   version = "unstable-2022-09-30";
 
+  # This src is also used to build pkgs/os-specific/linux/sheep-net
+  # Therefore changes to it may effect the sheep-net package
   src = fetchFromGitHub {
     owner = "kanjitalk755";
     repo = "macemu";

--- a/pkgs/os-specific/linux/sheep-net/default.nix
+++ b/pkgs/os-specific/linux/sheep-net/default.nix
@@ -1,0 +1,31 @@
+{
+  kernel,
+  kernelModuleMakeFlags,
+  stdenv,
+  basiliskii,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "sheep_net";
+  version = basiliskii.version;
+  src = basiliskii.src;
+  sourceRoot = "${finalAttrs.src.name}/BasiliskII/src/Unix/Linux/NetDriver";
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}/drivers/net
+    install -Dm444 sheep_net.ko $out/lib/modules/${kernel.modDirVersion}/drivers/net/sheep_net.ko
+    runHook postInstall
+  '';
+
+  meta = {
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -599,6 +599,8 @@ in
 
         rr-zen_workaround = callPackage ../development/tools/analysis/rr/zen_workaround.nix { };
 
+        sheep-net = callPackage ../os-specific/linux/sheep-net { };
+
         shufflecake = callPackage ../os-specific/linux/shufflecake { };
 
         sysdig = callPackage ../os-specific/linux/sysdig { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This builds and provides a module for `sheep_net`, which is a kernel module that allows you to bridge Appletalk over Ethernet to the BasiliskII emulator. It creates a char device `/dev/sheep_net` which is handled by the module I provide in this PR

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
