### PR TITLE
optolith: init at 1.5.2

### DIFF
--- a/pkgs/by-name/op/optolith/package.nix
+++ b/pkgs/by-name/op/optolith/package.nix
@@ -1,0 +1,136 @@
+{
+  stdenv,
+  fetchurl,
+  requireFile,
+  autoPatchelfHook,
+  makeWrapper,
+  makeDesktopItem,
+  lib,
+
+  libGL,
+  udev,
+  alsa-lib,
+  at-spi2-atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libdrm,
+  libgbm,
+  libxkbcommon,
+  nspr,
+  nss,
+  pango,
+  xorg,
+}:
+
+stdenv.mkDerivation rec {
+  name = "optolith";
+  version = "1.5.2";
+
+  src = requireFile rec {
+    name = "989002-Optolith_1.5.2.tar.gz";
+    hash = "sha256-CoGEsPxi8nZFJYdH51AgQVSrIFtlL6J6HYo8Lzp59Fg=";
+
+    message = ''
+      In order to install Optolith, you need to comply with the license agreement and download
+      the binaries, ${name}, from:
+
+      ${meta.downloadPage}
+
+      Once you have downloaded the file, please use the following command and re-run the
+      installation:
+
+      nix-prefetch-url file://\$PWD/${name}
+    '';
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    cairo
+    cups.lib
+    dbus.lib
+    expat
+    gdk-pixbuf
+    glib
+    gtk3
+    libdrm
+    libgbm
+    libxkbcommon
+    nspr
+    nss
+    pango
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libxcb
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  preferLocalBuild = true;
+
+  installPhase =
+    let
+      desktopicon = fetchurl {
+        name = "optolith.png";
+        url = "https://raw.githubusercontent.com/elyukai/optolith-client/refs/tags/v${version}/app/icon.png";
+        hash = "sha256-E18paIyCzdlEuU7ykolahb0pCq7JGD9/OpBWoUyazoA=";
+      };
+    in
+    ''
+      mkdir -p $out/opt/optolith
+      cp -r . $out/opt/optolith
+      install -Dm644 ${desktopicon} $out/share/pixmaps/optolith.png
+    '';
+
+  postFixup =
+    let
+      runtimeInputs = [
+        libGL
+        # leads to the following error if omitted:
+        # Zygote could not fork: process_type gpu-process numfds 3 child_pid -1
+        udev
+      ];
+    in
+    ''
+      makeWrapper $out/opt/optolith/Optolith $out/bin/optolith \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeInputs}:$out/opt/optolith \
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "optolith";
+      icon = "optolith";
+      desktopName = "Optolith";
+      exec = meta.mainProgram;
+      comment = meta.description;
+      terminal = false;
+      categories = [ "Game" ];
+    })
+  ];
+
+  meta = {
+    description = "Character generator for The Dark Eye 5th Edition";
+    homepage = "https://github.com/elyukai/optolith-client";
+    downloadPage = "https://www.ulisses-ebooks.de/product/220253";
+    mainProgram = "optolith";
+    # the program itself is MPLv2, but the bundled content yaml files are proprietary
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ valodim ];
+  };
+}


### PR DESCRIPTION
This PR packages [Optolith](https://github.com/elyukai/optolith-client), a character creation tool for the The Dark Eye pen & paper game (Das Schwarze Auge in German, where it is most popular).

While the client itself is MPLv2, the actual content yaml files are proprietary. Because of this, the package as a whole is unfree. The [download page](https://www.ulisses-ebooks.de/product/220253) is a "pay what you want" page ($0 allowed), which unfortunately means the installation archive must be obtained by the user.

This package is mostly valuable because optolith doesn't work with a simple nix-alien or steam-run call. It used to, but for some reason this broke at some point, so I decided to package it instead and save others the pain :)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
