### PR TITLE
crystal2nix: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/by-name/cr/crystal2nix/package.nix
+++ b/pkgs/by-name/cr/crystal2nix/package.nix
@@ -2,29 +2,31 @@
   lib,
   fetchFromGitHub,
   crystal,
-  makeWrapper,
+  makeBinaryWrapper,
   nix-prefetch-git,
 }:
 
 crystal.buildCrystalPackage rec {
   pname = "crystal2nix";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "peterhoeg";
+    owner = "nix-community";
     repo = "crystal2nix";
     rev = "v${version}";
-    hash = "sha256-gb2vgKWVXwYWfUUcFvOLFF0qB4CTBekEllpyKduU1Mo=";
+    hash = "sha256-O8X2kTzl3LYMT97tVqbIZXDcFq24ZTfvd4yeMUhmBFs=";
   };
 
   format = "shards";
 
   shardsFile = ./shards.nix;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
 
   postInstall = ''
-    wrapProgram $out/bin/crystal2nix \
+    mkdir -p $out/libexec
+    mv $out/bin/${meta.mainProgram} $out/libexec
+    makeWrapper $out/libexec/${meta.mainProgram} $out/bin/${meta.mainProgram} \
       --prefix PATH : ${lib.makeBinPath [ nix-prefetch-git ]}
   '';
 

--- a/pkgs/by-name/cr/crystal2nix/shards.nix
+++ b/pkgs/by-name/cr/crystal2nix/shards.nix
@@ -1,12 +1,7 @@
 {
-  spectator = {
+  "spectator" = {
     url = "https://gitlab.com/arctic-fox/spectator.git";
     rev = "v0.10.5";
     sha256 = "1fgjz5vg59h4m25v4fjklimcdn62ngqbchm00kw1160ggjpgpzw2";
-  };
-  version_from_shard = {
-    url = "https://github.com/hugopl/version_from_shard.git";
-    rev = "v1.2.5";
-    sha256 = "0xizj0q4rd541rwjbx04cjifc2gfx4l5v6q2y7gmd0ndjmkgb8ik";
   };
 }


### PR DESCRIPTION
The main thing here is to add support for shards that contain dots so we now quote them to be sure.

This means any `shards.nix` generated with this version *will* be different from earlier versions as we quote all the shard names even if they might not need to be.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
