### PR TITLE
omenrgb: init at rebase-16.5

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -56,7 +56,7 @@
 
 - [Sharkey](https://joinsharkey.org), a Sharkish microblogging platform. Available as [services.sharkey](#opt-services.sharkey.enable).
 
-- [omenrgb](https://github.com/lemogne/omenrgb), a kernel module for controlling HP Omen laptop keyboard backlights. Available as [hardware.omenrgb](#opt-hardware.omenrgb)
+- [omenrgb](https://github.com/lemogne/omenrgb), a kernel module for controlling HP Omen laptop keyboard backlights. Available as [hardware.omenrgb](#opt-hardware.omenrgb.enable)
 
 - [mautrix-discord](https://github.com/mautrix/discord), a Matrix-Discord puppeting/relay bridge. Available as [services.mautrix-discord](#opt-services.mautrix-discord.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -56,6 +56,8 @@
 
 - [Sharkey](https://joinsharkey.org), a Sharkish microblogging platform. Available as [services.sharkey](#opt-services.sharkey.enable).
 
+- [omenrgb](https://github.com/lemogne/omenrgb), a kernel module for controlling HP Omen laptop keyboard backlights. Available as [hardware.omenrgb](#opt-hardware.omenrgb)
+
 - [mautrix-discord](https://github.com/mautrix/discord), a Matrix-Discord puppeting/relay bridge. Available as [services.mautrix-discord](#opt-services.mautrix-discord.enable).
 
 - [SuiteNumérique Meet](https://github.com/suitenumerique/meet) is an open source alternative to Google Meet and Zoom powered by LiveKit: HD video calls, screen sharing, and chat features. Built with Django and React. Available as [services.lasuite-meet](#opt-services.lasuite-meet.enable).

--- a/nixos/modules/hardware/omenrgb.nix
+++ b/nixos/modules/hardware/omenrgb.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.hardware.omenrgb;
+in
+{
+  options.hardware.omenrgb = {
+    enable = mkEnableOption "Keyboard backlight rgb controller for HP Omen Laptops";
+    package = mkPackageOption pkgs "omenrgb" { };
+  };
+
+  config = mkIf cfg.enable {
+    boot = {
+      extraModulePackages = with config.boot.kernelPackages; [ hp-omen-wmi ];
+      kernelModules = [ "hp-wmi" ];
+    };
+
+    services.udev.packages = [ cfg.package ];
+
+    environment = {
+      systemPackages = [
+        cfg.package
+        pkgs.gtk3
+      ];
+
+      variables = {
+        GSETTINGS_SCHEMA_DIR = "${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}/glib-2.0/schemas";
+      };
+
+    };
+  };
+
+  meta.maintainers = pkgs.omenrgb.meta.maintainers;
+}

--- a/nixos/modules/hardware/omenrgb.nix
+++ b/nixos/modules/hardware/omenrgb.nix
@@ -22,17 +22,11 @@ in
 
     services.udev.packages = [ cfg.package ];
 
-    environment = {
-      systemPackages = [
-        cfg.package
-        pkgs.gtk3
-      ];
+    environment.systemPackages = [
+      cfg.package
+      pkgs.gtk3
+    ];
 
-      variables = {
-        GSETTINGS_SCHEMA_DIR = "${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}/glib-2.0/schemas";
-      };
-
-    };
   };
 
   meta.maintainers = pkgs.omenrgb.meta.maintainers;

--- a/nixos/modules/hardware/omenrgb.nix
+++ b/nixos/modules/hardware/omenrgb.nix
@@ -22,10 +22,7 @@ in
 
     services.udev.packages = [ cfg.package ];
 
-    environment.systemPackages = [
-      cfg.package
-      pkgs.gtk3
-    ];
+    environment.systemPackages = [ cfg.package ];
 
   };
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -92,6 +92,7 @@
   ./hardware/new-lg4ff.nix
   ./hardware/nfc-nci.nix
   ./hardware/nitrokey.nix
+  ./hardware/omenrgb.nix
   ./hardware/onlykey/default.nix
   ./hardware/openrazer.nix
   ./hardware/opentabletdriver.nix

--- a/pkgs/by-name/om/omenrgb/package.nix
+++ b/pkgs/by-name/om/omenrgb/package.nix
@@ -51,12 +51,12 @@ stdenv.mkDerivation {
     cp backlight.rules $out/etc/udev/rules.d/81-backlight.rules
   '';
 
-  meta = with lib; {
+  meta = {
     description = "GUI for controlling RGB lighting on OMEN laptops for Linux";
     homepage = "https://github.com/lemogne/omenrgb";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ ern775 ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ern775 ];
     mainProgram = "omenrgb";
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/om/omenrgb/package.nix
+++ b/pkgs/by-name/om/omenrgb/package.nix
@@ -5,6 +5,7 @@
   gcc,
   wxGTK32,
   coreutils,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation {
@@ -22,6 +23,10 @@ stdenv.mkDerivation {
     substituteInPlace ./backlight.rules \
       --replace-fail '/bin/chmod' '${coreutils}/bin/chmod'
   '';
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     gcc

--- a/pkgs/by-name/om/omenrgb/package.nix
+++ b/pkgs/by-name/om/omenrgb/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gcc,
+  wxGTK32,
+  coreutils,
+}:
+
+stdenv.mkDerivation {
+  pname = "omenrgb";
+  version = "master";
+
+  src = fetchFromGitHub {
+    owner = "lemogne";
+    repo = "omenrgb";
+    rev = "5b68bc0a299df8926a03cded868766cc95ba644f";
+    hash = "sha256-lIr0Er4kt4UKeqg8smroBZ7ToOywP8C80+eIgGs3tWg=";
+  };
+
+  postPatch = ''
+    substituteInPlace ./backlight.rules \
+      --replace-fail '/bin/chmod' '${coreutils}/bin/chmod'
+  '';
+
+  buildInputs = [
+    gcc
+    wxGTK32
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    bash ./build.sh
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp omenrgb $out/bin/omenrgb
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d
+    cp backlight.rules $out/etc/udev/rules.d/81-backlight.rules
+  '';
+
+  meta = with lib; {
+    description = "GUI for controlling RGB lighting on OMEN laptops for Linux";
+    homepage = "https://github.com/lemogne/omenrgb";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ern775 ];
+    mainProgram = "omenrgb";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/os-specific/linux/hp-omen-wmi/default.nix
+++ b/pkgs/os-specific/linux/hp-omen-wmi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ranisalt";
     repo = "hp-omen-linux-module";
-    rev = "${version}";
+    tag = "${version}";
     hash = "sha256-IOXHzcCB0n1InMjeIu3XYEJ4bhbHS3NIlS8/+4XIwkQ=";
   };
 

--- a/pkgs/os-specific/linux/hp-omen-wmi/default.nix
+++ b/pkgs/os-specific/linux/hp-omen-wmi/default.nix
@@ -1,0 +1,47 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+}:
+stdenv.mkDerivation rec {
+  pname = "hp-omen-wmi";
+  version = "rebase-6.15";
+
+  src = fetchFromGitHub {
+    owner = "ranisalt";
+    repo = "hp-omen-linux-module";
+    rev = "${version}";
+    hash = "sha256-IOXHzcCB0n1InMjeIu3XYEJ4bhbHS3NIlS8/+4XIwkQ=";
+  };
+
+  setSourceRoot = ''
+    export sourceRoot=$(pwd)/source/src
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "-C"
+    "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "M=$(sourceRoot)"
+  ];
+
+  enableParallelBuilding = true;
+
+  buildFlags = [ "modules" ];
+
+  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+
+  installTargets = [ "modules_install" ];
+
+  meta = with lib; {
+    description = "Linux kernel module for HP Omen Keyboards";
+    homepage = "https://github.com/ranisalt/hp-omen-linux-module";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ ern775 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -506,6 +506,12 @@ in
 
         openrazer = callPackage ../os-specific/linux/openrazer/driver.nix { };
 
+        hp-omen-wmi =
+          if lib.versionAtLeast kernel.version "6.15" then
+            callPackage ../os-specific/linux/hp-omen-wmi { }
+          else
+            null;
+
         ply = callPackage ../os-specific/linux/ply { };
 
         r8125 = callPackage ../os-specific/linux/r8125 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added a new kernel module [hp-omen-wmi](https://github.com/ranisalt/hp-omen-linux-module/tree/rebase-6.15) that allows for user control of omen laptop's keyboard backlights

Added a new package [omenrgb](https://github.com/lemogne/omenrgb) that is a gui for controlling the hp-omen-wmi module

Added a new hardware.omenrgb option to set some other options necessary for both the module and the package to function

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
