### PR TITLE
ecc: add llvm in inputs to fix cross compilation error

### DIFF
--- a/pkgs/by-name/ec/ecc/package.nix
+++ b/pkgs/by-name/ec/ecc/package.nix
@@ -24,6 +24,10 @@ let
       fetchSubmodules = true;
     };
 
+    nativeBuildInputs = [
+      llvmPackages.llvm
+    ];
+
     buildInputs = [
       llvmPackages.libllvm
       elfutils


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

fixed issue #423719 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Test

tested on cross compiling loongarch64 NixOS with `ecc`:

```nix
{ pkgs }:

with pkgs; [
  # programs
  vim
  htop
  curl
  wget
  fastfetch
  iproute2
  iputils
  netcat
  strace
  procps
  sysstat
  e2fsprogs
  gzip
  bzip2
  xz
  unzip
  tree
  nix
  pciutils
  file
  pkg-config
  elfutils
  zlib
  lsof
  # libs
  glibc
  libelf
  zlib
  zstd
  bpftools
  ecc
] 
```

```bash
[wheatfox@nixos:~]$ ecc-rs
error: the following required arguments were not provided:
  <SOURCE_PATH>

Usage: ecc-rs <SOURCE_PATH> [EXPORT_EVENT_HEADER]

For more information, try '--help'.

[wheatfox@nixos:~]$ fastfetch 
          ▗▄▄▄       ▗▄▄▄▄    ▄▄▄▖             wheatfox@nixos
          ▜███▙       ▜███▙  ▟███▛             --------------
           ▜███▙       ▜███▙▟███▛              OS: NixOS 25.11 (Xantusia) loongarch64
            ▜███▙       ▜██████▛               Host: QEMU Virtual Machine (virt)
     ▟█████████████████▙ ▜████▛     ▟▙         Kernel: Linux 6.16.0-rc4+
    ▟███████████████████▙ ▜███▙    ▟██▙        Uptime: 1 min
           ▄▄▄▄▖           ▜███▙  ▟███▛        Packages: 362 (nix-system)
          ▟███▛             ▜██▛ ▟███▛         Shell: bash 5.2.37
         ▟███▛               ▜▛ ▟███▛          Terminal: vt220
▟███████████▛                  ▟██████████▙    CPU: Loongson-3A5000 @ 2.00 GHz
▜██████████▛                  ▟███████████▛    Memory: 967.45 MiB / 7.81 GiB (12%)
      ▟███▛ ▟▙               ▟███▛             Swap: Disabled
     ▟███▛ ▟██▙             ▟███▛              Disk (/): 10.43 GiB / 11.67 GiB (89%) - ext4
    ▟███▛  ▜███▙           ▝▀▀▀▀               Disk (/mnt): 11.46 MiB / 503.70 MiB (2%) - vfat
    ▜██▛    ▜███▙ ▜██████████████████▛         Local IP (enp0s6): 192.168.76.9/24
     ▜▛     ▟████▙ ▜████████████████▛          Locale: en_US.UTF-8
           ▟██████▙       ▜███▙
          ▟███▛▜███▙       ▜███▙                                       
         ▟███▛  ▜███▙       ▜███▙                                      
         ▝▀▀▀    ▀▀▀▀▘       ▀▀▀▘

[wheatfox@nixos:~]$ which ecc-rs 
/run/current-system/sw/bin/ecc-rs

[wheatfox@nixos:~]$ file /run/current-system/sw/bin/ecc-rs
/run/current-system/sw/bin/ecc-rs: symbolic link to /nix/store/42mgi3kmqrizz6j45g6qk6jllbs9h4kf-ecc-loongarch64-unknown-linux-gnu-1.0.27/bin/ecc-rs

[wheatfox@nixos:~]$ /nix/store/42mgi3kmqrizz6j45g6qk6jllbs9h4kf-ecc-loongarch64-unknown-linux-gnu-1.0.27/bin/ecc-rs
error: the following required arguments were not provided:
  <SOURCE_PATH>

Usage: ecc-rs <SOURCE_PATH> [EXPORT_EVENT_HEADER]

For more information, try '--help'.

[wheatfox@nixos:~]$ file /nix/store/42mgi3kmqrizz6j45g6qk6jllbs9h4kf-ecc-loongarch64-unknown-linux-gnu-1.0.27/bin/ecc-rs
/nix/store/42mgi3kmqrizz6j45g6qk6jllbs9h4kf-ecc-loongarch64-unknown-linux-gnu-1.0.27/bin/ecc-rs: a /nix/store/413bjrygdrx5dggm99zd7bgpdfffh89x-bash-loongarch64-unknown-linux-gnu-5.2p37/bin/bash -e script, ASCII text executable

[wheatfox@nixos:~]$ 
```
