### PR TITLE
emacs: bump elisp packages

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -278,3 +278,6 @@ d7f1102f04c58b2edfc74c9a1d577e3aebfca775
 60e35e4ded6e91524364a74b3b4ec233ed9321f2
 99f2e655d9db009ee0b4ede3edced5f6c882c7f4
 b4532efe93882ae2e3fc579929a42a5a56544146
+
+# emacs: keep elpa/nongnu/melpa package overrides sorted
+9f2faf683ed48704aa17f693208a13aa64e22181

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-common-overrides.nix
@@ -14,11 +14,7 @@ let
     ;
 in
 {
-  cl-lib = null; # builtin
-  cl-print = null; # builtin
-  tle = null; # builtin
-  advice = null; # builtin
-
+  # keep-sorted start block=yes newline_separated=yes
   # Compilation instructions for the Ada executables:
   # https://www.nongnu.org/ada-mode/
   ada-mode = super.ada-mode.overrideAttrs (
@@ -65,6 +61,8 @@ in
   # native-compiler-error-empty-byte in old versions
   ada-ref-man = ignoreCompilationErrorIfOlder super.ada-ref-man "2020.1.0.20201129.190419";
 
+  advice = null; # builtin
+
   # elisp error in old versions
   ampc = ignoreCompilationErrorIfOlder super.ampc "0.2.0.20240220.181558";
 
@@ -73,6 +71,10 @@ in
   auctex-cont-latexmk = mkHome super.auctex-cont-latexmk;
 
   auctex-label-numbers = mkHome super.auctex-label-numbers;
+
+  cl-lib = null; # builtin
+
+  cl-print = null; # builtin
 
   # missing optional dependencies https://codeberg.org/rahguzar/consult-hoogle/issues/4
   consult-hoogle = addPackageRequiresIfOlder super.consult-hoogle [ self.consult ] "0.2.2";
@@ -234,8 +236,6 @@ in
   # native-ice https://github.com/mattiase/relint/issues/15
   relint = ignoreCompilationError super.relint;
 
-  shen-mode = ignoreCompilationErrorIfOlder super.shen-mode "0.1.0.20221221.82050"; # elisp error
-
   # native compilation for tests/seq-tests.el never ends
   # delete tests/seq-tests.el to workaround this
   seq = super.seq.overrideAttrs (old: {
@@ -250,6 +250,8 @@ in
         tar --create --verbose --file=$src $content_directory
       '';
   });
+
+  shen-mode = ignoreCompilationErrorIfOlder super.shen-mode "0.1.0.20221221.82050"; # elisp error
 
   # https://github.com/alphapapa/taxy.el/issues/3
   taxy = super.taxy.overrideAttrs (old: {
@@ -268,6 +270,8 @@ in
   tex-parens = mkHomeIfOlder super.tex-parens "0.4.0.20240630.70456";
 
   timerfunctions = ignoreCompilationErrorIfOlder super.timerfunctions "1.4.2.0.20201129.225252";
+
+  tle = null; # builtin
 
   # kv is required in triples-test.el
   # Alternatively, we can delete that file.  But adding a dependency is easier.
@@ -295,4 +299,6 @@ in
 
   # native-ice https://github.com/mattiase/xr/issues/9
   xr = ignoreCompilationError super.xr;
+
+  # keep-sorted end
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.0.9.0.20250530.145847";
+      version = "14.0.9.0.20250627.121203";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.0.9.0.20250530.145847.tar";
-        sha256 = "05mdn3ymwv7zr5ik8rga859cggvz5r4qwnmb5ri78jww6bk96dbj";
+        url = "https://elpa.gnu.org/devel/auctex-14.0.9.0.20250627.121203.tar";
+        sha256 = "1a5jfd7nmmmrgm8a319gv6f7356rpp9ccm5680qssx95pg67paax";
       };
       packageRequires = [ ];
       meta = {
@@ -740,10 +740,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.3.0.0.20250530.55351";
+      version = "1.4.0.0.20250628.65448";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/beframe-1.3.0.0.20250530.55351.tar";
-        sha256 = "1f9gf6cy46dd52701vg8xnm8nmbqk09c2xwhcz03f3djbd1fxhjl";
+        url = "https://elpa.gnu.org/devel/beframe-1.4.0.0.20250628.65448.tar";
+        sha256 = "1py8q76jfkvmvqsf15vpdaznlzqj464m8wwslkjyr25hysrgh6cl";
       };
       packageRequires = [ ];
       meta = {
@@ -782,10 +782,10 @@
     elpaBuild {
       pname = "bind-key";
       ename = "bind-key";
-      version = "2.4.1.0.20250227.73309";
+      version = "2.4.1.0.20250611.62842";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bind-key-2.4.1.0.20250227.73309.tar";
-        sha256 = "13ps20qb6ajnhn5qcaf4jncbn25q2iqji8r7f3mflp58h3m8gajm";
+        url = "https://elpa.gnu.org/devel/bind-key-2.4.1.0.20250611.62842.tar";
+        sha256 = "1wrkvjcbbki9lnlcq1miw3gnyayzmjg2wqrxwpyaq8429xh275qq";
       };
       packageRequires = [ ];
       meta = {
@@ -1105,10 +1105,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.1.0.20250521.64514";
+      version = "2.1.0.20250617.112523";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-2.1.0.20250521.64514.tar";
-        sha256 = "0ibaxcdsiki6zg08fmfsj7a5p9wsrp2nc6bnki5y1g1619ln5gk5";
+        url = "https://elpa.gnu.org/devel/cape-2.1.0.20250617.112523.tar";
+        sha256 = "1vr9rsa6lb8hcdpwlnczvrcf2ncpnnlcwclhqq3r9nbcfpbyvlmm";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1296,10 +1296,10 @@
     elpaBuild {
       pname = "code-cells";
       ename = "code-cells";
-      version = "0.5.0.20241119.142112";
+      version = "0.5.0.20250608.143915";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/code-cells-0.5.0.20241119.142112.tar";
-        sha256 = "1jzqp6d7xj2ya18x0dahqn2if46wphbk63f76pw09bhwh71qc9g3";
+        url = "https://elpa.gnu.org/devel/code-cells-0.5.0.20250608.143915.tar";
+        sha256 = "1chbb4sab9a73aj7a283g1qpsqbv6rvzfah4qqg5piykc2hk0yg0";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1318,10 +1318,10 @@
     elpaBuild {
       pname = "colorful-mode";
       ename = "colorful-mode";
-      version = "1.2.4.0.20250529.222523";
+      version = "1.2.4.0.20250621.201608";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.4.0.20250529.222523.tar";
-        sha256 = "1g1x1p6ayy6nqmhj109k3y4bddas0bdljia5rwzkkysfqqxj8rqr";
+        url = "https://elpa.gnu.org/devel/colorful-mode-1.2.4.0.20250621.201608.tar";
+        sha256 = "1lfgg7y8l37474966n76b5h3jl1dah73bfg27mscz8i24344p0nh";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1482,10 +1482,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.1.0.0.0.20250402.70347";
+      version = "30.1.0.1.0.20250619.142858";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/compat-30.1.0.0.0.20250402.70347.tar";
-        sha256 = "19xc2x70x539dp5c69dn796yq6ya2xjbfsjzs45sh3ikr76ki7w6";
+        url = "https://elpa.gnu.org/devel/compat-30.1.0.1.0.20250619.142858.tar";
+        sha256 = "0lxpm1kbshrq6f2j9ihdd5xd6lwabmypfmlk9fp2ibzv32wwajv7";
       };
       packageRequires = [ seq ];
       meta = {
@@ -1546,10 +1546,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.4.0.20250530.124807";
+      version = "2.6.0.20250702.84636";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-2.4.0.20250530.124807.tar";
-        sha256 = "09a7wyprhzlwyy0x3b3wpy68qdwxlkpff84sdhms76sz3mx5jnz9";
+        url = "https://elpa.gnu.org/devel/consult-2.6.0.20250702.84636.tar";
+        sha256 = "0k0av4i9ww7kwg7igllsak6wrbl3nj2d4r4kggh8dn77z4b19x81";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1569,10 +1569,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.3.1.0.20250501.44152";
+      version = "0.3.1.0.20250606.75450";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-denote-0.3.1.0.20250501.44152.tar";
-        sha256 = "1kxk38yi1m9z4j422skn43xyynazwd2n0d9sq78yn7cbnpf050wn";
+        url = "https://elpa.gnu.org/devel/consult-denote-0.3.1.0.20250606.75450.tar";
+        sha256 = "01dbnll9al7046kkbmfqwvgdp7bwhxgq552lzc4igqxm8kbb99gc";
       };
       packageRequires = [
         consult
@@ -1659,10 +1659,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.2.0.20250528.194504";
+      version = "2.3.0.20250617.112559";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-2.2.0.20250528.194504.tar";
-        sha256 = "0j9z6nm80h6016slgh8pzia84dry9kaj3m1rzjsqlpvjhvxwfc3l";
+        url = "https://elpa.gnu.org/devel/corfu-2.3.0.20250617.112559.tar";
+        sha256 = "110zk8s1dg4g447yfa2c8jb3gvfi1jfjz6kjn5mfgl0zz1llmhn1";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1940,10 +1940,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.24.1.0.20250529.103551";
+      version = "0.24.1.0.20250619.215347";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.24.1.0.20250529.103551.tar";
-        sha256 = "0wyhcncgxqp9jc65k8zwha21rvgxk0zfm79psmwz9i64rg9j9bn1";
+        url = "https://elpa.gnu.org/devel/dape-0.24.1.0.20250619.215347.tar";
+        sha256 = "0sn4v04rzyj0azb7mfm9dz3afr4jmi3irpacfj7cgbm25dsj5hxk";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -2074,10 +2074,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.0.0.0.20250525.143413";
+      version = "4.0.0.0.20250708.74730";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-4.0.0.0.20250525.143413.tar";
-        sha256 = "1n6zjpx5qbwahvnmj3al4xx17f6vrh6apll4vyla5xingp3h4mf5";
+        url = "https://elpa.gnu.org/devel/denote-4.0.0.0.20250708.74730.tar";
+        sha256 = "0f0czcsc5ql8g09lnjjcw3cg1yyzj5agm9aw5rmvxp7q70pwfw2s";
       };
       packageRequires = [ ];
       meta = {
@@ -2096,10 +2096,10 @@
     elpaBuild {
       pname = "denote-journal";
       ename = "denote-journal";
-      version = "0.1.1.0.20250517.43843";
+      version = "0.1.1.0.20250702.194716";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-journal-0.1.1.0.20250517.43843.tar";
-        sha256 = "1v5r87mdmdpfqdyb0zr3z9brkml7dac92pp6gam8qsc1l7zx359l";
+        url = "https://elpa.gnu.org/devel/denote-journal-0.1.1.0.20250702.194716.tar";
+        sha256 = "0qkgh5d6qky04blvbqwpw2231aj1gmj84m485m6zijlvbkcn9cy9";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2206,10 +2206,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.1.1.0.20250522.82830";
+      version = "0.1.1.0.20250707.134142";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-sequence-0.1.1.0.20250522.82830.tar";
-        sha256 = "1g0fxfkj5asv0zixwril4di3sqbgb5hzph6mam1igz359nnkabc3";
+        url = "https://elpa.gnu.org/devel/denote-sequence-0.1.1.0.20250707.134142.tar";
+        sha256 = "0iyv6cv4520sj1wgpr3zn4v86r8xjd9273y5nnc7ijsdfdjj26qz";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2228,10 +2228,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.1.1.0.20250419.74326";
+      version = "0.1.2.0.20250605.84406";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-silo-0.1.1.0.20250419.74326.tar";
-        sha256 = "1ysbm6mbnr4g4h3yhay1b7d98y1dh11dq5pv2ix2c3ld2952h7sy";
+        url = "https://elpa.gnu.org/devel/denote-silo-0.1.2.0.20250605.84406.tar";
+        sha256 = "12wj4ydi5gzavgxv3g170p7d8wi9ydqb2apnjvzq27gnf0n2kjzi";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2272,10 +2272,10 @@
     elpaBuild {
       pname = "devdocs";
       ename = "devdocs";
-      version = "0.6.1.0.20241113.134137";
+      version = "0.6.1.0.20250608.141406";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/devdocs-0.6.1.0.20241113.134137.tar";
-        sha256 = "0p8p0bp9wyrl4xqnj60k2hxmqcg40angzhsc240cvlyfg965ixx1";
+        url = "https://elpa.gnu.org/devel/devdocs-0.6.1.0.20250608.141406.tar";
+        sha256 = "155j0c3ldrp16399fv1mqppkky0zzjy1d4bls83j8w3xl2r8ai4v";
       };
       packageRequires = [
         compat
@@ -2318,10 +2318,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "0.5.0.20250512.155532";
+      version = "0.6.0.20250617.112606";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dicom-0.5.0.20250512.155532.tar";
-        sha256 = "1kbdc8m40z449p1r39ix10fvwq7gzqpg5q3i4xs4fyg6v2769z8d";
+        url = "https://elpa.gnu.org/devel/dicom-0.6.0.20250617.112606.tar";
+        sha256 = "152ny6k4bfydysbl534yky175ji65146x70glzy18xn40ay4pz5k";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2368,10 +2368,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20250520.20816";
+      version = "1.10.0.0.20250627.223032";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20250520.20816.tar";
-        sha256 = "15m4bca2arig6d6l2ml8ab4dg08rpi5m7pzps5lidad83ipl3cvv";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20250627.223032.tar";
+        sha256 = "101yzzclgagvfjzw3r9483vv27h6fbvniwnlycrri9agxv6n6qxm";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2664,10 +2664,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.1.0.0.20250530.91206";
+      version = "0.2.0.0.20250705.145026";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/doric-themes-0.1.0.0.20250530.91206.tar";
-        sha256 = "153gnj81lw4z6mrw509jv3022nnyqrxmk5fga7dqnmzpkydxbp8c";
+        url = "https://elpa.gnu.org/devel/doric-themes-0.2.0.0.20250705.145026.tar";
+        sha256 = "0w7zibcgcyn1vbhxy4xd7hbp3rd79aag9jl9hv75cln4zd0d99fp";
       };
       packageRequires = [ ];
       meta = {
@@ -2866,10 +2866,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20250216.0.20250305.175133";
+      version = "20250607.0.20250607.11108";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eev-20250216.0.20250305.175133.tar";
-        sha256 = "0xx9s43wix06agbwbvdsc3fqxc16q2jj5slyljz0nw9kw4h9lngs";
+        url = "https://elpa.gnu.org/devel/eev-20250607.0.20250607.11108.tar";
+        sha256 = "1gjqyr05qyp491dp095q2i9rq87g55ifbi1qy2z3i8s1ghfyp00l";
       };
       packageRequires = [ ];
       meta = {
@@ -2887,10 +2887,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.10.0.0.20250524.83143";
+      version = "1.10.0.0.20250704.54909";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-1.10.0.0.20250524.83143.tar";
-        sha256 = "1dmjfydzw5aabhbwfcvdxh123s08a11khj7vzg38whx4f4mxhji2";
+        url = "https://elpa.gnu.org/devel/ef-themes-1.10.0.0.20250704.54909.tar";
+        sha256 = "108rn50zqjlkzj1g99n6q4kabqd053f80yx2qk96wr35mvqifvvj";
       };
       packageRequires = [ ];
       meta = {
@@ -2915,10 +2915,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.18.0.20250524.65524";
+      version = "1.18.0.20250625.170717";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20250524.65524.tar";
-        sha256 = "0vxswngxr3bvwbcjmmsciw3is7b02ilz1wlppj1krmagpmwffsa2";
+        url = "https://elpa.gnu.org/devel/eglot-1.18.0.20250625.170717.tar";
+        sha256 = "0zjdrdl2bb2fx83kzz3d8q8kfyba7mv1zfmrzpm0ha6s4kckpq0v";
       };
       packageRequires = [
         eldoc
@@ -2944,10 +2944,10 @@
     elpaBuild {
       pname = "el-job";
       ename = "el-job";
-      version = "2.4.7.0.20250524.200444";
+      version = "2.4.8.0.20250606.193102";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/el-job-2.4.7.0.20250524.200444.tar";
-        sha256 = "0f5k94x24hhjrlxq4gjfm551pgir701hxyjb7k9hcbhxq06l4ay4";
+        url = "https://elpa.gnu.org/devel/el-job-2.4.8.0.20250606.193102.tar";
+        sha256 = "13p5mdll5qhf3h9y3k2c35frfnh8v9aci8f5la2c23b9k53qpvhb";
       };
       packageRequires = [ ];
       meta = {
@@ -3136,10 +3136,10 @@
     elpaBuild {
       pname = "embark";
       ename = "embark";
-      version = "1.1.0.20250530.134842";
+      version = "1.1.0.20250707.134730";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-1.1.0.20250530.134842.tar";
-        sha256 = "15lwgw9340h33crdhy8n2bfb7v2xlj5z02pvll7zmzr1wwiaqrja";
+        url = "https://elpa.gnu.org/devel/embark-1.1.0.20250707.134730.tar";
+        sha256 = "165wyrp252bdf2qqpiq5gqs41rn6pnz0s9fdxzz0rf5sajhmmajj";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3160,10 +3160,10 @@
     elpaBuild {
       pname = "embark-consult";
       ename = "embark-consult";
-      version = "1.1.0.20250530.134842";
+      version = "1.1.0.20250707.134730";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20250530.134842.tar";
-        sha256 = "1apy9ld2wi6yyqdqzyxamr6qascfghwc83wkdvqm54aiv2ks3g76";
+        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20250707.134730.tar";
+        sha256 = "11557bz8xhwmyg6qgjw9rr6c6d5l08haiyqai4k0zglbdnn8rd3b";
       };
       packageRequires = [
         compat
@@ -3224,10 +3224,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "22.0.20250405.101736";
+      version = "22.0.20250609.224757";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emms-22.0.20250405.101736.tar";
-        sha256 = "0vz92gq1hw9p4s24w0vc1finq9bx6is7vsi1izi9b5bghd837rb8";
+        url = "https://elpa.gnu.org/devel/emms-22.0.20250609.224757.tar";
+        sha256 = "1ghvwrjyzyfc80wxxvmlmhxdwzkbw6xxrk2h1hj23yc3q5hbfyi4";
       };
       packageRequires = [
         cl-lib
@@ -3360,10 +3360,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "25.1.0.0.20250508.73511";
+      version = "25.1.0.0.20250606.83117";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20250508.73511.tar";
-        sha256 = "126ld8y7qk9z72vrd85mzqc25mbyyc6k0wl0iilbhcl268szy7xi";
+        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20250606.83117.tar";
+        sha256 = "1mr16s1pxfw7nfv9fjgwygy0s173z99gl9spcjn9jpdm7ydg9nzl";
       };
       packageRequires = [ ];
       meta = {
@@ -3374,12 +3374,10 @@
   ) { };
   excorporate = callPackage (
     {
-      cl-lib ? null,
       elpaBuild,
       fetchurl,
       fsm,
       lib,
-      nadvice,
       soap-client,
       url-http-ntlm,
       url-http-oauth,
@@ -3387,15 +3385,13 @@
     elpaBuild {
       pname = "excorporate";
       ename = "excorporate";
-      version = "1.1.2.0.20240219.90343";
+      version = "1.1.3.0.20250627.211849";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/excorporate-1.1.2.0.20240219.90343.tar";
-        sha256 = "0wm1qx1y9az3fdh81hjccpsw4xxx0p9acz9pfvsyjlywclcycd4i";
+        url = "https://elpa.gnu.org/devel/excorporate-1.1.3.0.20250627.211849.tar";
+        sha256 = "16vj05282g69f3p6b3f9nfgnd6c8d6jan0srbfrxjiqmvlx51cxv";
       };
       packageRequires = [
-        cl-lib
         fsm
-        nadvice
         soap-client
         url-http-ntlm
         url-http-oauth
@@ -3436,10 +3432,10 @@
     elpaBuild {
       pname = "expreg";
       ename = "expreg";
-      version = "1.4.1.0.20250520.204305";
+      version = "1.4.1.0.20250703.235736";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/expreg-1.4.1.0.20250520.204305.tar";
-        sha256 = "1cvvwdbbkdm6npbyfz5w6pl3iha1v9sxqdvafqpj03nxlknjvjhh";
+        url = "https://elpa.gnu.org/devel/expreg-1.4.1.0.20250703.235736.tar";
+        sha256 = "0v661v52xhni1mljz8b952vaybkj30542xjabkfzdn6bby98k118";
       };
       packageRequires = [ ];
       meta = {
@@ -3480,10 +3476,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.33.0.20250528.173021";
+      version = "0.34.0.20250627.135417";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.33.0.20250528.173021.tar";
-        sha256 = "1nbjwvzl1rndz9ygmww1i80sxq5pxq68lamsw9ablbg19bvkajl6";
+        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20250627.135417.tar";
+        sha256 = "021ws9brxwzx25hdkm20c53qcgbzxx86jv1yaqvi4w21pc31079y";
       };
       packageRequires = [
         compat
@@ -3548,10 +3544,10 @@
     elpaBuild {
       pname = "filechooser";
       ename = "filechooser";
-      version = "0.2.2.0.20250411.154303";
+      version = "0.2.3.0.20250624.102108";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/filechooser-0.2.2.0.20250411.154303.tar";
-        sha256 = "0xgvwjxsckmdijmrsb4c6ln515an07x84az3x5vd4mjll85mcm86";
+        url = "https://elpa.gnu.org/devel/filechooser-0.2.3.0.20250624.102108.tar";
+        sha256 = "0va3sbq28xsg127yzn6fwjmqivykg0r74ll0gsi6knq7yggapfhg";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3635,10 +3631,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.4.1.0.20250508.221328";
+      version = "1.4.1.0.20250531.142308";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.4.1.0.20250508.221328.tar";
-        sha256 = "0sc45x3fwxmdbq4pz23kjibk38zwv1zxx8ihfg368syinik883gw";
+        url = "https://elpa.gnu.org/devel/flymake-1.4.1.0.20250531.142308.tar";
+        sha256 = "00h774wxsx8rgmlyph7b4w9d8k4mi67vfx6dnx45zgkicdkrp70h";
       };
       packageRequires = [
         eldoc
@@ -4193,10 +4189,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.12.6.0.20250526.83546";
+      version = "0.12.7.0.20250623.220009";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.12.6.0.20250526.83546.tar";
-        sha256 = "1ivmz9cjss4naf02si5ikmlkad0lbic3kbs989n561d0lq25dfmw";
+        url = "https://elpa.gnu.org/devel/greader-0.12.7.0.20250623.220009.tar";
+        sha256 = "1j8w628wypiq2wc5sl15qi9vv8w1qfbl9iv9zixq0kwmdzqgi8nd";
       };
       packageRequires = [
         compat
@@ -4217,10 +4213,10 @@
     elpaBuild {
       pname = "greenbar";
       ename = "greenbar";
-      version = "1.1.0.20221221.80217";
+      version = "1.2.0.20250603.210745";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greenbar-1.1.0.20221221.80217.tar";
-        sha256 = "00kch8c0sz5z3cx0likx0pyqp9jxvjd6lkmdcli4zzpc6j1f1a0k";
+        url = "https://elpa.gnu.org/devel/greenbar-1.2.0.20250603.210745.tar";
+        sha256 = "1rx0jivxr95pjfksf1k8dl2ic9sqmss7rm2cvq5ghazv2r1lpl1k";
       };
       packageRequires = [ ];
       meta = {
@@ -4238,10 +4234,10 @@
     elpaBuild {
       pname = "gtags-mode";
       ename = "gtags-mode";
-      version = "1.8.6.0.20250518.10237";
+      version = "1.9.3.0.20250618.235351";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/gtags-mode-1.8.6.0.20250518.10237.tar";
-        sha256 = "0xisbx4k8baj8hzklmpz0gfkx82f3sss3mnji9v0pbv1g9q7v2w9";
+        url = "https://elpa.gnu.org/devel/gtags-mode-1.9.3.0.20250618.235351.tar";
+        sha256 = "0009dg34n71lgf28dsqaghzyykfvid9la5mz6aw1d3130x6hd46j";
       };
       packageRequires = [ ];
       meta = {
@@ -4455,10 +4451,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20250518.175059";
+      version = "9.0.2pre0.20250707.10907";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250518.175059.tar";
-        sha256 = "1dcra27asrpfg1ymqbzqss6dy7vlrrk14070gna1x4b6fvag9jdg";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20250707.10907.tar";
+        sha256 = "0x5zznxmywgdh7pkp5s1j83qbasfkcszrzr4xyc06862rfvcyq4a";
       };
       packageRequires = [ ];
       meta = {
@@ -4519,10 +4515,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.8.4.0.20250529.164202";
+      version = "0.9.1.0.20250708.125252";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/indent-bars-0.8.4.0.20250529.164202.tar";
-        sha256 = "1zwrd6g43qqzm1kzacpgq6m20kir3m2r94li8yx74vqpw9cca8hp";
+        url = "https://elpa.gnu.org/devel/indent-bars-0.9.1.0.20250708.125252.tar";
+        sha256 = "1g2hg0cwch0a8dmknjq0kdakccl5qfd7y9igii4g46x0s865z06r";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4832,10 +4828,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.2.0.20250526.33048";
+      version = "2.2.0.20250619.145315";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-2.2.0.20250526.33048.tar";
-        sha256 = "0bh9mmknxnd62wbiga9s67dnrq5ggh1d9pqhk0vf163nk5bdng6a";
+        url = "https://elpa.gnu.org/devel/jinx-2.2.0.20250619.145315.tar";
+        sha256 = "1rcaxcsh85da3xcy4wdj3y0pwj63v518idw1aw0xl0yswxnqhkr2";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5025,10 +5021,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.4.3.0.20250422.135008";
+      version = "0.5.0.0.20250628.101732";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/kubed-0.4.3.0.20250422.135008.tar";
-        sha256 = "1mcx3zah4yifrissa5065gsbkaj90m11rbhz70pk8yl60hyn9d0a";
+        url = "https://elpa.gnu.org/devel/kubed-0.5.0.0.20250628.101732.tar";
+        sha256 = "1x5f65yqwx7cs6clg8q9yw8fbq81zv3l0y9jz3r7f76310cqd0zw";
       };
       packageRequires = [ ];
       meta = {
@@ -5284,10 +5280,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.26.0.0.20250526.213557";
+      version = "0.27.0.0.20250702.171702";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.26.0.0.20250526.213557.tar";
-        sha256 = "1fc895kvacwsimdbir51iy8xiyhxrad6hh8nj3lap07j3xki4107";
+        url = "https://elpa.gnu.org/devel/llm-0.27.0.0.20250702.171702.tar";
+        sha256 = "0mwzbjl83fz2hpzlicnaxnypaxs6cw27cw9756jiwkn6s5vd259p";
       };
       packageRequires = [
         compat
@@ -5417,10 +5413,10 @@
     elpaBuild {
       pname = "logos";
       ename = "logos";
-      version = "1.2.0.0.20240903.93854";
+      version = "1.2.0.0.20250601.73518";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/logos-1.2.0.0.20240903.93854.tar";
-        sha256 = "0vpvqzvxvgnvlrihd4ms3q76270x7my94rcxfskiis3547m8z1pp";
+        url = "https://elpa.gnu.org/devel/logos-1.2.0.0.20250601.73518.tar";
+        sha256 = "0c67ky0zvi26q7hzzhpj2gb9xlw1y7zzg3m94frc8glaibaj5cpl";
       };
       packageRequires = [ ];
       meta = {
@@ -5524,10 +5520,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.0.0.20250527.162947";
+      version = "2.1.0.20250702.61734";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-2.0.0.20250527.162947.tar";
-        sha256 = "1f3h4grgnxdkq0njpq9jfdlk4ljmzjsk324kz54799fj8v2n59qj";
+        url = "https://elpa.gnu.org/devel/marginalia-2.1.0.20250702.61734.tar";
+        sha256 = "14i37m535n0465dqmjsdy9pxmv852ljyw48d36kfyh38daa0mrpd";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5609,10 +5605,10 @@
     elpaBuild {
       pname = "mathsheet";
       ename = "mathsheet";
-      version = "1.1.0.20250513.62537";
+      version = "1.2.0.20250705.223649";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mathsheet-1.1.0.20250513.62537.tar";
-        sha256 = "05fghv85j1fddb8y3frdz61xa2x5srm1fv6d1k030arwqqzq7224";
+        url = "https://elpa.gnu.org/devel/mathsheet-1.2.0.20250705.223649.tar";
+        sha256 = "0a198rd5djvhbldscy5pnl4xifw787amnrla3s7wy6jrr1lqna19";
       };
       packageRequires = [ peg ];
       meta = {
@@ -5630,10 +5626,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "6.3.0.20250530.124947";
+      version = "6.3.0.20250607.211810";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/matlab-mode-6.3.0.20250530.124947.tar";
-        sha256 = "0kbm0y8qn72k01gh1ynz7cm1b59wr0lnq349ky9m6g7m13dc7zbq";
+        url = "https://elpa.gnu.org/devel/matlab-mode-6.3.0.20250607.211810.tar";
+        sha256 = "1pa9llf04ib6lzhf5lp3nf6asjland076bhrqkfp7h551qs7j4zs";
       };
       packageRequires = [ ];
       meta = {
@@ -5651,10 +5647,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.0.0.0.20241025.81140";
+      version = "1.1.0.0.20250707.74133";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mct-1.0.0.0.20241025.81140.tar";
-        sha256 = "121mb4aa0bgwndbvgxh8j9ra52ji7qn5vdrf7whn93rqaaygpk87";
+        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20250707.74133.tar";
+        sha256 = "1nykajgdcl6ash7fpzrsmr8v1qgfq6z3vfpzkacczjgm31hd64vg";
       };
       packageRequires = [ ];
       meta = {
@@ -5823,10 +5819,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.5.4.0.20250523.4704";
+      version = "0.5.4.0.20250619.15440";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/minuet-0.5.4.0.20250523.4704.tar";
-        sha256 = "0r4qajdknkcj9bmgnczxj7zw626aa2cicziy1h294dbmpia02021";
+        url = "https://elpa.gnu.org/devel/minuet-0.5.4.0.20250619.15440.tar";
+        sha256 = "19cr17cjfwsi6xdxqc65i2k2ps6q322756aizr0af99lwngvkzvr";
       };
       packageRequires = [
         dash
@@ -5869,10 +5865,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.7.0.0.20250527.103951";
+      version = "4.8.0.0.20250707.171448";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-4.7.0.0.20250527.103951.tar";
-        sha256 = "1r9jv8w0nb7x56hpgyqarljrpm1zbb5sfgsw0mxv9rfa1wb65zpj";
+        url = "https://elpa.gnu.org/devel/modus-themes-4.8.0.0.20250707.171448.tar";
+        sha256 = "0fkmrfxbdmpkbc6b4g52jgl4cjyadlxq33jnq24d96iib962qkvc";
       };
       packageRequires = [ ];
       meta = {
@@ -6429,10 +6425,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.4.0.20250316.204648";
+      version = "1.4.0.20250705.202309";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/orderless-1.4.0.20250316.204648.tar";
-        sha256 = "1v0rqw8s9zzlbnk6ijc588rp31qlflic9wag8ncv9bkjn150c0sa";
+        url = "https://elpa.gnu.org/devel/orderless-1.4.0.20250705.202309.tar";
+        sha256 = "15c7rangdl36m2zjr6rjjlma33yrjhg6is21agsz452zrpj8mp0f";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6450,10 +6446,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20250529.210300";
+      version = "9.8pre0.20250628.182216";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250529.210300.tar";
-        sha256 = "1nnas0kdnymi6c8m7i683cacimzfjvakmy5c347ayqq9z161jv78";
+        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250628.182216.tar";
+        sha256 = "1sl64n8izkr9q31175ivmqvjhpisqfdva9iv3njbkyx6dvjam849";
       };
       packageRequires = [ ];
       meta = {
@@ -6472,10 +6468,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.1.0.20250528.75549";
+      version = "1.1.0.20250619.32158";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250528.75549.tar";
-        sha256 = "187k9rkqpiw44301ymqsisfrdz6qd5f1d2hk82v4jzvy5jcd2b88";
+        url = "https://elpa.gnu.org/devel/org-contacts-1.1.0.20250619.32158.tar";
+        sha256 = "1lkf67m4c19mgj0pni07y3nvdncwy1xis7ax08m5kbq16i21ay3s";
       };
       packageRequires = [ org ];
       meta = {
@@ -6569,10 +6565,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.8.0.20250526.33139";
+      version = "1.9.0.20250617.112650";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.8.0.20250526.33139.tar";
-        sha256 = "03n21xa0y9hs8fiyfb9zzca402fxck4b13x42sizamns9dxwrh9y";
+        url = "https://elpa.gnu.org/devel/org-modern-1.9.0.20250617.112650.tar";
+        sha256 = "0pqv10bw7k4n9yq6rpxkfaa8ld9kz5gp9xrw2wg06zz63v1c5ydw";
       };
       packageRequires = [
         compat
@@ -6749,10 +6745,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.7.0.20250512.155425";
+      version = "1.7.0.20250617.112655";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-1.7.0.20250512.155425.tar";
-        sha256 = "0x0dxx1zy90lf0bfwhw9va4az6f9z1rlp3j75zd3a1vrh18dh2f4";
+        url = "https://elpa.gnu.org/devel/osm-1.7.0.20250617.112655.tar";
+        sha256 = "1pcii0bks4isjnfdi5k3jlx707g1nfv2sgmmr58h7hsvkc7y6k45";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6940,10 +6936,10 @@
     elpaBuild {
       pname = "perl-doc";
       ename = "perl-doc";
-      version = "0.81.0.20230805.210315";
+      version = "0.82.0.20250606.121940";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/perl-doc-0.81.0.20230805.210315.tar";
-        sha256 = "0n129rcmn827payv0aqg8iz7dc7wg4rm27hvvw1wwj2k5x5vnd6r";
+        url = "https://elpa.gnu.org/devel/perl-doc-0.82.0.20250606.121940.tar";
+        sha256 = "0ymxvkwphqykq7qznxdlmsid4l7946vrll95b92n8f896wn8zlqa";
       };
       packageRequires = [ ];
       meta = {
@@ -6984,10 +6980,10 @@
     elpaBuild {
       pname = "phpinspect";
       ename = "phpinspect";
-      version = "2.1.0.0.20240930.174944";
+      version = "3.0.1.0.20250605.141218";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/phpinspect-2.1.0.0.20240930.174944.tar";
-        sha256 = "04jhw53rjljf1qmha6xv4q9cx3j8r0af0307qlkm262brymqn6kg";
+        url = "https://elpa.gnu.org/devel/phpinspect-3.0.1.0.20250605.141218.tar";
+        sha256 = "0j9c7nzddc7krfan42jh3zlqv469ddq864wiym79n5xvjafalbz1";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7197,10 +7193,10 @@
     elpaBuild {
       pname = "polymode";
       ename = "polymode";
-      version = "0.2.2.0.20250525.212258";
+      version = "0.2.2.0.20250617.103312";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20250525.212258.tar";
-        sha256 = "1p0whbfzcd0fl8yz9id7sinmdyavb905aa826x25gdc9fpmlr01r";
+        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20250617.103312.tar";
+        sha256 = "0qc8gkkb6n059wbpbr3hk57lxsl5h22l1gsf7rvqk55l6dsb1hl0";
       };
       packageRequires = [ ];
       meta = {
@@ -7347,10 +7343,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1.0.20250529.192738";
+      version = "0.11.1.0.20250702.24624";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250529.192738.tar";
-        sha256 = "1p3g2h7yakj8vzffyilsgqifdrv2mdvl8zpqjv2x7dp3ljs79cqn";
+        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250702.24624.tar";
+        sha256 = "1xsdnr7gljjc89x1819r4h2i3ip3bsb7qrpknrdjqy6bzrdigpji";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7483,10 +7479,10 @@
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.30.0.20250505.74536";
+      version = "0.30.0.20250625.165705";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.30.0.20250505.74536.tar";
-        sha256 = "0xcwr1vrcqafc5q9lzi0g3hb7xhv2cqc163mfsbhi7y2a80gylwi";
+        url = "https://elpa.gnu.org/devel/python-0.30.0.20250625.165705.tar";
+        sha256 = "0rpn51f0hb088jsvril0w7igbbxd9cjf07z6cn97p50a4xw77i70";
       };
       packageRequires = [
         compat
@@ -7660,10 +7656,10 @@
     elpaBuild {
       pname = "realgud";
       ename = "realgud";
-      version = "1.5.1.0.20231113.141045";
+      version = "1.5.1.0.20250605.74308";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/realgud-1.5.1.0.20231113.141045.tar";
-        sha256 = "1nvmpbnx31fdi2ps243xx6cnvhmyv9n1kvb98ydnxydmalxs4iva";
+        url = "https://elpa.gnu.org/devel/realgud-1.5.1.0.20250605.74308.tar";
+        sha256 = "187r7zflc4f51jwbms8864j5vwp524g61rqzggjylcrc0zypgbry";
       };
       packageRequires = [
         load-relative
@@ -8558,10 +8554,10 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.6.1.0.20250429.100228";
+      version = "0.7.0.0.20250618.104647";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/spacious-padding-0.6.1.0.20250429.100228.tar";
-        sha256 = "189fqdm0j1mqpjwsl9jp3nqfr6ngn0y49nvraljakc9q6yxs46a3";
+        url = "https://elpa.gnu.org/devel/spacious-padding-0.7.0.0.20250618.104647.tar";
+        sha256 = "0g9zikr4kqkk155kpxiyg79dsjbf4755263msjhnr3088vj4c6sv";
       };
       packageRequires = [ ];
       meta = {
@@ -8754,10 +8750,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "2.2.0.0.20250519.60302";
+      version = "2.2.0.0.20250704.55025";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20250519.60302.tar";
-        sha256 = "170h064wawzm2h4sfrfwrn4zq87p6kmc6blkiprwzz0i4iw30y10";
+        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20250704.55025.tar";
+        sha256 = "14g3dvrkcv5niz70iw942aj2nrcj75azn265w7sinsf1jsny6xi1";
       };
       packageRequires = [ ];
       meta = {
@@ -9127,10 +9123,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.4.0.20250512.155414";
+      version = "1.5.0.20250620.115731";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.4.0.20250512.155414.tar";
-        sha256 = "173jl07yiv0kbb3gdci98dy08acaylmm564i4rgsrl4nyv32ad67";
+        url = "https://elpa.gnu.org/devel/tempel-1.5.0.20250620.115731.tar";
+        sha256 = "0rhgwzl9zlxjgg8vc7qlgavfpa40qhrwljpdvn2nfybhc1r28rvg";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9276,10 +9272,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.1.0.0.20250426.50246";
+      version = "1.1.0.0.20250616.63541";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tmr-1.1.0.0.20250426.50246.tar";
-        sha256 = "01ya6w9fhrj6jmhnkhaxck1a7z9vq1zgm5fq4vv8hs3xbmidzpsv";
+        url = "https://elpa.gnu.org/devel/tmr-1.1.0.0.20250616.63541.tar";
+        sha256 = "0lizpxy6v1947y5cvg1qqb3whmmvay5mv6q3k1gf7hpgfmfz3xs0";
       };
       packageRequires = [ ];
       meta = {
@@ -9365,10 +9361,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.2.4.0.20250530.70623";
+      version = "2.8.0.0.20250629.74034";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.7.2.4.0.20250530.70623.tar";
-        sha256 = "10vhj25haax1gj45cka8678i81lygr7v122j9wm7f3qcvxk68snb";
+        url = "https://elpa.gnu.org/devel/tramp-2.8.0.0.20250629.74034.tar";
+        sha256 = "0h9vxgwvm5nzjpa8hnq3bxinjsc1f3chql68y3qi0x7ll77g1r2v";
       };
       packageRequires = [ ];
       meta = {
@@ -9451,10 +9447,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.8.8.0.20250520.104007";
+      version = "0.9.3.0.20250701.122332";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.8.8.0.20250520.104007.tar";
-        sha256 = "1v5f6y6gmgj9x0ay4zs89818gav6rjfn5ifywmb5qkilsqzjfhxh";
+        url = "https://elpa.gnu.org/devel/transient-0.9.3.0.20250701.122332.tar";
+        sha256 = "1h8iv5ccmc2j3my97rsbn0b12rp8w0jrhvkkhz6w9pvp0braxlh6";
       };
       packageRequires = [
         compat
@@ -9475,10 +9471,10 @@
     elpaBuild {
       pname = "transient-cycles";
       ename = "transient-cycles";
-      version = "1.1.0.20250225.93512";
+      version = "2.0.0.20250625.85410";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-cycles-1.1.0.20250225.93512.tar";
-        sha256 = "1j6w8zy39h744wps9dgc05l7zrk7pg6vwx91rh7kvzrj6m8hmwds";
+        url = "https://elpa.gnu.org/devel/transient-cycles-2.0.0.20250625.85410.tar";
+        sha256 = "1782gr8hwidfxilggb83s2v9wzkvyhcxbv3nj8f4aylhcdahfzf8";
       };
       packageRequires = [ ];
       meta = {
@@ -9674,10 +9670,10 @@
     elpaBuild {
       pname = "urgrep";
       ename = "urgrep";
-      version = "0.5.2snapshot0.20250315.173144";
+      version = "0.5.3snapshot0.20250701.205050";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/urgrep-0.5.2snapshot0.20250315.173144.tar";
-        sha256 = "18rnj1dm8551sqkqjfq9485v455n97ixivbnds6lmwxaafrr8yxr";
+        url = "https://elpa.gnu.org/devel/urgrep-0.5.3snapshot0.20250701.205050.tar";
+        sha256 = "0anv784nnm0z6bnq5l59kdv4w0qy1q6kwxg3ahnq83ls3nl7sqpy";
       };
       packageRequires = [
         compat
@@ -9699,10 +9695,10 @@
     elpaBuild {
       pname = "url-http-ntlm";
       ename = "url-http-ntlm";
-      version = "2.0.5.0.20250314.123040";
+      version = "2.0.6.0.20250626.205101";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/url-http-ntlm-2.0.5.0.20250314.123040.tar";
-        sha256 = "0wqx83prdprlyjs7rvrxhf1kz6pzsmhiin0kqp74dsn407zq4g34";
+        url = "https://elpa.gnu.org/devel/url-http-ntlm-2.0.6.0.20250626.205101.tar";
+        sha256 = "05zx6vyqh2jkipl4srnp01agxrjy0lzvgsjbisnjk56nx4lhnfs3";
       };
       packageRequires = [ ntlm ];
       meta = {
@@ -9720,10 +9716,10 @@
     elpaBuild {
       pname = "url-http-oauth";
       ename = "url-http-oauth";
-      version = "0.8.3.0.20250314.122034";
+      version = "0.8.4.0.20250626.204641";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/url-http-oauth-0.8.3.0.20250314.122034.tar";
-        sha256 = "0f2ih3827r02alggi0hz6f9fyak2acc04x6gjahjmf65vy51rpbi";
+        url = "https://elpa.gnu.org/devel/url-http-oauth-0.8.4.0.20250626.204641.tar";
+        sha256 = "1krqpp8zvc79xqb8jn9pq9scxrv8cj8bim53nspr67v0z21y3wzc";
       };
       packageRequires = [ ];
       meta = {
@@ -9896,10 +9892,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.2.0.20250430.120738";
+      version = "0.3.0.20250707.95759";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-jj-0.2.0.20250430.120738.tar";
-        sha256 = "0gmqilpaaalg5sgdd7hcwgwz64k29v0a22zg14492bn7906zr1fs";
+        url = "https://elpa.gnu.org/devel/vc-jj-0.3.0.20250707.95759.tar";
+        sha256 = "0rblsz2ga0csc86mq276hqfxrc7dj3gnh1xlk0sfqbqyc39yx293";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10003,10 +9999,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.2.0.20250527.181301";
+      version = "2.4.0.20250702.140354";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-2.2.0.20250527.181301.tar";
-        sha256 = "1innhh4w5623d86b1y9a1llc0h240jvnfx4661yqgh62d7v47h94";
+        url = "https://elpa.gnu.org/devel/vertico-2.4.0.20250702.140354.tar";
+        sha256 = "0xr2kc9b82xng17m7lavjddaj4sy6ngq3dbzlffssrh6v5bn3lii";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10134,10 +10130,10 @@
     elpaBuild {
       pname = "vundo";
       ename = "vundo";
-      version = "2.4.0.0.20250417.151603";
+      version = "2.4.0.0.20250617.174826";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vundo-2.4.0.0.20250417.151603.tar";
-        sha256 = "0rcplghs9pxjpkr658phkp3dfyzxrmjavqwz66i2jzc9lnpfq6rl";
+        url = "https://elpa.gnu.org/devel/vundo-2.4.0.0.20250617.174826.tar";
+        sha256 = "17pshwr9drw113az1mbw9val2lpf0cafgh8g7cpspzkph5x9149q";
       };
       packageRequires = [ ];
       meta = {
@@ -10501,10 +10497,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.20.0.20250426.232241";
+      version = "0.21.0.20250706.151817";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xelb-0.20.0.20250426.232241.tar";
-        sha256 = "19w0k5kn7g2254l2hvrs9m368s3rkbxkl9ymdlcilcnzs8z91c66";
+        url = "https://elpa.gnu.org/devel/xelb-0.21.0.20250706.151817.tar";
+        sha256 = "0lg5iwxa9h2m2bfzm2crvsv2lar86hligvynvrxdkcig07hg6qkh";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10633,10 +10629,10 @@
     elpaBuild {
       pname = "yasnippet";
       ename = "yasnippet";
-      version = "0.14.2.0.20250403.152613";
+      version = "0.14.3.0.20250604.12916";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/yasnippet-0.14.2.0.20250403.152613.tar";
-        sha256 = "0lsd7j5g3fk0gbk5qjr3vrwffyy56pf6hzgkqcsjz7jps0s8jw2v";
+        url = "https://elpa.gnu.org/devel/yasnippet-0.14.3.0.20250604.12916.tar";
+        sha256 = "0dx89kw6pvbj8dhf0cza660zcpd2las9add9dm5ak6x6x56sw3s8";
       };
       packageRequires = [ cl-lib ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-packages.nix
@@ -58,6 +58,8 @@ let
       commonOverrides = import ./elpa-common-overrides.nix pkgs lib buildPackages;
 
       overrides = self: super: {
+        # keep-sorted start block=yes newline_separated=yes
+        # keep-sorted end
       };
 
       elpaDevelPackages =

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -719,10 +719,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.3.0";
+      version = "1.4.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/beframe-1.3.0.tar";
-        sha256 = "0dvlnshxq0h0vqddyf2g91a144f2sdg58zmchm5iiv7p2mg07ya2";
+        url = "https://elpa.gnu.org/packages/beframe-1.4.0.tar";
+        sha256 = "1766y7jwhsccmndd30v7hyh3i8gacvzwb73ix7g0zynp12m6x6kb";
       };
       packageRequires = [ ];
       meta = {
@@ -1462,10 +1462,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.1.0.0";
+      version = "30.1.0.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/compat-30.1.0.0.tar";
-        sha256 = "1wmq4sj3kkb4shvsi8djrk9znjxj20lm4v389jyn18q55gqigq6b";
+        url = "https://elpa.gnu.org/packages/compat-30.1.0.1.tar";
+        sha256 = "1rj5i709i0l7drr7f571gsk8d6b5slwrd2l9flayv63kwk1gizhn";
       };
       packageRequires = [ seq ];
       meta = {
@@ -1526,10 +1526,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "2.4";
+      version = "2.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-2.4.tar";
-        sha256 = "1jiqgh0f9dnh954hf3vql6l2crfarfnfc9bg7nvisqi3wywd35mf";
+        url = "https://elpa.gnu.org/packages/consult-2.6.tar";
+        sha256 = "1afji70i64w027r265ry8s21v4fic087lmfch7qvwdcjzj165pl4";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1639,10 +1639,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.2";
+      version = "2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/corfu-2.2.tar";
-        sha256 = "17armdh7369fyvxjbj7sv6vawy6mw72vsw4sqf21ra7q2m3h2vca";
+        url = "https://elpa.gnu.org/packages/corfu-2.3.tar";
+        sha256 = "1q86z90hbizvihnvpfn81vv2cd67jlwhp4w0cz1mr4fl1bnqq5g4";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2187,10 +2187,10 @@
     elpaBuild {
       pname = "denote-silo";
       ename = "denote-silo";
-      version = "0.1.1";
+      version = "0.1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/denote-silo-0.1.1.tar";
-        sha256 = "1jxr52npjiwisambwav6rasndjdxhll8x278q8cr7giq71am7c8b";
+        url = "https://elpa.gnu.org/packages/denote-silo-0.1.2.tar";
+        sha256 = "1z5afwd9gwn9fy132s87smffi5lgdk8f8c941y9ak6q7fbbpkya7";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2272,10 +2272,10 @@
     elpaBuild {
       pname = "dicom";
       ename = "dicom";
-      version = "0.5";
+      version = "0.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dicom-0.5.tar";
-        sha256 = "1qz4zhq0fcfl7l42qib60j2dzm1vp2vmwfhm48s0ia6dgdkvad3x";
+        url = "https://elpa.gnu.org/packages/dicom-0.6.tar";
+        sha256 = "0z548wa0hxj6z6vh7pwps4gsgrgh6p3g57j703777d5g75jb3j3m";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2618,10 +2618,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.1.0";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/doric-themes-0.1.0.tar";
-        sha256 = "12aj50hs7yydr40fj5wlzc8k7a1r2pl6r6gsmd5629bmhd8albmr";
+        url = "https://elpa.gnu.org/packages/doric-themes-0.2.0.tar";
+        sha256 = "1h4v5aqsigr9vk3rirsgpfw0py8cp5y7dpvx8ph2ia7wk8nw8zz3";
       };
       packageRequires = [ ];
       meta = {
@@ -2820,10 +2820,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20250216";
+      version = "20250607";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eev-20250216.tar";
-        sha256 = "07bxywrcb8w379nzn8yi307lafb3b7qv8r362mx9vv0w8fmv8r6b";
+        url = "https://elpa.gnu.org/packages/eev-20250607.tar";
+        sha256 = "0rrm6mldhmf0ijjr8nri9a6sasxknd8wivq2fkni60c47m65m2md";
       };
       packageRequires = [ ];
       meta = {
@@ -2902,10 +2902,10 @@
     elpaBuild {
       pname = "el-job";
       ename = "el-job";
-      version = "2.4.7";
+      version = "2.4.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/el-job-2.4.7.tar";
-        sha256 = "0gh4vwq986jhfld0cibxmy5zcngzq4mxw4j4rpsv8nhwg0wpr84j";
+        url = "https://elpa.gnu.org/packages/el-job-2.4.8.tar";
+        sha256 = "1g7kmsxq2hdsfl2glm9yaqhqx87kl4amg5wi3872kjlbrwfd78kk";
       };
       packageRequires = [ ];
       meta = {
@@ -3332,12 +3332,10 @@
   ) { };
   excorporate = callPackage (
     {
-      cl-lib ? null,
       elpaBuild,
       fetchurl,
       fsm,
       lib,
-      nadvice,
       soap-client,
       url-http-ntlm,
       url-http-oauth,
@@ -3345,15 +3343,13 @@
     elpaBuild {
       pname = "excorporate";
       ename = "excorporate";
-      version = "1.1.2";
+      version = "1.1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/excorporate-1.1.2.tar";
-        sha256 = "111wvkn0ks7syfgf1cydq5s0kymha0j280xvnp09zcfbj706yhbw";
+        url = "https://elpa.gnu.org/packages/excorporate-1.1.3.tar";
+        sha256 = "09szsql8qyca6hn7fib832fzi9fmcsf9wiacgqdw32lfjqv5fjwk";
       };
       packageRequires = [
-        cl-lib
         fsm
-        nadvice
         soap-client
         url-http-ntlm
         url-http-oauth
@@ -3438,10 +3434,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.33";
+      version = "0.34";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/exwm-0.33.tar";
-        sha256 = "13wywayvdxpr2z14lri3ggni1wj20r452a0gxnx0cpgif3c1l2sx";
+        url = "https://elpa.gnu.org/packages/exwm-0.34.tar";
+        sha256 = "1hp2ni9c6bn627275x37n6zhcismvni6vqp7cpdn3cx292n7sx6z";
       };
       packageRequires = [
         compat
@@ -3505,10 +3501,10 @@
     elpaBuild {
       pname = "filechooser";
       ename = "filechooser";
-      version = "0.2.2";
+      version = "0.2.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/filechooser-0.2.2.tar";
-        sha256 = "1y1f6nihay2xbnywki39kp01x20pmg41jl2r0qhw7s31q4qaxyrv";
+        url = "https://elpa.gnu.org/packages/filechooser-0.2.3.tar";
+        sha256 = "17dqms6knc0l47m02581jlm7ikcs662nmxdnsklipnnn0gfjmkmm";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4149,10 +4145,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.12.6";
+      version = "0.12.7";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/greader-0.12.6.tar";
-        sha256 = "0xv814p7cdf2wj7qdj9cpz3blnkcd8b6sjk2jajym5hilmr9a9b5";
+        url = "https://elpa.gnu.org/packages/greader-0.12.7.tar";
+        sha256 = "05i6fmfs9lvffhm54lkw97x7vxlw7x30ka6xrpxh827qml3m7z3q";
       };
       packageRequires = [
         compat
@@ -4173,10 +4169,10 @@
     elpaBuild {
       pname = "greenbar";
       ename = "greenbar";
-      version = "1.1";
+      version = "1.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/greenbar-1.1.tar";
-        sha256 = "14azd170xq602fy4mcc770x5063rvpms8ilbzzn8kwyfvmijlbbx";
+        url = "https://elpa.gnu.org/packages/greenbar-1.2.tar";
+        sha256 = "0w85b3gnckdiv32ki4kkwhgxc1m9ks7hayk87iapbzayqzvlqj3v";
       };
       packageRequires = [ ];
       meta = {
@@ -4194,10 +4190,10 @@
     elpaBuild {
       pname = "gtags-mode";
       ename = "gtags-mode";
-      version = "1.8.6";
+      version = "1.9.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/gtags-mode-1.8.6.tar";
-        sha256 = "0kmqndl7h6q4k7ziasfp4pi1lnskr394qia1msxsbz1cqcay1cqh";
+        url = "https://elpa.gnu.org/packages/gtags-mode-1.9.3.tar";
+        sha256 = "1cvmb6pnn4wpqna2h0a19m5yilh1jrzah61xzspwrdv2djf8zrlb";
       };
       packageRequires = [ ];
       meta = {
@@ -4479,10 +4475,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "0.8.4";
+      version = "0.9.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/indent-bars-0.8.4.tar";
-        sha256 = "0k674rzl32zzqgkix6924987rb09bs7f3blakqybvzi59cpz9afz";
+        url = "https://elpa.gnu.org/packages/indent-bars-0.9.1.tar";
+        sha256 = "1jb0jhfin728ld703y392gy99is7jywqak3z2xrrvpmn9q17q8vs";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4985,10 +4981,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.4.3";
+      version = "0.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/kubed-0.4.3.tar";
-        sha256 = "0aa4fwdprcmccmrsqnrvvhdzv01wjsvx29lnqw17hakyy5gkrgns";
+        url = "https://elpa.gnu.org/packages/kubed-0.5.0.tar";
+        sha256 = "00j0yx7bknjdl6mcfimlwp7plxgn7al3fl4rfxw7s4pgqgyyslsw";
       };
       packageRequires = [ ];
       meta = {
@@ -5244,10 +5240,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.26.0";
+      version = "0.27.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.26.0.tar";
-        sha256 = "0ihfppwqwxkmv63irca3r0wkp3vsf5imk8gk222vi1dviyqx5q0x";
+        url = "https://elpa.gnu.org/packages/llm-0.27.0.tar";
+        sha256 = "1vxhlkq05im6h1jjg4bs077iw0qw8spg2lz3n3k783zanfrifzi6";
       };
       packageRequires = [
         compat
@@ -5482,10 +5478,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.0";
+      version = "2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/marginalia-2.0.tar";
-        sha256 = "1qklwzz0swd96vdqymbm91y6h53id6ch1lr1dpdwmz6qknwamrlc";
+        url = "https://elpa.gnu.org/packages/marginalia-2.1.tar";
+        sha256 = "0yg2v8pjccfdrlyabn8kih3hf7dkksirgc9g7a83m2zbkrbhimms";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5557,6 +5553,28 @@
       };
     }
   ) { };
+  mathsheet = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+      peg,
+    }:
+    elpaBuild {
+      pname = "mathsheet";
+      ename = "mathsheet";
+      version = "1.2";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/mathsheet-1.2.tar";
+        sha256 = "1wx67cnpxlqnpr3bsdnw4ccsg2fgjazcdbddbkr6r69pdbrp6m3g";
+      };
+      packageRequires = [ peg ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/mathsheet.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   matlab-mode = callPackage (
     {
       elpaBuild,
@@ -5587,10 +5605,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/mct-1.0.0.tar";
-        sha256 = "0f8znz4basrdh56pcldsazxv3mwqir807lsaza2g5bfqws0c7h8k";
+        url = "https://elpa.gnu.org/packages/mct-1.1.0.tar";
+        sha256 = "0kv0j37bdsmc2jv7adpx5m48cp4h0kvjq2jfwv7d8nzpk5kk2d2p";
       };
       packageRequires = [ ];
       meta = {
@@ -5805,10 +5823,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.7.0";
+      version = "4.8.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/modus-themes-4.7.0.tar";
-        sha256 = "1p0lfcc897dxf9f3ylnym1ird4j90sgy2i34yvmbr22ii2pc47sw";
+        url = "https://elpa.gnu.org/packages/modus-themes-4.8.0.tar";
+        sha256 = "15d8ld7gf3c15i409pmp8pnv3b9bgy0r5xbb1bicga7knyqqaj6c";
       };
       packageRequires = [ ];
       meta = {
@@ -6383,10 +6401,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.7.30";
+      version = "9.7.31";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.7.30.tar";
-        sha256 = "1886c5aw050iwqh7k3grp73ghdr70y20nfbpxgcwbzwkhkz2w9xy";
+        url = "https://elpa.gnu.org/packages/org-9.7.31.tar";
+        sha256 = "13fxckj4pw4cwjqgz4fbw680jfypfqq8rc4hir26halsxz8lvi2m";
       };
       packageRequires = [ ];
       meta = {
@@ -6502,10 +6520,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.8";
+      version = "1.9";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-modern-1.8.tar";
-        sha256 = "0ibn6xwssg2llb6hgpbg0p62995skc6g1g469cr58wlb6xb2qxvl";
+        url = "https://elpa.gnu.org/packages/org-modern-1.9.tar";
+        sha256 = "09lgmng1g6l29alnwmxqk2qq0gx2vv5nrrmrxdzlrknkd8f07nl1";
       };
       packageRequires = [
         compat
@@ -6873,10 +6891,10 @@
     elpaBuild {
       pname = "perl-doc";
       ename = "perl-doc";
-      version = "0.81";
+      version = "0.82";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/perl-doc-0.81.tar";
-        sha256 = "1828jfl5dwk1751jsrpr2gr8hs1x315xlb9vhiis8frzvqmsribw";
+        url = "https://elpa.gnu.org/packages/perl-doc-0.82.tar";
+        sha256 = "1fj13361a9pgmlda8yix0p805r2gwzv1gxf43pq6y79a8hxbm8yn";
       };
       packageRequires = [ ];
       meta = {
@@ -6916,10 +6934,10 @@
     elpaBuild {
       pname = "phpinspect";
       ename = "phpinspect";
-      version = "2.1.0";
+      version = "3.0.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/phpinspect-2.1.0.tar";
-        sha256 = "1ic5dnp2sgahzpfxxgkfbk5as91l23vs1ly23b1igi3b4ajcaqjz";
+        url = "https://elpa.gnu.org/packages/phpinspect-3.0.1.tar";
+        sha256 = "138ipsmhhycm50a37kcx780j995xm0l2icrn2cjiw955fjf96rv7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -8426,10 +8444,10 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.6.1";
+      version = "0.7.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/spacious-padding-0.6.1.tar";
-        sha256 = "0g5f8hagv494773mdzaajmccjzzqgd2ixv2rmwwhjgwck910zwqg";
+        url = "https://elpa.gnu.org/packages/spacious-padding-0.7.0.tar";
+        sha256 = "0kzqg5nddwc061q44zzlhv1kniivda17khz94wdbpb1x2z9ym147";
       };
       packageRequires = [ ];
       meta = {
@@ -8949,10 +8967,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.4";
+      version = "1.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tempel-1.4.tar";
-        sha256 = "0gh573np15wdy7vd0zj92ivslaga7kalmnkdjlfiw5pamyy5xsl4";
+        url = "https://elpa.gnu.org/packages/tempel-1.5.tar";
+        sha256 = "14q5sn2xvxpy96qyk3w6r8y39ysz3xkxklly00zarfvkcdcdbw1x";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9187,10 +9205,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.2.4";
+      version = "2.8.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.7.2.4.tar";
-        sha256 = "0crlnb421z99vnbvzbq63cqhfy62q96j45qhrzx2v3kajijv77ha";
+        url = "https://elpa.gnu.org/packages/tramp-2.8.0.tar";
+        sha256 = "1sfrxd10q80j0f27dwxc594s6rflnnq97lgl45kgvwfwfwffwvn7";
       };
       packageRequires = [ ];
       meta = {
@@ -9273,10 +9291,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.8.8";
+      version = "0.9.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.8.8.tar";
-        sha256 = "0rirggilwk42ha9lykfca6ma4l1pn0wwkvdh2njviaksidy7jasi";
+        url = "https://elpa.gnu.org/packages/transient-0.9.3.tar";
+        sha256 = "0rbh2m2lpcn5xvaw1wn0rzc3xyq6pgja9k1a5601sl4pbs60cx4d";
       };
       packageRequires = [
         compat
@@ -9297,10 +9315,10 @@
     elpaBuild {
       pname = "transient-cycles";
       ename = "transient-cycles";
-      version = "1.1";
+      version = "2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-cycles-1.1.tar";
-        sha256 = "0y19kns3xfppyhriyapam3m134yvm9idylmsj12s9g9zva0sal45";
+        url = "https://elpa.gnu.org/packages/transient-cycles-2.0.tar";
+        sha256 = "0cq2k77rgbw3fx84a2d33nbb75wqxynrc1mx4gb32a9ysm0sa4s3";
       };
       packageRequires = [ ];
       meta = {
@@ -9496,10 +9514,10 @@
     elpaBuild {
       pname = "urgrep";
       ename = "urgrep";
-      version = "0.5.1";
+      version = "0.5.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/urgrep-0.5.1.tar";
-        sha256 = "1g0gcd3ayqjaj5yl95psh8qnjgaxd6l4r8gn4wlj5pnjnkz4llmv";
+        url = "https://elpa.gnu.org/packages/urgrep-0.5.2.tar";
+        sha256 = "1lwr601xyw0gcix6v53dn5h0jsxwpa5pkqgz56a6311z9d9qlj3c";
       };
       packageRequires = [
         compat
@@ -9513,26 +9531,20 @@
   ) { };
   url-http-ntlm = callPackage (
     {
-      cl-lib ? null,
       elpaBuild,
       fetchurl,
       lib,
-      nadvice,
       ntlm ? null,
     }:
     elpaBuild {
       pname = "url-http-ntlm";
       ename = "url-http-ntlm";
-      version = "2.0.5";
+      version = "2.0.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/url-http-ntlm-2.0.5.tar";
-        sha256 = "02b65z70kw37mzj2hh8q6z0zhhacf9sc4hlczpfxdfsy05b8yri9";
+        url = "https://elpa.gnu.org/packages/url-http-ntlm-2.0.6.tar";
+        sha256 = "06bfw1w128gg9b60pb3wcpcib33jf13y1niyhs6grhm7yq11waz2";
       };
-      packageRequires = [
-        cl-lib
-        nadvice
-        ntlm
-      ];
+      packageRequires = [ ntlm ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/url-http-ntlm.html";
         license = lib.licenses.free;
@@ -9548,10 +9560,10 @@
     elpaBuild {
       pname = "url-http-oauth";
       ename = "url-http-oauth";
-      version = "0.8.3";
+      version = "0.8.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/url-http-oauth-0.8.3.tar";
-        sha256 = "06lpzh8kpxn8cr92blxrjw44h2cfc6fw0pr024sign4acczx10ws";
+        url = "https://elpa.gnu.org/packages/url-http-oauth-0.8.4.tar";
+        sha256 = "10iznck31ilfjwjbbwfalqchg260yqypai487436cc0s1fm47vvf";
       };
       packageRequires = [ ];
       meta = {
@@ -9723,10 +9735,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.2";
+      version = "0.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vc-jj-0.2.tar";
-        sha256 = "19yhv1jgix49pvclf42xx23fh2zbr32q51664a99dncn8jhy7bdy";
+        url = "https://elpa.gnu.org/packages/vc-jj-0.3.tar";
+        sha256 = "1pikbl7i7cqwdqq01bm1rlcd1d9736bqa42g6dz2zxlavi7cbq6n";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9830,10 +9842,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.2";
+      version = "2.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-2.2.tar";
-        sha256 = "1mb2j32wkcv7j310xwhf9pjddf0b85ffna84ywbbnyn9x1xb8qyf";
+        url = "https://elpa.gnu.org/packages/vertico-2.4.tar";
+        sha256 = "1jxsxkmy80iba77iamrx4ybwg2phmxvsb5ab008iwz6rymjv60jv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10327,10 +10339,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.20";
+      version = "0.21";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/xelb-0.20.tar";
-        sha256 = "12ikrnvik1n1fdc6ixx53d0z84v269wi463380k0i5zb6q8ncwpk";
+        url = "https://elpa.gnu.org/packages/xelb-0.21.tar";
+        sha256 = "0fmms4dy5b9l6qlf246p61v3k8szm7qhl60lf84wc0xpa6ah2698";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10459,10 +10471,10 @@
     elpaBuild {
       pname = "yasnippet";
       ename = "yasnippet";
-      version = "0.14.2";
+      version = "0.14.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/yasnippet-0.14.2.tar";
-        sha256 = "0cq31r58vxh660bws26yhpnjz89yr5f2ldjw1q5a1gp3hbzd2130";
+        url = "https://elpa.gnu.org/packages/yasnippet-0.14.3.tar";
+        sha256 = "1c0zhdcqz0jrx2swbqwschnwb07wy4s2gld3x6b4b892psxc2cg8";
       };
       packageRequires = [ cl-lib ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -58,14 +58,16 @@ let
       commonOverrides = import ./elpa-common-overrides.nix pkgs lib buildPackages;
 
       overrides = self: super: {
+        # keep-sorted start block=yes newline_separated=yes
         # upstream issue: Wrong type argument: arrayp, nil
         org-transclusion =
           if super.org-transclusion.version == "1.2.0" then
             markBroken super.org-transclusion
           else
             super.org-transclusion;
-        rcirc-menu = markBroken super.rcirc-menu; # Missing file header
 
+        rcirc-menu = markBroken super.rcirc-menu; # Missing file header
+        # keep-sorted end
       };
 
       elpaPackages =

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-packages.nix
@@ -30,6 +30,7 @@ self:
 let
 
   inherit (import ./lib-override-helper.nix pkgs lib)
+    ignoreCompilationError
     markBroken
     ;
 
@@ -67,6 +68,8 @@ let
             super.org-transclusion;
 
         rcirc-menu = markBroken super.rcirc-menu; # Missing file header
+
+        vc-jj = ignoreCompilationError super.vc-jj; # native-ice
         # keep-sorted end
       };
 

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/el-easydraw/package.nix
@@ -21,9 +21,6 @@ melpaBuild {
 
   files = ''(:defaults "msg")'';
 
-  # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=76573
-  ignoreCompilationError = true;
-
   passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
   meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -851,9 +851,6 @@ let
           # Optimizer error: too much on the stack
           ack-menu = ignoreCompilationError super.ack-menu;
 
-          # https://github.com/skeeto/emacs-aio/issues/31
-          aio = ignoreCompilationError super.aio;
-
           # https://github.com/gongo/airplay-el/issues/2
           airplay = addPackageRequires super.airplay [ self.request-deferred ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1280,6 +1280,8 @@ let
           # TODO report to upstream
           global-tags = addPackageRequires super.global-tags [ self.s ];
 
+          gnosis = mkHome super.gnosis;
+
           go = ignoreCompilationError super.go; # elisp error
 
           graphene = ignoreCompilationError super.graphene; # elisp error

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1277,6 +1277,9 @@ let
           # https://github.com/nlamirault/emacs-gitlab/issues/68
           gitlab = addPackageRequires super.gitlab [ self.f ];
 
+          # https://github.com/TxGVNN/gitlab-pipeline/issues/8
+          gitlab-pipeline = addPackageRequires super.gitlab-pipeline [ self.glab ];
+
           # TODO report to upstream
           global-tags = addPackageRequires super.global-tags [ self.s ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1454,6 +1454,9 @@ let
             self.flycheck
           ];
 
+          # https://gitlab.com/arvidnl/magit-gitlab/-/issues/8
+          magit-gitlab = addPackageRequires super.magit-gitlab [ self.glab ];
+
           # missing optional dependencies
           magnatune = addPackageRequires super.magnatune [ self.helm ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1284,6 +1284,9 @@ let
 
           graphene = ignoreCompilationError super.graphene; # elisp error
 
+          # https://github.com/ppareit/graphviz-dot-mode/issues/85
+          graphviz-dot-mode = addPackageRequires super.graphviz-dot-mode [ self.flycheck ];
+
           greader = ignoreCompilationError super.greader; # elisp error
 
           # TODO report to upstream

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -1274,6 +1274,9 @@ let
 
           gh-notify = buildWithGit super.gh-notify;
 
+          # https://gitlab.com/emacs-stuff/git-commit-insert-issue/-/issues/24
+          git-commit-insert-issue = addPackageRequires super.git-commit-insert-issue [ self.glab ];
+
           # https://github.com/nlamirault/emacs-gitlab/issues/68
           gitlab = addPackageRequires super.gitlab [ self.f ];
 

--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -828,8 +828,11 @@ let
             else
               super.osx-dictionary;
 
+          # keep-sorted start block=yes newline_separated=yes
           # https://github.com/skeeto/at-el/issues/9
           "@" = ignoreCompilationErrorIfOlder super."@" "20240923.1318";
+
+          "git-gutter-fringe+" = ignoreCompilationError super."git-gutter-fringe+"; # elisp error
 
           abgaben = addPackageRequires (mkHome super.abgaben) [ self.mu4e ];
 
@@ -882,13 +885,13 @@ let
 
           auctex-latexmk = mkHome super.auctex-latexmk;
 
-          auto-indent-mode = ignoreCompilationError super.auto-indent-mode; # elisp error
-
           # missing optional dependencies
           auto-complete-auctex = addPackageRequires (mkHome super.auto-complete-auctex) [ self.auctex ];
 
           # depends on distel which is not on any ELPA https://github.com/massemanet/distel/issues/21
           auto-complete-distel = ignoreCompilationError super.auto-complete-distel;
+
+          auto-indent-mode = ignoreCompilationError super.auto-indent-mode; # elisp error
 
           auto-virtualenv = super.auto-virtualenv.overrideAttrs (
             finalAttrs: previousAttrs: {
@@ -1147,6 +1150,8 @@ let
           # missing optional dependencies
           ekg = addPackageRequires super.ekg [ self.denote ];
 
+          el-secretario-mu4e = addPackageRequires super.el-secretario-mu4e [ self.mu4e ];
+
           elfeed = super.elfeed.overrideAttrs (attrs: {
             postPatch =
               attrs.postPatch or ""
@@ -1170,16 +1175,15 @@ let
             ];
           });
 
-          el-secretario-mu4e = addPackageRequires super.el-secretario-mu4e [ self.mu4e ];
-
           embark-vc = buildWithGit super.embark-vc;
 
           # https://github.com/nubank/emidje/issues/23
           emidje = addPackageRequires super.emidje [ self.pkg-info ];
 
+          emms-player-mpv-jp-radios = ignoreCompilationError super.emms-player-mpv-jp-radios;
+
           # depends on later-do which is not on any ELPA
           emms-player-simple-mpv = ignoreCompilationError super.emms-player-simple-mpv;
-          emms-player-mpv-jp-radios = ignoreCompilationError super.emms-player-mpv-jp-radios;
 
           # missing optional dependencies
           # https://github.com/isamert/empv.el/pull/96
@@ -1273,8 +1277,6 @@ let
 
           gh-notify = buildWithGit super.gh-notify;
 
-          "git-gutter-fringe+" = ignoreCompilationError super."git-gutter-fringe+"; # elisp error
-
           # https://github.com/nlamirault/emacs-gitlab/issues/68
           gitlab = addPackageRequires super.gitlab [ self.f ];
 
@@ -1310,6 +1312,9 @@ let
 
           helm-ext = ignoreCompilationError super.helm-ext; # elisp error
 
+          # TODO report to upstream
+          helm-flycheck = fixRequireHelmCore super.helm-flycheck;
+
           # https://github.com/iory/emacs-helm-ghs/issues/1
           helm-ghs = addPackageRequires super.helm-ghs [ self.helm-ghq ];
 
@@ -1318,9 +1323,6 @@ let
             self.helm
             self.magit
           ];
-
-          # TODO report to upstream
-          helm-flycheck = fixRequireHelmCore super.helm-flycheck;
 
           # https://github.com/yasuyk/helm-git-grep/issues/54
           helm-git-grep = addPackageRequires super.helm-git-grep [ self.helm ];
@@ -1547,28 +1549,14 @@ let
 
           org-gtd = ignoreCompilationError super.org-gtd; # elisp error
 
+          # TODO report to upstream
+          org-kindle = addPackageRequires super.org-kindle [ self.dash ];
+
           # needs newer org than the Emacs 29.4 builtin one
           org-link-beautify = addPackageRequires super.org-link-beautify [
             self.org
             self.qrencode
           ];
-
-          # TODO report to upstream
-          org-kindle = addPackageRequires super.org-kindle [ self.dash ];
-
-          org-special-block-extras = ignoreCompilationError super.org-special-block-extras; # elisp error
-
-          # https://github.com/ichernyshovvv/org-timeblock/issues/65
-          org-timeblock = markBroken super.org-timeblock;
-
-          org-trello = ignoreCompilationError super.org-trello; # elisp error
-
-          # Requires xwidgets compiled into emacs, so mark this package
-          # as broken if emacs hasn't been compiled with the flag.
-          org-xlatex = if self.emacs.withXwidgets then super.org-xlatex else markBroken super.org-xlatex;
-
-          # Optimizer error: too much on the stack
-          orgnav = ignoreCompilationError super.orgnav;
 
           org-noter = super.org-noter.overrideAttrs (
             finalAttrs: previousAttrs: {
@@ -1589,15 +1577,6 @@ let
 
           org-noter-pdftools = mkHome super.org-noter-pdftools;
 
-          # elisp error and missing optional dependencies
-          org-ref = ignoreCompilationError super.org-ref;
-
-          # missing optional dependencies
-          org-roam-bibtex = addPackageRequires super.org-roam-bibtex [
-            self.helm-bibtex
-            self.ivy-bibtex
-          ];
-
           org-pdftools = mkHome super.org-pdftools;
 
           org-projectile = super.org-projectile.overrideAttrs (
@@ -1616,6 +1595,29 @@ let
 
           # https://github.com/colonelpanic8/org-project-capture/issues/66
           org-projectile-helm = addPackageRequires super.org-projectile-helm [ self.helm-org ];
+
+          # elisp error and missing optional dependencies
+          org-ref = ignoreCompilationError super.org-ref;
+
+          # missing optional dependencies
+          org-roam-bibtex = addPackageRequires super.org-roam-bibtex [
+            self.helm-bibtex
+            self.ivy-bibtex
+          ];
+
+          org-special-block-extras = ignoreCompilationError super.org-special-block-extras; # elisp error
+
+          # https://github.com/ichernyshovvv/org-timeblock/issues/65
+          org-timeblock = markBroken super.org-timeblock;
+
+          org-trello = ignoreCompilationError super.org-trello; # elisp error
+
+          # Requires xwidgets compiled into emacs, so mark this package
+          # as broken if emacs hasn't been compiled with the flag.
+          org-xlatex = if self.emacs.withXwidgets then super.org-xlatex else markBroken super.org-xlatex;
+
+          # Optimizer error: too much on the stack
+          orgnav = ignoreCompilationError super.orgnav;
 
           origami-predef = ignoreCompilationError super.origami-predef; # elisp error
 
@@ -1777,9 +1779,6 @@ let
           # optional dependency spamfilter is not on any ELPA
           wanderlust = ignoreCompilationError (addPackageRequires super.wanderlust [ self.shimbun ]);
 
-          # https://github.com/nicklanasa/xcode-mode/issues/28
-          xcode-mode = addPackageRequires super.xcode-mode [ self.hydra ];
-
           weechat = ignoreCompilationError super.weechat; # elisp error
 
           weechat-alert = ignoreCompilationError super.weechat-alert; # elisp error
@@ -1788,16 +1787,19 @@ let
 
           workgroups2 = ignoreCompilationError super.workgroups2; # elisp error
 
+          # https://github.com/nicklanasa/xcode-mode/issues/28
+          xcode-mode = addPackageRequires super.xcode-mode [ self.hydra ];
+
           xenops = mkHome super.xenops;
 
           # missing optional dependencies
           xmlunicode = addPackageRequires super.xmlunicode [ self.helm ];
 
-          # https://github.com/canatella/xwwp/issues/18
-          xwwp-follow-link-ivy = addPackageRequires super.xwwp-follow-link-ivy [ self.ivy ];
-
           # https://github.com/canatella/xwwp/issues/19
           xwwp-follow-link-helm = addPackageRequires super.xwwp-follow-link-helm [ self.helm ];
+
+          # https://github.com/canatella/xwwp/issues/18
+          xwwp-follow-link-ivy = addPackageRequires super.xwwp-follow-link-ivy [ self.ivy ];
 
           yara-mode = ignoreCompilationError super.yara-mode; # elisp error
 
@@ -1818,6 +1820,8 @@ let
 
           # missing optional dependencies
           zotxt = addPackageRequires super.zotxt [ self.org-noter ];
+
+          # keep-sorted end
         };
 
     in

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
@@ -8,6 +8,7 @@ let
     ;
 in
 {
+  # keep-sorted start block=yes newline_separated=yes
   # missing optional dependencies
   haskell-tng-mode = addPackageRequires super.haskell-tng-mode (
     with self;
@@ -35,4 +36,5 @@ in
       popd
     '';
   };
+  # keep-sorted end
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -54,10 +54,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.4.0.20250529.13102";
+      version = "1.5.0.20250707.183212";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.4.0.20250529.13102.tar";
-        sha256 = "0hsmzp9axsaiqvsw6y75s5yjn9imwhbl609py2xf8lys4jfj8xzg";
+        url = "https://elpa.nongnu.org/nongnu-devel/aidermacs-1.5.0.20250707.183212.tar";
+        sha256 = "11skkh7abmdf9jndl9qpk5bd8g3as1j5rmpx5p4mvzl3hsd8nhf4";
       };
       packageRequires = [
         compat
@@ -312,10 +312,10 @@
     elpaBuild {
       pname = "bash-completion";
       ename = "bash-completion";
-      version = "3.2.1snapshot0.20250425.222123";
+      version = "3.2.1snapshot0.20250626.204257";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20250425.222123.tar";
-        sha256 = "0a9z0r6sj5jyyqhmai5cfkc147aprqzy6kmbix2n3kwnn95vbqkq";
+        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20250626.204257.tar";
+        sha256 = "19ajv804fl520pk5wqni066dpklbc6i16wbkvm5d7hiwzybfpg44";
       };
       packageRequires = [ ];
       meta = {
@@ -333,10 +333,10 @@
     elpaBuild {
       pname = "beancount";
       ename = "beancount";
-      version = "0.9.0.20250220.225133";
+      version = "0.9.0.0.20250616.105101";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/beancount-0.9.0.20250220.225133.tar";
-        sha256 = "0apibxpakk6014fr6w3kmxcdfyk61baqib8aibx6920q7zj8yxv4";
+        url = "https://elpa.nongnu.org/nongnu-devel/beancount-0.9.0.0.20250616.105101.tar";
+        sha256 = "1h1hy46xqm70nilqx1z5v4a81y59j7ywikckw2xslilkrniw6wj5";
       };
       packageRequires = [ ];
       meta = {
@@ -438,10 +438,10 @@
     elpaBuild {
       pname = "blueprint-ts-mode";
       ename = "blueprint-ts-mode";
-      version = "0.0.3.0.20250510.181219";
+      version = "0.0.3.0.20250702.131748";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/blueprint-ts-mode-0.0.3.0.20250510.181219.tar";
-        sha256 = "0vz3ds7pm31gkckhhqy69k051x3gl7d1i143q1jb6k1xqvgiz6h4";
+        url = "https://elpa.nongnu.org/nongnu-devel/blueprint-ts-mode-0.0.3.0.20250702.131748.tar";
+        sha256 = "1w0annw8qrf6pik02i4f7nq469spninjzjgfvkkk56h2cabxf29n";
       };
       packageRequires = [ ];
       meta = {
@@ -572,10 +572,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.19.0snapshot0.20250530.85125";
+      version = "1.19.0snapshot0.20250704.84003";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.19.0snapshot0.20250530.85125.tar";
-        sha256 = "1mnafkqypqc01ggqa91gxr4m1q8l4hz9i2n8mbqwck4c72zph6k9";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.19.0snapshot0.20250704.84003.tar";
+        sha256 = "0m86kc0x6hd0q9zl785vzbzpvsjr461cshsp158xihjpp4jsa92q";
       };
       packageRequires = [
         clojure-mode
@@ -622,10 +622,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.5.0snapshot0.20250530.85704";
+      version = "0.6.0snapshot0.20250705.130718";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.5.0snapshot0.20250530.85704.tar";
-        sha256 = "13iwffh76x4463kjsg1kxbvaainq7ikn5idj03az9r8gdijbwz3g";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0snapshot0.20250705.130718.tar";
+        sha256 = "1f58y6v2rgz4srn26zdy6c8i2qxn79asxg8l35yqdnrh8l7f5609";
       };
       packageRequires = [ ];
       meta = {
@@ -666,10 +666,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.0.0.20250512.155519";
+      version = "1.0.0.20250617.112549";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250512.155519.tar";
-        sha256 = "09zzr69iais44669bm52ciw3jh55zi98z3kc0nr1v2h656z5yaq4";
+        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250617.112549.tar";
+        sha256 = "0i7p48sm95810a7a2yjjpz0s5m7a4hab44pwsnl27ap0qs6y7xcz";
       };
       packageRequires = [
         consult
@@ -781,10 +781,10 @@
     elpaBuild {
       pname = "cycle-at-point";
       ename = "cycle-at-point";
-      version = "0.2.0.20250421.105916";
+      version = "0.2.0.20250611.32851";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20250421.105916.tar";
-        sha256 = "1k8wx7lvdv6194l1367a3z15qbgx8ypipqwrk99wbq1hjiwqs07q";
+        url = "https://elpa.nongnu.org/nongnu-devel/cycle-at-point-0.2.0.20250611.32851.tar";
+        sha256 = "17pw2g8nh1byp42qb06568lrir0b6msbqhvkw45dwp89dd7nkrc4";
       };
       packageRequires = [ recomplete ];
       meta = {
@@ -930,10 +930,10 @@
     elpaBuild {
       pname = "diff-ansi";
       ename = "diff-ansi";
-      version = "0.2.0.20250408.234444";
+      version = "0.2.0.20250611.51010";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20250408.234444.tar";
-        sha256 = "1wkja7733l5kwj4j2jlfa9c9607059asyvap6xdihqqd1ic1l3w5";
+        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20250611.51010.tar";
+        sha256 = "1i7x02ccvsbaayvzv9sbi09a6vfzpqhnaqkzcqjbkff538v6kcy1";
       };
       packageRequires = [ ];
       meta = {
@@ -1015,10 +1015,10 @@
     elpaBuild {
       pname = "dracula-theme";
       ename = "dracula-theme";
-      version = "1.8.2.0.20250407.120528";
+      version = "1.8.3.0.20250626.195550";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.2.0.20250407.120528.tar";
-        sha256 = "04xy1glqxzildh9rbl529mlsvabx5bzwdd8gd12cki5lgx320fn5";
+        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.3.0.20250626.195550.tar";
+        sha256 = "14zlkirydnlydivmccg5129amnjmy6238m1b8b7gq68qz95spjxz";
       };
       packageRequires = [ ];
       meta = {
@@ -1227,10 +1227,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.0.0.20250529.95634";
+      version = "4.3.1.0.20250601.100932";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.0.0.20250529.95634.tar";
-        sha256 = "1q5jf8fbh7kj7lfm7qh2n6v3admqcdi7mgjbf9lr0j5zzfyz3bbc";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.1.0.20250601.100932.tar";
+        sha256 = "1kjzbz003r93315f1v92kzifdjnmi91dia242g14hkc3kwahzagg";
       };
       packageRequires = [ ];
       meta = {
@@ -2179,10 +2179,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.4.0.20250509.145352";
+      version = "1.4.5.0.20250531.221751";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.4.0.20250509.145352.tar";
-        sha256 = "11ylk079n4zhly3pp3a5b1d7h454dxhwf859r7rvj6njxkc1vwa8";
+        url = "https://elpa.nongnu.org/nongnu-devel/git-modes-1.4.5.0.20250531.221751.tar";
+        sha256 = "16h7v25rrd818lcnrdh7x6nq4v4q2qb9iisfh4vaya28jysj5wda";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2198,19 +2198,21 @@
       emacsql,
       fetchurl,
       lib,
+      org-gnosis,
       transient,
     }:
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.4.10.0.20241212.14747";
+      version = "0.5.3.0.20250702.65148";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.4.10.0.20241212.14747.tar";
-        sha256 = "1nzx6idhpzz33awaqsylnzzy13xlbgjraxzw2gfd0iwx9p28dj3k";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.3.0.20250702.65148.tar";
+        sha256 = "0kgwvyy28q76bbkf3az2c0lc212cq94yblskdpgxlz4zzvjdrdwj";
       };
       packageRequires = [
         compat
         emacsql
+        org-gnosis
         transient
       ];
       meta = {
@@ -2263,6 +2265,7 @@
   ) { };
   gnuplot = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -2270,12 +2273,12 @@
     elpaBuild {
       pname = "gnuplot";
       ename = "gnuplot";
-      version = "0.9.0.20250530.193710";
+      version = "0.11.0.20250613.122323";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.9.0.20250530.193710.tar";
-        sha256 = "1wbdpa3w8zsqzlhi28kcczxjrxw3jmysm0i1frbzkmw01cgpqjzp";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.11.0.20250613.122323.tar";
+        sha256 = "0mc5v1f8m6bv4lcdci2sk99xzfhb7597jniywb2n1bhwzz0mp7vj";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/gnuplot.html";
         license = lib.licenses.free;
@@ -2377,10 +2380,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.8.0.20250529.230850";
+      version = "0.9.8.5.0.20250705.205718";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.8.0.20250529.230850.tar";
-        sha256 = "1xza3riy1799sbqy2f5h1q5d1lpr8rl6xvbknxv51zmp74mnajkg";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.8.5.0.20250705.205718.tar";
+        sha256 = "1682337hiak8bdjrrik5blclarhapkkad3mkr3nnxm6mwm7izb2a";
       };
       packageRequires = [
         compat
@@ -2508,10 +2511,10 @@
     elpaBuild {
       pname = "haskell-mode";
       ename = "haskell-mode";
-      version = "17.5.0.20250519.115454";
+      version = "17.5.0.20250630.193117";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20250519.115454.tar";
-        sha256 = "17si5n0mdaij4kx19rhzy1p3asczkgcd5bhc1fsspi60kzwsmmi8";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20250630.193117.tar";
+        sha256 = "17z0fv7qrsncfiaqydvhmacc6g51f8g7k465gas7ffxq0504icr2";
       };
       packageRequires = [ ];
       meta = {
@@ -2551,10 +2554,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1.2.0.0.20250518.53811";
+      version = "1.3.2.0.20250629.84650";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.2.0.0.20250518.53811.tar";
-        sha256 = "1n5rnyd02mfp77r8h71dpi18q7kayf4dh9rz8aglsx1087mrfm3g";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.3.2.0.20250629.84650.tar";
+        sha256 = "09n25ag4pjxyx5k6ffwpny6cdgblrg9v9kw64v6ili4zni0bvf6k";
       };
       packageRequires = [ ];
       meta = {
@@ -2574,10 +2577,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.3.0.20250529.40054";
+      version = "4.0.4.0.20250707.55928";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.3.0.20250529.40054.tar";
-        sha256 = "05da9val6w0q3s0662625jp8f2s76mfrayfwpvj00zbvqbavw4i7";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.4.0.20250707.55928.tar";
+        sha256 = "0x5yskncxgk3g94mfkkchpdwfp8l9jv4rp1dnjiwa73cikhl4z85";
       };
       packageRequires = [
         helm-core
@@ -2599,10 +2602,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.3.0.20250529.40054";
+      version = "4.0.4.0.20250707.55928";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.3.0.20250529.40054.tar";
-        sha256 = "0xa2qp95wswlcqkmg3hngfkqk2mm78z0j2fms89kxm5sg2jkcf7d";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.4.0.20250707.55928.tar";
+        sha256 = "1hyg0wqmjwklfyv4yjx30vj2pfaky72kgbcgaw9nyka64d4ayhhj";
       };
       packageRequires = [ async ];
       meta = {
@@ -2704,10 +2707,10 @@
     elpaBuild {
       pname = "htmlize";
       ename = "htmlize";
-      version = "1.58.0.20240915.165713";
+      version = "1.58.0.20250704.192840";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/htmlize-1.58.0.20240915.165713.tar";
-        sha256 = "1i2gp0m2qy7rknymn3ps1ss1vsbrx0zkxb6ya1ymc5vlqblqfwya";
+        url = "https://elpa.nongnu.org/nongnu-devel/htmlize-1.58.0.20250704.192840.tar";
+        sha256 = "06gp2wgkcv971a3lkw5bq9yal3i2w1a5qzlf4yyy5gvhbh69h3bh";
       };
       packageRequires = [ ];
       meta = {
@@ -3030,10 +3033,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.3.0.20250509.122154";
+      version = "1.4.4.0.20250531.221920";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.3.0.20250509.122154.tar";
-        sha256 = "07gxsn77m6h6831mk4y8v10yxqzbamvcn9yysfy4hh0iywzqnx4b";
+        url = "https://elpa.nongnu.org/nongnu-devel/keycast-1.4.4.0.20250531.221920.tar";
+        sha256 = "03v4xsg22b86wbbf2cb9cgrid4c1mh5hrj6v7vmwg2f14rdqhl7q";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3073,10 +3076,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "0.6.2.0.20250509.122131";
+      version = "1.0.0.0.20250701.152904";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/llama-0.6.2.0.20250509.122131.tar";
-        sha256 = "0clbp1f4s98yzd7cw4yn4rmg06d6vfj5ik3kx92i57n58za73cdp";
+        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.0.0.20250701.152904.tar";
+        sha256 = "14c56w4n61kb5sd8m7898aw7fp28h56p74v0h84xbm0z1ylisvig";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3126,10 +3129,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.14.0.0.20250306.20614";
+      version = "0.14.0.0.20250706.11705";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.14.0.0.20250306.20614.tar";
-        sha256 = "0vggsncnj7fbc307sa78pl6aszzn7644mrhsa8q24syp9xn1xwrz";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.14.0.0.20250706.11705.tar";
+        sha256 = "0h42k1i38rsp90k5a1l46x2l5n7fp6pwmg4snaw3wl796nsqwh7w";
       };
       packageRequires = [
         compat
@@ -3252,10 +3255,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.3.5.0.20250520.83537";
+      version = "4.3.8.0.20250704.230026";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.3.5.0.20250520.83537.tar";
-        sha256 = "14x7qvkpgjyhf5wcc26gq4plrysd61dr8i4yywxyf09d67xmam8q";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.3.8.0.20250704.230026.tar";
+        sha256 = "0bardjnsk52yjz5yd10yv1grzr6rsgzc30v7azmp64hki175xakl";
       };
       packageRequires = [
         compat
@@ -3283,10 +3286,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.3.5.0.20250520.83537";
+      version = "4.3.8.0.20250704.230026";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.3.5.0.20250520.83537.tar";
-        sha256 = "1c0n0cdgc7mf910pdpxp75wsan7772k5iw307lybf465maabjx1i";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.3.8.0.20250704.230026.tar";
+        sha256 = "057npc4k3yxccjd2qwl7fr3zcms1q9n02nmjym1ysak3q16kkynm";
       };
       packageRequires = [
         compat
@@ -3308,10 +3311,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.8alpha0.20250501.55146";
+      version = "2.8alpha0.20250624.63145";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20250501.55146.tar";
-        sha256 = "14fij3h882brdixrw516hhcim9rmkjp2wbxf75rcmgnfvhfq4vx7";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20250624.63145.tar";
+        sha256 = "0pkc9cqsxnyr0i1bzyp7bnxbf7skdjad77h150yvx14g8hvyhpdn";
       };
       packageRequires = [ ];
       meta = {
@@ -3331,10 +3334,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.0.0.20250330.151927";
+      version = "2.0.1.0.20250602.141655";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.0.0.20250330.151927.tar";
-        sha256 = "16xfvaacilfd075nln38hijzmx1wr30gmibrksn6zhfl6mj0lhnk";
+        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-2.0.1.0.20250602.141655.tar";
+        sha256 = "0dzddf45f2h6790pwgi7hychv36adhanigbwvfivpvg9wxvrm3fi";
       };
       packageRequires = [
         persist
@@ -3852,10 +3855,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.2.0.20250527.133058";
+      version = "2.0.3.0.20250601.105749";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.2.0.20250527.133058.tar";
-        sha256 = "14k8qa0i895fqqqb62njyb0i1kd627gbq68jaamscpwwzw7km66y";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.0.3.0.20250601.105749.tar";
+        sha256 = "1dk63z953ph91llmh98xi1dfsbfkgp1q2mpn6m7l9wydv98y82w9";
       };
       packageRequires = [
         compat
@@ -3899,10 +3902,10 @@
     elpaBuild {
       pname = "package-lint";
       ename = "package-lint";
-      version = "0.26.0.20250527.184516";
+      version = "0.26.0.20250630.143113";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20250527.184516.tar";
-        sha256 = "0nm3z8cirwvhls4ihckfnydw11qczrgps1mc1h56q3gsyr901z43";
+        url = "https://elpa.nongnu.org/nongnu-devel/package-lint-0.26.0.20250630.143113.tar";
+        sha256 = "1jr9r5g86z23vs5aw3wmj4ny8mb5a4yqirvmflkd4vv0f00qylyc";
       };
       packageRequires = [ let-alist ];
       meta = {
@@ -4099,10 +4102,10 @@
     elpaBuild {
       pname = "php-mode";
       ename = "php-mode";
-      version = "1.26.1.0.20250528.130625";
+      version = "1.26.1.0.20250602.130847";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250528.130625.tar";
-        sha256 = "19zzmhak462xygriknnh3y83xfl2jrqvh4gz129vnwysnmb13lx3";
+        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250602.130847.tar";
+        sha256 = "0bhwg683jk5sjlq9kvp0318cgp1w7yvi7cfl5svr5qd3d44j7mgk";
       };
       packageRequires = [ ];
       meta = {
@@ -4162,10 +4165,10 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.9.1.0.20250527.53156";
+      version = "2.9.1.0.20250704.90814";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.1.0.20250527.53156.tar";
-        sha256 = "0gnig1w4w3sjlvhkc66kbv6hp5bf4bp35iqkhz902qs565sdsxzk";
+        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.1.0.20250704.90814.tar";
+        sha256 = "00prn27p6hip55p9srsgbaq3gf6dmg6s8iglqd3v1pqz3hggjjcr";
       };
       packageRequires = [ ];
       meta = {
@@ -4183,10 +4186,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.6snapshot0.20250527.143946";
+      version = "4.6snapshot0.20250623.210821";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20250527.143946.tar";
-        sha256 = "1xkk7hspy0zn4sm1j05j253fima73q0nbzma57vv1k8v68j933y9";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20250623.210821.tar";
+        sha256 = "0km27ky5ljzdw09c0idw72nxyl6qm15ci61vhfs2jrmqh1ncv645";
       };
       packageRequires = [ ];
       meta = {
@@ -4227,10 +4230,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250522.142050";
+      version = "1.0.20250707.155225";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250522.142050.tar";
-        sha256 = "19zc9y704b9naqgx9cs9j40q0z402jp02f83l1fpcpyq3gbhmi1y";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250707.155225.tar";
+        sha256 = "0wzg57y7yx5aqwlildi314ay8vf0gwxfpxdadjswjjc1zfifq6yy";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4437,10 +4440,10 @@
     elpaBuild {
       pname = "rust-mode";
       ename = "rust-mode";
-      version = "1.0.6.0.20250423.1515";
+      version = "1.0.6.0.20250705.144445";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20250423.1515.tar";
-        sha256 = "1vkbg2gg9i1lyz4g7zkqjrixh7867x8py7ay7pcq76srwn01hja3";
+        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20250705.144445.tar";
+        sha256 = "1misimvimmzdb3g23yjax0wl41cys7fghg5yhks56x0169q11mh3";
       };
       packageRequires = [ ];
       meta = {
@@ -4548,10 +4551,10 @@
     elpaBuild {
       pname = "scroll-on-jump";
       ename = "scroll-on-jump";
-      version = "0.2.0.20250113.92302";
+      version = "0.2.0.20250706.112423";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.2.0.20250113.92302.tar";
-        sha256 = "1m0xq5mnls82gvbvqlzvxl540wz53xz7s8xphpf93pfm5qf8lkw5";
+        url = "https://elpa.nongnu.org/nongnu-devel/scroll-on-jump-0.2.0.20250706.112423.tar";
+        sha256 = "0v2y99ihpmhcdabvmnglvvf4vmmfpp1nplb99bh6i3r6n0i58n4j";
       };
       packageRequires = [ ];
       meta = {
@@ -4612,10 +4615,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.31snapshot0.20250520.4450";
+      version = "2.31snapshot0.20250706.142233";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250520.4450.tar";
-        sha256 = "0b1kxhimlx73nmhgkidjpz3dm1nsyikqhflz2c7mhmdii50nramy";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250706.142233.tar";
+        sha256 = "1vn1vm0fh2acq522j30kngkgnvxy9gdh0v26w0vdi6mv21531cdd";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4655,10 +4658,10 @@
     elpaBuild {
       pname = "smartparens";
       ename = "smartparens";
-      version = "1.11.0.0.20250511.235418";
+      version = "1.11.0.0.20250612.105020";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/smartparens-1.11.0.0.20250511.235418.tar";
-        sha256 = "0ah3jlc4s90xziccf0s2kvbl4cildhf2li572pryps7zh1bn319f";
+        url = "https://elpa.nongnu.org/nongnu-devel/smartparens-1.11.0.0.20250612.105020.tar";
+        sha256 = "1cdicjah7mbkcg43zm5la75zb7cgg15gxf9178zhd2qd71gqfl8m";
       };
       packageRequires = [ dash ];
       meta = {
@@ -4697,10 +4700,10 @@
     elpaBuild {
       pname = "spacemacs-theme";
       ename = "spacemacs-theme";
-      version = "0.2.0.20241101.103011";
+      version = "0.2.0.20250613.211345";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/spacemacs-theme-0.2.0.20241101.103011.tar";
-        sha256 = "1sxj7xghkkayvpa1qb4d3ws81931r8s737wk3akwhayh50czh3fi";
+        url = "https://elpa.nongnu.org/nongnu-devel/spacemacs-theme-0.2.0.20250613.211345.tar";
+        sha256 = "0a2rf7kdwjnz8y90018f3ajmy9pd1iz5aq36s74l10fzd08ccqpj";
       };
       packageRequires = [ ];
       meta = {
@@ -4824,10 +4827,10 @@
     elpaBuild {
       pname = "sweeprolog";
       ename = "sweeprolog";
-      version = "0.27.6.0.20250430.125630";
+      version = "0.27.6.0.20250624.64526";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/sweeprolog-0.27.6.0.20250430.125630.tar";
-        sha256 = "172vzsbiy1xy08isxwn10cqzwh0vbcivj390qhnyzcmw1ncd22hx";
+        url = "https://elpa.nongnu.org/nongnu-devel/sweeprolog-0.27.6.0.20250624.64526.tar";
+        sha256 = "1ywcwm4r7hd21bayilvmw530axa2gc8f689fr5swxfyig49qjqz5";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4846,10 +4849,10 @@
     elpaBuild {
       pname = "swift-mode";
       ename = "swift-mode";
-      version = "9.3.0.0.20250524.53009";
+      version = "9.4.0.0.20250615.100102";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-9.3.0.0.20250524.53009.tar";
-        sha256 = "0dcr8d4d4bn6grxycc89bm14i4vq4z8vvhi9548v0iz5fh1bjwgs";
+        url = "https://elpa.nongnu.org/nongnu-devel/swift-mode-9.4.0.0.20250615.100102.tar";
+        sha256 = "13b7vbkhb8zw4x3inpfpdhaakgvp6msm1p377dmhpjddz3ngf3l5";
       };
       packageRequires = [ seq ];
       meta = {
@@ -5108,10 +5111,10 @@
     elpaBuild {
       pname = "treesit-fold";
       ename = "treesit-fold";
-      version = "0.2.1.0.20250521.182836";
+      version = "0.2.1.0.20250602.41006";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250521.182836.tar";
-        sha256 = "0d1a2fqm2j60cz3ssqnmdvp0qd906i7wnxvn6nxmq6ny77lvhk0y";
+        url = "https://elpa.nongnu.org/nongnu-devel/treesit-fold-0.2.1.0.20250602.41006.tar";
+        sha256 = "17lwdj39j7fx16q7949f0yfr8wkbpwg3iy48k33lsrhmd6wj1fw7";
       };
       packageRequires = [ ];
       meta = {
@@ -5193,10 +5196,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.12.0.0.20250424.101629";
+      version = "0.12.1.0.20250708.85145";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.0.0.20250424.101629.tar";
-        sha256 = "1yjiw5l6ni7rvp2ggfhf6jgiqpgb466sq6wwcsm0rqnmvs6y2jdz";
+        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.1.0.20250708.85145.tar";
+        sha256 = "00z3kw7bi435iw0rwndm8xhx730zv5zsydqnk2mqjmhxj56iv1fw";
       };
       packageRequires = [ ];
       meta = {
@@ -5235,10 +5238,10 @@
     elpaBuild {
       pname = "undo-fu";
       ename = "undo-fu";
-      version = "0.5.0.20241206.21950";
+      version = "0.5.0.20250611.233145";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-0.5.0.20241206.21950.tar";
-        sha256 = "0kslql79g5y0sszjm6xxyxjzrnskm70dgglwwl2g4a1rjwavcp3v";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-0.5.0.20250611.233145.tar";
+        sha256 = "043c0lswp9684naqka6j3jmqygrki2ylr4q7b3x8r8bi9xmdspb0";
       };
       packageRequires = [ ];
       meta = {
@@ -5256,10 +5259,10 @@
     elpaBuild {
       pname = "undo-fu-session";
       ename = "undo-fu-session";
-      version = "0.7.0.20241212.4030";
+      version = "0.7.0.20250611.33234";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20241212.4030.tar";
-        sha256 = "1nggzbk1xi0w5f5y2xkp2jk4imfbqfaldngavslz1rhskiqwdqqa";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20250611.33234.tar";
+        sha256 = "0nzm5y4diim3di2kyaxamgbibni0vrd59d92f3fi7wyxcwb0v8dw";
       };
       packageRequires = [ ];
       meta = {
@@ -5342,10 +5345,10 @@
     elpaBuild {
       pname = "vm";
       ename = "vm";
-      version = "8.3.0snapshot0.20250504.193215";
+      version = "8.3.0snapshot0.20250629.80737";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20250504.193215.tar";
-        sha256 = "0r64xnwzhx3h3yw6jac9x357rpbh2scg1zdzbg4aihj4r8d1x6lx";
+        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.0snapshot0.20250629.80737.tar";
+        sha256 = "0vv7chilnsrig15asv0iy916vmvksbyhxasvlldykq9z3w4r6abi";
       };
       packageRequires = [
         cl-lib
@@ -5366,10 +5369,10 @@
     elpaBuild {
       pname = "web-mode";
       ename = "web-mode";
-      version = "17.3.21.0.20241227.53016";
+      version = "17.3.21.0.20250619.133456";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.21.0.20241227.53016.tar";
-        sha256 = "0syhyqryfh2rvf2688rqfs3j0p0fh794vw85qwdh3kxi57w8ra8h";
+        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.21.0.20250619.133456.tar";
+        sha256 = "163ix98pqwd4qkzsikh588gd2airy7pb144v5jmdpnfxpmir6721";
       };
       packageRequires = [ ];
       meta = {
@@ -5477,10 +5480,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.3.0.20250521.153138";
+      version = "3.4.4.0.20250531.223012";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.3.0.20250521.153138.tar";
-        sha256 = "0i1912zgn5v06pbbyw03vxhn329d58p39li6b8jxrniz74si3h7x";
+        url = "https://elpa.nongnu.org/nongnu-devel/with-editor-3.4.4.0.20250531.223012.tar";
+        sha256 = "19qqvsr28qncfwhm2zvn6h74ymwgr3jfcr9qkbnc3kixsmjp4ps7";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5566,10 +5569,10 @@
     elpaBuild {
       pname = "ws-butler";
       ename = "ws-butler";
-      version = "1.3.0.20250310.20542";
+      version = "1.3.0.20250612.214058";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/ws-butler-1.3.0.20250310.20542.tar";
-        sha256 = "1np6n8n54awwbcny84l3k53416a4xa7gl6420296k7f9r588ngw0";
+        url = "https://elpa.nongnu.org/nongnu-devel/ws-butler-1.3.0.20250612.214058.tar";
+        sha256 = "0w580p3p2b3jmmfr46qzgg4zqxc8dg17b8808a9djjlz56v589w6";
       };
       packageRequires = [ ];
       meta = {
@@ -5587,10 +5590,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.12.20250517213917.0.20250517.214741";
+      version = "27.0.20250707145105.0.20250707.153146";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-26.12.20250517213917.0.20250517.214741.tar";
-        sha256 = "1wihfan7mxi1d4qxwdqwpfzdi0zjmwwq3ssiscg9i39mqnlyn93s";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-27.0.20250707145105.0.20250707.153146.tar";
+        sha256 = "1vz9ccksqsk3l6a99b79vlgcshhv536bsdk1znccswgwx2nfmyij";
       };
       packageRequires = [ ];
       meta = {
@@ -5673,10 +5676,10 @@
     elpaBuild {
       pname = "yasnippet-snippets";
       ename = "yasnippet-snippets";
-      version = "1.0.0.20250507.200229";
+      version = "1.0.0.20250612.151830";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20250507.200229.tar";
-        sha256 = "0nq70rc7kgm8ldgja0gyza99xljpcg4qqhfwn1qa7y1rvbvbbgk0";
+        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20250612.151830.tar";
+        sha256 = "0gr1pch82gb1b32j562aqz76wc88ricar27i59fvyr1gaqjdlxdi";
       };
       packageRequires = [ yasnippet ];
       meta = {
@@ -5716,10 +5719,10 @@
     elpaBuild {
       pname = "zig-mode";
       ename = "zig-mode";
-      version = "0.0.8.0.20250426.144319";
+      version = "0.0.8.0.20250618.122718";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250426.144319.tar";
-        sha256 = "1aaaarlbn15qmhmq7kxyh7c931h3x2cmxs7cf4c5j7n7qbzjna4w";
+        url = "https://elpa.nongnu.org/nongnu-devel/zig-mode-0.0.8.0.20250618.122718.tar";
+        sha256 = "0c0w6n55qvc8za1miwg26n49lddh3cya6dlxkl5m498bx08mdljf";
       };
       packageRequires = [ reformatter ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-packages.nix
@@ -46,11 +46,13 @@ let
       commonOverrides = import ./nongnu-common-overrides.nix pkgs lib;
 
       overrides = self: super: {
+        # keep-sorted start block=yes newline_separated=yes
         # missing optional dependencies
         haskell-tng-mode = addPackageRequires super.haskell-tng-mode [
           self.shut-up
           self.lsp-mode
         ];
+        # keep-sorted end
       };
 
     in

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -54,10 +54,10 @@
     elpaBuild {
       pname = "aidermacs";
       ename = "aidermacs";
-      version = "1.4";
+      version = "1.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.4.tar";
-        sha256 = "0432v40yr0yjma7lhd53dn7rlfsh8fampw9j2wvmcqpw6dhny4jy";
+        url = "https://elpa.nongnu.org/nongnu/aidermacs-1.5.tar";
+        sha256 = "1gfgk4g1942xjqr3g1q6rw330wgxlsm35p3vsiixszxcs0xh55sj";
       };
       packageRequires = [
         compat
@@ -333,10 +333,10 @@
     elpaBuild {
       pname = "beancount";
       ename = "beancount";
-      version = "0.9";
+      version = "0.9.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/beancount-0.9.tar";
-        sha256 = "1s0w17mq8kilkrd33pan78px6mz5z96d7gvdmy2shg3hvj1jbq09";
+        url = "https://elpa.nongnu.org/nongnu/beancount-0.9.0.tar";
+        sha256 = "0pr86vw8qkdbwvzvqs9pyhq6vabg6jik79cs0j3xrsjjpaz324zi";
       };
       packageRequires = [ ];
       meta = {
@@ -622,10 +622,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.4.0";
+      version = "0.5.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/clojure-ts-mode-0.4.0.tar";
-        sha256 = "177qqqr823mfbj0czm3y30c7bb2jb0cv2kd4799m8d283r77wkgg";
+        url = "https://elpa.nongnu.org/nongnu/clojure-ts-mode-0.5.1.tar";
+        sha256 = "1l1j7798vkzzlysaq6k87v6hw7v7hckysmjslyd0cb2vzbl3vizp";
       };
       packageRequires = [ ];
       meta = {
@@ -1038,10 +1038,10 @@
     elpaBuild {
       pname = "dracula-theme";
       ename = "dracula-theme";
-      version = "1.8.2";
+      version = "1.8.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/dracula-theme-1.8.2.tar";
-        sha256 = "04r7cn4n8n4fiwblmfsa23d1qh11mqfz0cghq6ss72flp5awj46g";
+        url = "https://elpa.nongnu.org/nongnu/dracula-theme-1.8.3.tar";
+        sha256 = "03md51d5ibfynnw9kavxi5wk353spivvpbg7bndiy9mdl1cqc1cg";
       };
       packageRequires = [ ];
       meta = {
@@ -1251,10 +1251,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.0";
+      version = "4.3.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.0.tar";
-        sha256 = "18nr7fvrdhny59lmr7x3z48y7kjsmrrdwi659dsqjnnlxz0xcl11";
+        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.1.tar";
+        sha256 = "0lqawas0zdrri1csy6vh25wffsxipwc642xzgxwrgxb4v3ga32zn";
       };
       packageRequires = [ ];
       meta = {
@@ -2196,10 +2196,10 @@
     elpaBuild {
       pname = "git-modes";
       ename = "git-modes";
-      version = "1.4.4";
+      version = "1.4.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/git-modes-1.4.4.tar";
-        sha256 = "161n8anh3i7aj9995nry879kkfvawm1dkzlxdqfwmzl85g8yqx58";
+        url = "https://elpa.nongnu.org/nongnu/git-modes-1.4.5.tar";
+        sha256 = "0m4z6hvm6zf90lbdhkny8fcj4k1y9bqwcxj4ikv51xhz03604l4d";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2215,19 +2215,21 @@
       emacsql,
       fetchurl,
       lib,
+      org-gnosis,
       transient,
     }:
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.4.10";
+      version = "0.5.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gnosis-0.4.10.tar";
-        sha256 = "16z0f93x8x4ldyld2aqpprmk6xqz4qnd5fbrclcvj8gcg6qj4iz8";
+        url = "https://elpa.nongnu.org/nongnu/gnosis-0.5.3.tar";
+        sha256 = "1dzijdw0c23k6r9l1p3n1a54k4ymk48ckpcz47z9q4i7d7vj8q3m";
       };
       packageRequires = [
         compat
         emacsql
+        org-gnosis
         transient
       ];
       meta = {
@@ -2280,6 +2282,7 @@
   ) { };
   gnuplot = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -2287,12 +2290,12 @@
     elpaBuild {
       pname = "gnuplot";
       ename = "gnuplot";
-      version = "0.9";
+      version = "0.11";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gnuplot-0.9.tar";
-        sha256 = "019cvjh4cqn6y5y2kxw8sy1y23jkh9mmi38wpg3mqayq4xfxdlyv";
+        url = "https://elpa.nongnu.org/nongnu/gnuplot-0.11.tar";
+        sha256 = "10zjkf0ba7jaqx41csa815apx58s0b87svvmzzld3i3xf91sash7";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/gnuplot.html";
         license = lib.licenses.free;
@@ -2394,10 +2397,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.8";
+      version = "0.9.8.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.8.tar";
-        sha256 = "1rym3y1fcwfw9dh51nhw7v8rbap8ixysjlrv39v4hksfwv17gvbr";
+        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.8.5.tar";
+        sha256 = "1zxmbp6b0ldycniciz592v28j3by7niz7m60rilpr97hzl5v56nl";
       };
       packageRequires = [
         compat
@@ -2567,10 +2570,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1.2.0";
+      version = "1.3.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/haskell-ts-mode-1.2.0.tar";
-        sha256 = "016722wrs24i5kzirlc5mzs12m4g6wg4aba6fda2q1ghmf41g8pp";
+        url = "https://elpa.nongnu.org/nongnu/haskell-ts-mode-1.3.2.tar";
+        sha256 = "0hc34lr24gjviqmlghaidv71mjmvvv4mpzb87z5a0mqkz9y0a2ds";
       };
       packageRequires = [ ];
       meta = {
@@ -2590,10 +2593,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.3";
+      version = "4.0.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-4.0.3.tar";
-        sha256 = "0hha3fkdxm6k74a73259la62dis1xp475a8f9a2r1ivs6qblv6b9";
+        url = "https://elpa.nongnu.org/nongnu/helm-4.0.4.tar";
+        sha256 = "1vlqn6v15ms9y1fwk8rip6my1x5ac3pkqxjnqvajv2csc4la1yh2";
       };
       packageRequires = [
         helm-core
@@ -2615,10 +2618,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.3";
+      version = "4.0.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.3.tar";
-        sha256 = "16c9fv3xh1rr1fcayvbf09c5jd0xvajlg19b2kfc2z40sryy95ip";
+        url = "https://elpa.nongnu.org/nongnu/helm-core-4.0.4.tar";
+        sha256 = "1zfwpasfrdh4hap9zs0jv7d0gkw06i3nzs80jkdizjp9vmjxc7sq";
       };
       packageRequires = [ async ];
       meta = {
@@ -3046,10 +3049,10 @@
     elpaBuild {
       pname = "keycast";
       ename = "keycast";
-      version = "1.4.3";
+      version = "1.4.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.3.tar";
-        sha256 = "1d0n8jshjblrb7c5finjpnkdil96zbcy0696sqx4si9kak6j4k5i";
+        url = "https://elpa.nongnu.org/nongnu/keycast-1.4.4.tar";
+        sha256 = "05i3n7kd5aj0rwxva21ri108w1hjsmgjgv5004r3ngim73h1qlw3";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3089,10 +3092,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "0.6.2";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/llama-0.6.2.tar";
-        sha256 = "1adafy7klbx2h0pjrbl989czh7yf2m8gmk5s87c26ih01sjiwwwz";
+        url = "https://elpa.nongnu.org/nongnu/llama-1.0.0.tar";
+        sha256 = "1awxli95p2wwddij7nyjlivcknnxz5j19i65zr9l8awj199scnlx";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3268,10 +3271,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.3.5";
+      version = "4.3.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-4.3.5.tar";
-        sha256 = "04hybghzplgdk4vlyss221lvlvny16i9g1043l7gds1iib8875pc";
+        url = "https://elpa.nongnu.org/nongnu/magit-4.3.8.tar";
+        sha256 = "03m2b155xanm9mjj886na7j9bky7a4f2lay4mm6i0r60adsz26nm";
       };
       packageRequires = [
         compat
@@ -3299,10 +3302,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.3.5";
+      version = "4.3.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-section-4.3.5.tar";
-        sha256 = "1rik2sh3v6y6qsyjnqiy5vbf5ls0gnc32lhsnrkyaryfc3kis7cf";
+        url = "https://elpa.nongnu.org/nongnu/magit-section-4.3.8.tar";
+        sha256 = "0h2l769ailf48an78cbrnmxsnpzhaklw23lq2lby3n2wm5d1gmn3";
       };
       packageRequires = [
         compat
@@ -3347,10 +3350,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.0.tar";
-        sha256 = "0zn1hr36bm1hqsa78q78c5qqwlwg4l23sqsds4gi8nmkcq7yrjlz";
+        url = "https://elpa.nongnu.org/nongnu/mastodon-2.0.1.tar";
+        sha256 = "1jqrb7a7zsz85sp9nzf2rds02waiams87n6mnhwkl7ar8wnycnxy";
       };
       packageRequires = [
         persist
@@ -3875,10 +3878,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.0.2";
+      version = "2.0.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/orgit-2.0.2.tar";
-        sha256 = "1sad3vhmlld60c9lx8hv102d61ihq2ydzb8app97hbk4cs8m3q8j";
+        url = "https://elpa.nongnu.org/nongnu/orgit-2.0.3.tar";
+        sha256 = "0iy12sl2qwgh30c5ycxgc38yv8kx6cjcj9x3akq88y5zwqqswvm9";
       };
       packageRequires = [
         compat
@@ -4250,10 +4253,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20250522.142050";
+      version = "1.0.20250707.155225";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250522.142050.tar";
-        sha256 = "0af5m48mjnyqyrpcb09g59w6jxlm7917b6xm62zliv0bns9k9irm";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250707.155225.tar";
+        sha256 = "1r4hshyja0hx6xa6krn62m9xxrk4ilasc1i5ghl6qyfr2sppj7bb";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4864,10 +4867,10 @@
     elpaBuild {
       pname = "swift-mode";
       ename = "swift-mode";
-      version = "9.3.0";
+      version = "9.4.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/swift-mode-9.3.0.tar";
-        sha256 = "04pp8hpqxibzcfyzrls1r18r6v3hyga4f39vxcdzn75lan4qgpqd";
+        url = "https://elpa.nongnu.org/nongnu/swift-mode-9.4.0.tar";
+        sha256 = "0zfwzz5n98svv1if9wwj37hraiw2in06ks7n3mnk1jjik54kmpxd";
       };
       packageRequires = [ seq ];
       meta = {
@@ -5233,10 +5236,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.12.0";
+      version = "0.12.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/typst-ts-mode-0.12.0.tar";
-        sha256 = "1wks4jqh1bh4gr0m507dqa0a0mka21v10agqpsy7ws4k2sjsyp9h";
+        url = "https://elpa.nongnu.org/nongnu/typst-ts-mode-0.12.1.tar";
+        sha256 = "02wzmpgm8in6b0pc1mqdwh3hqgkg9l73wdykk3d520pph2ni8496";
       };
       packageRequires = [ ];
       meta = {
@@ -5491,10 +5494,10 @@
     elpaBuild {
       pname = "with-editor";
       ename = "with-editor";
-      version = "3.4.3";
+      version = "3.4.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.3.tar";
-        sha256 = "1n0cnxhbqb49i6pknx47f81vlpwi9a6cjbjzr8b349fh6yv3q9w7";
+        url = "https://elpa.nongnu.org/nongnu/with-editor-3.4.4.tar";
+        sha256 = "02sb265fmh99apvz3v4hr788w3h0shnlcr917ygp9hn8byjkajm6";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5601,10 +5604,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.12.20250517213917";
+      version = "27.0.20250707145105";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-26.12.20250517213917.tar";
-        sha256 = "19wandxd82i2v3qm4njhvvmdd36rmf2d28nn5cp8ain71zx6vk4a";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-27.0.20250707145105.tar";
+        sha256 = "0257md3qjr4h6dpmk893d85vbf47x550qvd52z7pzx7n0v751yiz";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-packages.nix
@@ -41,7 +41,10 @@ let
 
       commonOverrides = import ./nongnu-common-overrides.nix pkgs lib;
 
-      overrides = self: super: { };
+      overrides = self: super: {
+        # keep-sorted start block=yes newline_separated=yes
+        # keep-sorted end
+      };
 
     in
     let

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -94615,11 +94615,11 @@
   "repo": "pinoaffe/org-vcard",
   "unstable": {
    "version": [
-    20250708,
-    814
+    20250710,
+    1155
    ],
-   "commit": "c438da390db9e5ad9e42b699aeaebe359ed7d9c2",
-   "sha256": "1c035xpvgdyjvmdpdk2mbv7vsch3mhwy54mmnbwlanjkpsld5l9v"
+   "commit": "92efba59824244defd4165ad0d65d53c882db209",
+   "sha256": "1s7ba46jmdi2j68yvvxc1rcmpq158wsqx04gc3anlb0m4agfjma1"
   },
   "stable": {
    "version": [

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -11567,26 +11567,26 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20250707,
-    2046
+    20250709,
+    1922
    ],
    "deps": [
     "transient"
    ],
-   "commit": "c7866a70b3e0689d58990b6903abaca2891e195c",
-   "sha256": "1jf12j92h88a624lg9vg82xf3djij3xkac9ycj5vavkypb6jnih2"
+   "commit": "a587b65b5e04003410610c1d264cf5f7d6bdf32a",
+   "sha256": "0vdgm2c3rbda1zhjmwd52kp3srd1wgqrzzl3iaz7rp2g271bwih0"
   },
   "stable": {
    "version": [
     2,
     7,
-    0
+    1
    ],
    "deps": [
     "transient"
    ],
-   "commit": "c7866a70b3e0689d58990b6903abaca2891e195c",
-   "sha256": "1jf12j92h88a624lg9vg82xf3djij3xkac9ycj5vavkypb6jnih2"
+   "commit": "a587b65b5e04003410610c1d264cf5f7d6bdf32a",
+   "sha256": "0vdgm2c3rbda1zhjmwd52kp3srd1wgqrzzl3iaz7rp2g271bwih0"
   }
  },
  {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -27278,11 +27278,14 @@
   "repo": "elken/doom-modeline-now-playing",
   "unstable": {
    "version": [
-    20250707,
-    950
+    20250710,
+    1417
    ],
-   "commit": "ba1619e98e011dabb24450db3e2e125bcce02a19",
-   "sha256": "0i8gdmfvw68qd8n3350jk4ndpzlldqrd5s4j8hlfdn1gcblr6k33"
+   "deps": [
+     "doom-modeline"
+   ],
+   "commit": "684bfde0b88a2cb31dd824216608ecbc2eb00c8b",
+   "sha256": "0ky4fhybl9181x4dw5siv459vryvv8gm8zv7y2pksgrsh2ya9r1i"
   },
   "stable": {
    "version": [

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -1802,11 +1802,11 @@
   "repo": "thierryvolpiatto/addressbook-bookmark",
   "unstable": {
    "version": [
-    20250412,
-    1903
+    20250603,
+    618
    ],
-   "commit": "21f19e0f4c1b7d0932e4655db8df200e73cc2f6e",
-   "sha256": "1wfc26fyf7gvyzrgbqj4vrbq573q09n6hz239gbw6v7kfia0zkah"
+   "commit": "c95cdf6b71c04dcab687cbcc40d5c0d61cb2cd59",
+   "sha256": "1gjv1111q5rfinf81y5lx5846p7vr1d8xmd3kx7wvdgkyvz1crmh"
   },
   "stable": {
    "version": [
@@ -2223,8 +2223,8 @@
   "repo": "tninja/aider.el",
   "unstable": {
    "version": [
-    20250530,
-    438
+    20250707,
+    1757
    ],
    "deps": [
     "magit",
@@ -2232,13 +2232,13 @@
     "s",
     "transient"
    ],
-   "commit": "b470775e17075693d98591fedaf2feee530ade38",
-   "sha256": "0jsz21jd1v89d1cda81ldwnygpgsfy0g1z73yhjvljvzi9kasqnm"
+   "commit": "dfe64d0361024631e1d2c3565ce1b4638994b854",
+   "sha256": "0gczwm9yjwfx6iadl2ip2pyppnf9azna2ny5q1yngrsqnap07w7p"
   },
   "stable": {
    "version": [
     0,
-    10,
+    13,
     0
    ],
    "deps": [
@@ -2247,8 +2247,8 @@
     "s",
     "transient"
    ],
-   "commit": "ddaa748907764694f4a83a35b67bf6584a73e961",
-   "sha256": "10vkd9ykk2kjvb0dqgz2z0n337zbh55d1vgq8nmavz6j6x7773di"
+   "commit": "e11be58103c03b49f6dce4d89a4068017fdfa95c",
+   "sha256": "0bqw48zxs31w5sajd4mchgz656w6qmmkgld86hb5x0b6mjaa8cp9"
   }
  },
  {
@@ -2259,29 +2259,29 @@
   "repo": "MatthewZMD/aidermacs",
   "unstable": {
    "version": [
-    20250529,
-    531
+    20250707,
+    1832
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "1f4fe4e8ac05c12c310e6c32893b4ab519efbd47",
-   "sha256": "1j6g6yf9ckarpmalckakfr3h2ligqinq1ybnxy1z5wn37i00nc21"
+   "commit": "5084913506b8b243c732a77b6de4768f18edcff3",
+   "sha256": "0p24acxdskc9khkk79aj216fn2sdwlbwsnw7q0jvsdxfi1ryymbj"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
    "deps": [
     "compat",
     "markdown-mode",
     "transient"
    ],
-   "commit": "727498e375e8320723f8adb3814163ce22e23c34",
-   "sha256": "11mmr222gk3g09rz4852yirxgrp0p7n7aa0x0hy7rfah7h2xy2vv"
+   "commit": "5084913506b8b243c732a77b6de4768f18edcff3",
+   "sha256": "0p24acxdskc9khkk79aj216fn2sdwlbwsnw7q0jvsdxfi1ryymbj"
   }
  },
  {
@@ -2575,16 +2575,16 @@
   "repo": "jwiegley/alert",
   "unstable": {
    "version": [
-    20221213,
-    1619
+    20250615,
+    1845
    ],
    "deps": [
     "cl-lib",
     "gntp",
     "log4e"
    ],
-   "commit": "c762380ff71c429faf47552a83605b2578656380",
-   "sha256": "0c3x54svfal236jwmz2a2jl933av2p1wm83g2vapmqzifz2c0ziw"
+   "commit": "d17ad05ade019fd3560c78f8ed57a352034797e8",
+   "sha256": "0lplkbhncmp4vyyx6vwqbr4rwq157l7vy53kqm4p7y8x1s3kyprf"
   },
   "stable": {
    "version": [
@@ -2907,11 +2907,11 @@
   "repo": "cryon/almost-mono-themes",
   "unstable": {
    "version": [
-    20250515,
-    743
+    20250606,
+    1558
    ],
-   "commit": "5d70b6860aed9a2ef312bff4ff4101b12561e3de",
-   "sha256": "1h507l0nwi5w9zms3zhxiwhjfxdlcg5ffx5f9pvzf8d3l1cm49v4"
+   "commit": "20bdff33fc007d5ef41f065418bef2042daa9d3b",
+   "sha256": "09rp3plbcvd1xx63cqm9zc51hl26k6qgb6s8iacr2vh3cjz9jnxn"
   }
  },
  {
@@ -3378,11 +3378,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20250308,
-    1011
+    20250606,
+    524
    ],
-   "commit": "ce90bc242753f798efc99a360e641b3184d687bb",
-   "sha256": "09pcym4fr29v6c9790fq3gnc5ky28wjg048x8jfqn8msd5hz6r19"
+   "commit": "55fd1c39038fa8c6ba800e0de160147543a697a7",
+   "sha256": "1pk00nvmh4vib8raxnnhl94ia25vfd4fhpc8b24jq9km3kklx7db"
   }
  },
  {
@@ -3541,12 +3541,11 @@
   "stable": {
    "version": [
     2,
-    7,
-    0,
-    1
+    8,
+    0
    ],
-   "commit": "a6fc20c27ae953149b53a8997ba4a1c8b17d628a",
-   "sha256": "1dh9fi8lwjv9rk6zik2bwjgqln0f0d36m3hm9m3zmmk4fby4rsi2"
+   "commit": "3d04bacca842729f9c0869b9287256321b5f450f",
+   "sha256": "0201x9f6v0s6fma9ybbwrkgwjilizj5n24kcwj3pg6rf9dzy1jya"
   }
  },
  {
@@ -3615,28 +3614,28 @@
   "repo": "emacs-ansible/emacs-ansible",
   "unstable": {
    "version": [
-    20250222,
-    1816
+    20250613,
+    2354
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "8474bd186ba0fd56ce86524869083947628eed08",
-   "sha256": "189mqb5sayhll5dr005b675rcswdb6jy4k6bjspx3cxgfbakk6h8"
+   "commit": "7385222a4f209eca6d72d412c03da99097e2755f",
+   "sha256": "0b5rrkxygxhnixbwhv5gsz3d216l2j6ljbvipdyysmvzv4fxmgwj"
   },
   "stable": {
    "version": [
     0,
     4,
-    1
+    2
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "8474bd186ba0fd56ce86524869083947628eed08",
-   "sha256": "189mqb5sayhll5dr005b675rcswdb6jy4k6bjspx3cxgfbakk6h8"
+   "commit": "7385222a4f209eca6d72d412c03da99097e2755f",
+   "sha256": "0b5rrkxygxhnixbwhv5gsz3d216l2j6ljbvipdyysmvzv4fxmgwj"
   }
  },
  {
@@ -3897,11 +3896,11 @@
   "repo": "emacsmirror/apel",
   "unstable": {
    "version": [
-    20250519,
-    1829
+    20250608,
+    1806
    ],
-   "commit": "bfd3ca11343ef5839dd1247622959891c740294b",
-   "sha256": "1lpqpzikvyk7681nky6pmmx4q6mwcg7zfp0qnyvf4n9ifrhf43kp"
+   "commit": "1b043cfea58ea146356c237a5286ead69e97417b",
+   "sha256": "0clh5qm21sq6rdgqlbr2cnbg4104n31633a346q0kisibg3pqkcr"
   }
  },
  {
@@ -3912,11 +3911,11 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20250519,
-    2342
+    20250611,
+    2251
    ],
-   "commit": "7eaaf3f45703d49e494f6dd0555633cf6b355817",
-   "sha256": "0iaid0b0z9wf9djcxlib85f26lms7j0fv1l1wwgk77v261pvch00"
+   "commit": "f3308f53d3fd15b808abc583fa4c50a197f0d1e9",
+   "sha256": "049gkaxg91s4cc85j2jm4hyhamg3r5x13pymyd5zcray2z6r6698"
   },
   "stable": {
    "version": [
@@ -4516,6 +4515,30 @@
   }
  },
  {
+  "ename": "ast-grep",
+  "commit": "0a2c5915b8e1fe52783101cbf7c708d803d08193",
+  "sha256": "1zhm9k0jdkqbcm95rrl9ljrhpwh5an7czx0nmdhgal2xl3wkyghl",
+  "fetcher": "github",
+  "repo": "sunskyxh/ast-grep.el",
+  "unstable": {
+   "version": [
+    20250703,
+    723
+   ],
+   "commit": "3682f0cab0147e85d3f8ffc6b68b1dc30ffba5cd",
+   "sha256": "01hcdqd4wccpynhfjgbvcm7rn343qkbfh61p2bkmsll29ias3lcs"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    2
+   ],
+   "commit": "cb9e9c453abaf7852dda84707152e52ad7f9e910",
+   "sha256": "08akfj0g27qy7a2l6p5rssinh5l2rgambzx95ggpdzg1rbzxw8yd"
+  }
+ },
+ {
   "ename": "astro-ts-mode",
   "commit": "184b376054d773db97c5b961620c713b3ba2d180",
   "sha256": "1dj5qvbcprbcz188m2r3jy7kv606nri1ayc0vnp3vnrfja0qgfm8",
@@ -4877,16 +4900,16 @@
   "repo": "jyp/attrap",
   "unstable": {
    "version": [
-    20250524,
-    1343
+    20250605,
+    1039
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "610c4cead025d9569bd0b4a465be93b9c5ee3a39",
-   "sha256": "0awz0smvkhg4fbji7sgl9x3kcg15cygzxxx6fwrm8wmm6gcaazs9"
+   "commit": "1ff353ea82beb4a338cc3979b62d69701d6bc877",
+   "sha256": "14ppmy0cd4pwd0q60v6g5b008x4bm1rl6ikrr9llvhjqvwmjpfn6"
   },
   "stable": {
    "version": [
@@ -5072,6 +5095,21 @@
   }
  },
  {
+  "ename": "australia-holidays",
+  "commit": "9781474bf0b7eaa7baca216e09e161a47c3a21b7",
+  "sha256": "0yg7z48hv3biz8bys2nbfra9pipsw3wj3ikjappywxv52zspc353",
+  "fetcher": "github",
+  "repo": "jmibanez/australia-holidays.el",
+  "unstable": {
+   "version": [
+    20250706,
+    1213
+   ],
+   "commit": "a73bbc940bc953164b8ed77e61e65a7a3aff4da5",
+   "sha256": "1ws6r6ahdpgx2g9iyxfc8riavwjyv5i8i9yb461br20cscyj0826"
+  }
+ },
+ {
   "ename": "auth-source-1password",
   "commit": "b28cfd883bad13f1f50959f4dade14a86748ab26",
   "sha256": "0ijm5y8dycd5hmz8y81avpnw97vwrnc5myx3fjr9r4yryldjhpvd",
@@ -5231,20 +5269,20 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20250414,
-    1548
+    20250531,
+    2214
    ],
-   "commit": "f92ad088e0b280178b8b19b3dcbecb382c014563",
-   "sha256": "02xi4fx310v9967h9nz4pjpj0ccd4k4vm9kkx8vwhnjjp7i7lyvi"
+   "commit": "b9e5df6f6d3f57263d6b22f2401f776380a37778",
+   "sha256": "1ndqm7b2mnrsb0rqigghzjqvk39gj8pjg4nhz8bapvrywb5s5zjk"
   },
   "stable": {
    "version": [
     2,
     0,
-    6
+    7
    ],
-   "commit": "f92ad088e0b280178b8b19b3dcbecb382c014563",
-   "sha256": "02xi4fx310v9967h9nz4pjpj0ccd4k4vm9kkx8vwhnjjp7i7lyvi"
+   "commit": "b9e5df6f6d3f57263d6b22f2401f776380a37778",
+   "sha256": "1ndqm7b2mnrsb0rqigghzjqvk39gj8pjg4nhz8bapvrywb5s5zjk"
   }
  },
  {
@@ -5885,26 +5923,26 @@
   "repo": "marcwebbie/auto-virtualenv",
   "unstable": {
    "version": [
-    20241112,
-    1959
+    20250608,
+    1633
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1f8efba02ef455aaa9cb84ab179949810e20213a",
-   "sha256": "0w9rfky6ms16c2ayr7bcd6cf9mn8imp6pcmqpi64s67f51vrqang"
+   "commit": "b39a7496cc4e226ef1f9fcdfeb5a12400f71c982",
+   "sha256": "09ndlyvqgfbbn2jixpa5lc9rx10q8dyha06iz21qs9wvczcnq3h6"
   },
   "stable": {
    "version": [
     2,
-    2,
+    3,
     0
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "1f8efba02ef455aaa9cb84ab179949810e20213a",
-   "sha256": "0w9rfky6ms16c2ayr7bcd6cf9mn8imp6pcmqpi64s67f51vrqang"
+   "commit": "b39a7496cc4e226ef1f9fcdfeb5a12400f71c982",
+   "sha256": "09ndlyvqgfbbn2jixpa5lc9rx10q8dyha06iz21qs9wvczcnq3h6"
   }
  },
  {
@@ -6384,30 +6422,6 @@
   }
  },
  {
-  "ename": "aws-athena-babel",
-  "commit": "98f54d427d1fbb6fe96b9639a795ab673f85ddfd",
-  "sha256": "0xz6kjwdl210vrmh4brb0xrngpw8ij1grkk8fcw6gffnl4m22piq",
-  "fetcher": "github",
-  "repo": "will-abb/aws-athena-babel",
-  "unstable": {
-   "version": [
-    20250420,
-    1632
-   ],
-   "commit": "fce1b2d49e0862782405168f37a2dc392f6f8928",
-   "sha256": "1kkqgybal4b61m5cyilwzq7dndfcpcl5qa2gqwrrb1xi9p2lcyrv"
-  },
-  "stable": {
-   "version": [
-    1,
-    1,
-    2
-   ],
-   "commit": "fce1b2d49e0862782405168f37a2dc392f6f8928",
-   "sha256": "1kkqgybal4b61m5cyilwzq7dndfcpcl5qa2gqwrrb1xi9p2lcyrv"
-  }
- },
- {
   "ename": "aws-ec2",
   "commit": "90ac00160cbf692baa1f3953122ac828356944e0",
   "sha256": "040c69g8rhpcmrdjjg4avdmqarxx3dfzylmz62yxhfpn02qh48xd",
@@ -6626,28 +6640,28 @@
   "repo": "tarsius/backline",
   "unstable": {
    "version": [
-    20250515,
-    1829
+    20250601,
+    1005
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "2c77490c76bbbc7b8954eaaf1f226567f5e40631",
-   "sha256": "0vwb99y4nnfrbh0zdwz45m1jlc7g8nbjrxdhcifywlpj7rvrvw8p"
+   "commit": "5141cc9852ee254ae07b8014027758413d9d4bdc",
+   "sha256": "1g0ckbnr481qipd72jjwqkj1x3222689j125bs6bwy52njpklq6a"
   },
   "stable": {
    "version": [
     1,
-    0,
-    2
+    1,
+    0
    ],
    "deps": [
     "compat",
     "outline-minor-faces"
    ],
-   "commit": "9c791fb9a4a2e4a09443ec8b0da8f1f10890c0c6",
-   "sha256": "1gpfg0bvp0333aw9nfaa61nyd01linn9fhishfsyri167k3avihr"
+   "commit": "5141cc9852ee254ae07b8014027758413d9d4bdc",
+   "sha256": "1g0ckbnr481qipd72jjwqkj1x3222689j125bs6bwy52njpklq6a"
   }
  },
  {
@@ -6891,11 +6905,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20250525,
-    140
+    20250629,
+    145
    ],
-   "commit": "178d602a5433ce7268f9d27a684622e16df442ef",
-   "sha256": "0wffxnnlwqkfd6hi87wlw0pqdaj5aq6rapibn0wv1a6cdmr94cz4"
+   "commit": "244ae9a10f3bd4e9f09705da434989cd3831ddf6",
+   "sha256": "180mb2syky61azq0p16n8b64b4m06ga8wjmiqmxdqli7k39pv87l"
   },
   "stable": {
    "version": [
@@ -6937,11 +6951,11 @@
   "repo": "szermatt/emacs-bash-completion",
   "unstable": {
    "version": [
-    20250425,
-    1830
+    20250626,
+    2042
    ],
-   "commit": "a96525afd9077c06d781c59e78bfc6620e41be8f",
-   "sha256": "11amjvs5k9jh5sld42sbay2yri32nlygxq3xnnz06hmwdsvqir6x"
+   "commit": "520503455d0ad762faa75b88501cccc71786343d",
+   "sha256": "0qvz8jard3dr9abln6288v6s4mcn4rf8bd6glna5rqlr5r7swh21"
   },
   "stable": {
    "version": [
@@ -7503,6 +7517,21 @@
   }
  },
  {
+  "ename": "beluga-mode",
+  "commit": "97ee01d9c26cbd1c6a644cf119fdc6effa8ef8c7",
+  "sha256": "1byax2zmwq9imc3w027rk8aks4d9fcy25dyf8dcdp7s0adfl06fi",
+  "fetcher": "github",
+  "repo": "Beluga-lang/Beluga",
+  "unstable": {
+   "version": [
+    20250519,
+    2027
+   ],
+   "commit": "8bf5054bc10e0d56f6ae8552f366da2f6d43b188",
+   "sha256": "0zmbkipla44m4hd6bdxr8fpfrd14n99hlv5dd60z6c0zlnk6q4s2"
+  }
+ },
+ {
   "ename": "benchmark-init",
   "commit": "54b9ae6fc10b0c56fcc7a0ad73743ffc85a3e9a0",
   "sha256": "0dknch4b1j7ff1079z2fhqng7kp4903b3v7mhj15b5vzspbp3wal",
@@ -7766,6 +7795,29 @@
   }
  },
  {
+  "ename": "bible-gateway",
+  "commit": "2e4449e68cb58f4638a52f1222c2a2ad50516545",
+  "sha256": "01ca32p0an3411iy13ynaq5j1k5xwc4fsfsm68f5nrkqrgsl8bjr",
+  "fetcher": "github",
+  "repo": "kristjoc/bible-gateway",
+  "unstable": {
+   "version": [
+    20250605,
+    905
+   ],
+   "commit": "c30789af353e37569e3dae7c910f3684320f8d8e",
+   "sha256": "018ahpad299a7yf7wp2ljc4w0b9rr557avq9zr0vk5zsggfnm37l"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "c30789af353e37569e3dae7c910f3684320f8d8e",
+   "sha256": "018ahpad299a7yf7wp2ljc4w0b9rr557avq9zr0vk5zsggfnm37l"
+  }
+ },
+ {
   "ename": "biblio",
   "commit": "c5fbaa8c59b0e64d13beb0e0f18b0734afa84f51",
   "sha256": "0ym7xvcfd7hh3qdpfb8zpa7w8s4lpg0vngh9d0ns3s3lnhz4mi0g",
@@ -8003,26 +8055,26 @@
   "repo": "tarsius/bicycle",
   "unstable": {
    "version": [
-    20250301,
-    1629
+    20250601,
+    1007
    ],
    "deps": [
     "compat"
    ],
-   "commit": "530eb666ebafb985c3ab227a0fcc4b580373af91",
-   "sha256": "0gsjw3mjj88ggb18ypqfq2h8xbsiddr3gnjb2pnpha7jyl3v5sj5"
+   "commit": "8d20cb42dc44080f3af4d712e54ae34d9a6b5e62",
+   "sha256": "0yly5hlfjr331p5pc7dpdwsvx45j9lg2hw98bzvh1j0nvi35siz4"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "530eb666ebafb985c3ab227a0fcc4b580373af91",
-   "sha256": "0gsjw3mjj88ggb18ypqfq2h8xbsiddr3gnjb2pnpha7jyl3v5sj5"
+   "commit": "8d20cb42dc44080f3af4d712e54ae34d9a6b5e62",
+   "sha256": "0yly5hlfjr331p5pc7dpdwsvx45j9lg2hw98bzvh1j0nvi35siz4"
   }
  },
  {
@@ -8270,8 +8322,8 @@
   "repo": "SqrtMinusOne/biome",
   "unstable": {
    "version": [
-    20250527,
-    1523
+    20250623,
+    1954
    ],
    "deps": [
     "compat",
@@ -8279,8 +8331,8 @@
     "request",
     "transient"
    ],
-   "commit": "ddefc33ef572978f84e0abc7aa1d49aa02b24b6a",
-   "sha256": "1xq8hjz765kgrsn00bag4mx908f093ca2l0i7ij42wdzrlpj6nh8"
+   "commit": "b26c0a6ec533ba5c3524721af224708de9362979",
+   "sha256": "0fsh21fgrqw0mlh1kwn7idk0sdah5yxlwwcz8f847pj0w1n4rvxg"
   }
  },
  {
@@ -8796,18 +8848,18 @@
   "repo": "joodland/bm",
   "unstable": {
    "version": [
-    20250318,
-    2308
+    20250603,
+    2137
    ],
-   "commit": "e69e01ec3afdcd8cf2a8d1553b6172a149a34455",
-   "sha256": "1xzlnp6vfd3kw982qm0gaksnb575xv0xl4fkhp8ma9lv0v32vdf4"
+   "commit": "1fefbc46d10d5398ecca93aa18ef1af3fc1f44b4",
+   "sha256": "0298hjdgx03y028pql6z3jcym47ji10hv66zydn1kicsjds0r45l"
   },
   "stable": {
    "version": [
-    202309
+    202506
    ],
-   "commit": "62fd17d27d5f16a92bccc9ce2ad3868c01413985",
-   "sha256": "1a47dcda196sb6qx45w94d0vfzyfprfs3g7yj0scjmna79rr3fqa"
+   "commit": "1fefbc46d10d5398ecca93aa18ef1af3fc1f44b4",
+   "sha256": "0298hjdgx03y028pql6z3jcym47ji10hv66zydn1kicsjds0r45l"
   }
  },
  {
@@ -9054,11 +9106,11 @@
   "repo": "ideasman42/emacs-bookmark-in-project",
   "unstable": {
    "version": [
-    20250303,
-    1040
+    20250611,
+    333
    ],
-   "commit": "02fb655301b446c94c994c37c44055adc24f162a",
-   "sha256": "14ml1q0n1yh69xrbqfh7pzbmd06kzfvsfbp51p3sq2m9qh4wljyg"
+   "commit": "ea732ab234faee6db75371d5993d9b479da3d66d",
+   "sha256": "19pin8mwrj5bgic5lsvpkn5l76i5q4qd9z70zhskwzm8gf8dnjn3"
   }
  },
  {
@@ -9141,28 +9193,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20250527,
-    2129
+    20250601,
+    1047
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "746d6cc25f8f42ef07ce911f2252c614cc5ffc77",
-   "sha256": "1ls0yxc971f7gdxl4mrnzmr8q2mg055id09hx9j1lf8s8269w5x3"
+   "commit": "bcec39d4f78b6f2145172d390ffd39f4e5bc74fe",
+   "sha256": "0c1irizwpwqicrhprq84mr7lwvagddl2iiy18hpljaf8jqq9ajpv"
   },
   "stable": {
    "version": [
     4,
-    1,
-    5
+    2,
+    0
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "a9a7ad9746a2b759d183e39166739f15da34604b",
-   "sha256": "12xd36ai6d177m750pn7aflwf3b1n9h0m3gyf0m0fasg2mr6944b"
+   "commit": "bcec39d4f78b6f2145172d390ffd39f4e5bc74fe",
+   "sha256": "0c1irizwpwqicrhprq84mr7lwvagddl2iiy18hpljaf8jqq9ajpv"
   }
  },
  {
@@ -9301,15 +9353,15 @@
   "repo": "museoa/bqn-mode",
   "unstable": {
    "version": [
-    20250410,
-    38
+    20250705,
+    1223
    ],
    "deps": [
     "compat",
     "eros"
    ],
-   "commit": "81eca6e1a6735e738cac3117810db5c9a4762452",
-   "sha256": "0zl6s0c0nd8m55f83yamgnl8kg1a9jrzl0wrmixrixzn7zmdj6qk"
+   "commit": "7c04ca9009e72b48da307b41d6814df1e383609a",
+   "sha256": "0bah6xpmb86rgjd3irnalpdqsb6wbf5izq6h1di5hh9axk55acsr"
   }
  },
  {
@@ -9353,11 +9405,11 @@
   "repo": "ideasman42/emacs-bray",
   "unstable": {
    "version": [
-    20250322,
-    358
+    20250607,
+    702
    ],
-   "commit": "4e335ef8287881a06841bf1d0bf9b0c59dd2469f",
-   "sha256": "0462mj2c0q2fxfmkcp9wx7d2mpabxphz33k77giwp5sk9xz9psxn"
+   "commit": "94067be7d07b23a546d7669c374bec95e9482a18",
+   "sha256": "1b2inacqpq0y67sm0xq7f1kippgvk4lyg39cnd6y1rpqh8vxxjn8"
   }
  },
  {
@@ -9687,6 +9739,24 @@
   }
  },
  {
+  "ename": "buck",
+  "commit": "b34c31c4ef9c491968e33161fd46f4f3bb761152",
+  "sha256": "0a04y4ki8hx7afvl1n7ma2ivsy8smqm7mxpbi33lp8f6f2zlfs1h",
+  "fetcher": "github",
+  "repo": "emacsattic/buck",
+  "unstable": {
+   "version": [
+    20250620,
+    1333
+   ],
+   "deps": [
+    "ghub"
+   ],
+   "commit": "3b6bd10ad5e7e6bf1ec36dce55b2b77545ec73e2",
+   "sha256": "0dlsrd2kfavvzhdvkjs1j80iaqwjxh4q2ppvihyabli14arjv4k1"
+  }
+ },
+ {
   "ename": "buckwalter",
   "commit": "7dd38487731cc978e104afa39f8954cfc33ba27f",
   "sha256": "08pnmfy910n5l00kmkn4533x48m3scsxzyra0nl6iry2n39y2kr1",
@@ -9823,11 +9893,11 @@
   "repo": "ideasman42/emacs-buffer-name-relative",
   "unstable": {
    "version": [
-    20241015,
-    1226
+    20250611,
+    322
    ],
-   "commit": "fdfd46bb14be76ad4de15f77d394f8ed1640cedd",
-   "sha256": "11lx849jj9zd7wgp6d1ljb7qy4gs4shrb8yqcmqb6f9azxka5zpd"
+   "commit": "6e9e74776f06ddab76f7e3536bff144921cbd334",
+   "sha256": "1i6was1mkh2ycbmsqdi32cj2g5qhwmzbwgxbw23kssvdpxmp6lg6"
   }
  },
  {
@@ -9902,11 +9972,11 @@
   "repo": "jamescherti/buffer-terminator.el",
   "unstable": {
    "version": [
-    20250323,
-    1828
+    20250627,
+    1241
    ],
-   "commit": "60a6dc3b46eea675eb5822b423f02676b2af032a",
-   "sha256": "1sidd0i2nf7ssvda0w7xjr7dy0kbwns7j79qm58cfh1rkjlpyn55"
+   "commit": "bcd7955c6de0fc3dca995656c4ab59ce3384800b",
+   "sha256": "0agg80dqm9bidsp9b9hgrpx7fw13q81spbc7x6wy9xmd1kwwvcvg"
   },
   "stable": {
    "version": [
@@ -10019,11 +10089,11 @@
   "repo": "jamescherti/bufferfile.el",
   "unstable": {
    "version": [
-    20250413,
-    1959
+    20250624,
+    1554
    ],
-   "commit": "39689ccff11fc592b6c83d8b05dcffc02a269df6",
-   "sha256": "0v00dbr6npnrb57n95sax9ii9qs82qfz88p22qam1hwaiaqw8lgg"
+   "commit": "8b5aa56907d10394672909be6d88a59a29a89d14",
+   "sha256": "0xf09b6lm7rjvm21pihgmcznkjv7aa9bgz9zz8f9ksb8y7115zgd"
   },
   "stable": {
    "version": [
@@ -10967,8 +11037,8 @@
   "repo": "chenyanming/calibredb.el",
   "unstable": {
    "version": [
-    20250527,
-    44
+    20250705,
+    225
    ],
    "deps": [
     "dash",
@@ -10978,8 +11048,8 @@
     "s",
     "transient"
    ],
-   "commit": "7d33947462c77f9e87e8078fa7b7b398feeef0f7",
-   "sha256": "1270nx2kjpbs6avq97lbaghl4kp2mycq267nc937g2z01gcjjllf"
+   "commit": "bbc9d573d5536be5b3530f27539c607f9b030b80",
+   "sha256": "1c6idn8l6894g55kp7bmvrdrhi10mndn24ym95sbv1zqajib653m"
   },
   "stable": {
    "version": [
@@ -11042,20 +11112,20 @@
   "repo": "kickingvegas/calle24",
   "unstable": {
    "version": [
-    20250507,
-    304
+    20250625,
+    2010
    ],
-   "commit": "7a80bfe2c58c3374f29011fd6f824f1011bc5a6a",
-   "sha256": "1p67pd6scf5v82c69rx5nq2kabhnc0c2pzkkqphk9zcwn3d1qyl2"
+   "commit": "34a9821ec8877945518ddab61fa8b93c2e9b1e79",
+   "sha256": "1sshsiii1b73f2md4gwrw04l97z5j1z4x9961q9nxs7jnj40ar99"
   },
   "stable": {
    "version": [
     1,
     0,
-    9
+    10
    ],
-   "commit": "7a80bfe2c58c3374f29011fd6f824f1011bc5a6a",
-   "sha256": "1p67pd6scf5v82c69rx5nq2kabhnc0c2pzkkqphk9zcwn3d1qyl2"
+   "commit": "34a9821ec8877945518ddab61fa8b93c2e9b1e79",
+   "sha256": "1sshsiii1b73f2md4gwrw04l97z5j1z4x9961q9nxs7jnj40ar99"
   }
  },
  {
@@ -11207,11 +11277,11 @@
   "stable": {
    "version": [
     1,
-    1,
+    2,
     0
    ],
-   "commit": "b34ec28cceaf15b1082b74b50f03f770873c3636",
-   "sha256": "0q1ki9l0rsbp446zkwzvzv3pvykpiqjzilllqrjr7j65naij86c3"
+   "commit": "d135c9ca5e15219eaf131dfce1a41afdbaea9aab",
+   "sha256": "1ix6zi7dy1lrn80cfxsnakq6z4ip5ks3rkczswysy6nrnbhjfdv8"
   }
  },
  {
@@ -11497,26 +11567,26 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20250519,
-    1616
+    20250707,
+    2046
    ],
    "deps": [
     "transient"
    ],
-   "commit": "006b3d4ba15969946c9aa9255c8ac6b1ac82a409",
-   "sha256": "11bghffxrs9r2m9hv5xdxqs6hcqrvz7g55ry60mcdcak19jr08gi"
+   "commit": "c7866a70b3e0689d58990b6903abaca2891e195c",
+   "sha256": "1jf12j92h88a624lg9vg82xf3djij3xkac9ycj5vavkypb6jnih2"
   },
   "stable": {
    "version": [
     2,
-    4,
-    3
+    7,
+    0
    ],
    "deps": [
     "transient"
    ],
-   "commit": "006b3d4ba15969946c9aa9255c8ac6b1ac82a409",
-   "sha256": "11bghffxrs9r2m9hv5xdxqs6hcqrvz7g55ry60mcdcak19jr08gi"
+   "commit": "c7866a70b3e0689d58990b6903abaca2891e195c",
+   "sha256": "1jf12j92h88a624lg9vg82xf3djij3xkac9ycj5vavkypb6jnih2"
   }
  },
  {
@@ -11649,11 +11719,11 @@
   "repo": "catppuccin/emacs",
   "unstable": {
    "version": [
-    20250309,
-    2135
+    20250622,
+    712
    ],
-   "commit": "44ceeef71057a674c512d1b4bf87fefff114f5f6",
-   "sha256": "17sfp3pks111dx8zr00c8qr2mzc53vjm8626dfawdfan1fxr0wf6"
+   "commit": "26766bbc61d59a94088aaa4cccbb9d39b5a8b5b8",
+   "sha256": "058g2ajw7h4y7dnh22ij70xrlhpj334prdzjfpvy3216b8kswbfh"
   },
   "stable": {
    "version": [
@@ -12138,16 +12208,16 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20250504,
-    804
+    20250706,
+    805
    ],
    "deps": [
     "f",
     "s",
     "yaml-mode"
    ],
-   "commit": "cea4db0ea7ffeef14cf667ecf0d5fddd1d0340b2",
-   "sha256": "02wjkaggvcv6sxcvaizn7pndbc4ybsmq33kb742r9v9pyjap5g2z"
+   "commit": "4982e0c346e29365352cc69225371a0ff6f86243",
+   "sha256": "0cry80is2yhc95b0nph280f9lbcqp06gf2dl7r7jz0yi3l6k681d"
   },
   "stable": {
    "version": [
@@ -12411,14 +12481,14 @@
   "repo": "xenodium/chatgpt-shell",
   "unstable": {
    "version": [
-    20250530,
-    1148
+    20250702,
+    1851
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "052973946b8cf556ff36e3a360628175c50fce5d",
-   "sha256": "1scm9xi6zn26xiks2x1vxjfqsj6hg8d1nq9q2495z9jjk2j62h0i"
+   "commit": "d5a6c91d80de7bbf9958fc6782bcdd0a852d8963",
+   "sha256": "00bgq4sbrsw3d7ab2c4j6mcxy7gysvnk5il83rq4a7h7vmqwg98y"
   },
   "stable": {
    "version": [
@@ -13096,8 +13166,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20250529,
-    1006
+    20250702,
+    1103
    ],
    "deps": [
     "clojure-mode",
@@ -13108,8 +13178,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "187a7e80b103fa706905ac7f43b8a25bbf6cebbf",
-   "sha256": "1am8dz59lxhbwx27lv4gj5wf4lnw9n4mb4aj27waid7jwa4cmqam"
+   "commit": "66edadb64f80de472f7ac47427db200c3df02060",
+   "sha256": "1hyzdxa3k30868br3ffqj1w1nxyp0l7zn90mspkljzc4kg9c11ap"
   },
   "stable": {
    "version": [
@@ -13408,11 +13478,11 @@
   "repo": "taquangtrung/emacs-circom-mode",
   "unstable": {
    "version": [
-    20250406,
-    1817
+    20250604,
+    1022
    ],
-   "commit": "6473decb0d89b756fcfc643ea302d476b9147186",
-   "sha256": "1jwivwy7qlrfakcxmjb9f2ddbic0rn720apxnkd96djmcv27bkl7"
+   "commit": "80240776507ac2454546a8999bcfb6c39ab04a32",
+   "sha256": "1srsasgihh7qj27xrfp6xafaj31n352nz3s0c1i1fszaiy5if2r7"
   }
  },
  {
@@ -13457,16 +13527,16 @@
   "repo": "pprevos/citar-denote",
   "unstable": {
    "version": [
-    20250528,
-    209
+    20250614,
+    2046
    ],
    "deps": [
     "citar",
     "dash",
     "denote"
    ],
-   "commit": "6bff8e830dcbf5a57384d065b4e127349841251d",
-   "sha256": "10z4yvb06s6yi5bvhz06lfp89ggfdwczv1vvx420rxcgig8r7h0f"
+   "commit": "9223c052d8583d5a9faa7f7237daedbbd55e9553",
+   "sha256": "10fshqxww7141f1y43my07wx9i4kyiykh10xq84g4k8a2vd615jf"
   },
   "stable": {
    "version": [
@@ -14617,20 +14687,20 @@
   "repo": "clojure-emacs/clojure-ts-mode",
   "unstable": {
    "version": [
-    20250530,
-    857
+    20250705,
+    1307
    ],
-   "commit": "a16c6b46f7af693b19f4b9ac712134fcf738fbf3",
-   "sha256": "06w3ma1f8ws587jynj6qdbvac124x31myafwpx85ris9fy1arb9g"
+   "commit": "603660f42df141016f7011fbf303250733df42c8",
+   "sha256": "07m4fgdhfkz744hnbzgyqbhn6c9fjdrk6xd5dw49qga85vygplc3"
   },
   "stable": {
    "version": [
     0,
-    4,
-    0
+    5,
+    1
    ],
-   "commit": "c2269ea10a9129113a98eb58fc8abd8888a07e94",
-   "sha256": "0xd2gdny14x43d553bxn63nmscgkcqhy30196fzyn7m7imfv6hkx"
+   "commit": "66cdee12e950f147e523849bcaf74c403ce06bad",
+   "sha256": "1nhz174z5vdjsvv2xzb32l0v8qgkac35lwmppck2bc4lrf5g3c52"
   }
  },
  {
@@ -14676,28 +14746,28 @@
   "repo": "magit/closql",
   "unstable": {
    "version": [
-    20250301,
-    2221
+    20250601,
+    1010
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "dc7924c1d206483a2555a98470c96fadf419f32d",
-   "sha256": "1gmad6gszy7imx3sq6s1sdkhgpmylp0c11p85ilz553cxyzv4n2r"
+   "commit": "05a2b048fd4e5c90aa971479cb9e71cf9aeba2bf",
+   "sha256": "0qk9g2f966iy534k0rbkgbz120psk3hvvw7hn720ym22rlbf214b"
   },
   "stable": {
    "version": [
     2,
     2,
-    1
+    2
    ],
    "deps": [
     "compat",
     "emacsql"
    ],
-   "commit": "dc7924c1d206483a2555a98470c96fadf419f32d",
-   "sha256": "1gmad6gszy7imx3sq6s1sdkhgpmylp0c11p85ilz553cxyzv4n2r"
+   "commit": "05a2b048fd4e5c90aa971479cb9e71cf9aeba2bf",
+   "sha256": "0qk9g2f966iy534k0rbkgbz120psk3hvvw7hn720ym22rlbf214b"
   }
  },
  {
@@ -14880,10 +14950,10 @@
    "version": [
     4,
     0,
-    2
+    3
    ],
-   "commit": "a12ed97b5c32a1e8f160ed557e7c97913ecf6ba5",
-   "sha256": "1c76ws079qd9yb5l9i645sz8prl04fxapdrm3d9yrdh1152b0hcv"
+   "commit": "79e82f371ca8f00696fb0b838521cb0f72bb7786",
+   "sha256": "08yw3qpk784942zs4nllviw2a2q2ag3x0a0vl09r3vng708k3z66"
   }
  },
  {
@@ -15388,14 +15458,14 @@
   "repo": "ankurdave/color-identifiers-mode",
   "unstable": {
    "version": [
-    20241023,
-    2217
+    20250612,
+    1046
    ],
    "deps": [
     "dash"
    ],
-   "commit": "89343c624ae64f568b5305ceca3db48d65711863",
-   "sha256": "1dly1xf2im3x1ikyrdc613jici16xgbhdb3sz357w1bfkxjhxzbj"
+   "commit": "8813aa7337d80462d5a8907cbce373c1592a4ed9",
+   "sha256": "1f7x3klxwaryafaabbrzm879y5h2yjhknxf46hz8l9l48l2sizvd"
   },
   "stable": {
    "version": [
@@ -16241,8 +16311,8 @@
   "repo": "cpitclaudel/company-coq",
   "unstable": {
    "version": [
-    20221130,
-    536
+    20250625,
+    922
    ],
    "deps": [
     "cl-lib",
@@ -16251,8 +16321,8 @@
     "dash",
     "yasnippet"
    ],
-   "commit": "5affe7a96a25df9101f9e44bac8a828d8292c2fa",
-   "sha256": "1i18w7byz0x9l7cka6cs7bk0d3wcy7r0gw34zz45np4r84arwsjd"
+   "commit": "9a872fe98cbf20a688ff35165f7f6a1b3f5b8380",
+   "sha256": "0rar1hamg3nna3ivq39sa55nxm8xyxca1m4k0lz17851g65nyrrz"
   },
   "stable": {
    "version": [
@@ -16549,15 +16619,15 @@
   "repo": "pkryger/company-forge.el",
   "unstable": {
    "version": [
-    20250522,
-    541
+    20250702,
+    1534
    ],
    "deps": [
     "company",
     "forge"
    ],
-   "commit": "fa185e94f453046ae3e1a89ff5412d4be1f26efb",
-   "sha256": "1301wxjnr4fzism4yd0rh623551hjlsic1w7fdr6vd1nc7i6jnma"
+   "commit": "a31ae799ed8e0c83380d6b2e9a112b76053e4ce9",
+   "sha256": "0bfyn7algjb5ys7jfln160zdx6dva9j2wq9fd6b1br8bqvaaf3v3"
   }
  },
  {
@@ -16568,16 +16638,16 @@
   "repo": "jcs-elpa/company-fuzzy",
   "unstable": {
    "version": [
-    20250424,
-    1433
+    20250602,
+    1018
    ],
    "deps": [
     "company",
     "ht",
     "s"
    ],
-   "commit": "536067f67281c5cc375bcc0ba1ce6e6a375e84a0",
-   "sha256": "0vs1spqy5zqhpi7s775cn1j9gqg73g4rh0x3bamv3b1k7qmjj1fa"
+   "commit": "e2da8ca84c9ba0a4fe6fa0ccdad83ce47aa14828",
+   "sha256": "1rfj4kivlc67xgh9garagzz082h1am25m2narr4kc33260bk0sq1"
   },
   "stable": {
    "version": [
@@ -17913,20 +17983,20 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20250323,
-    1331
+    20250704,
+    2211
    ],
-   "commit": "3b47285e0d47a792decc1fc42f0faf79e4c7477c",
-   "sha256": "0qy5dj61vfccy5q1yfanykgv3h356ivqsxfc3fcwwmlhjv20pzyp"
+   "commit": "4f26258dfce13288c21b7dbe218d670b4099e6a2",
+   "sha256": "0k9mdqgwwd8g57id3y4g6n4jml1l7q7ivmcs8yfdfz70mjz4lj8s"
   },
   "stable": {
    "version": [
     1,
-    0,
-    6
+    1,
+    1
    ],
-   "commit": "f5567d4f4ade48e74d24a2b8f3390f7efa18c801",
-   "sha256": "00i2m042yj883sk4l8zbq62ags3lvpsc21ys92ppbz6ldcbpw4fq"
+   "commit": "d8b0a801828772563e409ecc06d4e20d4522b6a1",
+   "sha256": "0sgzssrvqlg3lw0gra53sskic3krx9ipbq6h1ym6bnhxz9r29c22"
   }
  },
  {
@@ -18433,25 +18503,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20250530,
-    1248
+    20250702,
+    846
    ],
    "deps": [
     "compat"
    ],
-   "commit": "efad758b85b9b8af6d92e8c8d896eaba0623b8c3",
-   "sha256": "1jrjb0vl4yl928hi7mh6pdk0faancbrab1m1lcnfra7izbjwlbgf"
+   "commit": "d32cccdcb5559b503306291fa9f52df19594d687",
+   "sha256": "0kh16gclc6jdp1wv19sblg511irz5hfyy42c4shyl547im1cayar"
   },
   "stable": {
    "version": [
     2,
-    4
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e57fbb65584f3160f98a2569b1674c8065ec8df8",
-   "sha256": "1yppysk6jqgpqlrvid4h0vdw1sbg09a0rp966m8k2klpjxd1ihml"
+   "commit": "4314c45d84d9e00d45d2b611562d8fe2e4ddcf48",
+   "sha256": "18vnf1dca47d9rbs00gkhjxank34dxw6mbv165dgb3nq3hpzxgmw"
   }
  },
  {
@@ -18735,29 +18805,30 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250522,
-    523
+    20250531,
+    1028
    ],
    "deps": [
     "consult",
     "markdown-mode",
     "ox-gfm"
    ],
-   "commit": "c3513c6e66fe2871d54a32b4c469c26aa5db4da5",
-   "sha256": "109dapd54ywl62avr0xrwsxa11y6idlypw3qcq72fxxa7dw64qam"
+   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
+   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
   },
   "stable": {
    "version": [
     2,
-    5
+    5,
+    1
    ],
    "deps": [
     "consult",
     "markdown-mode",
     "ox-gfm"
    ],
-   "commit": "c3513c6e66fe2871d54a32b4c469c26aa5db4da5",
-   "sha256": "109dapd54ywl62avr0xrwsxa11y6idlypw3qcq72fxxa7dw64qam"
+   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
+   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
   }
  },
  {
@@ -18768,29 +18839,30 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250522,
-    523
+    20250531,
+    1028
    ],
    "deps": [
     "consult",
     "consult-gh",
     "embark-consult"
    ],
-   "commit": "c3513c6e66fe2871d54a32b4c469c26aa5db4da5",
-   "sha256": "109dapd54ywl62avr0xrwsxa11y6idlypw3qcq72fxxa7dw64qam"
+   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
+   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
   },
   "stable": {
    "version": [
     2,
-    5
+    5,
+    1
    ],
    "deps": [
     "consult",
     "consult-gh",
     "embark-consult"
    ],
-   "commit": "c3513c6e66fe2871d54a32b4c469c26aa5db4da5",
-   "sha256": "109dapd54ywl62avr0xrwsxa11y6idlypw3qcq72fxxa7dw64qam"
+   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
+   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
   }
  },
  {
@@ -18801,29 +18873,30 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250522,
-    523
+    20250531,
+    1028
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "c3513c6e66fe2871d54a32b4c469c26aa5db4da5",
-   "sha256": "109dapd54ywl62avr0xrwsxa11y6idlypw3qcq72fxxa7dw64qam"
+   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
+   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
   },
   "stable": {
    "version": [
     2,
-    5
+    5,
+    1
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "c3513c6e66fe2871d54a32b4c469c26aa5db4da5",
-   "sha256": "109dapd54ywl62avr0xrwsxa11y6idlypw3qcq72fxxa7dw64qam"
+   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
+   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
   }
  },
  {
@@ -18834,29 +18907,30 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20250522,
-    523
+    20250531,
+    1028
    ],
    "deps": [
     "consult",
     "consult-gh",
     "pr-review"
    ],
-   "commit": "c3513c6e66fe2871d54a32b4c469c26aa5db4da5",
-   "sha256": "109dapd54ywl62avr0xrwsxa11y6idlypw3qcq72fxxa7dw64qam"
+   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
+   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
   },
   "stable": {
    "version": [
     2,
-    5
+    5,
+    1
    ],
    "deps": [
     "consult",
     "consult-gh",
     "pr-review"
    ],
-   "commit": "c3513c6e66fe2871d54a32b4c469c26aa5db4da5",
-   "sha256": "109dapd54ywl62avr0xrwsxa11y6idlypw3qcq72fxxa7dw64qam"
+   "commit": "d640f86a6d8e419d27cc4cd67cbb526c617fcf18",
+   "sha256": "03274q4nfsass46amklkhda6vsfhb2y6idrm0rz5a1qcs6c5qz3s"
   }
  },
  {
@@ -19382,6 +19456,30 @@
   }
  },
  {
+  "ename": "conventional",
+  "commit": "fa524d77f33b4c06f5c206dee4327372e7702f08",
+  "sha256": "04bmadm96m099wskv5s8j7hjf4vxr5pjzp1iv1g4lscp064ksx9f",
+  "fetcher": "github",
+  "repo": "KeyWeeUsr/conventional",
+  "unstable": {
+   "version": [
+    20250630,
+    600
+   ],
+   "commit": "d4172953ddb8239108014ee82164892f08371b3b",
+   "sha256": "0j691ag568slprd28yc46znprxhx9wwrys0ha79k7h7fblgdasbq"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "d4172953ddb8239108014ee82164892f08371b3b",
+   "sha256": "0j691ag568slprd28yc46znprxhx9wwrys0ha79k7h7fblgdasbq"
+  }
+ },
+ {
   "ename": "cool-mode",
   "commit": "2e18a3bb58344b5b4b295f52402464b09b99d706",
   "sha256": "1nwa0hqygzg3g2dq8482n38xli5lfsi0x3ppqrjwwa35sxhg6cjs",
@@ -19404,16 +19502,16 @@
   "repo": "copilot-emacs/copilot.el",
   "unstable": {
    "version": [
-    20250506,
-    2016
+    20250630,
+    1059
    ],
    "deps": [
     "editorconfig",
     "f",
     "jsonrpc"
    ],
-   "commit": "fe3f51b636dea1c9ac55a0d5dc5d7df02dcbaa48",
-   "sha256": "0066zm38fpivz99fd0mam7yiw60pj3ihycgh20znmn7ir0a0ismd"
+   "commit": "4f51b3c21c42756d09ee17011201ea7d6e18ff69",
+   "sha256": "04w96rx2d4w858w9x76r2dqh4aqr940p60s95npk5jml8nr7ww76"
   },
   "stable": {
    "version": [
@@ -19438,8 +19536,8 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20250529,
-    1744
+    20250702,
+    934
    ],
    "deps": [
     "aio",
@@ -19450,14 +19548,14 @@
     "shell-maker",
     "transient"
    ],
-   "commit": "a2a920966a85e5bef5c36f5996cdda23030f6ef2",
-   "sha256": "0vdpbd98wdlhlg5pcjnj9nnb3p4fd6j0vcpkp91qvrpipl7wj9zr"
+   "commit": "434ac0c08f0aff04251a2e2ae37262e8d360ab67",
+   "sha256": "10ilz877srhhrcmhjwjchc6z2z6y0rfvsxvww67gbshqvz0r5iai"
   },
   "stable": {
    "version": [
-    2,
+    3,
     0,
-    1
+    0
    ],
    "deps": [
     "magit",
@@ -19468,8 +19566,8 @@
     "shell-maker",
     "transient"
    ],
-   "commit": "965ea54ec28d47ee8219831c93b1131ae51d8c06",
-   "sha256": "1zxp69p4c32wbh2sdd6779xsfk4zbygqsrr4vmq2cbkhxjw8s07c"
+   "commit": "765c08b45a6a35abaa67cd976fed37ab1b07370c",
+   "sha256": "1llj5513k3dqch7lfrxmv4rjbmk267hv8pq6zapa2k5y06h28gx2"
   }
  },
  {
@@ -19622,25 +19720,25 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20250528,
-    1945
+    20250611,
+    2329
    ],
    "deps": [
     "compat"
    ],
-   "commit": "52045e7168dadb00d374db557c44e6fcbcf8c762",
-   "sha256": "1i9855120bn9y8wzr2m165i16pw7ky8dh5acskb550illbc8avl2"
+   "commit": "53aa6c85be72ce220a4321487c535295b0de0488",
+   "sha256": "1f2hz1970f5ifd5p6lbxdi4krgxgvxrr477f6vbqakqj07bk9jps"
   },
   "stable": {
    "version": [
     2,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "77e639bc6b982be09f355390beef6f200936109a",
-   "sha256": "1zyjix22jinbnvc90kv31gzlvpqicfx5iyrwsjmbjcxm1cwpb59y"
+   "commit": "53aa6c85be72ce220a4321487c535295b0de0488",
+   "sha256": "1f2hz1970f5ifd5p6lbxdi4krgxgvxrr477f6vbqakqj07bk9jps"
   }
  },
  {
@@ -21825,14 +21923,14 @@
   "repo": "ideasman42/emacs-cycle-at-point",
   "unstable": {
    "version": [
-    20250421,
-    1059
+    20250611,
+    328
    ],
    "deps": [
     "recomplete"
    ],
-   "commit": "30cfa6ac1ebf6594e4947b11c9ac95148dcb6f96",
-   "sha256": "11qnzj27jpirajsh8dx62403daji36b68jvssx7rljipprci2cbs"
+   "commit": "3a635cdb6e0f106370ec762c8382b5cfc33690e7",
+   "sha256": "14ldsrzng49lp4prii3ilxc7ak3l9378ncjgj3m2ycf9lmn0w6wh"
   }
  },
  {
@@ -22484,6 +22582,21 @@
   }
  },
  {
+  "ename": "daselt",
+  "commit": "435b7cdd91b08fbb47bcfaa0ade99819957ba1a1",
+  "sha256": "19ymip7hv6d0ww60f3iwlr3kj4hvn19d8ll1p0irc5a1s6xgdn1v",
+  "fetcher": "gitlab",
+  "repo": "nameiwillforget/d-emacs",
+  "unstable": {
+   "version": [
+    20250627,
+    1245
+   ],
+   "commit": "99a3251cef48e9e85dda797f1897f4fe655ad1eb",
+   "sha256": "0d9ivn6nps8vyyn7msbdq6cafam1r1i1aancdfvyjlnqar65n37j"
+  }
+ },
+ {
   "ename": "dash",
   "commit": "2853d2fcf46eda788e5a3ea08815d0a2bf9d9d32",
   "sha256": "1z55hwp6xzbn44xbz6fzpcgbp1b1sf37amryl8p54likj3i21i8n",
@@ -22594,11 +22707,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20250521,
-    900
+    20250708,
+    57
    ],
-   "commit": "f07661b39bec3683cf9edb7b1c58f6e658b6f764",
-   "sha256": "0nc9sq12pppnl0yqgyczlrf8qqnxqnr942hbwg50wiqx57fkki0s"
+   "commit": "8c2cf0cfde4f5dac8c477f755380fffef6824108",
+   "sha256": "1fv33zivsjj0jnyisiqsif0ghj9wpklhlljpr219bqzh5pfa1r60"
   },
   "stable": {
    "version": [
@@ -23280,11 +23393,11 @@
   "repo": "ideasman42/emacs-default-font-presets",
   "unstable": {
    "version": [
-    20240421,
-    637
+    20250611,
+    330
    ],
-   "commit": "0087cbcbf78f107c0f908e4930f886a2d920eb90",
-   "sha256": "0vwj4b8ycb0im93k8nkbfwqi63wp0mywn5bigxhnd15d1339l04m"
+   "commit": "5f664dfc2765cbe0495c29f97712ed140aff8903",
+   "sha256": "011bbsjf59ximk0sc94cwig792f7igrrnan9x4i31ckkj5bh6fml"
   }
  },
  {
@@ -23431,6 +23544,36 @@
    ],
    "commit": "38e2f94779652fc6280a51b68dc910431513a8e1",
    "sha256": "1lyqd9cgj7cb2lasf6ycw5j8wnsx2nrfm8ra4sg3dgcspm01a89g"
+  }
+ },
+ {
+  "ename": "deflate",
+  "commit": "37388f645435af4932c6c428d192a8f3dff53a26",
+  "sha256": "18iqaix5m3bbz9ra09mcf02g1p83agjiw2h9z3l2gkvaayz1kax6",
+  "fetcher": "github",
+  "repo": "skuro/deflate",
+  "unstable": {
+   "version": [
+    20250703,
+    808
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "4896cdf0c1d031404c6705f52c03f048444ff927",
+   "sha256": "15zrjv3wqnqzscjy7vny6j13dy12vzri1i9zzmj2jii3x7wdkv4b"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    5
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "4896cdf0c1d031404c6705f52c03f048444ff927",
+   "sha256": "15zrjv3wqnqzscjy7vny6j13dy12vzri1i9zzmj2jii3x7wdkv4b"
   }
  },
  {
@@ -23668,27 +23811,27 @@
   "repo": "pprevos/denote-explore",
   "unstable": {
    "version": [
-    20250215,
-    2059
+    20250618,
+    1002
    ],
    "deps": [
     "dash",
     "denote"
    ],
-   "commit": "3f1678efe3470332bf9395cb07e15b928fb29d05",
-   "sha256": "118wrgfpmk36hm1vfpdfn7andm8r1zbl0cgc0cvwfyigzr1av7v1"
+   "commit": "9d9a6399551d707cd45606a1fdf54d3abfd43859",
+   "sha256": "02v67rafjw904wd2dagnqpif767jb3xrsrjq82sph6dqf1dc8k6i"
   },
   "stable": {
    "version": [
-    3,
-    3
+    4,
+    0
    ],
    "deps": [
     "dash",
     "denote"
    ],
-   "commit": "d2c1f94b6560d802755b010fcd4438068ddaa12f",
-   "sha256": "0773691jxyv039y407c8dppkky41b3icacavddcv9m8v481763b7"
+   "commit": "bd5b6db435b93a2c6da694b196b4b41c5b17f68a",
+   "sha256": "04lc5fw11wixbjdkzbl63g03rdybv6q4mh1dc6c9y322g8qq3r0k"
   }
  },
  {
@@ -23717,14 +23860,14 @@
   "repo": "swflint/denote-project-notes",
   "unstable": {
    "version": [
-    20250421,
-    1646
+    20250610,
+    1516
    ],
    "deps": [
     "denote"
    ],
-   "commit": "4dfa153659e68296fc4150b8ffd1e89e76406869",
-   "sha256": "1mnnm7qprbgdz17k44kllnrlnylsya0rba845p9q8835n4al562x"
+   "commit": "697420c089d313bf65e7963248c1909a8fdb348d",
+   "sha256": "1yh8idry374lxngv63rclaci5h8cpxc3b2fk8q15v70ivsc04gvj"
   }
  },
  {
@@ -23985,15 +24128,15 @@
   "repo": "astoff/devdocs.el",
   "unstable": {
    "version": [
-    20241113,
-    1341
+    20250608,
+    1414
    ],
    "deps": [
     "compat",
     "mathjax"
    ],
-   "commit": "d2214d34cdeb4483a594dd6973fcd095cef4653f",
-   "sha256": "0qgc2wb5bmpqjm7r9127cby97ps2bfxx5cx3yqcm0crmlgrayw2p"
+   "commit": "4023409017d37dc2d6c230fe010fadb917b4395b",
+   "sha256": "0dmy4s58cf2dj4k8w12yh7x1dy290454r2q8nywdw9qla74qfp04"
   }
  },
  {
@@ -24143,25 +24286,25 @@
   "repo": "minad/dicom",
   "unstable": {
    "version": [
-    20250114,
-    1926
+    20250604,
+    850
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3315d0c6444b15440c1b6ee0ac542c8392ccd909",
-   "sha256": "00h338yjivfzqms6zk567rqz55v15i2ad6knmsnaiwq9wwnq0dx7"
+   "commit": "33ef616725fb65270aecda68362caf1eaf8cbe07",
+   "sha256": "00w7sr6mfhkd2zkp91zq7vhk2v4ypg99gjrh2x1dqbd4vrh79rff"
   },
   "stable": {
    "version": [
     0,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "54440a704c573cd91b663ac79a01264a1aa59c51",
-   "sha256": "02n5wagcznl5fhyfh222kklj4z90pfrqpzm7q97agyx8bynzwr2p"
+   "commit": "33ef616725fb65270aecda68362caf1eaf8cbe07",
+   "sha256": "00w7sr6mfhkd2zkp91zq7vhk2v4ypg99gjrh2x1dqbd4vrh79rff"
   }
  },
  {
@@ -24258,11 +24401,11 @@
   "repo": "ideasman42/emacs-diff-ansi",
   "unstable": {
    "version": [
-    20250408,
-    2344
+    20250611,
+    510
    ],
-   "commit": "4cf357a4499a47c82e31fa1bd34485ae2c9eb353",
-   "sha256": "1nwvm14ag9a37qq9yqvlwiqhz8ly4waj9109pmqgja9sx3bx71kw"
+   "commit": "b5fc7fa7cea4e51dd201306a168d908a6d95c52a",
+   "sha256": "1niil7znxjjq3hm8ysmiqhp1v9mipgicd2giax5g8vw4mcjnv28x"
   }
  },
  {
@@ -24288,14 +24431,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20250519,
-    214
+    20250613,
+    2144
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "b5547efdd4196cc12109dee92c67ec8a804d92b1",
-   "sha256": "13zi6dy0zmd742liappmjyvbs99647spl7nr7myqik63lrfby7k0"
+   "commit": "830b05253ba8f35b80448e5de2201aecb6943840",
+   "sha256": "06g14mj493pxvb80yjw3739n4jnd5r4aldxvwy95m9ign8y00p13"
   },
   "stable": {
    "version": [
@@ -24411,16 +24554,16 @@
   "repo": "pkryger/difftastic.el",
   "unstable": {
    "version": [
-    20250527,
-    2100
+    20250702,
+    1543
    ],
    "deps": [
     "compat",
     "magit",
     "transient"
    ],
-   "commit": "239faba53f6d86cab4038e78fd13d4a33de0dddb",
-   "sha256": "0wrbsldz8c2xgckiwhvga725ji7xnz7g2kihnbb9sjvhxhmpmxxp"
+   "commit": "c4ab6b322b19f5ad06514a46b35a64f169e41f91",
+   "sha256": "1vncgv8jn7qncnraa1skcvs5z7w2v7g63a982li57yk7rgfhqcfv"
   }
  },
  {
@@ -24587,26 +24730,26 @@
   "repo": "tarsius/dim-autoload",
   "unstable": {
    "version": [
-    20250509,
-    1453
+    20250531,
+    2216
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f2d5e3f5b272d958423a9eec1fd094b4764c7395",
-   "sha256": "1gn7zz1c45ijkqay2mw2dwpjqgiyz3alxz20m4kr20h8m0qi9br0"
+   "commit": "52b87938ea61c78f21647b0ae185e13ba3653513",
+   "sha256": "10pwdhn80z0spiscmzsa060qmzlvsdnl8ynb5b7sb225shgr1sjn"
   },
   "stable": {
    "version": [
     2,
     0,
-    7
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "dbe0f038c0a7fcc7e0f021947a42db5b0e8f143d",
-   "sha256": "1mj1h0j6sdb5c7ylcks51xn69003l0j12kifwz7cmwrhv55g54az"
+   "commit": "52b87938ea61c78f21647b0ae185e13ba3653513",
+   "sha256": "10pwdhn80z0spiscmzsa060qmzlvsdnl8ynb5b7sb225shgr1sjn"
   }
  },
  {
@@ -25706,14 +25849,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20250526,
-    1647
+    20250615,
+    1518
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "6072d009712f31ec58a49140ffa9da05f0f2b2c1",
-   "sha256": "11l09gmw1j7rn1y0y4rp53h5q2smrj3gxqdm55nq86anqpr3p325"
+   "commit": "3e2599df299dd65e184af8725ce3c634e37d7540",
+   "sha256": "01na9d7ag0zm6bn119f5n2raz799vg3xjmw1g24fcisrrnzagiaq"
   },
   "stable": {
    "version": [
@@ -26200,14 +26343,14 @@
   "repo": "aurtzy/disproject",
   "unstable": {
    "version": [
-    20250529,
-    1432
+    20250622,
+    133
    ],
    "deps": [
     "transient"
    ],
-   "commit": "4cd9d4041f17826dd577bf777e5226c0b55f0f35",
-   "sha256": "17691mi013pp1l39dmgzil6kq3nl0dqnqmwsba5j1j3dbfzm9i42"
+   "commit": "ed818cd90042581e2b893b38af5dfca2b64dd0a0",
+   "sha256": "06pm09ssm73qvsi7q1h31c51dp3ny22x8a9k71br63r0l069s29l"
   },
   "stable": {
    "version": [
@@ -27101,21 +27244,21 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20250423,
-    1614
+    20250704,
+    1558
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "297b57585fe3b3de9e694512170c44c6e104808f",
-   "sha256": "0psh1k6fnjv9gazcdrqz6yzhcs1iaj45bh74hcz0dakn270c7n6m"
+   "commit": "14b09e0b20f0e210be54167b12c3b5a201eb0327",
+   "sha256": "093faiamd6lk2abk5n61i86drawqb00v319yg9vv95an6silcmmg"
   },
   "stable": {
    "version": [
     4,
-    1,
+    2,
     0
    ],
    "deps": [
@@ -27123,8 +27266,8 @@
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "bf880ae56f3f6aab7bd334de9bd9b455c63a24c0",
-   "sha256": "0l7yyn8yxyxbsjbs52bp9wh66wdj828scb1gjbi6pk1hrx5x8g9v"
+   "commit": "14b09e0b20f0e210be54167b12c3b5a201eb0327",
+   "sha256": "093faiamd6lk2abk5n61i86drawqb00v319yg9vv95an6silcmmg"
   }
  },
  {
@@ -27135,15 +27278,20 @@
   "repo": "elken/doom-modeline-now-playing",
   "unstable": {
    "version": [
-    20240522,
-    1704
+    20250707,
+    950
    ],
-   "deps": [
-    "async",
-    "doom-modeline"
+   "commit": "ba1619e98e011dabb24450db3e2e125bcce02a19",
+   "sha256": "0i8gdmfvw68qd8n3350jk4ndpzlldqrd5s4j8hlfdn1gcblr6k33"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
    ],
-   "commit": "1532f324f98a234aa14e12ebdfd17cebba978d6a",
-   "sha256": "0mk759hznnpwvwzqykncgij60773z87x976ql5ccarz4j79j44sv"
+   "commit": "bde17eb2d65cea890c18c516096d1580a812d366",
+   "sha256": "0qd0zls0d2fvy3vxp7ihaw02zrfq2xa69vqbq463yrwdzdx16z7d"
   }
  },
  {
@@ -27154,14 +27302,14 @@
   "repo": "doomemacs/themes",
   "unstable": {
    "version": [
-    20250521,
-    1746
+    20250614,
+    958
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "729ad034631cba41602ad9191275ece472c21941",
-   "sha256": "0g9p206mf9panfpln6linhkrcwv0mk9qdr51bs8czcq516z3qmhz"
+   "commit": "3152c60bb55365ebd3b042a40aa68c9b756667f7",
+   "sha256": "02ivxhzf9pb12viqprb3izy7r42y60axyna7400j70xnqsrrvvfi"
   },
   "stable": {
    "version": [
@@ -27434,20 +27582,20 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20250407,
-    1205
+    20250625,
+    2011
    ],
-   "commit": "8b3a005db9e8b7ac57e683bc6631cdc7643e8150",
-   "sha256": "1f0z53ad89cqs9nskinvqnz3286gvjr4ldifcyc5qyb7r58pivz6"
+   "commit": "ad30f50e06c1b4c3e461c647e976cd00b9bc4869",
+   "sha256": "1vv00hgik7pvj1p0ii8g6bcyvfjzwhh33hjh0gfgsh8gxm1lfij8"
   },
   "stable": {
    "version": [
     1,
     8,
-    2
+    3
    ],
-   "commit": "29d5180f7e34c0c858a520068fb650f705b8cfc2",
-   "sha256": "0hjimiv6a0kaszypndb5l0axhiv0zih728p8wffil6jff9k8pr38"
+   "commit": "ad30f50e06c1b4c3e461c647e976cd00b9bc4869",
+   "sha256": "1vv00hgik7pvj1p0ii8g6bcyvfjzwhh33hjh0gfgsh8gxm1lfij8"
   }
  },
  {
@@ -27911,10 +28059,10 @@
    "version": [
     3,
     19,
-    0
+    1
    ],
-   "commit": "645a7897e4b9540cc4d79ffbd59f9be259cd6317",
-   "sha256": "1cxv2wycppxi01616bp01qhyjhkzjcf3n0ji4gciz998lbbdg60w"
+   "commit": "76c0c3941798f81dcc13a305d7abb120c191f5fa",
+   "sha256": "01ys792jnld5yihhyirwkk4jlqm59bk0vrqjvvk5xjn8pp26vryq"
   }
  },
  {
@@ -28053,11 +28201,11 @@
   "repo": "sadiq/dwim-coder-mode",
   "unstable": {
    "version": [
-    20241121,
-    1117
+    20250622,
+    409
    ],
-   "commit": "dda1e9b991c9dc7ff2a2779731783db3176c3b61",
-   "sha256": "1kq29hrbdyfa2gc13w5f2c92pb9k2hr4m86f9s7vjc1lhx32v7gw"
+   "commit": "ce1383d3bcfef68fba6c632556d1a09045343781",
+   "sha256": "1fpizdald5ghrmhidwmypf81lw238lfzzmyzrqih9pgi3nkmgbnq"
   }
  },
  {
@@ -28168,11 +28316,11 @@
   "repo": "zellerin/dynamic-graphs",
   "unstable": {
    "version": [
-    20210908,
-    2010
+    20250701,
+    853
    ],
-   "commit": "64ca58dffecdecb636f7fe61c0c86e9c3c64d4dd",
-   "sha256": "15raac8fvsrlsca7vr4dakj4bh1zqc8fq61wkn6wh6pfyjm76r22"
+   "commit": "5aa3182174de28b6c034a43cd9ef2f26024911b1",
+   "sha256": "1jb2kc9z00ni660ff9bva6dkfsghlv490yyyd2bd85pzfhjvb3mk"
   }
  },
  {
@@ -28581,20 +28729,20 @@
   "repo": "emacs-eask/eask",
   "unstable": {
    "version": [
-    20250530,
-    308
+    20250707,
+    1919
    ],
-   "commit": "2a94f252d69df007385ed4e65870e5d557113db9",
-   "sha256": "17vwhx2pf5pqymjjq0cdm17b6445ijiks1cnh6hvf2valhy2dp8g"
+   "commit": "53bc76d3d5452f7d08b9e24188421751b54fff83",
+   "sha256": "0v73bfwcpnm2llp9pqpqc50vihrifabdwjdb1x1qq6ph4nsnwdzv"
   },
   "stable": {
    "version": [
     0,
     11,
-    5
+    7
    ],
-   "commit": "16f67c8eb1a6f53b361b608d129282dbd5f62a21",
-   "sha256": "0f2571i9gbgcl3h1x4876xgh32zklmnhk0457iq0hjdq0gq7fwvz"
+   "commit": "c80c69aaa78f2172f0619bc793877b2b8ace9e33",
+   "sha256": "1g4rr0b9nikrq8lmy9gvbaqf49qfwxcb3s24p1cwbaa5p82k8097"
   }
  },
  {
@@ -28632,8 +28780,8 @@
   "repo": "emacs-eask/easky",
   "unstable": {
    "version": [
-    20250404,
-    17
+    20250630,
+    1831
    ],
    "deps": [
     "ansi",
@@ -28642,8 +28790,8 @@
     "lv",
     "marquee-header"
    ],
-   "commit": "070c734bdc5fafdf0de060f9584b1a037681eac2",
-   "sha256": "0zcw1575kkabifxcyvw88dh5snp1b265f0s8fmhpvrbb350l24v5"
+   "commit": "8c9f23446e3e728fc9fb12e3cc02b9b67c1e837d",
+   "sha256": "1bxqcalzmp5in4lni72fpa5ya761hddygcvxgz7kzc6lnx9nxm7n"
   },
   "stable": {
    "version": [
@@ -28693,6 +28841,29 @@
   }
  },
  {
+  "ename": "easy-find",
+  "commit": "cd34aa5ae59811a1b6c15b26c4533fd21e97761b",
+  "sha256": "15xa2xli4nxs5flalf9igmilnkf17pd58785hfw5xy2sdj5jgyhy",
+  "fetcher": "github",
+  "repo": "emacselements/easy-find",
+  "unstable": {
+   "version": [
+    20250629,
+    2002
+   ],
+   "commit": "b67ce974a72263ef9af65f23f89feae852786a64",
+   "sha256": "129v1y47hymxfb2qjar804sl9k5dflbmw8mdjgzm114s4fdbcpzl"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "3145fc113d9d49c4646e3ccf8c8c0a7b4a6d988e",
+   "sha256": "05v7glnzpdp7hyilmznf1r2vxmrmvgnaa4njxqlc8wrq99x6pwd3"
+  }
+ },
+ {
   "ename": "easy-hugo",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "1m7iw6njxxsk82agyqay277iql578b3wz6z9wjs8ls30ps8s2b8g",
@@ -28700,21 +28871,21 @@
   "repo": "masasam/emacs-easy-hugo",
   "unstable": {
    "version": [
-    20250106,
-    1158
+    20250701,
+    2138
    ],
    "deps": [
     "popup",
     "request",
     "transient"
    ],
-   "commit": "b5a6d76d7ed653fd6ddaecf2a58045400e82e6a7",
-   "sha256": "10d5flqwr7v3fh3s31dap874ahjly0l9x4q2jylxg87q7fnsdxd6"
+   "commit": "649aa56b1f7a2fc096aedc417316ef4ec0082957",
+   "sha256": "1fndy1w6a3dqlfjrghjlqrjpdbaaj434ljzm4qnkcdr1pfr85jiy"
   },
   "stable": {
    "version": [
     3,
-    10,
+    11,
     61
    ],
    "deps": [
@@ -28722,8 +28893,8 @@
     "request",
     "transient"
    ],
-   "commit": "b5a6d76d7ed653fd6ddaecf2a58045400e82e6a7",
-   "sha256": "10d5flqwr7v3fh3s31dap874ahjly0l9x4q2jylxg87q7fnsdxd6"
+   "commit": "649aa56b1f7a2fc096aedc417316ef4ec0082957",
+   "sha256": "1fndy1w6a3dqlfjrghjlqrjpdbaaj434ljzm4qnkcdr1pfr85jiy"
   }
  },
  {
@@ -28847,20 +29018,20 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20250426,
-    1725
+    20250613,
+    1708
    ],
-   "commit": "2d478bf264b8f4e8bae9222e67fc69553bee7cc7",
-   "sha256": "0d5cipvgrxn07plim9af4lp59bfaliim4m63fjgad8ib6hxlfqrf"
+   "commit": "b28881254c639f5e6a34e4ab46ba1d84e2a8d225",
+   "sha256": "1g658l2vpk09j6mc0q6z1z2lqv1gcr0xvkxf7i1g3101ck72ynrz"
   },
   "stable": {
    "version": [
     1,
     1,
-    3
+    4
    ],
-   "commit": "1a72f4e0460d81c7b5c43fd5b96aa743b6340bec",
-   "sha256": "1wrw3x27fvh94bs6sajcfz421q01b1i4kdm3k5m3fd384md5jqr3"
+   "commit": "b28881254c639f5e6a34e4ab46ba1d84e2a8d225",
+   "sha256": "1g658l2vpk09j6mc0q6z1z2lqv1gcr0xvkxf7i1g3101ck72ynrz"
   }
  },
  {
@@ -28871,28 +29042,28 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20240428,
-    1852
+    20250704,
+    342
    ],
    "deps": [
     "ebdb",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
     "ebdb",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   }
  },
  {
@@ -28936,15 +29107,15 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20250526,
-    1211
+    20250607,
+    740
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "9503463cf1928b2d0bc46e45ea7c1cf498d3c577",
-   "sha256": "1xdzq5lyyfbg54pnlzgi777n3nviifllqfkppqgcdw6hvxdna45l"
+   "commit": "01a6b41c1e1034ee094b38d1b072500c5ae3ef67",
+   "sha256": "1ir7f95g2h3yw29l33siilziv1a481y0xkmbdn8ajk9zp9395agp"
   },
   "stable": {
    "version": [
@@ -28968,8 +29139,8 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20240428,
-    1852
+    20250704,
+    342
    ],
    "deps": [
     "citeproc",
@@ -28977,13 +29148,13 @@
     "universal-sidecar",
     "universal-sidecar-citeproc"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
@@ -28992,8 +29163,8 @@
     "universal-sidecar",
     "universal-sidecar-citeproc"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   }
  },
  {
@@ -29024,6 +29195,27 @@
    ],
    "commit": "45294cedeeefdcb0193b18dc3e2254db0aa700c3",
    "sha256": "11canjhvwpj2hy5czav2hn1hx0lzckicsbr3p8fr6pjrg3gg2bwh"
+  }
+ },
+ {
+  "ename": "eca",
+  "commit": "e94654b9959a5a2de2bae3cc5a60326e186b45b0",
+  "sha256": "0ls7091d9769kdvddvicw3nf7ps026pz097w3qkjbsbxh2gdyj9v",
+  "fetcher": "github",
+  "repo": "editor-code-assistant/eca-emacs",
+  "unstable": {
+   "version": [
+    20250706,
+    2133
+   ],
+   "deps": [
+    "compat",
+    "dash",
+    "f",
+    "markdown-mode"
+   ],
+   "commit": "912adf956e4bbeef30e47403c57a6d21502251e3",
+   "sha256": "06my4mzl0zapvj15xdqc3g7c4rc257d4jhd4ib94478735hh9mzb"
   }
  },
  {
@@ -30429,20 +30621,20 @@
   "repo": "meedstrom/el-job",
   "unstable": {
    "version": [
-    20250524,
-    2004
+    20250606,
+    1931
    ],
-   "commit": "24016a05bd5bf61a20a88ea79f63b0fb1881b55b",
-   "sha256": "087dsmij7jy2bfhcp2h72kl3p6cpv7y7wjwaji5d3af6prkd1cm6"
+   "commit": "6520508920acca44be090bd655ad943751e20ef1",
+   "sha256": "0acyk63052vsii7xnfp6l4n1s4063lprapp662p4p660wk559fnr"
   },
   "stable": {
    "version": [
     2,
     4,
-    7
+    8
    ],
-   "commit": "9258e707ad154170a8beae3f84b25161f42aa200",
-   "sha256": "0gspy2yvi7pyzvw73p49s42a3w104xlrwwvwykw93rf277kq4i6d"
+   "commit": "6520508920acca44be090bd655ad943751e20ef1",
+   "sha256": "0acyk63052vsii7xnfp6l4n1s4063lprapp662p4p660wk559fnr"
   }
  },
  {
@@ -30477,11 +30669,11 @@
   "repo": "radian-software/el-patch",
   "unstable": {
    "version": [
-    20231123,
-    2216
+    20250623,
+    1754
    ],
-   "commit": "92803e7ea6e07cd56667ed7ea0dfacfc1f37f6d9",
-   "sha256": "0x2x3ci5i428wgagbwjh9qp2zlflkzlrkbpi6qa4fv7dq3vgkrv2"
+   "commit": "654deaba847a761496f9baeb6f95031c187c019f",
+   "sha256": "18nmrvzqnmzzs05gqhhmp0m8fa5rb09pa2418n5fwsjv0swcqdp8"
   },
   "stable": {
    "version": [
@@ -30832,11 +31024,11 @@
   "repo": "vilij/slurpbarf-elcute",
   "unstable": {
    "version": [
-    20250326,
-    2158
+    20250707,
+    823
    ],
-   "commit": "47980a15f760d14a7c44a8dbc3e708a47d2f489e",
-   "sha256": "134ra4cshr3ldqwdaqvrv2iiqkdyfrh66i0kh17lc1yyyssn43fl"
+   "commit": "3f1c0befad5a70cf51ca38131cfa1f6fa287cbf6",
+   "sha256": "02swww902hj2kp3d9njs48iiz486vs4984nn1bv0giy7mwxvmwjw"
   }
  },
  {
@@ -31138,29 +31330,6 @@
    ],
    "commit": "5cbc688584ba103ea3be7d7b30e5d94e52f59eb6",
    "sha256": "13jv4dars81b42593zijpjm0qci0z7hizbjsjab3xfxi3m3r4pk4"
-  }
- },
- {
-  "ename": "elein",
-  "commit": "0ddcfbc20264759a22712130c8ccf0825d3d198b",
-  "sha256": "0nh3kvm3vdbpc48cbs1dlfb9yaxyg25nwr62w2diynqlpgl797d0",
-  "fetcher": "codeberg",
-  "repo": "rwv/elein",
-  "unstable": {
-   "version": [
-    20120120,
-    1116
-   ],
-   "commit": "d4c0c0491dbb7c90e953d7a16172107c37103605",
-   "sha256": "1ijrhm9vrzh5wl1rr9ayl11dwm05bh1i43fnbz3ga58l6whgkfpw"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "commit": "ae1aebc8abe293d5d6949d290628537c3705078d",
-   "sha256": "1vlrklhy18gswgjip5ih5g5v1b80zf5n4w3nrkygyq6f4s24r9ak"
   }
  },
  {
@@ -31649,11 +31818,11 @@
   "repo": "ideasman42/emacs-elisp-autofmt",
   "unstable": {
    "version": [
-    20250421,
-    1112
+    20250611,
+    2328
    ],
-   "commit": "30c9895f9cb64ac83a53b9f3e78a27f5abca322a",
-   "sha256": "192m68jwjplqxjnja4mc32fgrdixrxnr3y4xl64s8v4nwjd1rvs2"
+   "commit": "c4cd57b2599ec82a4363ae322aa734e34a719404",
+   "sha256": "1m7yrhphsm9s1xkhyd94pbdyxbh3iyr5z9bj8pnbp4pccb76xfcd"
   }
  },
  {
@@ -31744,6 +31913,24 @@
    ],
    "commit": "15909462e3f7daf445d3cecf402ee16c7e3263ed",
    "sha256": "0l08xy83b3avjjaydys7f25rr0l4ifh6awl8dyy6ww6wvrz7sd4c"
+  }
+ },
+ {
+  "ename": "elisp-dev-mcp",
+  "commit": "7496dd670880f012fa0a30449827201ad9d6a6d6",
+  "sha256": "0zz61da1fqj6dhk4y8zbjgmdhvxkq84hyn5h1dqini9z7nn1d52w",
+  "fetcher": "github",
+  "repo": "laurynas-biveinis/elisp-dev-mcp",
+  "unstable": {
+   "version": [
+    20250618,
+    611
+   ],
+   "deps": [
+    "mcp-server-lib"
+   ],
+   "commit": "7d0965f0642ca2e8d14153eef31bcdf5ba8acb75",
+   "sha256": "0vmjcdphdx315qqmgwpas0jv83g16vx4l2p1apam87fy1npyixw9"
   }
  },
  {
@@ -32727,30 +32914,30 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20250301,
-    1701
+    20250701,
+    1217
    ],
    "deps": [
     "compat",
     "llama",
     "seq"
    ],
-   "commit": "ff70b824c17193af6e66f748573d5120a3527377",
-   "sha256": "00savh3hgr1m14h84hnjfp8k1j38b7wmv9bwkchnzzrcy291azhx"
+   "commit": "fec8743eea83ed716ffac7659142ddfdd23d9e39",
+   "sha256": "16qmfwpl7bs8mrgmlii8jkkwzckmrm220w0z008bcjpc1wn9l5l7"
   },
   "stable": {
    "version": [
     2,
     2,
-    1
+    3
    ],
    "deps": [
     "compat",
     "llama",
     "seq"
    ],
-   "commit": "ff70b824c17193af6e66f748573d5120a3527377",
-   "sha256": "00savh3hgr1m14h84hnjfp8k1j38b7wmv9bwkchnzzrcy291azhx"
+   "commit": "fec8743eea83ed716ffac7659142ddfdd23d9e39",
+   "sha256": "16qmfwpl7bs8mrgmlii8jkkwzckmrm220w0z008bcjpc1wn9l5l7"
   }
  },
  {
@@ -32791,11 +32978,11 @@
   "repo": "tecosaur/emacs-everywhere",
   "unstable": {
    "version": [
-    20250325,
-    1523
+    20250609,
+    1444
    ],
-   "commit": "caeab3948ff02acec4e4bbc2ff17090f56c7040e",
-   "sha256": "1rh28n44jawmb8zqx8vd2cvg27x4q8jnrbw38l07yhza13zjz26l"
+   "commit": "4ec16c12ce1eef3c35b5ebb9ddadd928b907f823",
+   "sha256": "1jqs227xib3vj0iiq3x0r1xv86ax09hnfidild8c6xcpdgjw89z0"
   }
  },
  {
@@ -32845,20 +33032,20 @@
   "repo": "magit/emacsql",
   "unstable": {
    "version": [
-    20250401,
-    1500
+    20250601,
+    1009
    ],
-   "commit": "5470adaf5dcabebc80c913ac831258fd47a87cbe",
-   "sha256": "0bjw4qbm254r51kgl0bg4scblk998p0y3m140k5lmrdb7k4pnxq2"
+   "commit": "ced062890061b6e4fbe4d00c0617f7ff84fff25c",
+   "sha256": "0khnln4p4d8fcwx02zp3j6x002x2ik0hs0jxf17xif9b8p2rri3c"
   },
   "stable": {
    "version": [
     4,
     3,
-    0
+    1
    ],
-   "commit": "5470adaf5dcabebc80c913ac831258fd47a87cbe",
-   "sha256": "0bjw4qbm254r51kgl0bg4scblk998p0y3m140k5lmrdb7k4pnxq2"
+   "commit": "ced062890061b6e4fbe4d00c0617f7ff84fff25c",
+   "sha256": "0khnln4p4d8fcwx02zp3j6x002x2ik0hs0jxf17xif9b8p2rri3c"
   }
  },
  {
@@ -32965,14 +33152,14 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20250530,
-    1948
+    20250707,
+    1947
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2941f2ea36d61c1a84c3f79ebe47d604c9a92b5d",
-   "sha256": "14f2vn4g8iz9sfzd6bfb2kk3bjih397z7ij148wzi709kdr59pk9"
+   "commit": "89c7610fa7988b6c93029f87afa4ba6b7768bf81",
+   "sha256": "1iqghcrwn1wfz867l3cd9qvcsh3hg5fgicbsyvxll7fpbg9gw8v5"
   },
   "stable": {
    "version": [
@@ -32994,16 +33181,16 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20250201,
-    501
+    20250622,
+    535
    ],
    "deps": [
     "compat",
     "consult",
     "embark"
    ],
-   "commit": "d5df0eff182b014ab49328a4dbb1d69eb7faafbd",
-   "sha256": "0yirl32za3lx1spppckcdwx53hbyyrnnf8ry5wd2kx75j3nbirba"
+   "commit": "a563786d0e07fc43601c1c83d1ffc801b86506b9",
+   "sha256": "05inj6mq5kjs33sz4r7qjs0z179b15g1zr9cxqr9jpnzf8dgzapi"
   },
   "stable": {
    "version": [
@@ -33218,16 +33405,16 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20250405,
-    1417
+    20250610,
+    247
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "abb4f614dae6b7e90ee1f275d8a5e40721c39d54",
-   "sha256": "0xbqgv01say2hidrls6rwy2d902ks28z41h1hkpj73f8s4h0d520"
+   "commit": "e5f46561c3c140d774354f91d1e95c60039a1934",
+   "sha256": "0rrvs21p1gs7v2h2pr06adzw8s04rjsgjd5z4xycvq91s2mdnp9k"
   },
   "stable": {
    "version": [
@@ -33629,15 +33816,15 @@
   "repo": "isamert/empv.el",
   "unstable": {
    "version": [
-    20250406,
-    2037
+    20250629,
+    901
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "f14d4ac96e24368ad4688efc4a71da39804892f0",
-   "sha256": "06ahark9jin8cfk7d6d82xyhy0pp1yrd03c4lawhyppn1aswkb5z"
+   "commit": "2bb45a6a3119d2816af351ff097506c6f2801dd6",
+   "sha256": "153r4xbsa4a14sd6gdpa820qkmk82yd102v3zmm20b63akxbpmxf"
   },
   "stable": {
    "version": [
@@ -33795,11 +33982,11 @@
   "repo": "zenspider/enhanced-ruby-mode",
   "unstable": {
    "version": [
-    20240925,
-    1920
+    20250610,
+    2139
    ],
-   "commit": "b9cea578ef6738ce675243296c3abf91b9323e11",
-   "sha256": "0j130xxph6iygrxqagy1flsvxzlhk305ypzf8cb02bf3kvjdjfmg"
+   "commit": "ad18cf208afd828a65d707f075d64bb3e4c1509d",
+   "sha256": "0wbq18f3a598xi5dl2r5484713dcdlf378yc604jc0gyj27ykrpk"
   },
   "stable": {
    "version": [
@@ -33994,15 +34181,15 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20250401,
-    1656
+    20250602,
+    1734
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "4ca2166ac72e756d314fc2348ce1c93d807c1a14",
-   "sha256": "1l10nldvdb1dyikz1ahccbmp09i4dhqynl3w4sma7a29n8sciyyl"
+   "commit": "cb5f6d2a4217c1e2cc963072aaa5ecfe257ab378",
+   "sha256": "07krgk0px9756ihzc2z37xvky6919rpyp6w474mzjfkilqcp6z4a"
   },
   "stable": {
    "version": [
@@ -34138,8 +34325,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20250509,
-    1442
+    20250601,
+    1044
    ],
    "deps": [
     "closql",
@@ -34147,14 +34334,14 @@
     "emacsql",
     "llama"
    ],
-   "commit": "327709a01a6eded82016a24c478456b8be31da09",
-   "sha256": "0rxpcjkgmmishalhvg3lfc3lcq704kssq8w9g5c1v5ppppp36fnk"
+   "commit": "bc9a6018f07dc3e5e1bd2139d08d1dd1af92eea8",
+   "sha256": "1a4a56whm2m576mm2pzvvhnf2jkix8dg73wamgj8gn2m8b1591i3"
   },
   "stable": {
    "version": [
     4,
     0,
-    6
+    7
    ],
    "deps": [
     "closql",
@@ -34162,8 +34349,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "e66f246ec2df5d62665c0bdcf3f8f5534225b934",
-   "sha256": "0sl45frbvkfiblbbpa3xlv58bql8p8bms80p7yi2fp4ggipq8k19"
+   "commit": "bc9a6018f07dc3e5e1bd2139d08d1dd1af92eea8",
+   "sha256": "1a4a56whm2m576mm2pzvvhnf2jkix8dg73wamgj8gn2m8b1591i3"
   }
  },
  {
@@ -34174,30 +34361,30 @@
   "repo": "emacscollective/epkg-marginalia",
   "unstable": {
    "version": [
-    20250302,
-    21
+    20250601,
+    1049
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "ad41118a3fed2b4312a0b3266ffa029996523aa4",
-   "sha256": "1mkd0677mr21cyksv681nfvysc0r6xcc60h0pvr2mrlag97m50nh"
+   "commit": "d9e58d467c40bf71794f8eee758a83ab0e1933db",
+   "sha256": "1hymzfc2qydjhdhdisd3ba1bqajl7vpn4acdwk9xykip02bnxsfa"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    3
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "ad41118a3fed2b4312a0b3266ffa029996523aa4",
-   "sha256": "1mkd0677mr21cyksv681nfvysc0r6xcc60h0pvr2mrlag97m50nh"
+   "commit": "d9e58d467c40bf71794f8eee758a83ab0e1933db",
+   "sha256": "1hymzfc2qydjhdhdisd3ba1bqajl7vpn4acdwk9xykip02bnxsfa"
   }
  },
  {
@@ -34303,20 +34490,20 @@
   "repo": "alex-iam/epx",
   "unstable": {
    "version": [
-    20250520,
-    1527
+    20250607,
+    1427
    ],
-   "commit": "d0e5884ee6e75c90a214050d0b6ca42394a39797",
-   "sha256": "1fbkbgia6ibsb46c319bqd1p77n5n7q7kbl9gv7f18di7l2cfqpr"
+   "commit": "91d7b924981f3a8f300ae7f420972022faed4b99",
+   "sha256": "1pccks3cvb8fc02g643dkyrqvq8w81kmi2m4ivpc6icw9x8hidxl"
   },
   "stable": {
    "version": [
     0,
     3,
-    0
+    1
    ],
-   "commit": "e4b4d0cd5d772f14d2284a83b8b32f24e09e717b",
-   "sha256": "1jnbgwmz23aga40rml7i8f4kafyxgzf9lvr8im96js3f2ngs1cad"
+   "commit": "91d7b924981f3a8f300ae7f420972022faed4b99",
+   "sha256": "1pccks3cvb8fc02g643dkyrqvq8w81kmi2m4ivpc6icw9x8hidxl"
   }
  },
  {
@@ -34832,12 +35019,11 @@
   "stable": {
    "version": [
     2,
-    7,
-    0,
-    1
+    8,
+    0
    ],
-   "commit": "a6fc20c27ae953149b53a8997ba4a1c8b17d628a",
-   "sha256": "1dh9fi8lwjv9rk6zik2bwjgqln0f0d36m3hm9m3zmmk4fby4rsi2"
+   "commit": "3d04bacca842729f9c0869b9287256321b5f450f",
+   "sha256": "0201x9f6v0s6fma9ybbwrkgwjilizj5n24kcwj3pg6rf9dzy1jya"
   }
  },
  {
@@ -34882,19 +35068,20 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20250520,
-    1119
+    20250613,
+    1454
    ],
-   "commit": "9e6f6742c4d9e9915ee8af0dcb7d97cf1f836116",
-   "sha256": "06294x2y8x245v78xp6z035crpdhy248drxc0hjgblm9nghl78v6"
+   "commit": "d9454dbccbaaad4b8796095c8e653b71b066dfaf",
+   "sha256": "1giajqrz1h8mi3n59q6d56djl3d5hvdm9b5yk98v9bx3x2nw6q3r"
   },
   "stable": {
    "version": [
     28,
-    0
+    0,
+    1
    ],
-   "commit": "9e6f6742c4d9e9915ee8af0dcb7d97cf1f836116",
-   "sha256": "06294x2y8x245v78xp6z035crpdhy248drxc0hjgblm9nghl78v6"
+   "commit": "d9454dbccbaaad4b8796095c8e653b71b066dfaf",
+   "sha256": "1giajqrz1h8mi3n59q6d56djl3d5hvdm9b5yk98v9bx3x2nw6q3r"
   }
  },
  {
@@ -35278,6 +35465,21 @@
    ],
    "commit": "0f69f9f45ac15018c48853509ac38e68286f9c0e",
    "sha256": "0cairmqsaghl2ddb2v8zhcwy5ik756m7gkair8xrbigz4jklpcv9"
+  }
+ },
+ {
+  "ename": "esb",
+  "commit": "560e9de3dfaa842e6ad9c7bdbab4140dbeada732",
+  "sha256": "1450dck9k5773q3q46kq2pz8jyak34g6kmh6a2hcd3rw14crkri3",
+  "fetcher": "github",
+  "repo": "0xhenrique/esb",
+  "unstable": {
+   "version": [
+    20250602,
+    218
+   ],
+   "commit": "874ad790046f35c2a4a5589841f5ee9923ad8d8f",
+   "sha256": "0f3d1y1ikr24cfy5qihllqqfwm45xccah21v4h96lvrij5wc6vg0"
   }
  },
  {
@@ -35972,11 +36174,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20250508,
-    735
+    20250606,
+    831
    ],
-   "commit": "cf5c97bc68432c6d40b85803a5ce32b4f456fab2",
-   "sha256": "1z440ay4l5k81s8l14ywmnyv6ds02w49fwgnx121c7varijxwm8z"
+   "commit": "cd85d1e1f0e897b409a948a3a4afdaffe032812e",
+   "sha256": "18mx9137wk104s6h1ad384l9lbmz0fh4djjpxjfl2zhxwsjr562k"
   },
   "stable": {
    "version": [
@@ -36629,11 +36831,11 @@
   "repo": "mekeor/evenok",
   "unstable": {
    "version": [
-    20250506,
-    1255
+    20250606,
+    812
    ],
-   "commit": "f3c875139ae57fcb52f2d7ab2d4238c2af8e204c",
-   "sha256": "0r5j958zvqzsrmgj71rvwkmx69f8p360f5c26qlx0l0ng5ff12ng"
+   "commit": "eccc70e577bac3c9901e508fc06ae21b8364e6e9",
+   "sha256": "03qa62k1mi5nnkrvas1xf99vjg66gx3qdxzm2ddrixir8qszh3xz"
   },
   "stable": {
    "version": [
@@ -36878,15 +37080,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20250426,
-    1557
+    20250707,
+    1829
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "fca81ddb2ca1ac3838aa7e8969b2313712807a45",
-   "sha256": "0grp87nb9pxx47rzclhngqn9gvgbn39yfk0szz6a4xh0pf56f100"
+   "commit": "d74647169703362433b1f55420623f145880b898",
+   "sha256": "1p0l4yrkjk4j21a0d608sdjp81xllpy6snq9s5awd0cwcsr04z6j"
   },
   "stable": {
    "version": [
@@ -37298,6 +37500,36 @@
    ],
    "commit": "70a1154a531b7cfdbb9a31d6922482791e20a3a7",
    "sha256": "0nghisnc49ivh56mddfdlcbqv3y2vqzjvkpgwv3zp80ga6ghvdmz"
+  }
+ },
+ {
+  "ename": "evil-keypad",
+  "commit": "315a349736b0c9857e15153e297e19c5f938ad26",
+  "sha256": "1xzmf943ya7wy8r9dc0pphbh265nfl06cx3l0bb8kf7na3rsl7jw",
+  "fetcher": "github",
+  "repo": "achyudh/evil-keypad",
+  "unstable": {
+   "version": [
+    20250602,
+    2127
+   ],
+   "deps": [
+    "evil"
+   ],
+   "commit": "b51f3cb8072656be97424cca02c0c48fcc22dccd",
+   "sha256": "100yjraw8smjhc90rdr2x0wbq89ymgwjnvwcfhqsvnr3iwv5lr38"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    5
+   ],
+   "deps": [
+    "which-key"
+   ],
+   "commit": "faa3ec151caa5c5f7a72e7c8351da47a626b2684",
+   "sha256": "0xhsk2x85yi4ibbgkra1fpxjzk1s0022z7bd533qp8nnbjcr9y71"
   }
  },
  {
@@ -38473,11 +38705,11 @@
   "repo": "meain/evil-textobj-tree-sitter",
   "unstable": {
    "version": [
-    20241118,
-    1711
+    20250629,
+    1239
    ],
-   "commit": "bce236e5d2cc2fa4eae7d284ffd19ad18d46349a",
-   "sha256": "1w8ghsgi41kb08hwfcd4a5wr87aas93iyxp16ivwxj2rb4r4cc3h"
+   "commit": "61d4e04fbaf239653b38c6e50cf580845f43a5fc",
+   "sha256": "1wx3g96k4dcznzq5mysjhkj67a6jpjdjss8bvx8g1dnfvv9xh4dg"
   },
   "stable": {
    "version": [
@@ -39789,11 +40021,11 @@
   "repo": "ideasman42/emacs-fancy-compilation",
   "unstable": {
    "version": [
-    20250120,
-    946
+    20250629,
+    329
    ],
-   "commit": "0fc42482983d62e60bc48226464513505d128fb1",
-   "sha256": "183ff0paxq6nvgi85cb1sj21iy81v45dxvf88qkdlmndzhvzwnf5"
+   "commit": "51f6945c84e6d0e09d45698f1b9056e73fd79fa9",
+   "sha256": "091x4h8ly38cy1hq3ypk2k1l1qhqykgyjmjyjxd9h6k0cfng2922"
   }
  },
  {
@@ -40279,10 +40511,10 @@
  },
  {
   "ename": "feline",
-  "commit": "b123702e4b682826a00a42a1e5c14a137b88951e",
-  "sha256": "1pi5d2pv5i7w5nqjb8dgp4qr8xvd177nnpm400461mcx3is7j0a6",
-  "fetcher": "git",
-  "url": "https://opensource.chee.party/chee/feline-mode",
+  "commit": "32b231c337559bcd49fec865d2162c9c776ebea0",
+  "sha256": "1dliv90lpacn7c8k1smla1jwr3nm4adzqszbjl8xwrjlbyxmk55w",
+  "fetcher": "github",
+  "repo": "chee/feline-mode",
   "unstable": {
    "version": [
     20230301,
@@ -40692,20 +40924,20 @@
   "repo": "redguardtoo/find-file-in-project",
   "unstable": {
    "version": [
-    20250501,
-    50
+    20250612,
+    234
    ],
-   "commit": "f56292e7aba1d012fa51d65ee625e73dcc16dbe9",
-   "sha256": "07yzr2kxw58w9ab7dn3npalc0ljwx8wa3bs64n1n0ldnxpd7d6pl"
+   "commit": "6d6e132f5e9ebcbe5b475df939c556794dd1ce64",
+   "sha256": "0crr4597naffxa4cli6flzjrz3x73nml50kgv6x2i5bspxjzkv27"
   },
   "stable": {
    "version": [
     6,
     2,
-    3
+    5
    ],
-   "commit": "f56292e7aba1d012fa51d65ee625e73dcc16dbe9",
-   "sha256": "07yzr2kxw58w9ab7dn3npalc0ljwx8wa3bs64n1n0ldnxpd7d6pl"
+   "commit": "6d6e132f5e9ebcbe5b475df939c556794dd1ce64",
+   "sha256": "0crr4597naffxa4cli6flzjrz3x73nml50kgv6x2i5bspxjzkv27"
   }
  },
  {
@@ -41472,15 +41704,15 @@
   "repo": "emacsmirror/flim",
   "unstable": {
    "version": [
-    20250519,
-    1729
+    20250621,
+    1317
    ],
    "deps": [
     "apel",
     "oauth2"
    ],
-   "commit": "83d053d10e835664d978a21533ae182bf4bae245",
-   "sha256": "0vvswabzpvrpalbqy12rlfn19h970xirvdxkdbl2fihzcgldf182"
+   "commit": "f586caed9251f4bf9e6798a267c5e03e22c608db",
+   "sha256": "0hz380wsjyyrbcx1a92bm57fs680c935bv6zhdz9ag3b3xiwprzm"
   }
  },
  {
@@ -42599,15 +42831,15 @@
   "repo": "flycheck/flycheck-eglot",
   "unstable": {
    "version": [
-    20240927,
-    2343
+    20250626,
+    212
    ],
    "deps": [
     "eglot",
     "flycheck"
    ],
-   "commit": "18d0c9869585e6a9ea5c40678f266cf7f5bb2d2e",
-   "sha256": "0ilhf3jlknkmkqm67vc5r5n43gqzjxjxgj29p3ax5bp4g82lh327"
+   "commit": "0d7f0afc9bf08fce4a3ee225ec6540a91f8cfd76",
+   "sha256": "0px7nhalypm2xv1nbzms15b868950887wiad49d6xr8p0jlaxg88"
   }
  },
  {
@@ -44740,15 +44972,15 @@
   "repo": "mohkale/flymake-collection",
   "unstable": {
    "version": [
-    20250101,
-    2151
+    20250531,
+    1243
    ],
    "deps": [
     "flymake",
     "let-alist"
    ],
-   "commit": "5de95adb4c4981cee2f6152ef934230d7b2934eb",
-   "sha256": "1jx2y724xgv238nv3dxgvl1arjzg018vmq5jqy8zcbq21nrmwwgq"
+   "commit": "40e4f36dfa46ecbc621e7b161db4ff5b5079fdb4",
+   "sha256": "1g49978lkinr5hyn01z4kfzyai6dkalwxajgmv45xdxnl3p3n06g"
   },
   "stable": {
    "version": [
@@ -44958,20 +45190,20 @@
   "repo": "ROCKTAKEY/flymake-elisp-config",
   "unstable": {
    "version": [
-    20230711,
-    1833
+    20250621,
+    1609
    ],
-   "commit": "3607b1ee738141f67ae803b4daadd4e2906ff324",
-   "sha256": "1lzpl2x9rlvz1ribdk4178v0s7mjzfb9zlla7xgsy0w3d9l59gdl"
+   "commit": "1f9100e855aff8877c1af111fcdde6968038b4d2",
+   "sha256": "1zk1qsgm2zsz1xsxp8xq08m2rprjr2kkahlsz7bay9knwh4v204s"
   },
   "stable": {
    "version": [
     1,
-    0,
+    2,
     0
    ],
-   "commit": "a2d211fb7ae419186e42c4510c7477f8f2893b5f",
-   "sha256": "03lmjjxiqbckjkk6zfqzxj113mwj1wx0ld3p8s364svwfaghjg62"
+   "commit": "1f9100e855aff8877c1af111fcdde6968038b4d2",
+   "sha256": "1zk1qsgm2zsz1xsxp8xq08m2rprjr2kkahlsz7bay9knwh4v204s"
   }
  },
  {
@@ -45571,14 +45803,14 @@
   "repo": "flymake/emacs-flymake-perlcritic",
   "unstable": {
    "version": [
-    20240229,
-    953
+    20250615,
+    802
    ],
    "deps": [
     "flymake"
    ],
-   "commit": "f65ac37608b78ce785808c27fba86a8102a4ff95",
-   "sha256": "1hyjn4kqf3wcnw4gp859x1kdaf9fin482cws1ln41vld0cv4bqbc"
+   "commit": "311743e97d2f705e76755697eea9ff451a39dd64",
+   "sha256": "11h5jr7whwdgwq3zqi0wz9l5830qjazwinff2r8iyicp9azqf081"
   },
   "stable": {
    "version": [
@@ -45884,14 +46116,14 @@
   "repo": "erickgnavar/flymake-ruff",
   "unstable": {
    "version": [
-    20250428,
-    1558
+    20250707,
+    1557
    ],
    "deps": [
     "project"
    ],
-   "commit": "304c23393c5a959884df7595b9392957df1fd74c",
-   "sha256": "04sk7x2ykxxx68jd5fgq1lzc0knlnl1lwn2g0mlfb38vjh1wga62"
+   "commit": "1074f358736ace68d0eefa9cd7727ebed0de7c00",
+   "sha256": "1gw3yva3by1hia1wyb2z5fz08hccf0jjfyb73p3lr7jvcbk3zkbz"
   }
  },
  {
@@ -46115,6 +46347,24 @@
    ],
    "commit": "84d5a68bcfed4a295952c33ffcd11e880978d9d7",
    "sha256": "0j2mmr9f0d3zkhb92zc820iw4vkz958rm3ca7l9k3gx37cc4sn2l"
+  }
+ },
+ {
+  "ename": "flyover",
+  "commit": "a571f93e78cc5aa4be08a0e621469867d8107d0b",
+  "sha256": "14h9z6zi1jpwf31aif6cg1k8bb5sdvgsydhs0ck9wvkya3vzm2yp",
+  "fetcher": "github",
+  "repo": "konrad1977/flyover",
+  "unstable": {
+   "version": [
+    20250708,
+    1611
+   ],
+   "deps": [
+    "flymake"
+   ],
+   "commit": "dbbc13f67c427ca771137937105c256fa5989c64",
+   "sha256": "18irzq3yzbrm6mpwn90xfav5gi0g2v6x9bm0sxy96gz9ap2k4k63"
   }
  },
  {
@@ -46696,31 +46946,34 @@
   "repo": "jollm/fontsloth",
   "unstable": {
    "version": [
-    20230516,
-    1901
+    20250707,
+    829
    ],
    "deps": [
+    "async",
     "f",
     "logito",
     "pcache",
     "stream"
    ],
-   "commit": "8dd771aae34ce282036c7533735e6251770fcbd0",
-   "sha256": "16yk55nvpn8s4cv9wlfm2zp9wvaianal7c5pkk2jxildw7ras55x"
+   "commit": "0835098743e060b2f2191f53d181257d6444dce4",
+   "sha256": "125l3g0yiy3g74ghyq17sp79nq6spjfx1sqc5s1r7x03077v1w5c"
   },
   "stable": {
    "version": [
     0,
-    15,
-    3
+    20,
+    0
    ],
    "deps": [
+    "async",
     "f",
     "logito",
-    "pcache"
+    "pcache",
+    "stream"
    ],
-   "commit": "8ce1802b356962296a492d90cc9ae62e06c7ae43",
-   "sha256": "106ry9gqp10fpf24zsh9aar3qr3q6lg1l7wj38sfc73saq71mi17"
+   "commit": "0835098743e060b2f2191f53d181257d6444dce4",
+   "sha256": "125l3g0yiy3g74ghyq17sp79nq6spjfx1sqc5s1r7x03077v1w5c"
   }
  },
  {
@@ -46835,8 +47088,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20250528,
-    957
+    20250703,
+    1603
    ],
    "deps": [
     "closql",
@@ -46851,14 +47104,14 @@
     "transient",
     "yaml"
    ],
-   "commit": "d139e9ecae6df514dfb3c3ae06115df96a1b8392",
-   "sha256": "1wwr70rrrc0q8l9mgxh7xnx8v66rpd5jxwrf9hiksinc3jnhbnla"
+   "commit": "c39791ae9dbf99a78fe86d1d1036d9c9b02cbe92",
+   "sha256": "1ry5v51104gj64gw2izs0z20lfimxnq0mm78shj81izg1zwgcxwq"
   },
   "stable": {
    "version": [
     0,
     5,
-    0
+    3
    ],
    "deps": [
     "closql",
@@ -46873,8 +47126,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "9db4d386a1ce32b574e413771996d41d9b2407e8",
-   "sha256": "02ks8zc3nqqqqfq2picf0pxsw7wygb5hv9abnva1cv44x091w6zw"
+   "commit": "a31859547a1ea5e2acbab67b6b64f90134e2a156",
+   "sha256": "1vr7qrrcj2vdh5h3w43jzqym33ax58218jq3idjrr8wnlh7vdj18"
   }
  },
  {
@@ -47275,26 +47528,26 @@
   "repo": "tarsius/frameshot",
   "unstable": {
    "version": [
-    20250301,
-    1639
+    20250531,
+    2216
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2b0dab1dc1ed9a5e6f706d08538372c30fd2a5cd",
-   "sha256": "0xz98cy7h99v084ym2ghrhjy3r4sad9ibz4kxa8pmj8243mlzb7r"
+   "commit": "c1a3bb14ebd302db14b0530acfa08fef9f69ac2c",
+   "sha256": "1hq80igrnr8p9z1a9ml681487lkfbr1wa549h4lq62cv91z5mrf5"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2b0dab1dc1ed9a5e6f706d08538372c30fd2a5cd",
-   "sha256": "0xz98cy7h99v084ym2ghrhjy3r4sad9ibz4kxa8pmj8243mlzb7r"
+   "commit": "c1a3bb14ebd302db14b0530acfa08fef9f69ac2c",
+   "sha256": "1hq80igrnr8p9z1a9ml681487lkfbr1wa549h4lq62cv91z5mrf5"
   }
  },
  {
@@ -47752,11 +48005,11 @@
   "repo": "fsharp/emacs-fsharp-mode",
   "unstable": {
    "version": [
-    20250403,
-    1922
+    20250630,
+    1818
    ],
-   "commit": "d92a973e59e18d9510adaf9ddc7f0c866f2633a1",
-   "sha256": "0s2xxzmqxg9a6bql9yg0rpc0s79vvmbg5aibc93jkd0sf79dnz47"
+   "commit": "9b2405bb8367661fde1b55a6b8a5793bb324282d",
+   "sha256": "04xq6nvmhkhljk6yz2rlyaj6hfqxczk6yrlf4wsasgsd7jhzs904"
   },
   "stable": {
    "version": [
@@ -47775,11 +48028,11 @@
   "repo": "open-spaced-repetition/lisp-fsrs",
   "unstable": {
    "version": [
-    20250330,
-    1613
+    20250608,
+    644
    ],
-   "commit": "f6a31365d6e298749daea1bb91270fbc7d11cb53",
-   "sha256": "10fy6dscpin12hm8qsmh1h7ajf0i8a7cyhl8s2d5s3y0y7r7iplg"
+   "commit": "b2c9b8e928b030b80ae7278701eed2bf0c53a79d",
+   "sha256": "1rp40hbbd3y08j7mpghc2hpzljmd1lgbf20ww4ma5dy46r940gvk"
   }
  },
  {
@@ -48131,26 +48384,26 @@
   "repo": "tarsius/fwb-cmds",
   "unstable": {
    "version": [
-    20250509,
-    1453
+    20250531,
+    2217
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4001ed8f655a62d7a3974b18aed3471564d3837f",
-   "sha256": "07qy8p8kv8g7nn92c71qxdjm4kbww396ixiwbjprms39j2ggncp9"
+   "commit": "252a3a9d5420ac5db477047aa5c6a2c668b317b7",
+   "sha256": "07d85n11455pl8rnpcdd1s8jc2ii153wa5igp92mzm8v75pym4fy"
   },
   "stable": {
    "version": [
     2,
     0,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "973a0033c406ce644ce0fb87de70c2f4046ab1b7",
-   "sha256": "0dwrmm4hir83xbnhxqjyalb17zk40y62m32i90q7svp32ydw3abg"
+   "commit": "252a3a9d5420ac5db477047aa5c6a2c668b317b7",
+   "sha256": "07d85n11455pl8rnpcdd1s8jc2ii153wa5igp92mzm8v75pym4fy"
   }
  },
  {
@@ -48161,14 +48414,14 @@
   "repo": "msherry/fxrd-mode",
   "unstable": {
    "version": [
-    20170728,
-    1801
+    20250705,
+    116
    ],
    "deps": [
     "s"
    ],
-   "commit": "795b969346982b75e24b5c8619b46197982fbb4d",
-   "sha256": "0aha13vqj6ygyr7bflrxll837g4z6wrmrhh5rhcd0vphqg70frgn"
+   "commit": "7f755e1ff4a6451bc97fcefef8e96f563311fb1a",
+   "sha256": "08pjpfh62xanlwxnm75ksskhi5l0grm6arpp7wibm4ll9p449bn3"
   },
   "stable": {
    "version": [
@@ -48894,14 +49147,14 @@
   "repo": "noctuid/general.el",
   "unstable": {
    "version": [
-    20240410,
-    1650
+    20250612,
+    2309
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "826bf2b97a0fb4a34c5eb96ec2b172d682fd548f",
-   "sha256": "1jillsr80l4wfbcqsxh3zbgbvmbfih2wcz518mgw9p9pwg4xwvy7"
+   "commit": "a48768f85a655fe77b5f45c2880b420da1b1b9c3",
+   "sha256": "19k82p8pwyh3krq8i6l6calwy9wddqklj1klkdyawgh5ar230vb2"
   }
  },
  {
@@ -49339,8 +49592,8 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20250509,
-    1440
+    20250705,
+    1211
    ],
    "deps": [
     "compat",
@@ -49348,14 +49601,14 @@
     "llama",
     "treepy"
    ],
-   "commit": "6bb612e7b7eada22569d84cc529f4ca36e08032d",
-   "sha256": "1ivv031hsqd7jwlpx8frq9sj1z2nl8vvka569wbfj7l4w85ai12b"
+   "commit": "855706740689a5d5c821be1210f661a262b7a46d",
+   "sha256": "0ny75m9bwfwm5zczhjh9yp3kynqm0qi7bhq6kxy5gv7gxarzdz2g"
   },
   "stable": {
    "version": [
     4,
     3,
-    1
+    2
    ],
    "deps": [
     "compat",
@@ -49363,8 +49616,8 @@
     "llama",
     "treepy"
    ],
-   "commit": "214a14627f463449e8ad01d1beb172917120e816",
-   "sha256": "1a2kyiw63fpp2xbmzmc9hp9r73fq3iwvidvcjjhgs0y0hq7x5sqx"
+   "commit": "97a07691efad6fc16bc000a35be80d4f8dae251a",
+   "sha256": "0xy3kjfl7zpqypxk7dv14yppvdrim5qg1676hnnacyskglmvxgkv"
   }
  },
  {
@@ -49550,11 +49803,11 @@
   "repo": "jwiegley/git-annex-el",
   "unstable": {
    "version": [
-    20220807,
-    1542
+    20250626,
+    2344
    ],
-   "commit": "92f2d97c89980d2cea85850353836c68903514a1",
-   "sha256": "124qa11qzh5174jaidwkllbfzhi1rw9cxfc9px8bkarzqlizsnys"
+   "commit": "7f12f0acb2548e22946c17b3cdd58a3376434294",
+   "sha256": "189md49v0nj7nmbpg22145hwib3ajfsmibixsgzfkmfkbd0h40wf"
   },
   "stable": {
    "version": [
@@ -50012,11 +50265,11 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20250214,
-    1240
+    20250708,
+    1249
    ],
-   "commit": "8d0f98cf36f6b9c31285329b054ae77f9a3d9b33",
-   "sha256": "013rh88pk6g4iqp0l1ihxn8dhljnjkz8jqdkvvp0vin57p8rj0w6"
+   "commit": "e012173ba207cb4b10ce5fefe0a9ef836fcfc2c4",
+   "sha256": "09g7xcy24kyg80zp0vin0yi20hswcbkaad12pip4cbcysnw55wz3"
   },
   "stable": {
    "version": [
@@ -50065,26 +50318,26 @@
   "repo": "magit/git-modes",
   "unstable": {
    "version": [
-    20250509,
-    1453
+    20250531,
+    2217
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2b2d02e935ee6aa649afa99e9ebc77054a9974b9",
-   "sha256": "07s6yz7na4aj5vy3h49m639pf2b3jdypyvyn0spdwqm2dalwl1bi"
+   "commit": "27af84f31ed022267b7108ad10ea286631f88e88",
+   "sha256": "0fzln0j41vjclz1gygn61dgsyfslx2aw4g8fxblp56a0d5y9hz7q"
   },
   "stable": {
    "version": [
     1,
     4,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f99010bbeb8b6d8a0819fac0195a2ef0159d08f0",
-   "sha256": "0nvkpy3bv9816hvgm91fv9l8lla4xras4i05579bs7bc8fck1mr3"
+   "commit": "27af84f31ed022267b7108ad10ea286631f88e88",
+   "sha256": "0fzln0j41vjclz1gygn61dgsyfslx2aw4g8fxblp56a0d5y9hz7q"
   }
  },
  {
@@ -50918,6 +51171,24 @@
   }
  },
  {
+  "ename": "glab",
+  "commit": "b34c31c4ef9c491968e33161fd46f4f3bb761152",
+  "sha256": "0fxi50xxwq3yxv8mgk5bdyf759m1xbd23s04n06kw4lifc3sjri3",
+  "fetcher": "github",
+  "repo": "emacsattic/glab",
+  "unstable": {
+   "version": [
+    20250620,
+    1333
+   ],
+   "deps": [
+    "ghub"
+   ],
+   "commit": "655c0cd042b8e4abe6d314846f4c55b146f9fdee",
+   "sha256": "0ljw8qj44hsqxx1dqs59gbvpcfs94fgmsbqbgnw2xci4p1db3x34"
+  }
+ },
+ {
   "ename": "glass-tty-theme",
   "commit": "6e068f86055da66a2b43a4c11609902a4927c962",
   "sha256": "15zhnky3y580f3w0ihssbgx9bkzynf55ln9xi1cmckpnfbb85l3d",
@@ -51207,30 +51478,32 @@
   "url": "https://git.thanosapollo.org/gnosis",
   "unstable": {
    "version": [
-    20241212,
-    147
+    20250702,
+    651
    ],
    "deps": [
     "compat",
     "emacsql",
+    "org-gnosis",
     "transient"
    ],
-   "commit": "263075f83498b387161fef3e82b8b6f3619ff77a",
-   "sha256": "1z4mj8wjmv2d23mznjvcr9aqrz9xjlmq5kvldz0nbc2vx0bny1yh"
+   "commit": "4b87d58574d1b8cb2eb7bf7fe571efa758838c03",
+   "sha256": "11zw5lw32c6zzgl2h1rmklhmqw35xv07ymdddwa1wc2xf9a7mb3p"
   },
   "stable": {
    "version": [
     0,
-    4,
-    9
+    5,
+    3
    ],
    "deps": [
     "compat",
     "emacsql",
+    "org-gnosis",
     "transient"
    ],
-   "commit": "383f8b489dbbc7fd13b076acaad10ccf73e1dd48",
-   "sha256": "08pqz0xfih761hmaq1hs3fzmkxn2jhzfbkqrkisl84ayla8shnrn"
+   "commit": "4b87d58574d1b8cb2eb7bf7fe571efa758838c03",
+   "sha256": "11zw5lw32c6zzgl2h1rmklhmqw35xv07ymdddwa1wc2xf9a7mb3p"
   }
  },
  {
@@ -51288,25 +51561,31 @@
  },
  {
   "ename": "gnuplot",
-  "commit": "f623c44a97048249e88401d9d75378ca0cce4ef2",
-  "sha256": "1n349cx2qv8j549ljiivq62agylb3rd1cxif7qprdz1js9c4c40j",
+  "commit": "b1cdf9d66272795deca9511b78cd00d9edd41fb4",
+  "sha256": "1vi9zs5v1m9p8xb1i8rr6637lwqy24qkz5cs40lgs30mac0j23ab",
   "fetcher": "github",
   "repo": "emacs-gnuplot/gnuplot",
   "unstable": {
    "version": [
-    20250530,
-    2234
+    20250613,
+    1223
    ],
-   "commit": "f78da5b3394439f8f4f30a4aa30637eaf2bec63b",
-   "sha256": "1yk63x0z4k9y01s10k4xq5jsw3i99h7r39qmm20iyj16xw5m373v"
+   "deps": [
+    "compat"
+   ],
+   "commit": "f10d42221856e86c57dd5cc7400c078c021ba710",
+   "sha256": "17kh2mpbm5rir4bfrl2hmf8hic6v09z13y6svbf22fm0nkfvic1p"
   },
   "stable": {
    "version": [
     0,
-    9
+    11
    ],
-   "commit": "dad0462cd04190da3ec2603fba601260fa5e8a72",
-   "sha256": "1xig4nn22k62jfq7nrr67kny4d5pfg06xshmn8j501l0arxxgkyg"
+   "deps": [
+    "compat"
+   ],
+   "commit": "f10d42221856e86c57dd5cc7400c078c021ba710",
+   "sha256": "17kh2mpbm5rir4bfrl2hmf8hic6v09z13y6svbf22fm0nkfvic1p"
   }
  },
  {
@@ -51347,14 +51626,14 @@
   "repo": "wavexx/gnus-desktop-notify.el",
   "unstable": {
    "version": [
-    20180623,
-    1538
+    20250616,
+    816
    ],
    "deps": [
     "gnus"
    ],
-   "commit": "44ebe0241a19f4052cd427dff408206542aa3c8f",
-   "sha256": "1fqkclbddwfqywvkrb7l2cpibapxrk82ikdpbxapj09iwyn3ijlz"
+   "commit": "344777f35a65f0cf76bf29ea97c6f4b6880aed4a",
+   "sha256": "1jpv4acwn2889qmjm4lh505s2hp8x2n0nj5gr704y38j4m33z9qb"
   },
   "stable": {
    "version": [
@@ -52135,11 +52414,14 @@
   "repo": "lorniu/go-translate",
   "unstable": {
    "version": [
-    20250318,
-    907
+    20250630,
+    1545
    ],
-   "commit": "a924e0bd6b37d424c222377982e6f71a4ddf4452",
-   "sha256": "0n5w7whg134innyqwrvx86cyqfb2wffm2j0kyddcnbfcmhhr6lrf"
+   "deps": [
+    "pdd"
+   ],
+   "commit": "7c99960aec50719d7f95caa3e8fdd381ca5fd22b",
+   "sha256": "1j59l5a37f4a84yrr30vvsz38m5nrppi5jhywyxmyywm4hhxx2wr"
   },
   "stable": {
    "version": [
@@ -52259,6 +52541,24 @@
    ],
    "commit": "41d3669d7ae7b73bd39d298e5373ece48b656ce3",
    "sha256": "1fczxygg1blfmlwswck49rllww77rc7qn91wqw1kvjwfz31sk8z4"
+  }
+ },
+ {
+  "ename": "gogs",
+  "commit": "b34c31c4ef9c491968e33161fd46f4f3bb761152",
+  "sha256": "0nnmxcny3jwjk1ms5d1alfavw2yvi94v2c2f540syn6ibxzm9dys",
+  "fetcher": "github",
+  "repo": "emacsattic/gogs",
+  "unstable": {
+   "version": [
+    20250620,
+    1333
+   ],
+   "deps": [
+    "ghub"
+   ],
+   "commit": "87f47b3b3d7a336c2a41fcf65b30fc48e497d53e",
+   "sha256": "1cn4lk5s4rg0zzbqyc7k8937504398vna3hy4f5jh0a1dfvv0phy"
   }
  },
  {
@@ -52767,8 +53067,8 @@
   "repo": "vmware/govmomi",
   "unstable": {
    "version": [
-    20250503,
-    250
+    20250702,
+    120
    ],
    "deps": [
     "dash",
@@ -52776,8 +53076,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "95320a7de48d30233d7125b01727fb50c1cbc310",
-   "sha256": "14yrw8ddrpv3c2wq3h3c85brfaxdzzjdjfnp6d74pa7w5c7wwp77"
+   "commit": "bedcaadc5399abbaaaebac504718a1b043cd354d",
+   "sha256": "09ni161jrs4gylm2wsa5pkf5kw2m5mjay8ay5j1b1by1vv5hryq7"
   },
   "stable": {
    "version": [
@@ -52869,17 +53169,17 @@
  },
  {
   "ename": "gpt",
-  "commit": "0064e7b747b695a213c233480c962233d10b7bb3",
-  "sha256": "1yd2fiaq21bk6pnx3gdl5mrj0n0i3jbxfagdrawsfs9i3ys7m7vf",
+  "commit": "f613b6073b8676da5402f79d95a8e67ac435c30b",
+  "sha256": "0br5l504bdvcsj2mxj1xql1mf8fqrz4l6h4w5g2drpvgi6wm8lg4",
   "fetcher": "github",
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20250525,
-    2325
+    20250623,
+    352
    ],
-   "commit": "fea2e77ff1488a716878880f125f59287e7e26b0",
-   "sha256": "0vid7s1g1v0hv33qs0yx2ac2d26i4mmkwrflrkmda1amn75vmg51"
+   "commit": "17de2035a9299729391b6e42d47bf4f67907906e",
+   "sha256": "0dgp0qz017b69amgph4jxqg289wwk4fqqfj0h84yphiijcwngcf0"
   }
  },
  {
@@ -52946,28 +53246,29 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20250530,
-    2314
+    20250706,
+    357
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "45814df5dca127cc2b0ec6d4e3daa1b7e57d8a5b",
-   "sha256": "0y4qxrb96v63dlizj75as7s4asfpg8idbqvvk4swpppr4gaya0z5"
+   "commit": "e9d92423d138e6f217a494ac4b28fe68d349233a",
+   "sha256": "1n2jlc8q454qi3jd3ki27265jn0r84njmq46pyivm1dp4i9j8nss"
   },
   "stable": {
    "version": [
     0,
     9,
-    8
+    8,
+    5
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "975c3e64eb834b939e0d61dfc39fed8395afcc45",
-   "sha256": "1wjzv39pcg6lcmlw6yc4fdfln2cnshzaa0dxgkniq9dfznf7hnmd"
+   "commit": "a5af15c770b66a61d0609a736e1db37495655559",
+   "sha256": "0ix0k9dv91mbibwih1s5wzx9hj5nkr3cz799m6gb52vpwf9gixg7"
   }
  },
  {
@@ -52978,14 +53279,44 @@
   "repo": "dolmens/gptel-aibo",
   "unstable": {
    "version": [
-    20250524,
-    822
+    20250605,
+    859
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "4289d563273c5f48db41f8057a81ea2a9f2ea156",
-   "sha256": "0v5x531h5hrvnb02n86b3hliww1zfdjkr3hgxwwmilh03nfp7h94"
+   "commit": "36a5b96332c88e7157023e41f6dafc5b5e84dccb",
+   "sha256": "1wgx440076jrf40w0imlqwif7jhlm5my4ngz7lx7yngi7ic75ndf"
+  }
+ },
+ {
+  "ename": "gptel-commit",
+  "commit": "5f3ece581e399ebc3b72b924ff48c64810f7cf8d",
+  "sha256": "1wld1rsnzrdi297yqhdwvnkrx3r0yyixmpz3k95h4zasxnrv7lzx",
+  "fetcher": "github",
+  "repo": "lakkiy/gptel-commit",
+  "unstable": {
+   "version": [
+    20250630,
+    1324
+   ],
+   "deps": [
+    "gptel"
+   ],
+   "commit": "9caf217c9864c3f4cf819c2c48d35628ac729427",
+   "sha256": "0ipccfms95319hxrjd042zgmkwhqwm53jgyxh6jrnkxn7c5rrjpg"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "deps": [
+    "gptel"
+   ],
+   "commit": "1bd5d85bb0beffce0bb27ac136949f4341f0932b",
+   "sha256": "1f2y2bd1pkjzyf9yd04yjg1baqmr3mqmfx5bw9xva1hyrqwbz6k3"
   }
  },
  {
@@ -53415,11 +53746,11 @@
   "repo": "ppareit/graphviz-dot-mode",
   "unstable": {
    "version": [
-    20230325,
-    1050
+    20250708,
+    1125
    ],
-   "commit": "8ff793b13707cb511875f56e167ff7f980a31136",
-   "sha256": "02z2qyzqvwyqighzsgn1v0s72lq28j5h039qbaf8gcmn7mipif0r"
+   "commit": "1840165b60df7409cfccacbe5365843309d51aaa",
+   "sha256": "0brx74hv7qasbshf65srk64fq89jk9zavg7xax0h0ia3l4j5xakg"
   },
   "stable": {
    "version": [
@@ -53508,15 +53839,15 @@
   "repo": "michelangelo-rodriguez/greader",
   "unstable": {
    "version": [
-    20250526,
-    835
+    20250623,
+    2200
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "a0bc3fa176f30193d06e54d137aa8d41fa02377b",
-   "sha256": "1y2i2rqg00fkmnavkzrvb28i91azkcq0x1cvd65d849h09gg0xph"
+   "commit": "320a62803350d776bc3295bad792a898fee40fa4",
+   "sha256": "0wnqbxi0dkbr4ihwdyv1xbxiic2gzq46lwxy838fmv602wx70f9y"
   }
  },
  {
@@ -53595,6 +53926,21 @@
    ],
    "commit": "774e8f6c033786406267f71ec07319d906a30b75",
    "sha256": "0f12lqgfi1vlhq8p5ia04vlmvmyb4f40q7dm2nbh5y8r6k89hisg"
+  }
+ },
+ {
+  "ename": "greger",
+  "commit": "920404f2f0cd0ec41138a959969c719b64a2e074",
+  "sha256": "11f6zwp2f5dl13md4bcjhp0aj9bhravfgrw15fycq6c9f1xrln1f",
+  "fetcher": "github",
+  "repo": "andreasjansson/greger.el",
+  "unstable": {
+   "version": [
+    20250704,
+    1635
+   ],
+   "commit": "b9591c30193cc764b23f1741fbb43159f85e945b",
+   "sha256": "0dhh83j4w2ln46z9bybzhpyvaphqwxdxqksvp47kj8d4syzmyaai"
   }
  },
  {
@@ -53986,6 +54332,24 @@
   }
  },
  {
+  "ename": "gtea",
+  "commit": "b34c31c4ef9c491968e33161fd46f4f3bb761152",
+  "sha256": "1fh7xjv6hcnzzjn8yj56r8v0x80y68ymj3rx6p3f2nymhqiypiva",
+  "fetcher": "github",
+  "repo": "emacsattic/gtea",
+  "unstable": {
+   "version": [
+    20250620,
+    1334
+   ],
+   "deps": [
+    "ghub"
+   ],
+   "commit": "942988625b6ff01c958a16899ad7f7113e4b324b",
+   "sha256": "0f90wgp13w1jzqs3iq5yjy6h0wjw72czs5lvjjg20a1rsd4fykcc"
+  }
+ },
+ {
   "ename": "gtk-pomodoro-indicator",
   "commit": "a58f1acaafc459e055d751acdb68427e4b11275e",
   "sha256": "1lkz1bk3zl51jdgp7pg6sr57drdwz8mlvl9ryky3iv73kr5i0q6c",
@@ -54234,11 +54598,11 @@
   "repo": "rodw/gvpr-lib",
   "unstable": {
    "version": [
-    20201007,
-    2054
+    20250604,
+    1329
    ],
-   "commit": "a729fa4623a6d846ab860778842b38f685246c95",
-   "sha256": "0lx6ypgr2n3nknzy8g13dp234hcnayl5jb2rvxnbacqmi0j44sx1"
+   "commit": "db3aac0b51d8f624d94f8b022503b645ae97d926",
+   "sha256": "1yxic69lmvv5viydzngdk1qq4ww8admm47m8p1hid391qgwdsqkb"
   }
  },
  {
@@ -54302,14 +54666,14 @@
   "repo": "abrochard/emacs-habitica",
   "unstable": {
    "version": [
-    20240601,
-    2029
+    20250622,
+    2058
    ],
    "deps": [
     "org"
    ],
-   "commit": "b884301058c075e6f530f10e970b744aa29f5937",
-   "sha256": "1jfizwqi54bw0w9p77wrz9b2a5jbyd2v14nrb1nr03l5jxmx0f1n"
+   "commit": "ed123a2adf82f5e5ecb119a0a55c860f17906aad",
+   "sha256": "0zb09j2qwyg363c15668n7ay2carm44sq402ww8d484dsfhxpj93"
   }
  },
  {
@@ -55177,6 +55541,21 @@
   }
  },
  {
+  "ename": "hdf5-viewer",
+  "commit": "77101a1bd1e0f091a908a20527606ed8f95ba829",
+  "sha256": "0ww3f9wygnpzrssg2lzri77rspy1mdgqllx7zg7ibnym0n60ypcz",
+  "fetcher": "github",
+  "repo": "hdf5-viewer/hdf5-viewer",
+  "unstable": {
+   "version": [
+    20250625,
+    519
+   ],
+   "commit": "0700e660579012ab20650d337ccf8c40700d83b9",
+   "sha256": "15ksiyg0x3i6plhhrdrql55jmr43xjydglyxg86lpxfqb3xjcxn7"
+  }
+ },
+ {
   "ename": "headlong",
   "commit": "826e9a8221d9378dd3b9fcc16ce5f50fd6ed2dce",
   "sha256": "042ybplkqjb30qf5cpbw5d91j1rdc71b789v277h036bri7hgxz6",
@@ -55231,6 +55610,30 @@
   }
  },
  {
+  "ename": "helix",
+  "commit": "0da3fefe1f7c9fca95847faeb805867d99f31f61",
+  "sha256": "11v7sg7i1xdnhmi5pm1y0hixb7baxyn19x4z1c3ixbaix6682874",
+  "fetcher": "github",
+  "repo": "mgmarlow/helix-mode",
+  "unstable": {
+   "version": [
+    20250630,
+    1623
+   ],
+   "commit": "b3f8c18b5cff37571f9d6bc02e47c8da62296d85",
+   "sha256": "1zr79zavc4g7912ayiaih25c2q05qb6wnnr7hlmym6r7bcrfnypm"
+  },
+  "stable": {
+   "version": [
+    0,
+    7,
+    0
+   ],
+   "commit": "4b247cc6a5b8e774a5fb306b2d2c612c3d338146",
+   "sha256": "0n6zpn8b902xfk98fxqk0mh1n187qsgp3fk3zv6p0c9v8gqycaiz"
+  }
+ },
+ {
   "ename": "helix-theme",
   "commit": "80c21c8b511b2fdf7948c37f0cfb81ca2a138404",
   "sha256": "1wkrfr5d79h847g44y5gxw0lr9vfy2nxnm68pqlvzgps4wc9l9h8",
@@ -55253,28 +55656,28 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250529,
-    400
+    20250707,
+    559
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "7634902a5f7cb3a2b081721b06fe1355e58f94f7",
-   "sha256": "18dncnf5v8fqf817i2sqvvrvr273kl3qv67zcaxhm8k8f827qz4i"
+   "commit": "3e9e33bf0312443439854b49b478cb773472ab89",
+   "sha256": "1wgdv52bpk2pxphcqs9dc34c69xi2kcn5mx5zgc5jncidz7h2c2w"
   },
   "stable": {
    "version": [
     4,
     0,
-    3
+    4
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "e03edf775af41053c8a4de98f370689d4525077b",
-   "sha256": "1amm4n5v2v5z2ln1qzhf0n2rj4v89flhk9dip3kbngdwy2a8q2h4"
+   "commit": "6befd6e60f756936062fed6d4b905e508aa141fc",
+   "sha256": "0bj8sp0c6ll3kj9ac4js8lv441p8h9310bkg5rwvxz3gpvlw55ys"
   }
  },
  {
@@ -55297,37 +55700,6 @@
   }
  },
  {
-  "ename": "helm-ack",
-  "commit": "2a2670edb1155f02d1cbe2600db84a82c8f3398b",
-  "sha256": "124w7grwindyv86xfshfm70h0xfq29ns067pchk8dcbjbgh9yl7b",
-  "fetcher": "github",
-  "repo": "emacsorphanage/helm-ack",
-  "unstable": {
-   "version": [
-    20141030,
-    1226
-   ],
-   "deps": [
-    "cl-lib",
-    "helm"
-   ],
-   "commit": "5982f3cb6ec9f460ebbe06ec0ce7b3590bca3118",
-   "sha256": "0ps86zpyywibjwcm9drmamla979ad61fyqr8d6bv71fr56k9ak21"
-  },
-  "stable": {
-   "version": [
-    0,
-    13
-   ],
-   "deps": [
-    "cl-lib",
-    "helm"
-   ],
-   "commit": "5982f3cb6ec9f460ebbe06ec0ce7b3590bca3118",
-   "sha256": "0ps86zpyywibjwcm9drmamla979ad61fyqr8d6bv71fr56k9ak21"
-  }
- },
- {
   "ename": "helm-ad",
   "commit": "b44ec4e059ab830a3708697fa95fada5f6a30a91",
   "sha256": "0h2zjfj9hy7bkpmmjjs0a4a06asbw0yww8mw9rk2xi1gc2aqq4hi",
@@ -55344,35 +55716,6 @@
    ],
    "commit": "8ac044705d8620ee354a9cfa8cc1b865e83c0d55",
    "sha256": "0hxfgdn56c7qr64r59g9hvxxwa4mw0ad9c9m0z5cj85bsdd7rlx4"
-  }
- },
- {
-  "ename": "helm-ag",
-  "commit": "2a2670edb1155f02d1cbe2600db84a82c8f3398b",
-  "sha256": "0jzfycbaz88r6scsiw74prcnbvilsaphljdys6i5k9g5rhn5sxh5",
-  "fetcher": "github",
-  "repo": "emacsorphanage/helm-ag",
-  "unstable": {
-   "version": [
-    20241028,
-    144
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "01d36d6eb689305ea3aae0a23aa8be0029f0410f",
-   "sha256": "1fipr4vaafsvkkypj3qlyigq2dqiy1jgkm99djzv0378g7mk25k8"
-  },
-  "stable": {
-   "version": [
-    0,
-    64
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "6a3e738c1bb5e80c7ea80f7166fda34a714284d8",
-   "sha256": "0ml9yp3qaiwn7iixyxvsj3fxn7gw913qxisr47df57q4ka912law"
   }
  },
  {
@@ -55424,10 +55767,10 @@
  },
  {
   "ename": "helm-aws",
-  "commit": "421182006b8af17dae8b5ad453cc11e2d990a053",
-  "sha256": "0sjgdjpznjxsf6nlv2ah45fw17j8j5apdphd1fp43rjv1lskkgc5",
+  "commit": "4012a91c1c40276c2290b6b3cec4f735bce116e2",
+  "sha256": "1ffz1wf6z9sflwlxlfiww56zznnaa0rqn39vhs0j5l1zrwy9w9g5",
   "fetcher": "github",
-  "repo": "istib/helm-aws",
+  "repo": "emacsattic/helm-aws",
   "unstable": {
    "version": [
     20180514,
@@ -55747,25 +56090,6 @@
    ],
    "commit": "70f1ca7d1847c7d5cd5a3e488562cd4a295b809f",
    "sha256": "12wz98fcs8v8w74ck4jqbh47pp5956xxh9ld5kpym9zrm39adpq2"
-  }
- },
- {
-  "ename": "helm-c-moccur",
-  "commit": "462a43341a5811822928bcac331d617a38b52e8a",
-  "sha256": "1i6a4jqjy9amlhdbj5d26wzagndfgszha09vs5qf4760vjl7kn4b",
-  "fetcher": "github",
-  "repo": "myuhe/helm-c-moccur.el",
-  "unstable": {
-   "version": [
-    20151230,
-    924
-   ],
-   "deps": [
-    "color-moccur",
-    "helm"
-   ],
-   "commit": "b0a906f85fa352db091f88b91a9c510de607dfe9",
-   "sha256": "0w4svbg32y63v049plvk7djc1m2amjzrr1v979d9s6jbnnpzlb5c"
   }
  },
  {
@@ -56143,26 +56467,26 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20250516,
-    408
+    20250705,
+    1413
    ],
    "deps": [
     "async"
    ],
-   "commit": "fe4ecf4187ade81fbf6c8284dd1cb7257cbed8b2",
-   "sha256": "0vydrfd73lr853radzriz35ffj74gj2chljzy79al1xrgph7j0fg"
+   "commit": "edfbe48205db5a03c7d0dbdd623702c9a3117ab7",
+   "sha256": "1zlbsg7jarqxs8z5nfdclqysz88vxnxq70200ay7v56ip48zwsif"
   },
   "stable": {
    "version": [
     4,
     0,
-    3
+    4
    ],
    "deps": [
     "async"
    ],
-   "commit": "e03edf775af41053c8a4de98f370689d4525077b",
-   "sha256": "1amm4n5v2v5z2ln1qzhf0n2rj4v89flhk9dip3kbngdwy2a8q2h4"
+   "commit": "6befd6e60f756936062fed6d4b905e508aa141fc",
+   "sha256": "0bj8sp0c6ll3kj9ac4js8lv441p8h9310bkg5rwvxz3gpvlw55ys"
   }
  },
  {
@@ -56278,14 +56602,14 @@
   "repo": "emacs-helm/helm-descbinds",
   "unstable": {
    "version": [
-    20250204,
-    451
+    20250705,
+    942
    ],
    "deps": [
     "helm"
    ],
-   "commit": "c12bc85ef3ce342fe1c78cdd86117c05d5310789",
-   "sha256": "0dfm8a8dc3a75pizkjl6304aqx2m9yaqcjk8j0d802ad0zk31g64"
+   "commit": "0aff44badad976ebf2666a7e9b6ddf4db53e59e5",
+   "sha256": "03834fvccxlrf2swnmr8w9ffgs9b74mdb58d3g3m6393g64ibz4p"
   },
   "stable": {
    "version": [
@@ -56334,36 +56658,6 @@
    ],
    "commit": "725cc0df42ad57a7902c330065d9e8ee1216791c",
    "sha256": "1ipia68s5x1ny6w99g56hfcnhphlz7zh7bhmrrjyv3aflr7d3170"
-  }
- },
- {
-  "ename": "helm-directory",
-  "commit": "d0c066d6f285ab6d572dab4549781101547cb704",
-  "sha256": "01c5a08v6rd867kdyrfwdvj05z4srzj9g6xy4scirlbwbff0q76n",
-  "fetcher": "github",
-  "repo": "masasam/emacs-helm-directory",
-  "unstable": {
-   "version": [
-    20170709,
-    1103
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "2c6d45404506ba744888dcdb65e9f63878f2da16",
-   "sha256": "1a5j4zzn249jdm4kcri64x1dxazhhk7g5dmgnhflrnbrc2kdwm8h"
-  },
-  "stable": {
-   "version": [
-    0,
-    6,
-    4
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "2c6d45404506ba744888dcdb65e9f63878f2da16",
-   "sha256": "1a5j4zzn249jdm4kcri64x1dxazhhk7g5dmgnhflrnbrc2kdwm8h"
   }
  },
  {
@@ -56625,55 +56919,6 @@
   }
  },
  {
-  "ename": "helm-file-preview",
-  "commit": "acd2e8a57e818e02c404d15bb3371f94db6ecc8d",
-  "sha256": "18hlcvdqnb74ww7i8q6xs2pjvh9l7bkbjb5a8aibmfjjgb0mg5lx",
-  "fetcher": "github",
-  "repo": "jcs-legacy/helm-file-preview",
-  "unstable": {
-   "version": [
-    20240101,
-    1005
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "7cf9264bfd106975e90d92a94fe7f150f7d31b8c",
-   "sha256": "017ar1ahlll3h595bawgyilbnzgjz8bw9k5x921y578h245b3f41"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    5
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "59adbf2d3c67b174a354f0dd64f647b4391ab8d0",
-   "sha256": "1x2ds29k4wwv406j49nzjkh43scahmrshx4lssqrkc9cay7210nx"
-  }
- },
- {
-  "ename": "helm-filesets",
-  "commit": "71c0d98ede6119e838e3db146dea5c16d8ba8ed8",
-  "sha256": "1yhhchksi0r4r5c5q1mggz2hykkvk93baq91b5hkaflqi30d1v8f",
-  "fetcher": "github",
-  "repo": "gcla/helm-filesets",
-  "unstable": {
-   "version": [
-    20140929,
-    1835
-   ],
-   "deps": [
-    "filesets+",
-    "helm"
-   ],
-   "commit": "b352910af4c3099267a8aa0169c7f743b35bb1fa",
-   "sha256": "00yhmpv5xjlw1gwbcrznz83gkaby8zlqv74d3p7plca2cwjll1g9"
-  }
- },
- {
   "ename": "helm-firefox",
   "commit": "257e452d37768d2f3a6e0a5ccd062d128b2bc867",
   "sha256": "0677nj0zsk11vvp3q3xl9nk8dhz3ki9yl3kfb57wgnmprp109wgs",
@@ -56821,21 +57066,6 @@
    ],
    "commit": "8d4d947c687cb650cb149aa2271ad5201ea92594",
    "sha256": "0q0xcgg8w9rrlsrrnk0l7qd8q7jc6x1agm2i769j21wpyfv1nbns"
-  }
- },
- {
-  "ename": "helm-frame",
-  "commit": "8bbb56b883658fdf91b984c01d2472bdf6787003",
-  "sha256": "1hmml0209z3ap35bqk9b1fh0lcfksysqszgj1ifh1mdjz81xx9sq",
-  "fetcher": "github",
-  "repo": "chee/helm-frame",
-  "unstable": {
-   "version": [
-    20220803,
-    1528
-   ],
-   "commit": "1b5e895e9199deeea049010e5fe4de7a338f41f3",
-   "sha256": "0c7qb16yad5qfv40d419mgf4307mif46733ws1cnwxnhvz4dfxqd"
   }
  },
  {
@@ -56987,51 +57217,6 @@
   }
  },
  {
-  "ename": "helm-git",
-  "commit": "707696fbec477027e675ff01c502e0b81096025c",
-  "sha256": "1ib73p7cmkw96csxxpkqwn6m60k1xrd46z6vyp29gj85cs4fpsb8",
-  "fetcher": "github",
-  "repo": "maio/helm-git",
-  "unstable": {
-   "version": [
-    20120630,
-    2103
-   ],
-   "commit": "5b4a6eb7a97b2583236a1f919b75249957918e29",
-   "sha256": "1z5q47sly41amjiq5wcvdxf8slhl8wd24crgzpbn6m3lw2jk420r"
-  }
- },
- {
-  "ename": "helm-git-grep",
-  "commit": "338d28c3fe201a7b2f15793be6d540f44819f4d8",
-  "sha256": "1ww6a4q78w5hnwikq7y93ic2b7x070c27r946lh6p8cz1k4b8vqi",
-  "fetcher": "github",
-  "repo": "yasuyk/helm-git-grep",
-  "unstable": {
-   "version": [
-    20170614,
-    1411
-   ],
-   "deps": [
-    "helm-core"
-   ],
-   "commit": "744cea07dba6e6a5effbdba83f1b786c78fd86d3",
-   "sha256": "172m7wbgx9qnv9n1slbzpd9j24p6blddik49z6bq3zdg1vlnf3dv"
-  },
-  "stable": {
-   "version": [
-    0,
-    10,
-    1
-   ],
-   "deps": [
-    "helm-core"
-   ],
-   "commit": "744cea07dba6e6a5effbdba83f1b786c78fd86d3",
-   "sha256": "172m7wbgx9qnv9n1slbzpd9j24p6blddik49z6bq3zdg1vlnf3dv"
-  }
- },
- {
   "ename": "helm-github-stars",
   "commit": "2e77f4a75504ca3e1091cdc757e91fb1ae361fa7",
   "sha256": "1r4mc4v71171sq9rbbhm346s92fb7jnvvl91y2q52jqmrnzzl9zy",
@@ -57150,24 +57335,6 @@
    ],
    "commit": "7db5ea9ce97502152a6bb1fe38f8fabb5a49abd2",
    "sha256": "08llqkswilzsigh28w9qjbqi5g5z0ylfabz5sqia7c18gjshvz0h"
-  }
- },
- {
-  "ename": "helm-google",
-  "commit": "f0a8eb0eefe88b4ea683a4743c0f8393506e014b",
-  "sha256": "0hv7wfrahjn8j4914dp2p4fl2cj85pmxnyxf5cnmv6p97yis0ham",
-  "fetcher": "git",
-  "url": "https://framagit.org/steckerhalter/helm-google.git",
-  "unstable": {
-   "version": [
-    20210527,
-    900
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "27834161391c350ef790062391cb7eab1d59fb62",
-   "sha256": "1rb1pmzr6szg8jjm43dndnk99v4i5zb1wp24rs9w8zmhygdn8jf4"
   }
  },
  {
@@ -57313,24 +57480,6 @@
   }
  },
  {
-  "ename": "helm-helm-commands",
-  "commit": "f8bd33d5d5c8653df5373984d01c3ec87b30c51b",
-  "sha256": "0dq9p37i5rrp2nb1vhqzzqfmdg11va2xr3yz8hdxpwykm1ldqdcf",
-  "fetcher": "github",
-  "repo": "vapniks/helm-helm-commands",
-  "unstable": {
-   "version": [
-    20130902,
-    1748
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "1c37bb0d4cda6877162603cd1ddc9f596a7a5cb9",
-   "sha256": "0c31qr8lk58w86n5iisx0vpd19y44vmqg7xnpjh6mnz102xif7rn"
-  }
- },
- {
   "ename": "helm-hoogle",
   "commit": "8ccc21c2acc76a6794aee94902b1bc4c14119901",
   "sha256": "0vhk4vwqfirdm5d0pppplfpqyc2sfj6jybhzp9n1w8xgrh2d1c0x",
@@ -57364,26 +57513,6 @@
    ],
    "commit": "6392bf716f618eac23ce81140aceb0dfacb9c6d0",
    "sha256": "1ih2pgyhshv8nl7hhchd4h0pbjgj45irp5dy1fq2gy05v4rn7wi4"
-  }
- },
- {
-  "ename": "helm-icons",
-  "commit": "388e1c96b251fd68adc08288c9109dad19840bc7",
-  "sha256": "074s4pv0lgvcmvfqv34bsi45cy4rlskc6skmfffkflyf1kddpz1g",
-  "fetcher": "github",
-  "repo": "yyoncho/helm-icons",
-  "unstable": {
-   "version": [
-    20231027,
-    616
-   ],
-   "deps": [
-    "dash",
-    "f",
-    "treemacs"
-   ],
-   "commit": "0d113719ee72cb7b6bb7db29f7200d667bd86607",
-   "sha256": "1rnw3vkxrsx8xvvi43anvmljw22av072wyda9jlxflk8agbhpdw6"
   }
  },
  {
@@ -57679,14 +57808,14 @@
   "repo": "emacs-helm/helm-ls-git",
   "unstable": {
    "version": [
-    20250528,
-    629
+    20250615,
+    1418
    ],
    "deps": [
     "helm"
    ],
-   "commit": "f7dfed1bad4243dad3f92b791ee6bd613f016447",
-   "sha256": "1n7vz7rg417qsnf86fbcfpa6cldil9kfv3c04gxwwxwfzihfr80k"
+   "commit": "ca44995c570f855a41730e912fdc8f3b429558f7",
+   "sha256": "1ylacawwqzvzdjv8z8h4b4nf9p70jdzi1mfafddb6k7m7iqcncrl"
   },
   "stable": {
    "version": [
@@ -57846,43 +57975,11 @@
   }
  },
  {
-  "ename": "helm-migemo",
-  "commit": "ce6eb840368f8cbee66dc061478d5096b9dacb68",
-  "sha256": "1cjvb1lm1fsg5ky63fvrphwl5a7r7xf6qzb4mvl06ikj8hv2h33x",
-  "fetcher": "github",
-  "repo": "emacs-jp/helm-migemo",
-  "unstable": {
-   "version": [
-    20240921,
-    1551
-   ],
-   "deps": [
-    "helm",
-    "migemo"
-   ],
-   "commit": "6da30a3ee3ddcfde6068a5b05be24f888d9a7b53",
-   "sha256": "0x72ja6pkrq62wrac2bwfx1d0xsb5c9isx5w1g8jx5bf6s2d5l2y"
-  },
-  "stable": {
-   "version": [
-    1,
-    22
-   ],
-   "deps": [
-    "cl-lib",
-    "helm-core",
-    "migemo"
-   ],
-   "commit": "2d964309a5415cf47f5154271e6fe7b6a7fffec7",
-   "sha256": "03588hanfa20pjp9w1bqy8wsf5x6az0vfq0bmcnr4xvlf6fhkyxs"
-  }
- },
- {
   "ename": "helm-mode-manager",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "04yhqbb9cliv1922b0abpc1wrladvhyfmwn8ifqfkzaks4067rhl",
+  "commit": "4012a91c1c40276c2290b6b3cec4f735bce116e2",
+  "sha256": "1nzi63h7vhi0lkid84b904xh3wq7v7r7q265pf1z5ciqkz0fxp1s",
   "fetcher": "github",
-  "repo": "istib/helm-mode-manager",
+  "repo": "emacsattic/helm-mode-manager",
   "unstable": {
    "version": [
     20210108,
@@ -58430,25 +58527,6 @@
   }
  },
  {
-  "ename": "helm-posframe",
-  "commit": "a99c37bc50c371aae8ccc27de8120d4773981cf7",
-  "sha256": "16mhi17kl3cgwk7ymzg8crakwrwrzsg5p9ijgrdawa7px2z9ym78",
-  "fetcher": "github",
-  "repo": "tumashu/helm-posframe",
-  "unstable": {
-   "version": [
-    20230822,
-    2030
-   ],
-   "deps": [
-    "helm",
-    "posframe"
-   ],
-   "commit": "0b6bb016f0ff4980860a9d00574de311748c40b0",
-   "sha256": "1asw6q53xbk7xc0da4w03f8p5z3jhfhg16ggwslgwxx8vjv5zvg7"
-  }
- },
- {
   "ename": "helm-proc",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "11mh8ny8mhdmp16s21vy9yyql56zxcgmj2aapqs5jy4yad5q62rz",
@@ -58580,35 +58658,6 @@
    ],
    "commit": "f94f970c2d375e0973b66ba99b29c7aa42fd550f",
    "sha256": "1kfifsqxybvrff6mwifjp0igbad11winsks05l8k661blsh7m5ir"
-  }
- },
- {
-  "ename": "helm-pt",
-  "commit": "91d196ef71e66508c827a9201b07ba7218a9bdf5",
-  "sha256": "1j6nh53yd46ghz30c9afn1fny103h1y72ayza4jc8h08hras3r4q",
-  "fetcher": "github",
-  "repo": "punassuming/helm-pt",
-  "unstable": {
-   "version": [
-    20160214,
-    2342
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "8acc52911dad1ed0c3975f134a468762afe0b76b",
-   "sha256": "03ys40rr0pvgp35j5scw9c28j184f1c9m58a3x0c8f0lgyfpssjk"
-  },
-  "stable": {
-   "version": [
-    0,
-    2
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "03e35e2bb5b683d79897d07acb57ee67009cc6cd",
-   "sha256": "0jm6nnnjyd4kmm1knh0mq3xhnw2hvs3linwlynj8yaliqvlv6brv"
   }
  },
  {
@@ -59124,36 +59173,6 @@
   }
  },
  {
-  "ename": "helm-selector",
-  "commit": "91193d76993bc65cc71bfa06148ef375b8034bd7",
-  "sha256": "19v1xvrbc9pn6ilbf28g4bjd4psmb34as6cjmksyaw5rn71ps2ay",
-  "fetcher": "github",
-  "repo": "emacs-helm/helm-selector",
-  "unstable": {
-   "version": [
-    20210125,
-    857
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "4da4711c4cfd14527abe20d66787beeb49171b26",
-   "sha256": "01lh1df0bnas1p7xlqc4i1jd67f8lxgq0q2zsvx10z8828i76j3v"
-  },
-  "stable": {
-   "version": [
-    0,
-    6,
-    1
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "4da4711c4cfd14527abe20d66787beeb49171b26",
-   "sha256": "01lh1df0bnas1p7xlqc4i1jd67f8lxgq0q2zsvx10z8828i76j3v"
-  }
- },
- {
   "ename": "helm-sheet",
   "commit": "010c5c5e6ad6e7b05e63936079229739963bf970",
   "sha256": "0lx70l5gq43hckgdfna8s6wx287sw5ms9l1z3n6vg2x8nr9m61kc",
@@ -59169,24 +59188,6 @@
    ],
    "commit": "d360b68d0ddb09aa1854e7b2f3cb39caeee26463",
    "sha256": "00wnqcgpf4hqdnqj5zrizr4s0pffb93xwya8k5c3rp4plncrcdzx"
-  }
- },
- {
-  "ename": "helm-shell-history",
-  "commit": "93d2ca7bf89a96a8a2eac59d2a34d8f152fa9752",
-  "sha256": "1krb7i00rf9dwq9pq8zppiyhhahpk661qbg8hazg7bpsb58kxy8r",
-  "fetcher": "github",
-  "repo": "anoopemacs/helm-shell-history",
-  "unstable": {
-   "version": [
-    20210214,
-    948
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "dfa657ae76ef1ba768e970a557739efdf0436cb0",
-   "sha256": "1mjg2nvz6d0k9430r2w58bwaz3q7fzmgbgcp992lckvaad8y7qrv"
   }
  },
  {
@@ -59424,36 +59425,6 @@
   }
  },
  {
-  "ename": "helm-swoop",
-  "commit": "7a4e84530b4607a277fc3b678fe7b34b1c5e3b4f",
-  "sha256": "0dbn0mzzsjhpxh0dpxrrzqam9hl2sjsp1izq2qv3z11iv2hylzx4",
-  "fetcher": "github",
-  "repo": "emacsorphanage/helm-swoop",
-  "unstable": {
-   "version": [
-    20240104,
-    2356
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "df90efd4476dec61186d80cace69276a95b834d2",
-   "sha256": "01nrak72inmic9n30dval6608cfzsbv5izwzykbim46ifjhcipag"
-  },
-  "stable": {
-   "version": [
-    3,
-    0,
-    0
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "533dcd14198b61fd2fbf8c6f286f65feae5b6bd2",
-   "sha256": "1qjay0fvryxa8n1ws6r1by512p2fylb2nj7ycm1497fcalb0d706"
-  }
- },
- {
   "ename": "helm-system-packages",
   "commit": "0c46cfb0fcda0500e15d04106150a072a1a75ccc",
   "sha256": "01mndx2zzh7r7gmpn6gd1vy1w3l6dnhvgn7n2p39viji1r8b39s4",
@@ -59553,35 +59524,6 @@
   }
  },
  {
-  "ename": "helm-themes",
-  "commit": "2a2670edb1155f02d1cbe2600db84a82c8f3398b",
-  "sha256": "15qs23f467j99wybjd0n6dacgik5ibf96jn00j9fip55v8rp66gj",
-  "fetcher": "github",
-  "repo": "emacsorphanage/helm-themes",
-  "unstable": {
-   "version": [
-    20240925,
-    748
-   ],
-   "deps": [
-    "helm-core"
-   ],
-   "commit": "4b234d4bdf61bd7ad82c5302c6178f7fee3ee66f",
-   "sha256": "0qnh198q063rcrkanzid8xqm76w94m47mkqg0rj04gdkv1wqliz9"
-  },
-  "stable": {
-   "version": [
-    0,
-    5
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "8c979f4efc6174eed7df5f3b62db955246202818",
-   "sha256": "0rzbdrs5d5a0icpxrqik2iaz8i5bacw6nm2caf75s9w9j0j6s9li"
-  }
- },
- {
   "ename": "helm-tramp",
   "commit": "855ea20024b606314f8590129259747cac0bcc97",
   "sha256": "0wqnabaywkhj1fnc3wpx7czrqbja1hsqwcpixmvv0fyrflmza517",
@@ -59649,36 +59591,6 @@
    ],
    "commit": "27fbec24cc250d508cd2f4286da16262752908eb",
    "sha256": "1sair8har6blwn1s12msz780cfsjpn0fzhy6ckhjh4sw9747808b"
-  }
- },
- {
-  "ename": "helm-unicode",
-  "commit": "f720b9f9b667bf9ff3080938beab36aa0036dc92",
-  "sha256": "1j95qy2zwdb46dl30ankfx7013l0akc61m14s473j93w320j5224",
-  "fetcher": "github",
-  "repo": "bomgar/helm-unicode",
-  "unstable": {
-   "version": [
-    20180608,
-    1407
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "b7092ed6a7191805651efae40947e4781c453211",
-   "sha256": "15qn5xynah23dfz3mdw5jabv9qfs2hjdjgn3ifmqn3r6sgd8hcjn"
-  },
-  "stable": {
-   "version": [
-    0,
-    0,
-    3
-   ],
-   "deps": [
-    "helm"
-   ],
-   "commit": "3b2a61dd9d4c9e85946567e07d8e70e276c5136b",
-   "sha256": "1247ghg1jkslgvwbffzsaxabz5l6qszw14vrwgln9smsc42cxjy2"
   }
  },
  {
@@ -61036,11 +60948,11 @@
   "repo": "ideasman42/emacs-hl-indent-scope",
   "unstable": {
    "version": [
-    20250121,
-    2358
+    20250611,
+    330
    ],
-   "commit": "3f88fbc324d6b164643b302d36db598721423a1d",
-   "sha256": "03pfwl3lrcdby9c8l1d35phipxak06aa5ly1fqz96gvkbcyv9b6n"
+   "commit": "643827712a41e8ff17e71573c87be1ffddcc2a90",
+   "sha256": "01bxrkzgn8ay3vg7gakyqg083i6fypa6dy2kh2a4r4540ylj41c3"
   }
  },
  {
@@ -61069,11 +60981,11 @@
   "repo": "ideasman42/emacs-hl-prog-extra",
   "unstable": {
    "version": [
-    20250427,
-    111
+    20250611,
+    323
    ],
-   "commit": "83624cd4a4bb39d9c62173a9d5edc802d022e3e9",
-   "sha256": "0s646klgnnvq3mmn8l7kaxid9s800j2q7jzrb4sp4vcp2q8hc1yq"
+   "commit": "7146a61ef27e52279e80b436537f19248fda2235",
+   "sha256": "0vy7x85lhhhig34a9nmqcd2jilx28qi13815g3wizznsrnyqzzaj"
   }
  },
  {
@@ -61106,26 +61018,26 @@
   "repo": "tarsius/hl-todo",
   "unstable": {
    "version": [
-    20250301,
-    1643
+    20250531,
+    2218
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0ce21c329b686802121df45bf4ae15ae201137bf",
-   "sha256": "0yhy29khisj8cr359d6f2x2zyfjcvvhyyg0kkkvifzqnzkkaa9v0"
+   "commit": "7ed8bbcadb5229d648b194e0e4c4d261825aa91b",
+   "sha256": "14x53z0mf43igvsiafi0bbmljy5nwzib95amrr5qm69jj5k9n082"
   },
   "stable": {
    "version": [
     3,
     8,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0ce21c329b686802121df45bf4ae15ae201137bf",
-   "sha256": "0yhy29khisj8cr359d6f2x2zyfjcvvhyyg0kkkvifzqnzkkaa9v0"
+   "commit": "7ed8bbcadb5229d648b194e0e4c4d261825aa91b",
+   "sha256": "14x53z0mf43igvsiafi0bbmljy5nwzib95amrr5qm69jj5k9n082"
   }
  },
  {
@@ -61212,16 +61124,16 @@
   "repo": "thanhvg/emacs-hnreader",
   "unstable": {
    "version": [
-    20241109,
-    1931
+    20250703,
+    328
    ],
    "deps": [
     "org",
     "promise",
     "request"
    ],
-   "commit": "b422628a272d7672cc2c7dfcef1c8bf06371afd5",
-   "sha256": "1zi7v0bkssl8pv6hgpgkyww1645zxpwr8s2rxw5yw8ddxm5b7zzr"
+   "commit": "a56f67a99a855ca656da1c1985e09f44509e4bbb",
+   "sha256": "1abqjrzq75ijhn3sfmy0wy6acp8x7nj5gihqy34mickz4v5wqbil"
   }
  },
  {
@@ -61508,14 +61420,14 @@
   "repo": "kaorahi/howm",
   "unstable": {
    "version": [
-    20250512,
-    1135
+    20250620,
+    1052
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "ad8385817e478f97eeb65d8e13081fede7d6f8a5",
-   "sha256": "176q6vania09nw1ajz08q9lsciygy3n5ni0l7dkarkrrdx80bsf1"
+   "commit": "89b370b2f10653ec3f8ce09bf6fa3de581bb047d",
+   "sha256": "1n9i6j6b9fnkdjbkvrvfrrmcvk6rkxz8kiirlwayyi1i1x6kxy4q"
   },
   "stable": {
    "version": [
@@ -61678,17 +61590,17 @@
  },
  {
   "ename": "htmlize",
-  "commit": "f9103b6c58996e75c0e5c23fc0fb12afd65424c0",
-  "sha256": "0c0bfw6vixamrm04ghgmddbfw7xc9v7bb5s1v9chrwmf7994wq46",
+  "commit": "bfae97cdf7426c67e8ce73b3bc0984583ecc07c7",
+  "sha256": "1k54jqiggwf2wrcahrr3pvwg51cjh9d5knpa8f7kfs6aqj0p76z7",
   "fetcher": "github",
-  "repo": "hniksic/emacs-htmlize",
+  "repo": "emacsorphanage/htmlize",
   "unstable": {
    "version": [
-    20240915,
-    1657
+    20250704,
+    1928
    ],
-   "commit": "8e3841c837b4b78bd72ad7f0436e919f39315a46",
-   "sha256": "04fvpignf0qy9ws2z90vxbyqzmc4zsqc98m9fnq167x92dp87ibw"
+   "commit": "bf759aa3b2c4099a4252dccdc1db361fbb13a520",
+   "sha256": "1zxx2cns3haxff4862g01llhcn9scck3k9jrcqkjixgy9fynk6pw"
   },
   "stable": {
    "version": [
@@ -61892,11 +61804,11 @@
   "repo": "humanoid-colors/emacs-humanoid-themes",
   "unstable": {
    "version": [
-    20231222,
-    1052
+    20250701,
+    855
    ],
-   "commit": "7dd4fe1211e0af187ae9ad4db6d5bea9e3e944f9",
-   "sha256": "13wibzz7dvsrkzimwjrnkc93j27jw5jwg4bg3dal712cvpfj4avw"
+   "commit": "ea7c03ba933be01b0bab2fe3ca52063903385c17",
+   "sha256": "01v9xfn76p257bx5g9gx46qns6vldgkrbdwz6ahgpn83gk5aism3"
   },
   "stable": {
    "version": [
@@ -62135,11 +62047,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20250528,
-    240
+    20250707,
+    509
    ],
-   "commit": "b8d3e67c58a01f22b5a9a376472944d983279469",
-   "sha256": "11x434zjwmsjaf2iys4qlc6858ly2hyimv3hmms7qs2ka1c2aga8"
+   "commit": "0adae2bbea101423fe555377dd33214f0b5adc74",
+   "sha256": "1j7qc3skhhkym53bx96wl0wgqyfzapsyzvfky96699phfvbbdz2s"
   },
   "stable": {
    "version": [
@@ -62308,20 +62220,20 @@
   "repo": "precompute/hyperstitional-themes",
   "unstable": {
    "version": [
-    20250303,
-    1837
+    20250611,
+    1813
    ],
-   "commit": "998d7fea95a4f8071a806c497fb70619dcd900ac",
-   "sha256": "12w84nbxnkiqldcky47hz0c63n48qic1y1kypaj8cccc8309x88v"
+   "commit": "0fe57ce5edb4237608ff93a41d9f24edb287eec0",
+   "sha256": "09rynnz9cnj1m80cg6mxcxxf4ipcppkab966p0wq4hmk3z5s3hcz"
   },
   "stable": {
    "version": [
+    3,
     1,
-    2,
-    4
+    0
    ],
-   "commit": "998d7fea95a4f8071a806c497fb70619dcd900ac",
-   "sha256": "12w84nbxnkiqldcky47hz0c63n48qic1y1kypaj8cccc8309x88v"
+   "commit": "430e035e842fb9afe58d76a96d0a49504746f620",
+   "sha256": "0y268282bmg97r9vhpn1bhhpbrxql3wmjpn3cvm37bf002ivmrqy"
   }
  },
  {
@@ -63533,26 +63445,26 @@
   "repo": "tarsius/imake",
   "unstable": {
    "version": [
-    20250509,
-    1454
+    20250531,
+    2218
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2cd1b2451fdd91da6f2d9450c202729cc1ef7cf1",
-   "sha256": "0b0xncspir2yqmg5dnnnndicgghfv1rr3smcfn390p1iqs3c0gcd"
+   "commit": "151c0f14dee48f43582a21df3812e2f9a33ff05d",
+   "sha256": "1r5g9vvr27idka3x3mdl22mxxp3nxljkbaqx6fdr9nypmv5cww2y"
   },
   "stable": {
    "version": [
     1,
     2,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "21951b7081e4b36641bf87793b064e06670943d1",
-   "sha256": "11dykwg2dll66n5yivhmcy7pv5hr2ai05z6phml7lw941qh7nhhb"
+   "commit": "151c0f14dee48f43582a21df3812e2f9a33ff05d",
+   "sha256": "1r5g9vvr27idka3x3mdl22mxxp3nxljkbaqx6fdr9nypmv5cww2y"
   }
  },
  {
@@ -64006,20 +63918,20 @@
   "repo": "jcs-elpa/indent-control",
   "unstable": {
    "version": [
-    20250211,
-    48
+    20250602,
+    1131
    ],
-   "commit": "d8fcfff53abfb47cc806c99ebb7b151e9fff4811",
-   "sha256": "0jlg10g31bjj3szlgzkfr000rw421if7bpg0r2pva25nb3saqxh8"
+   "commit": "9bcc2d1a35772cd55d2b11536cb21ffcd7eea365",
+   "sha256": "0l94nx6kd804p6vyg8xbrhzk5lz9qdz9p7dqn37ayckpifwpnr7v"
   },
   "stable": {
    "version": [
     0,
-    3,
-    4
+    4,
+    0
    ],
-   "commit": "2594740d8e8b324722d133a2db051ba4941eb170",
-   "sha256": "0v42lv5ig5hpnc02saqqmrjcvy8n216s7jnlc4f9jjyl7bl7lfsx"
+   "commit": "fb8b9772effa8206d82be9c8e597f6dd5f4ceaec",
+   "sha256": "11h8l0af2xzibc69plvxxw6n6m7sp5bk2rqbx17kykcwa2zhpwmr"
   }
  },
  {
@@ -64508,20 +64420,20 @@
   "repo": "rrthomas/inform-mode",
   "unstable": {
    "version": [
-    20250422,
-    1949
+    20250602,
+    2351
    ],
-   "commit": "71ae49c060b0cef8deee9fe6361d42ed64980e48",
-   "sha256": "1dhjpjgd50nihjmxfzapa1278g496cqmkv6xr68g0c42c1vn05kz"
+   "commit": "e03289d0d056a6e35737612650c7a6060537f726",
+   "sha256": "1gij9hva86m37kfbajh8ywi6gsarlfkwg6qhswy6wa6z81w60sk7"
   },
   "stable": {
    "version": [
     2,
     0,
-    0
+    1
    ],
-   "commit": "f24b44dfd623d47a3a83b43bd969dad33435cd09",
-   "sha256": "1sh2v50x4abf6ni7r8mgss2lxi9q6syj2m7bzciv0f50z8q75jq5"
+   "commit": "e03289d0d056a6e35737612650c7a6060537f726",
+   "sha256": "1gij9hva86m37kfbajh8ywi6gsarlfkwg6qhswy6wa6z81w60sk7"
   }
  },
  {
@@ -65089,10 +65001,10 @@
  },
  {
   "ename": "interaction-log",
-  "commit": "b72951c339c601350a7f10aee05a7fb94bac37ea",
-  "sha256": "1r9qbvgssc2zdwgwmmwv5kapvmg1y3px7268gkiakkfanw3kqk6j",
+  "commit": "19e56644686f7738fe17c638c140b6f901db7aab",
+  "sha256": "1jpis3i6zgw0vbwnmfx178z98w92k7mfcfnza2afnfqd5bws2xk0",
   "fetcher": "github",
-  "repo": "michael-heerdegen/interaction-log.el",
+  "repo": "emacsattic/interaction-log",
   "unstable": {
    "version": [
     20160305,
@@ -67201,15 +67113,15 @@
   "repo": "tkf/emacs-jedi",
   "unstable": {
    "version": [
-    20191011,
-    1750
+    20250602,
+    2107
    ],
    "deps": [
     "auto-complete",
     "jedi-core"
    ],
-   "commit": "9d5f29116c4d42cae561a9d69e6fba2b61e2cf43",
-   "sha256": "1bckxppfzd5gwn0aw4h86igb7igal9axqncq7j8zmflg7zppncf1"
+   "commit": "0a92f57dcfd76f1daf6d382d1e2eb437784a71e0",
+   "sha256": "0d88nyr689b311abi4zbjifm0llnyd16h3riwkq11y0vjkp5i6vq"
   },
   "stable": {
    "version": [
@@ -67233,16 +67145,16 @@
   "repo": "tkf/emacs-jedi",
   "unstable": {
    "version": [
-    20210503,
-    1315
+    20250602,
+    2109
    ],
    "deps": [
     "cl-lib",
     "epc",
     "python-environment"
    ],
-   "commit": "ecb53487c6131d39931ab2927e4b77e9cbfb7204",
-   "sha256": "0gn62y928zpxwmx8g0fk7svph6czjlcbqynk0w12zh1sqzjvksdk"
+   "commit": "94a031d54c55d22aa36ad557f45c972cb3f5833b",
+   "sha256": "09p577ky1k7jn0dld51b0q2hawrx719v7vw69sf6jsfyg85z9mza"
   },
   "stable": {
    "version": [
@@ -67567,14 +67479,14 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20250526,
-    330
+    20250619,
+    1453
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1e143deb27ff9906bf93bd17bbf07e244cc7ca58",
-   "sha256": "1cindzj43vnhmfxn2kx2920fv2pgmrl2p7qv4gsbbb6cqnm8c3zx"
+   "commit": "e4a94a48adfc03afbb8cfb2a2cf76fd7ad1f0e7b",
+   "sha256": "0x3ywxjfz0s47pl5mgbf89g528jymj0w5h36f54chgrg2vh93xbn"
   },
   "stable": {
    "version": [
@@ -67596,8 +67508,8 @@
   "repo": "unmonoqueteclea/jira.el",
   "unstable": {
    "version": [
-    20250526,
-    717
+    20250708,
+    1454
    ],
    "deps": [
     "magit-section",
@@ -67605,14 +67517,14 @@
     "tablist",
     "transient"
    ],
-   "commit": "99b894b70739aa336324fc45f9453cbe80006301",
-   "sha256": "1cmj4w4pxj13hlwh8wshpr6fz9av6ghipbxvys9kzkbmxn8d0s4p"
+   "commit": "422f57129a304ea33c79cabe0bc4055c6fe03ecc",
+   "sha256": "0pblk8npy18wi3d06wqv8w6larn8avipkhvmmn97ss3vpn17z19l"
   },
   "stable": {
    "version": [
+    2,
     1,
-    0,
-    3
+    0
    ],
    "deps": [
     "magit-section",
@@ -67620,8 +67532,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "99b894b70739aa336324fc45f9453cbe80006301",
-   "sha256": "1cmj4w4pxj13hlwh8wshpr6fz9av6ghipbxvys9kzkbmxn8d0s4p"
+   "commit": "422f57129a304ea33c79cabe0bc4055c6fe03ecc",
+   "sha256": "0pblk8npy18wi3d06wqv8w6larn8avipkhvmmn97ss3vpn17z19l"
   }
  },
  {
@@ -68569,6 +68481,21 @@
   }
  },
  {
+  "ename": "json5-ts-mode",
+  "commit": "393dcc546847eacc16ea316962890ec0fc715590",
+  "sha256": "0lsvr6jdrkkfjv23p9vhsqazrbkz9ndn6mqgy1n5gd2r18qfd81c",
+  "fetcher": "github",
+  "repo": "dochang/json5-ts-mode",
+  "unstable": {
+   "version": [
+    20250526,
+    1505
+   ],
+   "commit": "21233ff6386529be26d147d46681119918a9451a",
+   "sha256": "0aj181c1p29ly0r4h53ds5gp5x3fcfyxh0bga9jjmkjymr1asq3d"
+  }
+ },
+ {
   "ename": "jsonian",
   "commit": "b6a2f221f15a20916fb6a90f57ea5c5c3a658751",
   "sha256": "1ma51fby2gwv9izihv0sypwwfajpnj8arzhl98n2i5dhhj3mlnb9",
@@ -68645,11 +68572,11 @@
   "repo": "joshbax189/jsonp-el",
   "unstable": {
    "version": [
-    20250513,
-    23
+    20250603,
+    2133
    ],
-   "commit": "91c6ef2f998c4a70d3ebe30bf72d99f9c70ff6c7",
-   "sha256": "0jwa4gdy601z7pckbhjhkh61qrxvdmc5jl5sx8r57h84bs5i12aw"
+   "commit": "3964615915a69f9cc2b1ec3fd8f32825b8380f72",
+   "sha256": "0zkcy0i25dfk293xyvggyhay0lp7ab45jc9a8gza2n82r38nfixs"
   },
   "stable": {
    "version": [
@@ -68789,14 +68716,14 @@
   "repo": "tpapp/julia-repl",
   "unstable": {
    "version": [
-    20241213,
-    1619
+    20250702,
+    821
    ],
    "deps": [
     "s"
    ],
-   "commit": "317d56021889a336b4be241604ba71e46dc80581",
-   "sha256": "1xmpplqvwqzqb5r3kjs078kh7bqaj3vzv1q797smhsn8mxraa6y0"
+   "commit": "cb511c6a9c8cd42f1bb22e76f3bf5f87a489d2ff",
+   "sha256": "1n340kqa75f6ncmczgjgddciiy3fi5h8khvwi2f40fqv4ahdi0kl"
   },
   "stable": {
    "version": [
@@ -68905,14 +68832,14 @@
   "repo": "shg/julia-vterm.el",
   "unstable": {
    "version": [
-    20250502,
-    1103
+    20250621,
+    854
    ],
    "deps": [
     "vterm"
    ],
-   "commit": "310fa8fc32e86d4e588985b0dd46e2162e42560f",
-   "sha256": "0anr5jycj9553wq3s9w3kkbj8ww33b2mv2b842x6c1mf57sz1ax0"
+   "commit": "742255606a7a7712566dd15759cf316d584a4dc7",
+   "sha256": "1a1x2f0xlzpnrya68lzfj9m9lwq8wl1nq7vvvlgrbchhlrb3bvji"
   },
   "stable": {
    "version": [
@@ -69149,8 +69076,8 @@
   "repo": "psibi/justl.el",
   "unstable": {
    "version": [
-    20241212,
-    255
+    20250703,
+    1538
    ],
    "deps": [
     "f",
@@ -69158,8 +69085,8 @@
     "s",
     "transient"
    ],
-   "commit": "1c3d0550cd4f53139ce9a63b9954685162e838f7",
-   "sha256": "04gk6908qb435af9d0f5fl0b9ynh9vwymgcw77ya645p04m74zs0"
+   "commit": "c126a60a21dbc71151f17819df500d150d9b273e",
+   "sha256": "1pl9z69jq08d9hd53459g5xck13f032ibc22bxh2v880v33ik2gj"
   },
   "stable": {
    "version": [
@@ -69597,28 +69524,28 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20250207,
-    1100
+    20250616,
+    1431
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "95ef38ab680fecddd8141702b533f9a0a1577797",
-   "sha256": "0cqa704hbrfvqp1qf37w5vrpycn4ch8d0q5vvx5wgp6i4kv702fp"
+   "commit": "4b64a70625c1640d369392e9a79cdfd534b8e4be",
+   "sha256": "00cav4pj69m1kv46y8lcgrb71jfjw6s5sqnnllp0fq5hqdxnmcw1"
   },
   "stable": {
    "version": [
     1,
     7,
-    2
+    3
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "0411236811220cad845b8f80ebe73e4a0317af05",
-   "sha256": "1f6wd5vm9p9nwa8km72g8c4g5q2cz915qxrjyjrjhgpp32pfq33d"
+   "commit": "4b64a70625c1640d369392e9a79cdfd534b8e4be",
+   "sha256": "00cav4pj69m1kv46y8lcgrb71jfjw6s5sqnnllp0fq5hqdxnmcw1"
   }
  },
  {
@@ -69742,11 +69669,11 @@
   "repo": "taquangtrung/emacs-kdl-mode",
   "unstable": {
    "version": [
-    20250522,
-    1339
+    20250620,
+    259
    ],
-   "commit": "ff291d0ef0caa260b07d5b3d7736d32b046a04c8",
-   "sha256": "0i4hgsgv53qnwnfbgsnw4bklywm3ixyg1biksj3ayxs1lv1d749g"
+   "commit": "0723706e1248bf07b2761f630ad0de2393a76aeb",
+   "sha256": "1711iqffn71cn4dxbax667hvr1sxpfjckcj65h8y1v9s40nzlv7n"
   }
  },
  {
@@ -70015,26 +69942,26 @@
   "repo": "tarsius/keycast",
   "unstable": {
    "version": [
-    20250505,
-    2146
+    20250531,
+    2219
    ],
    "deps": [
     "compat"
    ],
-   "commit": "965ceb09db7af1d20c2848e7dfdc9d83a2b7dada",
-   "sha256": "18xvyki6jlq6m2l14rsy32bmhj4n5qyr3314xj2jmb7xmvs05l2v"
+   "commit": "6570b73c4d726d18d6ee48a46494b6ff35aacea6",
+   "sha256": "1r57crwq6if56rscf9hvni4zq7bhb7cdvf31ir9j6qyqcdjnhgc1"
   },
   "stable": {
    "version": [
     1,
     4,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "83216f97b3dd99dbb1d4dbc781e863f205b6d5d9",
-   "sha256": "0s6mrz52si6kdd25l0nmv1lbjpkv7qsz049rmmnrsww9kz8jvrdi"
+   "commit": "6570b73c4d726d18d6ee48a46494b6ff35aacea6",
+   "sha256": "1r57crwq6if56rscf9hvni4zq7bhb7cdvf31ir9j6qyqcdjnhgc1"
   }
  },
  {
@@ -70118,26 +70045,26 @@
   "repo": "tarsius/keymap-utils",
   "unstable": {
    "version": [
-    20250511,
-    1413
+    20250531,
+    2219
    ],
    "deps": [
     "compat"
    ],
-   "commit": "0fa24784cbdd48912a95fd88db602a41fdfd3cfd",
-   "sha256": "0rxfpkgvspcx6kjnz8zfa7xklnn2xknbbmxkfd2jmzvvhif9ldxv"
+   "commit": "5acd65f35aa12303e3ea1f205c368e82f0fa89c3",
+   "sha256": "100vc8a7llgpi350yldw1g00rymlda92ns1ljglpgvqkq4g1czib"
   },
   "stable": {
    "version": [
     4,
     0,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a1ea60ce0adfbb4b47cdd7f29943e5ee362b71ce",
-   "sha256": "1va7dsh0c2xf234lfkkmw63c9p0m9h8aiikrlf361nllrzz77497"
+   "commit": "5acd65f35aa12303e3ea1f205c368e82f0fa89c3",
+   "sha256": "100vc8a7llgpi350yldw1g00rymlda92ns1ljglpgvqkq4g1czib"
   }
  },
  {
@@ -70310,20 +70237,20 @@
   "repo": "hperrey/khalel",
   "unstable": {
    "version": [
-    20250225,
-    1846
+    20250612,
+    503
    ],
-   "commit": "c4548265ee5947a4fc391ae615c6fb31c2e8dacd",
-   "sha256": "1j3j1rlnz8mj4xa53biq8n2x8rrfg725vn4svh5aany8i2mrl5p5"
+   "commit": "a8ea2706e5dce6d3d31ba58176dd1b8873dac04e",
+   "sha256": "1ivy61r48xs8dxh2p9wsyidcyn1n04n4w4s3gph1pkyr4ad1n6wl"
   },
   "stable": {
    "version": [
     0,
     1,
-    13
+    14
    ],
-   "commit": "c4548265ee5947a4fc391ae615c6fb31c2e8dacd",
-   "sha256": "1j3j1rlnz8mj4xa53biq8n2x8rrfg725vn4svh5aany8i2mrl5p5"
+   "commit": "a8ea2706e5dce6d3d31ba58176dd1b8873dac04e",
+   "sha256": "1ivy61r48xs8dxh2p9wsyidcyn1n04n4w4s3gph1pkyr4ad1n6wl"
   }
  },
  {
@@ -70364,28 +70291,28 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20250423,
-    1331
+    20250706,
+    1950
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "964a784acff6905f3eb7cbf76dff557228513aee",
-   "sha256": "1pn2srzmy5j5fpmj944lf8kszba1s4pdsbybcwlz84grjz45hi78"
+   "commit": "9a215141f00e75e09386825f49cbf643155d9c9a",
+   "sha256": "1v0sk45s7sfqdlzl1r5pgzkyxbh5sabifqiwpjkadjl35c0w2id5"
   },
   "stable": {
    "version": [
     1,
-    41,
-    0
+    42,
+    9
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "964a784acff6905f3eb7cbf76dff557228513aee",
-   "sha256": "1pn2srzmy5j5fpmj944lf8kszba1s4pdsbybcwlz84grjz45hi78"
+   "commit": "0a34a83d45f9f2b8f96c414ca93284d2f5d428df",
+   "sha256": "14f51774fickblidjl1s8mdqc4zknb20by6f525q9h7vckn55qy2"
   }
  },
  {
@@ -70649,14 +70576,14 @@
   "repo": "benotn/kkp",
   "unstable": {
    "version": [
-    20250206,
-    2000
+    20250608,
+    1431
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ad23d961c3a5dce83b1c9a6b4c65b48809c7af9a",
-   "sha256": "1yx2bambn4m16awndpqh0qp9hqc2mkawzc34sx07cragk1qhz8l2"
+   "commit": "1a7b4f395aa4e1e04afc45fe2dbd6a045871803b",
+   "sha256": "0p0bz0d4qhjms833hb8xprzbizapddjc3pzibhvzwd5qpln1q9ib"
   }
  },
  {
@@ -70860,11 +70787,11 @@
   "repo": "bricka/emacs-kotlin-ts-mode",
   "unstable": {
    "version": [
-    20241226,
-    1643
+    20250617,
+    843
    ],
-   "commit": "a25d56cecac9160ba7c140f982ec16ca7b2fe97f",
-   "sha256": "0d1y8inz0ljd85s8ndlg1lk5whqm7y68kfdh2klhf0qc42phrr6z"
+   "commit": "051c9ef534956c235343fb41546623ff87a1695b",
+   "sha256": "03x9522fmfads4iknsgdj7b1f86cn4j4wly0y1vv162zscp8441m"
   }
  },
  {
@@ -71431,16 +71358,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20250418,
-    1238
+    20250707,
+    1800
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "4f22b700f61665e3d87e7a86774b61d26f0b6efb",
-   "sha256": "1nk9mvf0y3ya49jlmgpc6zkhn8qxvnh9nwnv61jm8klhvnfc7hlj"
+   "commit": "0739f007f42e6b9327979d83c1207f71bdc22e9a",
+   "sha256": "0cz2zx5naifypd168pwiiz3dhxqcg2cf2xyk6h0a2nms3l46mnnh"
   },
   "stable": {
    "version": [
@@ -72116,14 +72043,14 @@
   "repo": "AnselmC/le-gpt.el",
   "unstable": {
    "version": [
-    20250311,
-    1510
+    20250630,
+    244
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "f1c43803df8078ee5f0de5d1e5300ca8b3449568",
-   "sha256": "11ismm1fyfngy74cwhddp49kjjc93mqj9q2zzd0w6b97ziagjbzh"
+   "commit": "3ae0bacaae68ee6bd6c1e2d73ea312c2224b4e21",
+   "sha256": "0wmczjd69lljap83rh5x8z9alln1fag5664wlm6lmrf002mrcg7z"
   }
  },
  {
@@ -72772,11 +72699,11 @@
   "repo": "rvirding/lfe",
   "unstable": {
    "version": [
-    20241206,
-    1536
+    20250702,
+    1243
    ],
-   "commit": "7ba1e7538f3efad909e0a1d7b54fbbb970d84596",
-   "sha256": "18klpw8k6a0waqxl701dwvw5c699ixj1sg276g2qnvfy22a9hgvr"
+   "commit": "ebd7d221c52b6bf8c47c9e4f7daf15b3dee4d3fa",
+   "sha256": "1j6qj7rsbzaif91b7582qyfm98m2d2n7jdwfj89fyvrxq8wilvi7"
   },
   "stable": {
    "version": [
@@ -72933,11 +72860,11 @@
   "repo": "mpdel/libmpdel",
   "unstable": {
    "version": [
-    20230816,
-    839
+    20250623,
+    533
    ],
-   "commit": "ca5397f1d66462e11c9ff4a49d308d92aef31b29",
-   "sha256": "1170lmj79r3hm05j58l9fgxsn57027pa9syplbqhv37cgpram6np"
+   "commit": "8ed0b79cf6527468471e683b7b2a68aeedd37170",
+   "sha256": "0gyk359z3qhjfwgg5p8sgcbsjg1k62hwr2fyzmshbdc6031ay7rz"
   },
   "stable": {
    "version": [
@@ -73916,11 +73843,11 @@
   "repo": "countvajhula/lithium",
   "unstable": {
    "version": [
-    20250521,
-    2255
+    20250703,
+    243
    ],
-   "commit": "fb278a9fbc6c20f21250e1c38ab20edc7736abf3",
-   "sha256": "02ja601b3bkfsi9b858gfs6sxfw3wzfs1nyp877b2k2104lf7hi5"
+   "commit": "5ed65cba5ff3de06764ddf1b5efc6761c932017a",
+   "sha256": "1vlfp1d3w80i5cxnln94l6s6ixdncgzj4xx63bjm5iaizgnzk3sl"
   },
   "stable": {
    "version": [
@@ -74110,26 +74037,26 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20250509,
-    1221
+    20250701,
+    1529
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7de288e79329bfb3e2b4a2f9b574cf834bd371dd",
-   "sha256": "1cmm0yiv0aq0jq54m5amwb1g9gagfajhblb1m8871gpcfw4f5am0"
+   "commit": "0cc2daffded18eea7f00a318cfa3e216977ffe50",
+   "sha256": "0yp1k70pgi45k8gb7xn229g1dzmwnijabvzxgrwacp02n7v1piyh"
   },
   "stable": {
    "version": [
+    1,
     0,
-    6,
-    2
+    0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "48e5bc4919a4a29665362832d59ade8e248b0c3e",
-   "sha256": "0agn4n744fzf1f5i22448p1r7njd0kyxzs763gvml588r2ql2ja5"
+   "commit": "0cc2daffded18eea7f00a318cfa3e216977ffe50",
+   "sha256": "0yp1k70pgi45k8gb7xn229g1dzmwnijabvzxgrwacp02n7v1piyh"
   }
  },
  {
@@ -74734,8 +74661,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20250306,
-    206
+    20250706,
+    117
    ],
    "deps": [
     "compat",
@@ -74743,8 +74670,8 @@
     "seq",
     "stream"
    ],
-   "commit": "348eae3bc01b920e38bfdc8fb1a14e38f5886bda",
-   "sha256": "1syawy975wf1s8q63x3gpwpx6bglaxlrfyq4md5d6mjnkg6hi2k5"
+   "commit": "30ca70a9d4bc4201c57bd6fbc87c14b1c0f416f7",
+   "sha256": "0bfipy9s73d2bvm8zrrypbhi3pm24yanf0jy81jcasbdqsrr1ala"
   },
   "stable": {
    "version": [
@@ -75348,8 +75275,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20250529,
-    838
+    20250708,
+    39
    ],
    "deps": [
     "dash",
@@ -75360,8 +75287,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "dc75f2ad9fb7e516be30585653fd40452e752441",
-   "sha256": "1anfziv5zvfnmr2nf6nfk0yd94jsa6c5ag09qdbz89lbci1wrlli"
+   "commit": "147233313576c844e2bf56640827b0d0e5c2ee6c",
+   "sha256": "14317wgi0mrxbcrlgrfqyf80lh86n7x6bv07b43cxl3k4c4fqk0l"
   },
   "stable": {
    "version": [
@@ -76300,6 +76227,40 @@
   }
  },
  {
+  "ename": "magik-company",
+  "commit": "3ece7bc4b25a5fb652c280ca587a458738bbbb14",
+  "sha256": "1151ran03akpb7s5nskaqh6dz4mcxp5p3n0ichjq30wgk886ppk2",
+  "fetcher": "github",
+  "repo": "reinierkof/magik-company",
+  "unstable": {
+   "version": [
+    20250618,
+    1240
+   ],
+   "deps": [
+    "company",
+    "magik-mode",
+    "yasnippet"
+   ],
+   "commit": "6ff5ab12d97afee960fb1556db623c3278d77812",
+   "sha256": "1dfihmhcglyjvy5fbwn8gjfbcwqyrs4wz7c19faka8qyz51n1bnb"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "company",
+    "magik-mode",
+    "yasnippet"
+   ],
+   "commit": "dccabc933d4cb2cad1807d7ec643e1536da70d53",
+   "sha256": "0f679s3addachrnyfhq493f9aff8m8pmn6vxnxv4m3fvwyrzrxy5"
+  }
+ },
+ {
   "ename": "magik-mode",
   "commit": "0a0a3425d94f48d9804478c0d1a2d77f41c6d6b9",
   "sha256": "0i1y6kjsmi5q5jzf51srb1wm544xw8b5glgn48cmyzria277rygg",
@@ -76307,15 +76268,15 @@
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20250429,
-    1530
+    20250705,
+    2053
    ],
    "deps": [
     "compat",
     "yasnippet"
    ],
-   "commit": "17f1a1a7d3145cebd958fa8bfe786957728a5e18",
-   "sha256": "1sap5ix4bia1fgkdigk478cjhpdsy5pxmxnmj07sp5m0mhaaiik0"
+   "commit": "3b835448c05fb786e605fd28081ee2bd20bc36a4",
+   "sha256": "1hc8bg03366ql81jqsx449is7wnghcakr3mzm53r4j7mp0p6s5dj"
   },
   "stable": {
    "version": [
@@ -76338,8 +76299,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250528,
-    1146
+    20250704,
+    2300
    ],
    "deps": [
     "compat",
@@ -76349,14 +76310,14 @@
     "transient",
     "with-editor"
    ],
-   "commit": "479c4670806dda3589853fa8054c227b89506be1",
-   "sha256": "154nl7klx5ybnr0h63p4bknmgp4944r6yqynaizadsla0f6jcvic"
+   "commit": "5b820a1d1e94649e0f218362286d520d9f29ac2c",
+   "sha256": "0y5151flgsxb1cv123kkj4v74xs5s6sh7ycq00gqc7bm0n09lcdb"
   },
   "stable": {
    "version": [
     4,
     3,
-    5
+    8
    ],
    "deps": [
     "compat",
@@ -76366,8 +76327,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "04ee83d93fabbfbe202e9e7dc781b0dcd4d5b502",
-   "sha256": "0g0ji4m39z8mcq1krj8v3kdhb2a8v2w0m00dqq3z925ibq0lv01r"
+   "commit": "5b820a1d1e94649e0f218362286d520d9f29ac2c",
+   "sha256": "0y5151flgsxb1cv123kkj4v74xs5s6sh7ycq00gqc7bm0n09lcdb"
   }
  },
  {
@@ -76408,14 +76369,14 @@
   "repo": "ideasman42/emacs-magit-commit-mark",
   "unstable": {
    "version": [
-    20241110,
-    245
+    20250611,
+    2320
    ],
    "deps": [
     "magit"
    ],
-   "commit": "e468518c7b8f90deda03cc4f0e2616b367cfdee8",
-   "sha256": "00daa22z32zksxgmrls6fkywf01wvr6h28fjhw3mrirgdwz5i7ab"
+   "commit": "e4a6ea43206c1b640c125fb7e489b0522647b52e",
+   "sha256": "0wa4bzip2aj3mfl6vfypd92fs3czhkilwb64zb9nx3mxrm4sa55i"
   }
  },
  {
@@ -76926,30 +76887,30 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20250518,
-    653
+    20250704,
+    2300
    ],
    "deps": [
     "compat",
     "llama",
     "seq"
    ],
-   "commit": "c556fee1bd3ccc44da9f2322ec17dc5c3f0ef5be",
-   "sha256": "0kpq59fqglisxxk6wq5cnqlwk1aq0jfw4rm69bb7q1adcbqmqar3"
+   "commit": "5b820a1d1e94649e0f218362286d520d9f29ac2c",
+   "sha256": "0y5151flgsxb1cv123kkj4v74xs5s6sh7ycq00gqc7bm0n09lcdb"
   },
   "stable": {
    "version": [
     4,
     3,
-    5
+    8
    ],
    "deps": [
     "compat",
     "llama",
     "seq"
    ],
-   "commit": "04ee83d93fabbfbe202e9e7dc781b0dcd4d5b502",
-   "sha256": "0g0ji4m39z8mcq1krj8v3kdhb2a8v2w0m00dqq3z925ibq0lv01r"
+   "commit": "5b820a1d1e94649e0f218362286d520d9f29ac2c",
+   "sha256": "0y5151flgsxb1cv123kkj4v74xs5s6sh7ycq00gqc7bm0n09lcdb"
   }
  },
  {
@@ -77604,6 +77565,24 @@
   }
  },
  {
+  "ename": "mantra",
+  "commit": "629e9b73ebaafd31c42cdb2544cbb56bd3febc01",
+  "sha256": "0mzmvw7nn3lp0rx0wvfp8q5h9699y3gk755rlr3dxf65vlwjiz8z",
+  "fetcher": "github",
+  "repo": "countvajhula/mantra",
+  "unstable": {
+   "version": [
+    20250706,
+    1916
+   ],
+   "deps": [
+    "pubsub"
+   ],
+   "commit": "da8a4fcd96340deb908c4c416bbe2b621f5b55d3",
+   "sha256": "1pfb2i8p436q25xwqb6x30kkiv2n4i0bmljs89nbbv2rqwpm8mhz"
+  }
+ },
+ {
   "ename": "map-progress",
   "commit": "5ed3335eaf0be7368059bcdb52c46f5e47c0c1a5",
   "sha256": "0zc5vii72gbfwbb35w8m30c8r9zck971hwgcn1a4wjczgn4vkln7",
@@ -77707,25 +77686,25 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20250527,
-    1629
+    20250702,
+    617
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ea65ac9d5dccae5183a2f52e21f5545225a86e28",
-   "sha256": "1vqzmrrr7wbw8fgq058fyzi45r5gacn5sc4pxyrwibxqkhdx1dc9"
+   "commit": "aa8e48b86f66739a86fb2e180103f8f9682004be",
+   "sha256": "1hy1p4xpchsg6kircs94fbls50c6iw39w3sckvpr3ajgg8zmzkbj"
   },
   "stable": {
    "version": [
     2,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c51fd9e4d4258543e0cd8dedda941789163bec5a",
-   "sha256": "00dzckksfzvwjdy3v1g71nvkxnnpw2bmh8bmhf56qn3nzfj2yr89"
+   "commit": "151ac0abd70da0fc4cae753e2ac156bbaa10d317",
+   "sha256": "0h7qn2lrw0y789j4z4i9cycfnzqd6w6a2sg50qhdjiirn5i8s2kk"
   }
  },
  {
@@ -77849,11 +77828,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20250501,
-    551
+    20250624,
+    631
    ],
-   "commit": "90ad4af79a8bb65a3a5cdd6314be44abd9517cfc",
-   "sha256": "19c1jza1xkj3dhf23jw7if2qmr26db7qq6xp5d8q5gyc4v2pm11w"
+   "commit": "7c51a2167c5a1330e0ab52fe5b2d03c1ead122ca",
+   "sha256": "0lbrd9hi1r17y2zmm2r5wly5vy5ydr76v9jlpmlvc7d5bkwh00ph"
   },
   "stable": {
    "version": [
@@ -78209,28 +78188,28 @@
   "repo": "martianh/mastodon.el",
   "unstable": {
    "version": [
-    20250330,
-    1519
+    20250602,
+    1416
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "163ba2b0b89a292b99bff0f574f5584ec888469a",
-   "sha256": "1j4n6ipiahxk6v84dnsrcpzaqsd4v9q2mviqkznm189cp98h6zxk"
+   "commit": "f6247f0c9b8c15b19e8ddca2f600ceb2cf48beb9",
+   "sha256": "1dvj51x17msyl5baa7sicshkndnbag0zcrakvm9w22gmqjhjimy5"
   },
   "stable": {
    "version": [
     2,
     0,
-    0
+    1
    ],
    "deps": [
     "persist",
     "tp"
    ],
-   "commit": "163ba2b0b89a292b99bff0f574f5584ec888469a",
-   "sha256": "1j4n6ipiahxk6v84dnsrcpzaqsd4v9q2mviqkznm189cp98h6zxk"
+   "commit": "f6247f0c9b8c15b19e8ddca2f600ceb2cf48beb9",
+   "sha256": "1dvj51x17msyl5baa7sicshkndnbag0zcrakvm9w22gmqjhjimy5"
   }
  },
  {
@@ -78368,11 +78347,11 @@
   "repo": "mathworks/Emacs-MATLAB-Mode",
   "unstable": {
    "version": [
-    20250529,
-    1756
+    20250605,
+    1434
    ],
-   "commit": "3e1d826e3a4981c8c6fc2b051569abc03c191863",
-   "sha256": "0w2mcccfnkmm3bbihy9j8297jm6yxl4zlyqwksnpllms1wid3pdm"
+   "commit": "0c2cf1da3dbee9c82f924c31dface78771319996",
+   "sha256": "1iha55l59pranpwrdnhsg1wwjfg86a2wsk5s66png4q887b04sas"
   },
   "stable": {
    "version": [
@@ -78491,11 +78470,11 @@
   "repo": "dochang/mb-url",
   "unstable": {
    "version": [
-    20240831,
-    2003
+    20250518,
+    621
    ],
-   "commit": "9f94a465183974404fdfdc8b7659fc3fe00e8a71",
-   "sha256": "01p7w96amjs1b7b92dr5ma2ry1z5kj8xlxsx78grlryvlhmpyhd3"
+   "commit": "3d714075ad31c7c0e119c289b074f143575e86b7",
+   "sha256": "0mxa2szwmd91i9v60f8d0x43yk5l5piyxj0qqmg4bi63m10vnb36"
   },
   "stable": {
    "version": [
@@ -78612,6 +78591,39 @@
    ],
    "commit": "8718cbdaa7bf3dd5c0f30c66a36a6bfbdf7f07c1",
    "sha256": "1xrlp192wi51qpzgpkn9ph5zlpj08ifd8r3444llskyv0bay6g14"
+  }
+ },
+ {
+  "ename": "mcp",
+  "commit": "5fc02724f00f1e26e67a3ca36c371a46dcc78a16",
+  "sha256": "1rk51hsr5yzj8x8xmzapgh2s93mhl39fk7xvvxbqhqw3ypazn5ah",
+  "fetcher": "github",
+  "repo": "lizqwerscott/mcp.el",
+  "unstable": {
+   "version": [
+    20250708,
+    1119
+   ],
+   "deps": [
+    "jsonrpc"
+   ],
+   "commit": "2fcda27b15395fe1ed55d15a88e6187a69af09e9",
+   "sha256": "0q4ycgb4dx4p0v449vncmb4j0nklpy14wasz4x7pkyq6yhsx8lmz"
+  }
+ },
+ {
+  "ename": "mcp-server-lib",
+  "commit": "cba0a5b3b2b8ee04b3ee48b52ae9a397634d6385",
+  "sha256": "09b6dbi5h6jvfzhh6ayacv2ikq99khjjfdq1c4sz88fmcsnm37wg",
+  "fetcher": "github",
+  "repo": "laurynas-biveinis/mcp-server-lib.el",
+  "unstable": {
+   "version": [
+    20250626,
+    331
+   ],
+   "commit": "ad181dd49162c8a4bb5064f081a60baa9fe7852e",
+   "sha256": "07jxkm43q4jc4vz9dr04m22cy7b0332jxqcad0v6lan801bbxj52"
   }
  },
  {
@@ -79477,19 +79489,19 @@
   "repo": "kazu-yamamoto/Mew",
   "unstable": {
    "version": [
-    20240911,
-    749
+    20250708,
+    204
    ],
-   "commit": "c46d8ee784d098244abaf162660073d1d4787b60",
-   "sha256": "03xgwkciyq5yyagam48qhfd2xj4ly0qfjjv67d4adw3c1im8qq66"
+   "commit": "2392ee9b869029a9900587011fe541abe08a2fd5",
+   "sha256": "13ajr51yk2hcfiq532cayb0kvpdb3psf877cxl6qwx0pgaf1qm57"
   },
   "stable": {
    "version": [
     6,
-    9
+    10
    ],
-   "commit": "69a395ec481c66fece53ec07e6a02d82f9e403ee",
-   "sha256": "1y7l5d2c07dhq2rfq5rdpfd2zvpb1gv971sdwdc3m06iy6qrq9fs"
+   "commit": "2392ee9b869029a9900587011fe541abe08a2fd5",
+   "sha256": "13ajr51yk2hcfiq532cayb0kvpdb3psf877cxl6qwx0pgaf1qm57"
   }
  },
  {
@@ -79691,14 +79703,14 @@
   "repo": "SqrtMinusOne/micromamba.el",
   "unstable": {
    "version": [
-    20231225,
-    2320
+    20250705,
+    2025
    ],
    "deps": [
     "pythonic"
    ],
-   "commit": "cd3ce4b7142790f25f20e5cfd6ed5ebbf4498c6c",
-   "sha256": "1bsz301jrlwpcsyyjsvyasbpfm6midn628a5f39xrxi69w0mzww7"
+   "commit": "f0cc31ea2e3d64e1055a8c63700f373a389dc4c0",
+   "sha256": "0j7h245hpim3vibw33f98f7zk2vgm9s9d6syxn5gpl22rhrn8y9v"
   }
  },
  {
@@ -79709,11 +79721,11 @@
   "repo": "emacs-jp/migemo",
   "unstable": {
    "version": [
-    20250228,
-    324
+    20250616,
+    309
    ],
-   "commit": "fbc16b57eace9bf25bcb325032c59c50b186b9d7",
-   "sha256": "10d27jrmn7k4mqqd5cgqf8jwa0pq9yh2550b1r6lwmz6wx509552"
+   "commit": "c0d84b4092ddade01110ba875559bfd454862ac2",
+   "sha256": "0wi2awi58raajqnxaw9xnmv09lh1jhc538sbsq07crgpav0y1n62"
   },
   "stable": {
    "version": [
@@ -79851,14 +79863,14 @@
   "repo": "eki3z/mini-echo.el",
   "unstable": {
    "version": [
-    20250525,
-    1515
+    20250603,
+    1543
    ],
    "deps": [
     "hide-mode-line"
    ],
-   "commit": "d3d39ae892e9facce8fb2ab96f8f7303bcd162a6",
-   "sha256": "13wmr29xckaj0ycmamdd0xspcf8x6mjv7mnl6558zlp3mw3l85yh"
+   "commit": "bf75ba6db68dc622b537cf322019afcf282cfe3d",
+   "sha256": "0viacf7k7z7wlrpxz4p0w09iggxg5pp3fb833has2v4qkkl6vsw9"
   },
   "stable": {
    "version": [
@@ -80081,26 +80093,26 @@
   "repo": "tarsius/minions",
   "unstable": {
    "version": [
-    20250428,
-    1253
+    20250531,
+    2220
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8d5acf28bb332ad75410e1d280d41f5d602c63c9",
-   "sha256": "1zln984w4bvflxvm922fs052qlri514p68cgxz4rrm56j8cddiqw"
+   "commit": "7aeabcab964fefacb15a72d983953c53e238d344",
+   "sha256": "0hlb0d4lhwclvng4kdzngk4i9d1nbylcrp1ninpjdn8k310ni728"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "8d5acf28bb332ad75410e1d280d41f5d602c63c9",
-   "sha256": "1zln984w4bvflxvm922fs052qlri514p68cgxz4rrm56j8cddiqw"
+   "commit": "7aeabcab964fefacb15a72d983953c53e238d344",
+   "sha256": "0hlb0d4lhwclvng4kdzngk4i9d1nbylcrp1ninpjdn8k310ni728"
   }
  },
  {
@@ -80180,17 +80192,17 @@
  },
  {
   "ename": "minsk-theme",
-  "commit": "2f78d25a094cfa5d5a6dad2f0c6d051138b8744b",
-  "sha256": "1sf93ycd6a1p4xf1bhgjbqd4y38v1b4qgf0mh6pag2xz93jr7lw5",
-  "fetcher": "github",
-  "repo": "jlpaca/minsk-theme",
+  "commit": "aa2b9746b3aa5f62e27dc83b01085c006e5ef8f9",
+  "sha256": "15fjkj9v4rfsdzglq97nfhcyfl5ywky686ihwiizykxaq4qycb8q",
+  "fetcher": "codeberg",
+  "repo": "loj/minsk-theme",
   "unstable": {
    "version": [
-    20200306,
-    1220
+    20250706,
+    1827
    ],
-   "commit": "c924eb90fc2ef53d4c366b752ea8cb5c5b8f87ea",
-   "sha256": "0cw5d98yvpixc8pk2yx15b97pakxh8xpjjbd45frdqwv4fsr0im4"
+   "commit": "c9caae876ef184053fef0bd3fee6243632702487",
+   "sha256": "0lmf5wdwffgi9l0y8wpis45gg7wzhvvflzfnxly681byginaqjrc"
   }
  },
  {
@@ -80225,15 +80237,15 @@
   "repo": "milanglacier/minuet-ai.el",
   "unstable": {
    "version": [
-    20250523,
-    447
+    20250619,
+    554
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "b77fe73ace89e7bb9d7fd662c57dee9acffa0709",
-   "sha256": "1g5a533gay571f0mv1ya29b59378jlqfnpa7pmscqqwgax96a9l3"
+   "commit": "8dc40b5e6b92e6c54a664afcb917caa954673e90",
+   "sha256": "0ggcqpcx2cbz66ixjnd1zi9wminksx4k2h2pciv8nihmj01hx0di"
   },
   "stable": {
    "version": [
@@ -80296,15 +80308,15 @@
   "repo": "eki3z/mise.el",
   "unstable": {
    "version": [
-    20250216,
-    2030
+    20250706,
+    357
    ],
    "deps": [
     "inheritenv",
     "llama"
    ],
-   "commit": "97d244417d28605306f3a98eac0b67564677f277",
-   "sha256": "1qk24z3rmyc1s4cxg3d2pzzdzc0yvn3h07q2bybyqb2dbmqcs2hq"
+   "commit": "af4796442b99f6f3b58c52790d0cd32bb250b540",
+   "sha256": "10b7nsnkaxcf6dfhnw9h0h6z3hbv4892wa0ycl1rc27nl2lk0cvr"
   },
   "stable": {
    "version": [
@@ -80328,11 +80340,11 @@
   "repo": "szermatt/mistty",
   "unstable": {
    "version": [
-    20250528,
-    1516
+    20250708,
+    1715
    ],
-   "commit": "8f4ca3224fca36179e8182b9d3e19ebbf58b6d62",
-   "sha256": "199n25qgmq26mas1njfzhp742svdz2rd6234hhypj4m38y8xq999"
+   "commit": "1418f8f356e3af54ffa434225445b70746a8c786",
+   "sha256": "0dg14vi4c97azs59adxirp84ppjr2s8mn92z6vbhdyvlrk1619f1"
   },
   "stable": {
    "version": [
@@ -80783,26 +80795,26 @@
   "repo": "tarsius/mode-line-debug",
   "unstable": {
    "version": [
-    20250509,
-    1454
+    20250531,
+    2220
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d7bf6862b97e53d47c4b1841c70d3c776f21e50e",
-   "sha256": "0jq315crrmni0hvprlrm58k8mcz3i05wi1mvw71yz2a0kf3hnh5x"
+   "commit": "0cb356097366e25dc9a4c95811a8a21a40b9de56",
+   "sha256": "17q8pxb8x90ghqha70r7mkdr540a6mw6l1j1dcvy9bw51hyfk5rx"
   },
   "stable": {
    "version": [
     1,
     4,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "a88406d1a999107610a765550c3bc4d64850f8a0",
-   "sha256": "07mbq8psd5mzsqigdvjk5hdc8kbppfghg976p5nqq4xfy3p6n0v9"
+   "commit": "0cb356097366e25dc9a4c95811a8a21a40b9de56",
+   "sha256": "17q8pxb8x90ghqha70r7mkdr540a6mw6l1j1dcvy9bw51hyfk5rx"
   }
  },
  {
@@ -80981,20 +80993,20 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20250527,
-    1039
+    20250707,
+    1714
    ],
-   "commit": "3576d14f06f245c3111496bfb035bb0926f48089",
-   "sha256": "1s4cndz36vmv66zn96r59gfyni556hm5gzfwa8cj3w32cgvaxw6m"
+   "commit": "6639604271fc5bef2dcdd2b0af2d9bcb2259f8b6",
+   "sha256": "0kdw2q1i8f6b0slvfjrmk9frn00y5v4sa44kbb5fw53wlaxkbhbc"
   },
   "stable": {
    "version": [
     4,
-    7,
+    8,
     0
    ],
-   "commit": "d5a0eeb4f0fc5f865862465c6d17482d166b3b3d",
-   "sha256": "06snn66nb9qs8d8gs1dl2jhmgdris9y6pslpm0lsnq58w3ha71vl"
+   "commit": "b7aa3ae780975b6dda98a75197a6ff89876bb7b7",
+   "sha256": "1nwb5jb58pg3fskc98qvxjv3ikfiwbzdkgxwpmvw13bhhwcmc408"
   }
  },
  {
@@ -81172,11 +81184,11 @@
   "repo": "ideasman42/emacs-mono-complete",
   "unstable": {
    "version": [
-    20250127,
-    427
+    20250611,
+    321
    ],
-   "commit": "b55a2ee553a3d96d38400309497a31ce6a75a357",
-   "sha256": "04k2lqkflmg6bablj2g648p0lv1slzshdrgldw13wqzkb8cw533q"
+   "commit": "3e4b84606f2c5c4563c4491ca63f88baf5b0f465",
+   "sha256": "03maki7gdwywdj76s4x810ci2562ijpsxv6i25jfz1pydzx8fa97"
   }
  },
  {
@@ -81343,26 +81355,26 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20250505,
-    1556
+    20250701,
+    1218
    ],
    "deps": [
     "compat"
    ],
-   "commit": "bc7d4c2e89fb9e568ad58f5f34d4bb6fc76b8c75",
-   "sha256": "0baj5pgc9jisw4isz8x9dljggd0dajpws3n93gy250k1rkxk2fni"
+   "commit": "404400af5415a35b5639dd1bfbc192751e85d737",
+   "sha256": "1m92yac6h4kzswwmjxc3qjhbqcmrgv6243h5zdpqbqrgkc9wmjp6"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "26dd59b300c149a0e2e332023115b280b42ead12",
-   "sha256": "1byphhdp41cn2qs91la6fvgzrwgbyx4yaajknvwz8qxzgl2c4aq2"
+   "commit": "404400af5415a35b5639dd1bfbc192751e85d737",
+   "sha256": "1m92yac6h4kzswwmjxc3qjhbqcmrgv6243h5zdpqbqrgkc9wmjp6"
   }
  },
  {
@@ -81373,11 +81385,11 @@
   "repo": "takaxp/moom",
   "unstable": {
    "version": [
-    20250327,
-    141
+    20250620,
+    1635
    ],
-   "commit": "127563df03abad087b68478bb57ee016dd50bede",
-   "sha256": "1fpbjywb5bq6b3an0y0vkd2x27ldxlpsf31g8yqf9c8ppwj1lyhi"
+   "commit": "32c9ebafe80b51677605ffc1c37f555fdf5738c8",
+   "sha256": "132zyaln89vvcaq1jmdgf0cn8v8vc01kjnyyn14m18pms4dz3wnw"
   },
   "stable": {
    "version": [
@@ -81470,20 +81482,20 @@
   "repo": "tarsius/morlock",
   "unstable": {
    "version": [
-    20250314,
-    2018
+    20250531,
+    2221
    ],
-   "commit": "7f60075bd928948a7c6901a52b560d7e05a688ef",
-   "sha256": "0v8fxlaq95s2hrxi72y3dqcl9nd21jw56lpmdwkmcqjn8rialcas"
+   "commit": "d66b4d4e7f2239c2b4fc6e3ad19aa9ea7b3037c5",
+   "sha256": "1dnd834clqmi3gvanhaxl6mc5a86ixjwa6h6mv4qm3vh9in0bmkp"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
-   "commit": "7f60075bd928948a7c6901a52b560d7e05a688ef",
-   "sha256": "0v8fxlaq95s2hrxi72y3dqcl9nd21jw56lpmdwkmcqjn8rialcas"
+   "commit": "d66b4d4e7f2239c2b4fc6e3ad19aa9ea7b3037c5",
+   "sha256": "1dnd834clqmi3gvanhaxl6mc5a86ixjwa6h6mv4qm3vh9in0bmkp"
   }
  },
  {
@@ -81553,11 +81565,11 @@
   "repo": "mekeor/most-faces",
   "unstable": {
    "version": [
-    20240620,
-    2145
+    20250606,
+    814
    ],
-   "commit": "846ca6db64527fe26d21421b8eaf7a63d8844c3e",
-   "sha256": "1r3gzrryd1pnhplnwzgh9x31hmm8bw9fys2mqfr40sbwzqphsdna"
+   "commit": "6b97ecab10d0a9e6e9faaecac3af543263fe658a",
+   "sha256": "0r9nmh3rmw93pcgqs3izxny22afgwppv2x89j0d3m6vzmb4c9gbi"
   },
   "stable": {
    "version": [
@@ -81774,21 +81786,21 @@
   "repo": "google/mozc",
   "unstable": {
    "version": [
-    20250116,
-    1442
+    20250602,
+    713
    ],
-   "commit": "58ebfadae04bc46c46e70edc9662347a29d8b7bc",
-   "sha256": "1n930s9dmgwrb4adxkwzxnpbd9dji6saf2k2vqwxcqkfhpn33b7f"
+   "commit": "d703e617246b3916edcb5b95812badef1a2764bc",
+   "sha256": "15wjfmz7bjac9dcyvv1ndxcnskgaz5jn95rac5y43jwljvw3nnfx"
   },
   "stable": {
    "version": [
     2,
     31,
-    5712,
+    5851,
     102
    ],
-   "commit": "58ebfadae04bc46c46e70edc9662347a29d8b7bc",
-   "sha256": "1n930s9dmgwrb4adxkwzxnpbd9dji6saf2k2vqwxcqkfhpn33b7f"
+   "commit": "d703e617246b3916edcb5b95812badef1a2764bc",
+   "sha256": "15wjfmz7bjac9dcyvv1ndxcnskgaz5jn95rac5y43jwljvw3nnfx"
   }
  },
  {
@@ -81903,15 +81915,15 @@
   "repo": "mpdel/mpdel",
   "unstable": {
    "version": [
-    20230903,
-    915
+    20250704,
+    1510
    ],
    "deps": [
     "libmpdel",
     "navigel"
    ],
-   "commit": "b7a76a95bde185a3dc2c948c68465b1d532b095b",
-   "sha256": "1iklxpq05k72g6x7b7jmx2c6m4hmxp6v17r2z1avlmdzq9gkzmj9"
+   "commit": "3ef97e161329d37b1e02eefaae6a92dd970195a1",
+   "sha256": "1vfk8lp0x5hs6pqg2y1dcgl9zpvcii06rxwbbwnj4621hpjy6dck"
   },
   "stable": {
    "version": [
@@ -82058,14 +82070,14 @@
   "repo": "lorniu/mpvi",
   "unstable": {
    "version": [
-    20250523,
-    947
+    20250702,
+    632
    ],
    "deps": [
     "emms"
    ],
-   "commit": "5c71ec5c870a12fef2fea1b33fbd27d1fc761756",
-   "sha256": "0inhz7rkc350y6nj0mp1jb4pxa47hc0l5vc13pzbw4mdjllyjp9y"
+   "commit": "fe03352032dd7bb5b9b3818086091b13353138f1",
+   "sha256": "0y67vmkhq5nadv8bkm8xl658hh8i9x7hyq4wxmwg4dl1ak0l49jg"
   }
  },
  {
@@ -82406,29 +82418,30 @@
   "repo": "danielfleischer/mu4easy",
   "unstable": {
    "version": [
-    20241008,
-    1920
+    20250621,
+    1238
    ],
    "deps": [
     "mu4e-alert",
     "mu4e-column-faces",
     "org-msg"
    ],
-   "commit": "f104605240f479f14d9f3dc0d712e71561d81896",
-   "sha256": "1mzmdgh6lkn2ac0flhg17lxw46v0rsa34r6wmhxzw7zak5hfcbqp"
+   "commit": "5767f6fed2ae077116f2876e872943a3dd5ea788",
+   "sha256": "13wcvmz0sc404815aczd344md96lar07yhfqlws4qi83aasx4dwz"
   },
   "stable": {
    "version": [
     1,
-    4
+    4,
+    1
    ],
    "deps": [
     "mu4e-alert",
     "mu4e-column-faces",
     "org-msg"
    ],
-   "commit": "c23930ce118ba498584e3b373f24c09aebdd0f45",
-   "sha256": "1i2ygnk9xzldqpzqjyir10n2hjv7i3xcqscafvnz89vh44d1fsrc"
+   "commit": "5767f6fed2ae077116f2876e872943a3dd5ea788",
+   "sha256": "13wcvmz0sc404815aczd344md96lar07yhfqlws4qi83aasx4dwz"
   }
  },
  {
@@ -83234,11 +83247,11 @@
   "repo": "kenranunderscore/emacs-naga-theme",
   "unstable": {
    "version": [
-    20250523,
-    1259
+    20250608,
+    1926
    ],
-   "commit": "99fcebef1619466bd30f5c35939c232891fa0cc4",
-   "sha256": "0l3aq04z3hbbdddr6dn18l5hs08yjsxs8d7y3wvdy1gw3z5fkck5"
+   "commit": "c150b397d1a14e470dd54d2628b2bd9d3e2faad0",
+   "sha256": "1c689cwq9ar9fa8nk9hqnrg3kyrj0cykhwwnmcwgiwxkk1cm53b9"
   }
  },
  {
@@ -83872,14 +83885,14 @@
   "repo": "jaypei/emacs-neotree",
   "unstable": {
    "version": [
-    20240721,
-    233
+    20250703,
+    2202
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "599bd049a5d9cfab8a0d7ab7bec99d58b4581751",
-   "sha256": "0xa9kz5rhqidhfcpjp9m7l4pgprhwd3wfps0y9wfgddb61rh5klp"
+   "commit": "3178805a0942696d1e5162575d9cab43d14b7970",
+   "sha256": "151qrdwrw624n6cz6v4s78i69p8qcnk7m1njbnj6jj7prcb5ll6y"
   },
   "stable": {
    "version": [
@@ -83902,11 +83915,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20250506,
-    1721
+    20250621,
+    1548
    ],
-   "commit": "1cb883d928ec046358d2b65db0bb898a1dfffd0a",
-   "sha256": "0r3gv9z04asqjsnasjm2avk9gllqkng6ns14l0svrqxac4c2pp70"
+   "commit": "4476b4cabe63f5efafa3c0a8b370db4f6a92e90c",
+   "sha256": "1d345y4z9j2m065j03kd6zb8hcr139mqzvpvxmg1147hrb9w25hn"
   },
   "stable": {
    "version": [
@@ -83986,6 +83999,24 @@
   }
  },
  {
+  "ename": "nerd-icons-grep",
+  "commit": "7b204e0a5f33fa53a78ef0a036aa5e1291bb16d4",
+  "sha256": "1zs5l7c4rm483yxzaabl4j6v18n4m1qiaffwaa6iyb6xk59751lw",
+  "fetcher": "github",
+  "repo": "hron/nerd-icons-grep",
+  "unstable": {
+   "version": [
+    20250625,
+    1435
+   ],
+   "deps": [
+    "nerd-icons"
+   ],
+   "commit": "7179ff3384efce53f7de2f3c1a98070a310a10da",
+   "sha256": "1fm6p3sllrcdr00v618b4b03yi3zdk8kiy2ig09idaq47cf5dvbs"
+  }
+ },
+ {
   "ename": "nerd-icons-ibuffer",
   "commit": "af87c310b6efce1ec86ce05538f593bdf0c4fe18",
   "sha256": "100m10m9ksj03xsg50aiqm1pp48gar5jy4b883wxafx5r64akz2h",
@@ -84045,6 +84076,25 @@
    ],
    "commit": "ecf86cea522a551bf9a0eb10088b84cc84cce29d",
    "sha256": "0psfjjqxrfkk7qaj44d20rrks31cik318vq2im5jff83bw1hgcbn"
+  }
+ },
+ {
+  "ename": "nerd-icons-xref",
+  "commit": "e3f85f7e1b21de0a967727d3a11fd8ea05aeb8f7",
+  "sha256": "0xx0va06pwr1n2f2wc2nfyacjhx0h2msvy8jjmyzynwavjq0khsd",
+  "fetcher": "github",
+  "repo": "hron/nerd-icons-xref",
+  "unstable": {
+   "version": [
+    20250625,
+    1113
+   ],
+   "deps": [
+    "nerd-icons",
+    "xref"
+   ],
+   "commit": "477369eac3597199a42c15aa0b9bbce9498d56fe",
+   "sha256": "06k1f50nb6mwqwpll2ppb80xzjqzngnmpkhf08dihxpdg8kjfgca"
   }
  },
  {
@@ -84181,11 +84231,11 @@
   "repo": "vekatze/neut-mode",
   "unstable": {
    "version": [
-    20241207,
-    16
+    20250608,
+    958
    ],
-   "commit": "7b599bbe96b77ac75b9c2c5b857126749501b70b",
-   "sha256": "0ivyair2xfyg5agxvfic6k89nw1i5sni400rhk9s8xfa11d4smxg"
+   "commit": "8cfea9d387dd252de40c941c52b08699d45e1f04",
+   "sha256": "01pifaj9dsilxh020v2qqhw070r8hhy4s3n73bfs6ka957wrjja9"
   }
  },
  {
@@ -84325,8 +84375,8 @@
   "repo": "ewantown/nice-org-html",
   "unstable": {
    "version": [
-    20250203,
-    848
+    20250608,
+    1715
    ],
    "deps": [
     "dash",
@@ -84334,8 +84384,8 @@
     "s",
     "uuidgen"
    ],
-   "commit": "8f35b640cf8335aa40ce9bb6e471e76b79192774",
-   "sha256": "1rsvl74d3amp5nsgdsjpyzrkywbaq1h6zshbs28kxxnc4da85nck"
+   "commit": "bdb49bbe22dbd99489f2c65a10cb90f29d39d80d",
+   "sha256": "1gm9dr5914hgq07xng06w2myhn115ayv5x8br6s2njw9lqmj6zxz"
   }
  },
  {
@@ -84973,26 +85023,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20250401,
-    1510
+    20250701,
+    1219
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ea15b1c607d4036ce37326bd5b4b2f4291ddfd60",
-   "sha256": "0bfyd276v32yflxd1ad3x5rlndmw3fk7z4q0p79ff09m993fsb54"
+   "commit": "57a7b63fe467eb89b716fdd1729d47f0b789727b",
+   "sha256": "1kpr982w1syr65jdjg72ivqgdhk133a1rx2jwwnwc9rph2xmmwkk"
   },
   "stable": {
    "version": [
     1,
     7,
-    6
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ea15b1c607d4036ce37326bd5b4b2f4291ddfd60",
-   "sha256": "0bfyd276v32yflxd1ad3x5rlndmw3fk7z4q0p79ff09m993fsb54"
+   "commit": "57a7b63fe467eb89b716fdd1729d47f0b789727b",
+   "sha256": "1kpr982w1syr65jdjg72ivqgdhk133a1rx2jwwnwc9rph2xmmwkk"
   }
  },
  {
@@ -85348,11 +85398,11 @@
   "repo": "ashton314/nordic-night",
   "unstable": {
    "version": [
-    20250508,
-    2029
+    20250624,
+    1732
    ],
-   "commit": "6b274e5d2e6136a5108f0278806e52270c2b12e2",
-   "sha256": "1g3svq8clyq4kp6kngh4sj42k48sn99iiy3w570lrnsklykyhkns"
+   "commit": "a500ccc22fab22b291dfbddc8c534e665ae144f9",
+   "sha256": "03h3q9kwq3ss89hbs8ahl8xxafnx1fx3cdfidz3hbh5nm7ycz08l"
   },
   "stable": {
    "version": [
@@ -85469,11 +85519,11 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20250320,
-    1017
+    20250620,
+    1557
    ],
-   "commit": "dfc800c26e7bee1e42a8d96c300508ed9d5a109b",
-   "sha256": "0fcqddvb168bw3s62f0cbq8macm3fzi225mh5n0q8dwjxw7krx1m"
+   "commit": "63665f1ebd6eff7753b7798add657fd6dbd110d6",
+   "sha256": "0103y9ssm8cqgv3vv81fljvxs028p3vr9wdmnfv6s6b70iaw31mv"
   },
   "stable": {
    "version": [
@@ -85492,28 +85542,28 @@
   "repo": "tarsius/notmuch-addr",
   "unstable": {
    "version": [
-    20250117,
-    1240
+    20250531,
+    2222
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "7dde87a44b6576eb736cb6a3b69df6b9946c5ecc",
-   "sha256": "1xr78yw679swbl1bcwhk5k6qj1l9zr9nyl34ry2bpdryi370zkkp"
+   "commit": "29aed7910254dc43d4a2070eb6443d7c0b28ade9",
+   "sha256": "0z3445wnh0zjfwixzq0cqf0a0mzgpdgq6c5b6h6b4vfh9qwd5ra2"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "7dde87a44b6576eb736cb6a3b69df6b9946c5ecc",
-   "sha256": "1xr78yw679swbl1bcwhk5k6qj1l9zr9nyl34ry2bpdryi370zkkp"
+   "commit": "29aed7910254dc43d4a2070eb6443d7c0b28ade9",
+   "sha256": "0z3445wnh0zjfwixzq0cqf0a0mzgpdgq6c5b6h6b4vfh9qwd5ra2"
   }
  },
  {
@@ -85584,28 +85634,28 @@
   "repo": "tarsius/notmuch-maildir",
   "unstable": {
    "version": [
-    20250301,
-    1647
+    20250701,
+    1221
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "3e458cefe3289b56072a76300a0140054c64040f",
-   "sha256": "1lvfr4g4l3nnvw44h3x3zz22j7lqn9m6mq7hslpsdvn03r5h7gsi"
+   "commit": "1e52a31d2e9a7ae68e2d512fa82fc89437945809",
+   "sha256": "1b31qqbdnj2zf9bcs1za5am5gs3xpzsxln269kd2c53pzffbnvyg"
   },
   "stable": {
    "version": [
     1,
-    2,
-    1
+    3,
+    0
    ],
    "deps": [
     "compat",
     "notmuch"
    ],
-   "commit": "3e458cefe3289b56072a76300a0140054c64040f",
-   "sha256": "1lvfr4g4l3nnvw44h3x3zz22j7lqn9m6mq7hslpsdvn03r5h7gsi"
+   "commit": "1e52a31d2e9a7ae68e2d512fa82fc89437945809",
+   "sha256": "1b31qqbdnj2zf9bcs1za5am5gs3xpzsxln269kd2c53pzffbnvyg"
   }
  },
  {
@@ -85616,30 +85666,30 @@
   "repo": "tarsius/notmuch-transient",
   "unstable": {
    "version": [
-    20250117,
-    1241
+    20250601,
+    1056
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "4902879d93402e140a048def88f8fec8cf45d9cb",
-   "sha256": "16c0b87pz4mixqsz44ws02ynlbzgnyvn3j98rxfg24m1hl38c7zm"
+   "commit": "c49e1e80246fd6a6f72f353441c9c4b83e2bb680",
+   "sha256": "1wv2a43wr1vk2wn8c51zd4ydldnpnlk2qy5wax3qwwg7f9y36lb1"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "4902879d93402e140a048def88f8fec8cf45d9cb",
-   "sha256": "16c0b87pz4mixqsz44ws02ynlbzgnyvn3j98rxfg24m1hl38c7zm"
+   "commit": "c49e1e80246fd6a6f72f353441c9c4b83e2bb680",
+   "sha256": "1wv2a43wr1vk2wn8c51zd4ydldnpnlk2qy5wax3qwwg7f9y36lb1"
   }
  },
  {
@@ -85650,14 +85700,14 @@
   "url": "https://depp.brause.cc/nov.el.git",
   "unstable": {
    "version": [
-    20250309,
-    1937
+    20250615,
+    1051
    ],
    "deps": [
     "esxml"
    ],
-   "commit": "b37d9380752e541db3f4b947c219ca54d50ca273",
-   "sha256": "1s1ar3c9819mzalybp0pi6pzzwwnihal7pjyin2804h1gbappli8"
+   "commit": "933816c190633fa1f2f0667ba105d1311572b3c6",
+   "sha256": "0bjvgdhjh10yhg8hyi7bkbfdrv78s46y3ijzagi3ba3d6fvs7vdk"
   },
   "stable": {
    "version": [
@@ -86187,16 +86237,16 @@
   "repo": "telotortium/emacs-oauth2-auto",
   "unstable": {
    "version": [
-    20240326,
-    2225
+    20250624,
+    1919
    ],
    "deps": [
     "aio",
     "alert",
     "dash"
    ],
-   "commit": "ff9a45e27621aad5b1a2e12a09b01f3e4eaecf96",
-   "sha256": "00vwxdxgcnx86i56093vp5j75zgg7iilpzxrhl4s9ccg00vp220n"
+   "commit": "20b3153d9cfb7aafe68a0168647a17373adf5e22",
+   "sha256": "11174advb9kjrd8c75p043ps0b6ihy0x8hdd4qv50rp3v5s6z8fk"
   }
  },
  {
@@ -86334,6 +86384,30 @@
   }
  },
  {
+  "ename": "ob-athena",
+  "commit": "6b8462d86f95ec1cf73709dc2767359f678d9d8d",
+  "sha256": "0rhibw3jls5f2cijn7v4x8mgn156h18cjkh4lxblzpyrpw8xchsz",
+  "fetcher": "github",
+  "repo": "will-abb/aws-athena-babel",
+  "unstable": {
+   "version": [
+    20250709,
+    12
+   ],
+   "commit": "9ae4c947f070f0c6ad3ae28e7c78c306b39154cb",
+   "sha256": "15llx7z1p5w625q8kk4q4ry5p142if4mqv6j9mbljz9zya7y0l43"
+  },
+  "stable": {
+   "version": [
+    2,
+    1,
+    2
+   ],
+   "commit": "33679e231335e88ddf8b05a5a5809829d2d1faf8",
+   "sha256": "0hg8gajh46p593k0prqf6i01z0wm9vkcnmi3v5za38rd5yg6361w"
+  }
+ },
+ {
   "ename": "ob-base64",
   "commit": "d82c7daa606c1c0c2ed4abe7601c16e8b261de12",
   "sha256": "0ki8hkf4b34w1x597vx9mjf7jwzwlsk8z2i8zljip47jibg01913",
@@ -86454,26 +86528,26 @@
   "repo": "xenodium/ob-chatgpt-shell",
   "unstable": {
    "version": [
-    20241118,
-    1001
+    20250704,
+    705
    ],
    "deps": [
     "chatgpt-shell"
    ],
-   "commit": "754ddf54a99bd98427c91a6c7374757026f8bd45",
-   "sha256": "19xj8vm7kkv4a1xa7l5lrz1fk14v34pcbly8i3fpjqx1wgj04waa"
+   "commit": "0e592d19528f8f3283a93e0e2844299e9ea21fcc",
+   "sha256": "07bdm3xzff8k5f360mwz3xachxzfsljrrhnxmk5ivpgfczbswmrh"
   },
   "stable": {
    "version": [
-    1,
-    20,
+    2,
+    0,
     1
    ],
    "deps": [
     "chatgpt-shell"
    ],
-   "commit": "a24c003c79a720eafffc79bc3885070735f667f6",
-   "sha256": "161q8d2b4sq481jh4zwagvh88wg51dsnf76n2l2b7wv3nh7cjh2m"
+   "commit": "0e592d19528f8f3283a93e0e2844299e9ea21fcc",
+   "sha256": "07bdm3xzff8k5f360mwz3xachxzfsljrrhnxmk5ivpgfczbswmrh"
   }
  },
  {
@@ -86762,14 +86836,14 @@
   "repo": "zweifisch/ob-elixir",
   "unstable": {
    "version": [
-    20170725,
-    1419
+    20250706,
+    556
    ],
    "deps": [
     "org"
    ],
-   "commit": "8990a8178b2f7bd93504a9ab136622aab6e82e32",
-   "sha256": "19awvfbjsnd5la14ad8cfd20pdwwlf3d2wxmz7kz6x6rf48x38za"
+   "commit": "8e5d2f3c7adb0d5acde390264fec94627aa7af31",
+   "sha256": "0cxad3fwiq2mc8zvjq77sssnkm89960v4409x3l8qvdf7irlfjq9"
   }
  },
  {
@@ -87051,27 +87125,27 @@
   "repo": "shg/ob-julia-vterm.el",
   "unstable": {
    "version": [
-    20250501,
-    1404
+    20250619,
+    1430
    ],
    "deps": [
     "julia-vterm",
     "queue"
    ],
-   "commit": "bb2eea8a98046c5f63501bca7b4c2df2b3bff087",
-   "sha256": "18vlmrdargdgxfhz79ybb2hjbjdd8zy3hr43r8cnjsxff23rm609"
+   "commit": "bc0f851d4a64f1659021b480f61cdac024ce76fe",
+   "sha256": "05micnsynwqhqqkhknkvpan3lxcx97rqrjy7197fpxns3i2768ha"
   },
   "stable": {
    "version": [
     0,
-    7
+    11
    ],
    "deps": [
     "julia-vterm",
     "queue"
    ],
-   "commit": "bb2eea8a98046c5f63501bca7b4c2df2b3bff087",
-   "sha256": "18vlmrdargdgxfhz79ybb2hjbjdd8zy3hr43r8cnjsxff23rm609"
+   "commit": "bc0f851d4a64f1659021b480f61cdac024ce76fe",
+   "sha256": "05micnsynwqhqqkhknkvpan3lxcx97rqrjy7197fpxns3i2768ha"
   }
  },
  {
@@ -87148,6 +87222,30 @@
   }
  },
  {
+  "ename": "ob-llm",
+  "commit": "ce5b76aae5f740df335ee9d99614e96ae7bc21ba",
+  "sha256": "1bzyxm9jxadr7axm59kp47gbrxgf6w0zbwnprrmjg1vzzvcf8w3w",
+  "fetcher": "github",
+  "repo": "sunflowerseastar/ob-llm",
+  "unstable": {
+   "version": [
+    20250611,
+    415
+   ],
+   "commit": "7058cb271416d56e5bcf73cfadde646141dcabad",
+   "sha256": "1yp85jzzkrxrn5fmir7xb3l5279lh1ki9c7286vljavqmhynv4mf"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "35d14e29652d9532c03454524fff6f8baed94c45",
+   "sha256": "06nmx1599zab83gg2r380l9pn96isx86h6nhsxbdnsx3628j8qd5"
+  }
+ },
+ {
   "ename": "ob-lurk",
   "commit": "8399712211a0fb927970917aec906a97488d00fb",
   "sha256": "0ajy98lzgq2k4dz4m03qlxndy38xqyr4whhd33v97mqwgzsdrf7c",
@@ -87173,11 +87271,11 @@
   "repo": "arnm/ob-mermaid",
   "unstable": {
    "version": [
-    20250124,
-    1831
+    20250621,
+    1655
    ],
-   "commit": "0e7abc14f887e7da6914caf6aaa3226d00d590f7",
-   "sha256": "0agq1nkzx62ki9n8qhyvhkvl4anxpbxm6s9smjknhzlllwr4xraj"
+   "commit": "9b64cbc4b58a8e46ae7adbaa0cedc0e7d4c2eaf9",
+   "sha256": "1vnw5g05l88x3rrcy1j7qldaq743r2b1ifpkl81vilywg30s27zm"
   }
  },
  {
@@ -87319,11 +87417,11 @@
   "repo": "ddoherty03/ob-pic",
   "unstable": {
    "version": [
-    20241209,
-    1043
+    20250604,
+    2027
    ],
-   "commit": "6bb3cbf814ab0c3e3dfc41a7535dee5e30340ba3",
-   "sha256": "0mi78pa8985zxw2nmxshpf4kdinany8wgb5p2680l0b17bmaad1k"
+   "commit": "e60eab82e8fa70ebb288350166baff56ec8f1342",
+   "sha256": "1dki8dkjylipi1cdd02dbk1d38zz7awlxlws8z6bddcx8fxbfapz"
   }
  },
  {
@@ -88114,11 +88212,11 @@
   "repo": "OCamlPro/ocp-indent",
   "unstable": {
    "version": [
-    20211019,
-    907
+    20250629,
+    1639
    ],
-   "commit": "7c4d434132cebc15a8213c8be9e7323692eb0a2b",
-   "sha256": "036qvsjvs1div39w4rkkivg3yicmxcjdjsmdpp64asdzk7531bqq"
+   "commit": "12138576832400d7fbe6938258f646ddab314fbd",
+   "sha256": "0lzypyazc2dzmb154q1gpps96lmf00r3r2x3bxml3jd5l4ip2l6z"
   },
   "stable": {
    "version": [
@@ -88197,26 +88295,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20250324,
-    1446
+    20250623,
+    1056
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "c502603057dea68b4e4e96434bb3b6260456fd6e",
-   "sha256": "0k1h27ach29v5clvfpdgj2q2p5sgcijh0k9ch92zlms197rw57zm"
+   "commit": "3d2b94ecc9489c85a8bac09a3bdb690b0df1a9c6",
+   "sha256": "1r6rwiz53jd29w52spg8hslkmc105vpm5wscn01y2sc1m2njs058"
   },
   "stable": {
    "version": [
     4,
-    30,
-    2
+    32,
+    0
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "c502603057dea68b4e4e96434bb3b6260456fd6e",
-   "sha256": "0k1h27ach29v5clvfpdgj2q2p5sgcijh0k9ch92zlms197rw57zm"
+   "commit": "e942059cdaf5ef36fcc7f1473c7261f9bb9bb740",
+   "sha256": "1lxmj4w9nqrh7i45jh528wjplbr4zs36d4ryjck1ankszgqvz02x"
   }
  },
  {
@@ -88267,30 +88365,30 @@
   "repo": "tarsius/ol-notmuch",
   "unstable": {
    "version": [
-    20250117,
-    1242
+    20250531,
+    2228
    ],
    "deps": [
     "compat",
     "notmuch",
     "org"
    ],
-   "commit": "9a69506a3f9ed31e2f1f967dfaa600702089be45",
-   "sha256": "1xipph77bzxhd6jspxz0ppja4p0wzrkhp4y41nix3lcky3f7a6s1"
+   "commit": "06288ed5ec088f2702afb8f0d952f7db18bb7d56",
+   "sha256": "15n3hsfqnr4srmr3n2kry4348kbnx71x3cl00knqkr3a3bm66izy"
   },
   "stable": {
    "version": [
     2,
     1,
-    0
+    1
    ],
    "deps": [
     "compat",
     "notmuch",
     "org"
    ],
-   "commit": "9a69506a3f9ed31e2f1f967dfaa600702089be45",
-   "sha256": "1xipph77bzxhd6jspxz0ppja4p0wzrkhp4y41nix3lcky3f7a6s1"
+   "commit": "06288ed5ec088f2702afb8f0d952f7db18bb7d56",
+   "sha256": "15n3hsfqnr4srmr3n2kry4348kbnx71x3cl00knqkr3a3bm66izy"
   }
  },
  {
@@ -88397,11 +88495,11 @@
   "repo": "captainflasmr/ollama-buddy",
   "unstable": {
    "version": [
-    20250525,
-    1925
+    20250621,
+    851
    ],
-   "commit": "3d2e0ae084036c57799003d36b5e8dc19aa9cc25",
-   "sha256": "0x1xxpi97xbgpfsg7wdb7kchbiryn6hpg538l4i9ggaa70gq9a4z"
+   "commit": "2c2d4723a83b9a243d6f4f5ab81161cfd16bb4e0",
+   "sha256": "107ddm7sn83kjilwkrzak2dnsivzn1vjipaynnra3vyqdj5yhrx5"
   },
   "stable": {
    "version": [
@@ -88666,11 +88764,20 @@
   "repo": "ajgrf/on.el",
   "unstable": {
    "version": [
-    20221206,
-    600
+    20250703,
+    2313
    ],
-   "commit": "3cf623e1a4331e259ef92e49154ed0551f300436",
-   "sha256": "161ivhq7plx15s65dskzfdy28wmiwwjysmjsyli8bgrhjh59bm42"
+   "commit": "101619bc008564adeecf2e6d27b16aa7cf68ba0e",
+   "sha256": "00ljs4zqz29iq942z2009dyhbydgw8p92mc34pz0pjdqw5885kn0"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "commit": "101619bc008564adeecf2e6d27b16aa7cf68ba0e",
+   "sha256": "00ljs4zqz29iq942z2009dyhbydgw8p92mc34pz0pjdqw5885kn0"
   }
  },
  {
@@ -89086,6 +89193,36 @@
   }
  },
  {
+  "ename": "ordered-set",
+  "commit": "5ca156d140e2bcbf3e939a6f3dc408208b3104e6",
+  "sha256": "080s81clcxgi26h76mzfd3an0lrciwcxhwx8irjzbqlzfvwh27yg",
+  "fetcher": "github",
+  "repo": "kisaragi-hiu/ordered-set.el",
+  "unstable": {
+   "version": [
+    20250616,
+    1432
+   ],
+   "deps": [
+    "seq"
+   ],
+   "commit": "9688d9e39f365ac86f852c5381f294a757d3bdf4",
+   "sha256": "1ibzcg9sy3a97wb9xaqnssqa9xbaxslyj4d68xa5py90aiyj5zkc"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    1
+   ],
+   "deps": [
+    "seq"
+   ],
+   "commit": "9688d9e39f365ac86f852c5381f294a757d3bdf4",
+   "sha256": "1ibzcg9sy3a97wb9xaqnssqa9xbaxslyj4d68xa5py90aiyj5zkc"
+  }
+ },
+ {
   "ename": "orderless",
   "commit": "3f1f2c378e63c5ce8a8d37735f914ce0663a76d3",
   "sha256": "102jfzq2zskaa8jcb4mmmndcdc8221qp0hqlgvwirnzkxms9ij4a",
@@ -89093,14 +89230,14 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20250316,
-    2046
+    20250705,
+    2023
    ],
    "deps": [
     "compat"
    ],
-   "commit": "254f2412489bbbf62700f9d3d5f18e537841dcc3",
-   "sha256": "1la91fk322n600h4wnavx7a6rdc44mz4v4gg1fb3cpwjsw746sl8"
+   "commit": "082a487f79ca5e960046a31599a5f97dac79a858",
+   "sha256": "112y64hq8zbwj1a0w7i7nl2kbrsyhipdwylfhsd0fb4z28j570sw"
   },
   "stable": {
    "version": [
@@ -89341,30 +89478,30 @@
   "repo": "eyeinsky/org-anki",
   "unstable": {
    "version": [
-    20250518,
-    1737
+    20250610,
+    911
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "9482845bac5c8d563e2022ad884f05d1b3d6fb2d",
-   "sha256": "0y0mh0nqhrqi9bw4kpdnwx0v4j61zrs3kac1g939iy3jl3hsm6sf"
+   "commit": "55724018316c76a9db4ce6a886bb2b563b26184e",
+   "sha256": "1dl69h5r1v42f9maqygq8v8mir04m80ff08k9f777q4fpf7jrajw"
   },
   "stable": {
    "version": [
     4,
     0,
-    0
+    2
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "9482845bac5c8d563e2022ad884f05d1b3d6fb2d",
-   "sha256": "0y0mh0nqhrqi9bw4kpdnwx0v4j61zrs3kac1g939iy3jl3hsm6sf"
+   "commit": "55724018316c76a9db4ce6a886bb2b563b26184e",
+   "sha256": "1dl69h5r1v42f9maqygq8v8mir04m80ff08k9f777q4fpf7jrajw"
   }
  },
  {
@@ -89719,14 +89856,14 @@
   "url": "https://repo.or.cz/org-bookmarks.git",
   "unstable": {
    "version": [
-    20250519,
-    659
+    20250619,
+    104
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "9376d6dd8e877c94e0c9e0cf4bbc9205d9acb6b6",
-   "sha256": "0fa9zbcl9zxzn7kdjz5q0ay5iihqq3nzxwsnw95hfhjkq1dai6b7"
+   "commit": "965f5aab0586fe57ebbd978d4d0ef247dc8f7576",
+   "sha256": "17q0jicl63i1npmfb3cy95j2xn8bmjc4j7z74359bcj5xx5dqwh1"
   },
   "stable": {
    "version": [
@@ -89760,8 +89897,8 @@
   "repo": "lepisma/org-books",
   "unstable": {
    "version": [
-    20210408,
-    1913
+    20250630,
+    1215
    ],
    "deps": [
     "dash",
@@ -89771,8 +89908,8 @@
     "org",
     "s"
    ],
-   "commit": "9f4ec4a981bfc5eebff993c3ad49a4bed26aebd1",
-   "sha256": "1sgckvpjdaig9r2clcvs6ckgf2kx7amikkpq26y30jbnfnbskf0v"
+   "commit": "a07acc0895e7d5e5c237b050b0e743c8717e7afd",
+   "sha256": "19ha3jwkp0qazkr59dvzzmz9s7z2w3zvrmfnvjk91fildv29jl70"
   },
   "stable": {
    "version": [
@@ -89972,14 +90109,14 @@
   "repo": "Chobbes/org-chef",
   "unstable": {
    "version": [
-    20231127,
-    1601
+    20250608,
+    130
    ],
    "deps": [
     "org"
    ],
-   "commit": "1710b54441ed744dcdfb125d08fb88cfaf452f10",
-   "sha256": "0adkfcci8scgv8d9a3f9sa3wfb2c03xp3znsd1lfa6g881xmq8d8"
+   "commit": "6a6bccfd857d3fc03aa79e0a09fed5733af2c5c3",
+   "sha256": "1mr1ws1mcn8qsgb7sl2yfflngqcmmsr0a3nkxn3nm8072846wnqa"
   }
  },
  {
@@ -90215,14 +90352,14 @@
   "url": "https://repo.or.cz/org-contacts.git",
   "unstable": {
    "version": [
-    20250528,
-    755
+    20250619,
+    321
    ],
    "deps": [
     "org"
    ],
-   "commit": "b668b76162314379d729eed628717d561034074e",
-   "sha256": "00r0q34ww790ifgl3khc6gp1nvfzrknb0429rc6zkzs2xk93qzwk"
+   "commit": "3a592c71b5352f36d3584b393841b4c6a2adb638",
+   "sha256": "1yb16fppvcp4pllckkwakh01a8vj6mv510prz90x9q608yg1wcvh"
   }
  },
  {
@@ -90818,20 +90955,21 @@
   "repo": "kidd/org-gcal.el",
   "unstable": {
    "version": [
-    20240426,
-    2253
+    20250624,
+    1628
    ],
    "deps": [
     "aio",
     "alert",
     "elnode",
+    "oauth2-auto",
     "org",
     "persist",
     "request",
     "request-deferred"
    ],
-   "commit": "9f9d93e4f0d5863b1318e9e702e1ee6e841c2649",
-   "sha256": "1v0mq8fh3d0az6w9bgn599l8rmns741j92iw0fskarfyfyn63z57"
+   "commit": "c7ad854ee44e88a55db74269d53819c931d55b8e",
+   "sha256": "1ja06l4yqp92cjcncyp7mq7lx3rcf7hixk0m4xqppahk6bkhq0s8"
   },
   "stable": {
    "version": [
@@ -91002,20 +91140,20 @@
   "repo": "krisbalintona/org-hide-drawers",
   "unstable": {
    "version": [
-    20250428,
-    1637
+    20250613,
+    507
    ],
-   "commit": "e6311f1d72027ec701d3a0f88fc0c72ed114e8d0",
-   "sha256": "1c2vqjm33wmkdw2jp0jfn50lii2shim79r53lbskxjhm80zsa544"
+   "commit": "995de47ef3652d76d53eed043e50fba9612b77c7",
+   "sha256": "0dfcahd3j6s4jd3gn4wbpk0g5qsxp82p58cfi76y5f0l9sv4q2ip"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "ce5d12bdfa8629c8d69b689ffa103f7c6207f249",
-   "sha256": "101gd1f8nf0gm597kvsg92j4205pd3x6p3gja5z5dmvycvl6rasw"
+   "commit": "fe6c2e40d439e1cef518eba97e4f8a02a2eb2592",
+   "sha256": "1l460a4f6lbsa3c93qx0vi1l0lbxy86qx6rbsgf2vydywyrqfifs"
   }
  },
  {
@@ -91563,15 +91701,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20250526,
-    131
+    20250606,
+    129
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "f410bb532754fa056f0157bc1232ebfae0a60f00",
-   "sha256": "053b13dsr0a7w6wpg537wpb2paja778phzzkkj7b2vmi6mhn0c0h"
+   "commit": "ce90824b7e5a7ef44568e64cef0848a51a955c64",
+   "sha256": "18kgskfvwakvxq12h77f6n1yxsvgilwm3qlnhfazvfcflhs56bk6"
   },
   "stable": {
    "version": [
@@ -91732,28 +91870,28 @@
   "repo": "meedstrom/org-mem",
   "unstable": {
    "version": [
-    20250530,
-    1743
+    20250621,
+    2137
    ],
    "deps": [
     "el-job",
     "llama"
    ],
-   "commit": "d777d0f162a88ff8c0d08996d8529e89add59ffa",
-   "sha256": "1id9484nvhfw8p4v4rap0z0w58416a7v1lsl2r4r86mj5izccya9"
+   "commit": "3ef1012cd7730d47d44fd19084a906f82d739778",
+   "sha256": "0r7yv40p6svvcznr6lzfffmj0dypnbsyxj0xvx1p72f75krn0vxh"
   },
   "stable": {
    "version": [
     0,
-    14,
+    17,
     2
    ],
    "deps": [
     "el-job",
     "llama"
    ],
-   "commit": "d777d0f162a88ff8c0d08996d8529e89add59ffa",
-   "sha256": "1id9484nvhfw8p4v4rap0z0w58416a7v1lsl2r4r86mj5izccya9"
+   "commit": "6048fc50c1899fd3764d15d216592d2798edc8f5",
+   "sha256": "12aqv1lay6g6vz02s0zqw4620agm0r3s5j87w16gvbawi240x096"
   }
  },
  {
@@ -91859,27 +91997,27 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20250526,
-    331
+    20250611,
+    2334
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "a58534475b4312b0920aa9d3824272470c8e3500",
-   "sha256": "1kkjha95zccnsmcdqcsx3hv3r16j8sf3c7a4d08pm7mg11bk6q4s"
+   "commit": "16bef888cb8e0198dd26f869b85c10c4491a3444",
+   "sha256": "08ddrzqvlckj10b0anhdis6cfx448dw3n027cswklmzx6bj3rmfz"
   },
   "stable": {
    "version": [
     1,
-    8
+    9
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "a58534475b4312b0920aa9d3824272470c8e3500",
-   "sha256": "1kkjha95zccnsmcdqcsx3hv3r16j8sf3c7a4d08pm7mg11bk6q4s"
+   "commit": "16bef888cb8e0198dd26f869b85c10c4491a3444",
+   "sha256": "08ddrzqvlckj10b0anhdis6cfx448dw3n027cswklmzx6bj3rmfz"
   }
  },
  {
@@ -92095,30 +92233,30 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20250530,
-    1205
+    20250704,
+    1816
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "324e946c992207cd0839da1d55024b2155ef2da3",
-   "sha256": "05sqrf96fs9yx9fw7mwl6y2376rwxk97jd4zdh74f9w56hkf5y6p"
+   "commit": "090bac4bccbddbc18aa360c9c3dc724fc43dc789",
+   "sha256": "0q918yz6fkgg3l8qqgzvz8cgdrkxk644iljlibb8lv43dk1d8bvq"
   },
   "stable": {
    "version": [
     3,
-    4,
-    1
+    7,
+    2
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "324e946c992207cd0839da1d55024b2155ef2da3",
-   "sha256": "05sqrf96fs9yx9fw7mwl6y2376rwxk97jd4zdh74f9w56hkf5y6p"
+   "commit": "090bac4bccbddbc18aa360c9c3dc724fc43dc789",
+   "sha256": "0q918yz6fkgg3l8qqgzvz8cgdrkxk644iljlibb8lv43dk1d8bvq"
   }
  },
  {
@@ -92397,16 +92535,16 @@
   "repo": "fuxialexander/org-pdftools",
   "unstable": {
    "version": [
-    20250210,
-    118
+    20250630,
+    1734
    ],
    "deps": [
     "org",
     "org-noter",
     "pdf-tools"
    ],
-   "commit": "5613b7ae561e0af199f25aacc0a9c34c16638408",
-   "sha256": "0p86943abk55bc2402w5lb7115l3b61wv0w07m84wxi4hbfqk8k6"
+   "commit": "20d1ffd2b047c05a4bdf6735e51d2d7852d8f7bf",
+   "sha256": "1hvy8c64r2c73cy9dxd39wnzmhvsks2al3xdhfbrzi0a11jlvm1s"
   }
  },
  {
@@ -92807,28 +92945,28 @@
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20250323,
-    840
+    20250606,
+    1856
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "53e9be7d89a4ffd96690271bef0d7d5c58b8eae6",
-   "sha256": "1aj225d59isdpmyzghlb6v6ph54vp4v8cylv0p8wiqrf197fyz58"
+   "commit": "da7e1feba964cd5542515c1ca354a407e70bd06a",
+   "sha256": "1xq650vcyh4z4qlsgx96wf7xdlh06hvz93i1icybm8vi1lmm2nm3"
   },
   "stable": {
    "version": [
     3,
-    35,
+    36,
     0
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "53e9be7d89a4ffd96690271bef0d7d5c58b8eae6",
-   "sha256": "1aj225d59isdpmyzghlb6v6ph54vp4v8cylv0p8wiqrf197fyz58"
+   "commit": "da7e1feba964cd5542515c1ca354a407e70bd06a",
+   "sha256": "1xq650vcyh4z4qlsgx96wf7xdlh06hvz93i1icybm8vi1lmm2nm3"
   }
  },
  {
@@ -93151,8 +93289,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20250527,
-    1558
+    20250701,
+    528
    ],
    "deps": [
     "dash",
@@ -93160,14 +93298,14 @@
     "magit-section",
     "org"
    ],
-   "commit": "031ee63bee7ecffee2eebb0faae37a37e2b8a603",
-   "sha256": "17g2ynd40cxag5kayz72vqrfqlfr344pbrg0dlpkpsa6d15lg0l4"
+   "commit": "89dfaef38b6caa3027f20f96a551dc8f194ac533",
+   "sha256": "0lxblmbc87ra5wa9rs2y1qd6zmy4ihg6vhkhf9g147vrmpjfp6d3"
   },
   "stable": {
    "version": [
     2,
     3,
-    0
+    1
    ],
    "deps": [
     "dash",
@@ -93175,8 +93313,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "2ff616fbd8277bd797254befe34d5036b35a7dbf",
-   "sha256": "00ijpvsghak5d9p703gnyaksfbniwj062qids0m8xkvvxbzqsdda"
+   "commit": "7ce95a286ba7d0383f2ab16ca4cdbf79901921ff",
+   "sha256": "0cl0f50din00hj541iskl5mxr8ijaf5pnpy6z7zvsam8l4gj8f73"
   }
  },
  {
@@ -93219,8 +93357,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20250509,
-    2337
+    20250702,
+    142
    ],
    "deps": [
     "dash",
@@ -93230,8 +93368,8 @@
     "s",
     "transient"
    ],
-   "commit": "27059ae662a75bc0b2c9d2e8f6dcbbd6179d4a45",
-   "sha256": "1dz33vzhf9lb6pkkm5blsjlgfqy6zii3rgybcwl8gv01sw0wzn07"
+   "commit": "24eac25bf666ec2f361a116d1711fe62c1f463c8",
+   "sha256": "0r1b2hk2lnm8csm58lqzdc3n41y5pfmsqg7kp9ifgqvxask6a8dv"
   },
   "stable": {
    "version": [
@@ -94477,11 +94615,11 @@
   "repo": "pinoaffe/org-vcard",
   "unstable": {
    "version": [
-    20250325,
-    1512
+    20250708,
+    814
    ],
-   "commit": "c15d70fd8cc983f185b86c884dee0e2e0dadaf07",
-   "sha256": "1lyfiwpqq96qnjygw0m7r91ykikc749g7pz80par5bww2km3ika1"
+   "commit": "c438da390db9e5ad9e42b699aeaebe359ed7d9c2",
+   "sha256": "1c035xpvgdyjvmdpdk2mbv7vsch3mhwy54mmnbwlanjkpsld5l9v"
   },
   "stable": {
    "version": [
@@ -94664,30 +94802,30 @@
   "repo": "marcIhm/org-working-set",
   "unstable": {
    "version": [
-    20230803,
-    1640
+    20250620,
+    1501
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "c83a63f34829dca137941bc06e29c34bf056a43b",
-   "sha256": "1vz2f2f37gz2jbybidh0s6zl331sa2qw0nrw500ignd2hjcf30pr"
+   "commit": "ab14880f7875381ba574183af9e4eec0b5975b07",
+   "sha256": "1ya9c3hb9nixw2ls9lk8h9nk9nmjmic7g9q6mh5h1j8vgqfjri12"
   },
   "stable": {
    "version": [
     2,
-    6,
-    4
+    7,
+    0
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "d5375818919f21910a97c4617b2a316c40272fb9",
-   "sha256": "0kdb3m36msy2hqq1mkzzdvbp5dxazv3rfgr17vhi4nm0na47wk2p"
+   "commit": "ab14880f7875381ba574183af9e4eec0b5975b07",
+   "sha256": "1ya9c3hb9nixw2ls9lk8h9nk9nmjmic7g9q6mh5h1j8vgqfjri12"
   }
  },
  {
@@ -95016,30 +95154,30 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20250527,
-    1330
+    20250601,
+    1057
    ],
    "deps": [
     "compat",
     "magit",
     "org"
    ],
-   "commit": "85b074a3e7069a07f5c0bb042d544de9349a4ea0",
-   "sha256": "17arbw0qn76hb1l49kf2zs30ma09n8z23gg24c6w4jnzbby84m6w"
+   "commit": "224350397df0987f8cdc770eb7f4618eca34a727",
+   "sha256": "0vnqzhvizq3xpcbarcvfdp4m89vxwbzf7dqm3izr1qcqmw2rd1cc"
   },
   "stable": {
    "version": [
     2,
     0,
-    2
+    3
    ],
    "deps": [
     "compat",
     "magit",
     "org"
    ],
-   "commit": "efd98e5caaac1d08677dae95be40fab65dcda2c8",
-   "sha256": "0pzcmd4d82nmg98nrnk73qr02k1hy0qyagsbrxyjdpfzrg3ysmp9"
+   "commit": "224350397df0987f8cdc770eb7f4618eca34a727",
+   "sha256": "0vnqzhvizq3xpcbarcvfdp4m89vxwbzf7dqm3izr1qcqmw2rd1cc"
   }
  },
  {
@@ -95050,8 +95188,8 @@
   "repo": "magit/orgit-forge",
   "unstable": {
    "version": [
-    20250401,
-    1810
+    20250601,
+    1059
    ],
    "deps": [
     "compat",
@@ -95060,14 +95198,14 @@
     "org",
     "orgit"
    ],
-   "commit": "764820769e321a76622aaafe7617b4231985b5f0",
-   "sha256": "0v79xc4ss9c4wz6spplrlfzzgynfs264c6gxhzjffpa9vqnvbc6g"
+   "commit": "050590fbc79bc3acd0ab87c0257f6719bff1e33a",
+   "sha256": "02l9l5s8ncv92k2zijgi1jrqfjf24310ydxa8mj3j6m3vz5i0qjv"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
    "deps": [
     "compat",
@@ -95076,8 +95214,8 @@
     "org",
     "orgit"
    ],
-   "commit": "764820769e321a76622aaafe7617b4231985b5f0",
-   "sha256": "0v79xc4ss9c4wz6spplrlfzzgynfs264c6gxhzjffpa9vqnvbc6g"
+   "commit": "050590fbc79bc3acd0ab87c0257f6719bff1e33a",
+   "sha256": "02l9l5s8ncv92k2zijgi1jrqfjf24310ydxa8mj3j6m3vz5i0qjv"
   }
  },
  {
@@ -95088,30 +95226,30 @@
   "repo": "tarsius/orglink",
   "unstable": {
    "version": [
-    20250301,
-    1703
+    20250531,
+    2228
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "dca26f299545aa74a0caf5381daa53ad8ae2227f",
-   "sha256": "0i6qm2vsz9csi7zxlwdfh26pvq86bdjznxiixydh11czkzdv3s3v"
+   "commit": "1df4181ae33dc470ba0cbfa0f8f9efd2a6fec6d9",
+   "sha256": "0xcylj4nfs8jdi8qf6ymf7404zmr8l0lcbdwzj3xri3v0ki6q9v2"
   },
   "stable": {
    "version": [
     1,
     2,
-    5
+    6
    ],
    "deps": [
     "compat",
     "org",
     "seq"
    ],
-   "commit": "dca26f299545aa74a0caf5381daa53ad8ae2227f",
-   "sha256": "0i6qm2vsz9csi7zxlwdfh26pvq86bdjznxiixydh11czkzdv3s3v"
+   "commit": "1df4181ae33dc470ba0cbfa0f8f9efd2a6fec6d9",
+   "sha256": "0xcylj4nfs8jdi8qf6ymf7404zmr8l0lcbdwzj3xri3v0ki6q9v2"
   }
  },
  {
@@ -95243,11 +95381,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20250525,
-    621
+    20250708,
+    1111
    ],
-   "commit": "988ea09d22a4a04e8ecf572e3ff13da4aa0db66c",
-   "sha256": "191kqizhjl5zvpqmi1iky6kdlij1713zcvgpqbvqfny9xs5ppbjv"
+   "commit": "ad7caf71e0360e310dab405235be0820412dee3d",
+   "sha256": "0hbfgv720nh0ks1bayv4zn7x7kr363byaql7xc8aln4fkvv91iai"
   }
  },
  {
@@ -95288,11 +95426,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20250525,
-    2051
+    20250607,
+    833
    ],
-   "commit": "78c6e31b2637dfdc7626f4d71f6805034971416e",
-   "sha256": "1pldbm6kdlsp5vz8hpc9ys077a25j1g45v16r826fx7izfzmjpgp"
+   "commit": "90ad97d0cf3371ae99290f8c4b0ebb6542fcde7c",
+   "sha256": "122scil58zsa9g11iyp18m3k5x7y96r3vxnq09b9iq7rln5knlaq"
   }
  },
  {
@@ -95724,26 +95862,26 @@
   "repo": "abougouffa/one-tab-per-project",
   "unstable": {
    "version": [
-    20250514,
-    2103
+    20250704,
+    2352
    ],
    "deps": [
     "compat"
    ],
-   "commit": "96ae7c156cd9a78a577942db5d1b12ecdecf519b",
-   "sha256": "0n64zgxiqshq9b82x9yzdzi1v1mdi65sgpf1w821hwx1knwi84l0"
+   "commit": "1744f6d3754b3adf02e69bf4f58c93e7a16ab048",
+   "sha256": "0fnbvsfypa3yx883nd87yrrbscibsaa966zb78m5705kl4s22nfq"
   },
   "stable": {
    "version": [
     3,
-    2,
-    1
+    3,
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "96ae7c156cd9a78a577942db5d1b12ecdecf519b",
-   "sha256": "0n64zgxiqshq9b82x9yzdzi1v1mdi65sgpf1w821hwx1knwi84l0"
+   "commit": "3d7495d921202a374745b5353994ff3481c1c819",
+   "sha256": "09f2f11q6vz3nl8qacbzlxzlh2nmrf94vrrqal9cmg3b582a9knd"
   }
  },
  {
@@ -95774,11 +95912,11 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20250320,
-    1659
+    20250704,
+    1609
    ],
-   "commit": "e844d1e4b34bd3e2d0ccfd4cd289c90972673606",
-   "sha256": "0p517kmx85c225wqmff6b4s5rw49b4vaq28rmv03s1q26im7q7ip"
+   "commit": "11483c97c83aad5f626cc3cf385a1f9effc8a356",
+   "sha256": "15v14sbab8f6r0fbmmr3nbx8kbxhi78n8b4azl36xn8g2nj9s9v2"
   },
   "stable": {
    "version": [
@@ -95813,26 +95951,26 @@
   "repo": "tarsius/outline-minor-faces",
   "unstable": {
    "version": [
-    20250529,
-    1604
+    20250601,
+    1003
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4a67945e85f752c19ee6507d04dba4c12bae05a5",
-   "sha256": "0bwdgfj4g4sg87qvnnfmd4v92ka5vrvhf47va46nj2fqpg1y5h4w"
+   "commit": "cb06d2db125ba65fb8c4eb7e5dc6cc6bf3b6dc7e",
+   "sha256": "1mgqcldi426g5ikdc05wvxrr9g97wwm6xhz5qbjcg6rp0zk2wfm1"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f9be85200c8bba29b0a9df354b4795f186840dfa",
-   "sha256": "0cbwx9aw37lkzmmxag7y0x7gv25lxrv2w37dycbimh3rj1mh3a3b"
+   "commit": "cb06d2db125ba65fb8c4eb7e5dc6cc6bf3b6dc7e",
+   "sha256": "1mgqcldi426g5ikdc05wvxrr9g97wwm6xhz5qbjcg6rp0zk2wfm1"
   }
  },
  {
@@ -95999,8 +96137,8 @@
   "repo": "vale981/overleaf.el",
   "unstable": {
    "version": [
-    20250528,
-    2048
+    20250627,
+    1227
    ],
    "deps": [
     "plz",
@@ -96008,14 +96146,14 @@
     "webdriver",
     "websocket"
    ],
-   "commit": "c401fb10fcea710e607d65c20e0e6820daa747d3",
-   "sha256": "0xcivmksrdvg9580d3gc8iafyl2jlahsnmsgdygwfr9gy3ng246i"
+   "commit": "e94c4d8d04760656497a8d774e568c30ca157510",
+   "sha256": "0mgzc8wagg255hq0pzdd6lqq7phxgcbw46qvcw13p101ayyk56fb"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    3
    ],
    "deps": [
     "plz",
@@ -96023,8 +96161,8 @@
     "webdriver",
     "websocket"
    ],
-   "commit": "30ced16c971db1382a7a6486fd9835d28eebef27",
-   "sha256": "14gwcgmc9w1ffgjrz0bmrzv9xjd95jhjlk0rzpaxnd1yn75lwpzj"
+   "commit": "c9e7fbb51a2d22d24172f4500a5e83f15616b006",
+   "sha256": "08w9ca3mrpzx9apxv7ii6c0i4gnnbx51izplsmnfn78pxzy9cp13"
   }
  },
  {
@@ -96709,14 +96847,14 @@
   "repo": "DarkBuffalo/ox-report",
   "unstable": {
    "version": [
-    20231220,
-    1625
+    20250611,
+    2053
    ],
    "deps": [
     "org-msg"
    ],
-   "commit": "36e7f5e6e8cd836bbfcb0e85be01faab21f725fd",
-   "sha256": "0lz6nj42yprddmjd1zhcirg1ila4kvrjirip89nby96zxnswqr72"
+   "commit": "81973dafc10fd06d46b8f7abaab9ac90ff5ccca2",
+   "sha256": "1yd60fsxclqk8yk91d1vr1vaqf1vlw69w7alwq9p7fkfzp4fxdg1"
   },
   "stable": {
    "version": [
@@ -97042,14 +97180,14 @@
   "repo": "jmpunkt/ox-typst",
   "unstable": {
    "version": [
-    20250520,
-    1803
+    20250704,
+    1835
    ],
    "deps": [
     "org"
    ],
-   "commit": "e7110b97401242a85449d05957a169b29642e89a",
-   "sha256": "0xk6pgmlyyj7wn3vig6l1y77qhq19l1l82h2s9pp1rc5gmh44nrq"
+   "commit": "5c855902fe11c10292e495501e7f1b4adbb53d16",
+   "sha256": "1ycagrb2valm5wlabknagjbd3xyx1g7lri2j5l5mxb2d709105lk"
   }
  },
  {
@@ -97131,6 +97269,36 @@
    ],
    "commit": "b53bd82116c9f7dbb5b476d2cfcc8ed0f3bc9c78",
    "sha256": "1n57bzsp73g5iqdnhc4jhsylif93h4kkl7zgqi1i9b8bi90sqrl1"
+  }
+ },
+ {
+  "ename": "p-search",
+  "commit": "90bf1ee96813129643468b0c1d5d1a435d40ff30",
+  "sha256": "14xhbc1mfcqh5ai2gfn503bgczcmmi3n3f5ali02m9bxg4rixc7x",
+  "fetcher": "github",
+  "repo": "zkry/p-search",
+  "unstable": {
+   "version": [
+    20250608,
+    617
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "38a66610a094d4026aaf7733148582375387fd99",
+   "sha256": "1j7h5hag65ksvljj6p7qh857rdg1wdjw0a9vzl77aaz7xmc4w3bc"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "4cab2337796e92311894149d87f26f576b997298",
+   "sha256": "1cl10c7pmp9blzibgw6ni81v8v7xpa1n9w8dg4k60rfl409np2dx"
   }
  },
  {
@@ -97280,11 +97448,11 @@
   "repo": "zenspider/package",
   "unstable": {
    "version": [
-    20230805,
-    2115
+    20240823,
+    2307
    ],
-   "commit": "57a53a1da75d76a9dcd17008d1c1d77475b9671a",
-   "sha256": "1qdbn78xsc7r0bx1fpsbf3amf0wc9h84mj60fyxich1jqyq3m7j3"
+   "commit": "c677513c61b273f3c688464b6005149aeed700ff",
+   "sha256": "1nv45dzbijgk5ayls2xjsrvhzi13mxak7y6wqpym6qnqsdbffl87"
   },
   "stable": {
    "version": [
@@ -97304,14 +97472,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20250520,
-    1504
+    20250708,
+    1908
    ],
    "deps": [
     "compat"
    ],
-   "commit": "59f91ad5026eaf21db72973de89b56a5d1597fb3",
-   "sha256": "12jghjj40iccb4c1aj2aizsxmqd6aglf0008lh8i95s62r070qa5"
+   "commit": "79fbbb9df3a4dfa9fb7a3f547b6f1982fde508bb",
+   "sha256": "0m29ri2sk7n2wyn49pxnc3816i5n34hipmbznvkdhf5pjyvinfvh"
   },
   "stable": {
    "version": [
@@ -97985,26 +98153,26 @@
   "repo": "tarsius/paren-face",
   "unstable": {
    "version": [
-    20250301,
-    1705
+    20250531,
+    2229
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9a7c19aab050c23962049fdeb8d27091ff7bbf10",
-   "sha256": "1j619m08lz6bg2kr4jm2rbyn2r8a9f1z124ashzjkiwky0mvs1v9"
+   "commit": "80b26f6409a615d13738c480d543b47be1af0c0a",
+   "sha256": "1dzxf1a0c8ri6pnidx50jlk7n2x03kpisyh4bipkdccixvdqj6m5"
   },
   "stable": {
    "version": [
     1,
     1,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9a7c19aab050c23962049fdeb8d27091ff7bbf10",
-   "sha256": "1j619m08lz6bg2kr4jm2rbyn2r8a9f1z124ashzjkiwky0mvs1v9"
+   "commit": "80b26f6409a615d13738c480d543b47be1af0c0a",
+   "sha256": "1dzxf1a0c8ri6pnidx50jlk7n2x03kpisyh4bipkdccixvdqj6m5"
   }
  },
  {
@@ -98262,16 +98430,16 @@
   "repo": "NicolasPetton/pass",
   "unstable": {
    "version": [
-    20250525,
-    1239
+    20250616,
+    1457
    ],
    "deps": [
     "f",
     "password-store",
     "password-store-otp"
    ],
-   "commit": "896696999dde9b6ac950ab485cb09f8701ad7626",
-   "sha256": "0ss6haf66mygqi8zz8napyijcs7macqz9p7qz6zli60mm1yafbfa"
+   "commit": "2391d6ee4e3b65d6c6ae522e362a0ec1f2d57866",
+   "sha256": "0rimfbysb0q5khkj4s65w5df743k04jhvjz5xijngckas3mmgjhj"
   },
   "stable": {
    "version": [
@@ -98295,11 +98463,11 @@
   "repo": "vandrlexay/emacs-password-genarator",
   "unstable": {
    "version": [
-    20210425,
-    2227
+    20250615,
+    2300
    ],
-   "commit": "c1da9790d594bc745cdbcc8003153e408aa92a5f",
-   "sha256": "0nwfdf5ik7d11l2h2fg4pszifv3fncpxjzs933gj91mvjy2wrw98"
+   "commit": "2d0deb52f2fd978bff9001e155e36ac5bd287d52",
+   "sha256": "0qxf8amnjvcbqfqcr526idrw4pc7v7l2948b1pn7vswcv35r9695"
   }
  },
  {
@@ -98310,20 +98478,20 @@
   "repo": "rnadler/password-menu",
   "unstable": {
    "version": [
-    20240407,
-    2241
+    20250608,
+    2335
    ],
-   "commit": "46fb7241f7ee8ff646b9a3ea1b3138031de1c0d6",
-   "sha256": "07ksbdzb17pmdgyrk77wf3nr5pn9y95jf8c1hmdi4bifvhqyr4c6"
+   "commit": "071f4b2fc596946f5284689da15263f8bd33957a",
+   "sha256": "0b2p2ll4bmci553g2dccaawph0v4r097ck3yb5ghja6vqd4ljc4r"
   },
   "stable": {
    "version": [
     0,
     1,
-    0
+    1
    ],
-   "commit": "46fb7241f7ee8ff646b9a3ea1b3138031de1c0d6",
-   "sha256": "07ksbdzb17pmdgyrk77wf3nr5pn9y95jf8c1hmdi4bifvhqyr4c6"
+   "commit": "071f4b2fc596946f5284689da15263f8bd33957a",
+   "sha256": "0b2p2ll4bmci553g2dccaawph0v4r097ck3yb5ghja6vqd4ljc4r"
   }
  },
  {
@@ -98349,14 +98517,14 @@
   "repo": "zx2c4/password-store",
   "unstable": {
    "version": [
-    20231201,
-    954
+    20250618,
+    951
    ],
    "deps": [
     "with-editor"
    ],
-   "commit": "b5e965a838bb68c1227caa2cdd874ba496f10149",
-   "sha256": "0hb5zm7hdp7vmqk39a9s1iyncx4swmwfq30dnnzkjk2y08lnb7ac"
+   "commit": "3ca13cd8882cae4083c1c478858adbf2e82dd037",
+   "sha256": "1fap54sc72h3phwj43hs8847pcvs5iykxjnzagb1ws8i4zn7ma8q"
   },
   "stable": {
    "version": [
@@ -98381,28 +98549,28 @@
   "repo": "rjekker/password-store-menu",
   "unstable": {
    "version": [
-    20250127,
-    1459
+    20250706,
+    1858
    ],
    "deps": [
     "password-store",
     "transient"
    ],
-   "commit": "bb765da3d519d87306e13e983bc2847d3abe84a1",
-   "sha256": "02sqwhqgyrw8rgwfhxz0pmiibiq2y8iafxaf9g6vwgcygiq2bnk6"
+   "commit": "31b0884d1cdc80ad4ee7d84680c11653e659bb18",
+   "sha256": "1jz8r0h2anq5q9nz0klnn2ig89d0d133qq5gmhsgf5j29cbhgphl"
   },
   "stable": {
    "version": [
     1,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "password-store",
     "transient"
    ],
-   "commit": "bb765da3d519d87306e13e983bc2847d3abe84a1",
-   "sha256": "02sqwhqgyrw8rgwfhxz0pmiibiq2y8iafxaf9g6vwgcygiq2bnk6"
+   "commit": "31b0884d1cdc80ad4ee7d84680c11653e659bb18",
+   "sha256": "1jz8r0h2anq5q9nz0klnn2ig89d0d133qq5gmhsgf5j29cbhgphl"
   }
  },
  {
@@ -98932,11 +99100,11 @@
   "repo": "lorniu/pdd.el",
   "unstable": {
    "version": [
-    20250531,
-    1253
+    20250708,
+    1559
    ],
-   "commit": "cf45dccead3895463d284dda135d1236fb5d760d",
-   "sha256": "03nwfq96zy1qy5a88nc7njnw9xrgp8qfllzxv6bb1c36kpb9wbpn"
+   "commit": "2ac3e9a2954009e6ccfeda3d7cad6e4debd40299",
+   "sha256": "1ar5vjkrxiqgrpv5v2np3hkx17y0s1ij4pdzabxfc5xh8lxn1hrg"
   }
  },
  {
@@ -99686,25 +99854,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20250503,
-    834
+    20250629,
+    1346
    ],
    "deps": [
     "peg"
    ],
-   "commit": "4f2d0cf8e7a0d3b1ffbfe84989f38eabea5589b4",
-   "sha256": "0q7s0f1clqr57pifs0wz7kcws0i1gb824c0glrdpmjagax87w28v"
+   "commit": "63690547ce37f627b163c3138bcf28c8f07ef3bc",
+   "sha256": "1frxa7v3s92y44mdhgw257zq1j4pia4a53s36nivg83lp629zigb"
   },
   "stable": {
    "version": [
     0,
-    54
+    55
    ],
    "deps": [
     "peg"
    ],
-   "commit": "4f2d0cf8e7a0d3b1ffbfe84989f38eabea5589b4",
-   "sha256": "0q7s0f1clqr57pifs0wz7kcws0i1gb824c0glrdpmjagax87w28v"
+   "commit": "63690547ce37f627b163c3138bcf28c8f07ef3bc",
+   "sha256": "1frxa7v3s92y44mdhgw257zq1j4pia4a53s36nivg83lp629zigb"
   }
  },
  {
@@ -99834,11 +100002,11 @@
   "repo": "zk-phi/phi-search",
   "unstable": {
    "version": [
-    20200510,
-    906
+    20250611,
+    1725
    ],
-   "commit": "c34f5800968922d1f9e7b10092b8705d6640ad18",
-   "sha256": "1ss2ywx93wm372fvgc9vp4h8xkjbpl5i4268r7556n4zwk5nngf5"
+   "commit": "2caee8a353608eb41a41e794e7999a5950dbfee3",
+   "sha256": "0wh2xmw3fl9jjlp6k7xvg7asdzfhlzc2bb2lkl0jdg3yfj2mn5nc"
   },
   "stable": {
    "version": [
@@ -100031,11 +100199,11 @@
   "repo": "emacs-php/php-mode",
   "unstable": {
    "version": [
-    20250528,
-    1306
+    20250602,
+    1308
    ],
-   "commit": "38d8adb17c5a7ffb5ff9f017e9ff8eb4b2ce2da1",
-   "sha256": "1jf9nwz60z64rhgi5a3qzmlr2vq2c688yn6xfybrr2kwcmr6qwwc"
+   "commit": "40b8abed3079771e060dd99a56703520dabf5be4",
+   "sha256": "0f558vrgsb354jp4q7z52s3ybpybwjw2yxr8vlj58jg7dam6smyp"
   },
   "stable": {
    "version": [
@@ -100993,26 +101161,28 @@
   "repo": "skuro/plantuml-mode",
   "unstable": {
    "version": [
-    20250514,
-    1906
+    20250705,
+    1148
    ],
    "deps": [
-    "dash"
+    "dash",
+    "deflate"
    ],
-   "commit": "5e6b505c0695f75666a571b9e6fe1d52fa3ec34d",
-   "sha256": "1gxblp31ihvi51n5ywa68kknzas421zdj8rbl24wz7p0rba6w24y"
+   "commit": "0a19d9988879c57b176dd4c03f59003644f9c9b0",
+   "sha256": "02nck5f8f7vlwi57kb33679d912dq2n2g9ipvkp0x9dsivz1fpi3"
   },
   "stable": {
    "version": [
     1,
-    5,
+    8,
     0
    ],
    "deps": [
-    "dash"
+    "dash",
+    "deflate"
    ],
-   "commit": "5e6b505c0695f75666a571b9e6fe1d52fa3ec34d",
-   "sha256": "1gxblp31ihvi51n5ywa68kknzas421zdj8rbl24wz7p0rba6w24y"
+   "commit": "0eaf340303cf65ddd20cfb65fee1137b52ea229f",
+   "sha256": "1h68bfczpvbzi29ggl3dciiz5187px14xi2sz5pywwl84sg5x2b5"
   }
  },
  {
@@ -101649,6 +101819,21 @@
   }
  },
  {
+  "ename": "polish-holidays",
+  "commit": "b738129f11db62ba083efa35a8458b62ccb56c8b",
+  "sha256": "1l84pbv3axxjqr3yjgf5qp0lhqc6f8zykgxhd8ky823paxv6m9nj",
+  "fetcher": "github",
+  "repo": "przemarbor/polish-holidays",
+  "unstable": {
+   "version": [
+    20250613,
+    2245
+   ],
+   "commit": "3a1e11f53b0fa41bc511c65ae1699394f49cbb08",
+   "sha256": "1g8p63rv1pm7d7b7zddns4zmvhqpw0kpqvz5z6y94bvnb9ai3mi2"
+  }
+ },
+ {
   "ename": "pollen-mode",
   "commit": "97bda0616abe3bb632fc4231e5317d9472dfd14f",
   "sha256": "1kskvdh6rczlki724h5xym8s4iychqzm0i82qdj87x1cg1kx9i85",
@@ -101798,15 +101983,15 @@
   "repo": "polymode/poly-markdown",
   "unstable": {
    "version": [
-    20230202,
-    1210
+    20250531,
+    1935
    ],
    "deps": [
     "markdown-mode",
     "polymode"
    ],
-   "commit": "98695eb7ca4ca11dcec71a1cab64903bbf79b4d3",
-   "sha256": "0x22ablv7qc7h0llqkp6n42cg1nlwlx305ssigijcxbi99dyf3pz"
+   "commit": "f4815f0327e0b3849373870a8867d49bfee37713",
+   "sha256": "1db40pxwlg7crg6wm94ix36y2izmbc4x67d830iyw9bg8mbnmvdv"
   },
   "stable": {
    "version": [
@@ -102020,11 +102205,11 @@
   "repo": "polymode/polymode",
   "unstable": {
    "version": [
-    20250525,
-    2122
+    20250617,
+    1033
    ],
-   "commit": "14b3abc1e2467707398b6e7e5852b56f1463994b",
-   "sha256": "1ahy963yplh7bdxzjz204ynhmc7dm2b8sqvdb9s1dc0l1ppxfjjd"
+   "commit": "25ba9463a443f0e904147138f226284e437248d3",
+   "sha256": "0cpx4c4db76yiwwmyhlf5mlwwzddlf5n3cxsm29p9jvwpcw6n0xg"
   },
   "stable": {
    "version": [
@@ -102685,11 +102870,11 @@
   "repo": "jschaf/powershell.el",
   "unstable": {
    "version": [
-    20250417,
-    2013
+    20250614,
+    1529
    ],
-   "commit": "9efa1b4d0a3cc5c0caae166c144a0f76b1d0e5f4",
-   "sha256": "0lgvri5frma2pz8aqn9v50dzajdn198jjh7lzs1s8xvmz9q74zg2"
+   "commit": "99e0e73082fd48314a9825254dac45f318e5bb59",
+   "sha256": "0m4sric9va2235sl790prbsxxc6gpaqz1lgdy0qkn9ah1p3v27gb"
   }
  },
  {
@@ -102918,11 +103103,11 @@
   "repo": "radian-software/prescient.el",
   "unstable": {
    "version": [
-    20240803,
-    2320
+    20250704,
+    505
    ],
-   "commit": "2b8a8b41228bddb2e11eb1c200e98a9edd04797c",
-   "sha256": "0qz3xv38vazxqsl7lan7fshj3gmb0qagkrvl5xzwqhdg0rir981j"
+   "commit": "85ab01b89f881a131a5b3ec5a617ca4c1d7854c2",
+   "sha256": "1abglp7436l7yrlc0963d849afbmifdk6s1rf5g7lfhzwig3d0cw"
   },
   "stable": {
    "version": [
@@ -103020,11 +103205,11 @@
   "repo": "prettier/prettier-emacs",
   "unstable": {
    "version": [
-    20180109,
-    726
+    20250705,
+    322
    ],
-   "commit": "0e8b95c4e5898a03e85dbc555c37b4f968292aec",
-   "sha256": "0l8i0fbwwyhllkpk8xd6w5gcv65z4ja1ygf6slh5sd1g0ixh29md"
+   "commit": "1ce7a310b000200e333f0015b87d910672ebdb7e",
+   "sha256": "0li8r8jipcvq6wqmin5rxf5mgrik072w5ppa9fa9ghfil3sl5a5p"
   }
  },
  {
@@ -103465,11 +103650,11 @@
   "repo": "ideasman42/emacs-prog-face-refine",
   "unstable": {
    "version": [
-    20230710,
-    113
+    20250611,
+    331
    ],
-   "commit": "c99853ad732784e27300bdb70d4f1aa59c1f6476",
-   "sha256": "1r4i9jrlwfa4iynyipyrmp4wzgxyf0sqgcb6nfjpcyg5gmlv7ikr"
+   "commit": "2205eeb6fa0b4e2b71e27a87683a40183a0c829e",
+   "sha256": "1arn29hh8fjycjvgp0iqhjc7mf7sh1p3lk01z4nl0fwmhc6ibh4a"
   }
  },
  {
@@ -103787,11 +103972,11 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20250527,
-    446
+    20250704,
+    908
    ],
-   "commit": "4e1cfd5af2111643480f8b84aebb2f5266bf89fb",
-   "sha256": "0yl6smg4pk34f9spycplp1xkjbv7h3kslg61sm8xswv8m1ysdg9n"
+   "commit": "5c1b32d9548982d470c3fd48639fb0ec8d239c50",
+   "sha256": "122lxq9c2d78mlf40z4g2gm93hm3q9rv6jcjlrw52h031zimwsgn"
   },
   "stable": {
    "version": [
@@ -104052,8 +104237,8 @@
   "repo": "mohkale/projection",
   "unstable": {
    "version": [
-    20241107,
-    2107
+    20250531,
+    1228
    ],
    "deps": [
     "compat",
@@ -104061,8 +104246,8 @@
     "project",
     "s"
    ],
-   "commit": "50d4f0ec4edfddd24f7c1c540f299a919aa4c151",
-   "sha256": "0s0bs395cczxq53axii514kjk32kj1rv3x68l16ni8jcys8bdy1w"
+   "commit": "8b5f59c12097ca7507d12fef15c8d02f2fd9ab5b",
+   "sha256": "09s0scqy0cyd0mvq0mhd674r28q5m4y61bkhpz1a2rg8s09bvm3v"
   }
  },
  {
@@ -104222,6 +104407,24 @@
   }
  },
  {
+  "ename": "prompt-binder",
+  "commit": "d34ea474038762241d41b83a2144ce37d3903162",
+  "sha256": "1waa8q52adhkwg596dbj85qfmhkz6z3jnmpx0ajsng46ryk4pnb6",
+  "fetcher": "github",
+  "repo": "tracym/prompt-binder",
+  "unstable": {
+   "version": [
+    20250621,
+    853
+   ],
+   "deps": [
+    "llm"
+   ],
+   "commit": "e0e81fba2f1eaf7fa82827fbf32c0cdbf1328d2f",
+   "sha256": "1q3abf6zpj8w37vzghqbgr39v79ycshz4rikjl005xnj0xmkqz1s"
+  }
+ },
+ {
   "ename": "prompt-text",
   "commit": "17d2bc3e53865fe8c98aabb6ef0ad1d10fcb1061",
   "sha256": "1b9sj9kzx5ydq2zsfmkwsx78pzg0vsvrn92397js6b2cm24vrwwc",
@@ -104286,11 +104489,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20250527,
-    1439
+    20250623,
+    2108
    ],
-   "commit": "964a5958e7c8ebdf1bf264342861f6644c34c6cd",
-   "sha256": "1p8z6pc6ag6p3gz6wnnal5fgffv4namnwd8yyya6q28h9bff0a30"
+   "commit": "999cafbe7320ae887f7eebd441beab7e5b0ae6eb",
+   "sha256": "06ba11lsl0944pg03lq3105s1x7a857lfc1xncbr3fsk57ln815h"
   },
   "stable": {
    "version": [
@@ -104745,6 +104948,21 @@
   }
  },
  {
+  "ename": "pubsub",
+  "commit": "dd1d51facd6387fefe2143aaf0cafc556113a944",
+  "sha256": "1siam0l72gq7p56q2kh7yp3ql7l1n4i9y057r5ds40qlqqj0jnbz",
+  "fetcher": "github",
+  "repo": "countvajhula/pubsub",
+  "unstable": {
+   "version": [
+    20250616,
+    2221
+   ],
+   "commit": "7691efbe3a28b4b546486474526c0b5c89a583d7",
+   "sha256": "18bzjcnpd6ps0ncg076a8ghqbydbp4pskskj1smqg46cghh0zaw4"
+  }
+ },
+ {
   "ename": "pueue",
   "commit": "6e4ee777af744d43a8ab3116e2dced0e48d6d8d6",
   "sha256": "156nkdn5nv98mm8jsjai1dpbjih876b1h5063nhydxxir5s6ikyp",
@@ -104982,11 +105200,11 @@
   "repo": "purescript-emacs/purescript-mode",
   "unstable": {
    "version": [
-    20250529,
-    1902
+    20250613,
+    944
    ],
-   "commit": "530dc6d480567646f48e6424e45c2ab1cc1abf6d",
-   "sha256": "0xh4x9b5bhji2z7dn5n99j0y07zifva3ijcnpjz806c4hsjd0f2x"
+   "commit": "61732e23bd33b7d0d71bc6cff84b612bd2d9dff2",
+   "sha256": "19fycmdzyipb1lwdr4p86sg4j6qjy1j2rl8raml5yrbm1cra791a"
   }
  },
  {
@@ -105238,15 +105456,15 @@
   "repo": "vale981/py-vterm-interaction.el",
   "unstable": {
    "version": [
-    20250122,
-    1757
+    20250619,
+    108
    ],
    "deps": [
     "python",
     "vterm"
    ],
-   "commit": "461b8c423b53dfd1b40e94377724e9b7b0911811",
-   "sha256": "0bkn2h47iwcba6xgbfgwjsm21g03pa9xfh339ilp9k2y6v00z58i"
+   "commit": "f6320d0560e28fa1301439ab29b0dfa33988492a",
+   "sha256": "19pa0id26c6xp78ylx4zxirzzyz4dmly1wvgq3wh06qkh531pzbc"
   },
   "stable": {
    "version": [
@@ -105546,14 +105764,14 @@
   "repo": "cor5corpii/pyim-smzmdict",
   "unstable": {
    "version": [
-    20210505,
-    1445
+    20250621,
+    828
    ],
    "deps": [
     "pyim"
    ],
-   "commit": "fcddbde17a04d174c7353548056524687f7be8d2",
-   "sha256": "1mi4a8sizlplys93lac34d3fv8338lbk3hfg3n45vp14wvfvpjnq"
+   "commit": "853908d2ae88a30038dd03a7cd3f00aeabd89ac2",
+   "sha256": "1zyfr608d6yd7zp1hv8hjraff8k9hvxnx0pgzi5n5kw53dggps4a"
   }
  },
  {
@@ -105626,11 +105844,11 @@
   "repo": "emacsorphanage/pyimpsort",
   "unstable": {
    "version": [
-    20160130,
-    453
+    20250707,
+    1327
    ],
-   "commit": "d5c61d70896b642646dfd3c809c06174ae086c1a",
-   "sha256": "05qx1p19dw3nr264shihfn33k579hd0wf4cxki5cqrxi7xzpjgrc"
+   "commit": "e26c8932fc666c33a9dcbec6207c966c5b3b81ad",
+   "sha256": "0kpn8b4z42pmaklyc4612l2708z3x25hshvxwxqh02xdka0l4q04"
   }
  },
  {
@@ -105834,16 +106052,16 @@
   "repo": "wbolster/emacs-python-coverage",
   "unstable": {
    "version": [
-    20240703,
-    917
+    20250601,
+    1621
    ],
    "deps": [
     "dash",
     "s",
     "xml+"
    ],
-   "commit": "7077dabdee59efe1d7116149cdc0ef40e6816c2b",
-   "sha256": "0pf01b9xnzzibkbfx1l3i25ckljf73vr20fpnmfc9giaiz5lzl5l"
+   "commit": "ec1789b8cbbfd58b8f4f687c2e4efb7e30429643",
+   "sha256": "0hvschfsvj6wg00nab0c1kki9m74ii4zbnzmn6a46yqvnyxjy2qc"
   }
  },
  {
@@ -105997,20 +106215,20 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20250520,
-    1831
+    20250624,
+    1530
    ],
-   "commit": "1d184822bdcdc1d41536597b29948bc5a12a583e",
-   "sha256": "000q538f16xvf348035mj5ygbi8bppf4gwpp57404v9mvg21r14z"
+   "commit": "37a14e1c07fe2d99786c7faa12b928b9654e79ed",
+   "sha256": "1p77gjxnk1v7bgx51kr6yklg7f9d38jjb7zh5rc0vbl84s9mh9x8"
   },
   "stable": {
    "version": [
     6,
     3,
-    0
+    1
    ],
-   "commit": "906b0a107f7bcfe6e32bcfedb977e6f0f99fda59",
-   "sha256": "0d7hc2llr9dkjyfgyyjb2k72rny0j395a29pqgqgqyrwcn8b1py1"
+   "commit": "fdd3b2eebaf496b52da7e385394e5408a57bea13",
+   "sha256": "0xrx88asia9yar5j6sqzvp6svzqcbpzg95hskcm4yhd16wy0mh3j"
   }
  },
  {
@@ -106021,16 +106239,16 @@
   "repo": "wbolster/emacs-python-pytest",
   "unstable": {
    "version": [
-    20240826,
-    948
+    20250706,
+    2057
    ],
    "deps": [
     "dash",
     "s",
     "transient"
    ],
-   "commit": "9390f9fc35f98884131e5b3ec572be04d5409b73",
-   "sha256": "1yxrr9ia9vc6yphjalmwls04355lwvisfqr2yf0v8zlba36g85r9"
+   "commit": "02784b0701cf0698277e3252c2e394cf02fab055",
+   "sha256": "0sibih2nw1l7bpp9clr6bfd246vgdsig967qxqy6k9qpfzsk634l"
   },
   "stable": {
    "version": [
@@ -106276,6 +106494,21 @@
    ],
    "commit": "d7896e9594d45d7b2622d4617ff9cb7037378167",
    "sha256": "0yrshahci319lnjdpsksdy11a69k1n91qk9r2zfyhqmng09s6i0y"
+  }
+ },
+ {
+  "ename": "qso",
+  "commit": "857f74e21f8f3914a68508a95ebdc22aa56ca8a0",
+  "sha256": "1l68fr1xrl27m4jh6vg89zk5m7a7n3dr6y0qh5lfs6gr3a47dqlj",
+  "fetcher": "github",
+  "repo": "K6SM/Emacs-QSO-Logger",
+  "unstable": {
+   "version": [
+    20250701,
+    1933
+   ],
+   "commit": "09bfabd9d2f3336ee66371c102064e0d508035ec",
+   "sha256": "14g2m8jjhk7pzj5spszbjx8sbf0qj4ii1p2rpp2c81qcladsg37g"
   }
  },
  {
@@ -106780,14 +107013,14 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20250521,
-    1303
+    20250609,
+    1522
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7b4b77cd4ef9746538ad0bd386bebfe57a0043db",
-   "sha256": "0938bdryhnc2m6hyq52fk21y40p2dfpj8bg2p5l7p4hadvv2jaxq"
+   "commit": "4395797ff130fcdcc9750fb2456d4f762d56852f",
+   "sha256": "0lfzl09d6rxi4qjrykd4xg78gaj3bbpd6s1g8n9l9fxwd31vgix9"
   }
  },
  {
@@ -106883,10 +107116,10 @@
  },
  {
   "ename": "rainbow-blocks",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "1zf1z1hnp8q0s9za7nnpq83isbpmz26l8hxafz0h0b5dz1w2vlvs",
+  "commit": "4012a91c1c40276c2290b6b3cec4f735bce116e2",
+  "sha256": "1jssgxcr9a4mxysr1n4brs3mmi3wn3iv1y8z19b4aj9sdrp8l773",
   "fetcher": "github",
-  "repo": "istib/rainbow-blocks",
+  "repo": "emacsattic/rainbow-blocks",
   "unstable": {
    "version": [
     20210715,
@@ -107129,6 +107362,21 @@
    ],
    "commit": "59b5f7e8102570b65040e8d55781c7ea28de7338",
    "sha256": "1i16361klpdsxphcjdpxqswab3ing69j1wb9nygws7ghil85h0bx"
+  }
+ },
+ {
+  "ename": "rasi-mode",
+  "commit": "76929f783c420a7e25e1fad48564c6076b7fca1e",
+  "sha256": "1lb8ga6pfxkkl8xq40rf7grm59vpxk9vavxs9i27yfhl2wc5ycdk",
+  "fetcher": "github",
+  "repo": "taquangtrung/emacs-rasi-mode",
+  "unstable": {
+   "version": [
+    20250603,
+    758
+   ],
+   "commit": "f6c8551cdc98cb893997f482b9d8d6b366fa39d8",
+   "sha256": "0fx895xz7azy449fn1jkqbjzwjfjxj5dnj91c8p1b304k2x56h26"
   }
  },
  {
@@ -107570,16 +107818,16 @@
   "repo": "realgud/realgud",
   "unstable": {
    "version": [
-    20231113,
-    1910
+    20250605,
+    1143
    ],
    "deps": [
     "load-relative",
     "loc-changes",
     "test-simple"
    ],
-   "commit": "365063ea8ce8ec6a852cb388088d84147421c3c2",
-   "sha256": "1ankjwwsbkv5i9x9dbv0lzbs5qrqb486ds2qymdb0w4kg2g3d11z"
+   "commit": "bc479d7e1b14721006ec76b47bc070756baec16b",
+   "sha256": "0mq5chsfm7y6pjqyx70cm946wifdp1rzplgcxq38m2l27h96p2rf"
   },
   "stable": {
    "version": [
@@ -107913,11 +108161,11 @@
   "repo": "vic/rebecca-theme",
   "unstable": {
    "version": [
-    20180324,
-    821
+    20250603,
+    428
    ],
-   "commit": "1fe3662d1b02caea96e9a780252b2c45f7a49b1d",
-   "sha256": "0qcfnc9slhm4y2bpld0ckbv3wijr9y7h6555sy23z3dlmz7xs1wm"
+   "commit": "718787fb8c9f3e29e09bb9cbdd966c810f15aa81",
+   "sha256": "0fipwj1xncdgfvizq37gzxynd9ykbbkaf57y57bwfrd98mhdimj2"
   },
   "stable": {
    "version": [
@@ -108702,11 +108950,11 @@
   "repo": "Reagankm/renpy-mode",
   "unstable": {
    "version": [
-    20250509,
-    825
+    20250707,
+    1816
    ],
-   "commit": "fd97f97c12ab7e3fae9590b7f39362d6084d6fc8",
-   "sha256": "0kclg1mm4i4lrpc0sd0jdfwsvcy8kh5a6ljgflxz65aj3ln05qi0"
+   "commit": "6755d59b5153b61829a2ccf266d89c5b69bc0c21",
+   "sha256": "135j4g1l5y06cny1mk92nq7sjxbkn466d1naajjsj622mlf87bdk"
   }
  },
  {
@@ -108717,11 +108965,11 @@
   "repo": "ideasman42/emacs-repeat-fu",
   "unstable": {
    "version": [
-    20250428,
-    2323
+    20250613,
+    304
    ],
-   "commit": "c7707c98730bb3ffaf84aeed341fae3cf35c314b",
-   "sha256": "0qfbf8rg9lpdmr4xfy5nmq4130zbjbkaqhk780zp5jin8p71jb5s"
+   "commit": "b91d55001cca71e5df7a9f665c7da73ab9f55efd",
+   "sha256": "04kpzwcl3lzqvaw16wy7qjw5kfnbhndby1adwkv8p3bbqjqj5g48"
   }
  },
  {
@@ -109157,25 +109405,28 @@
  },
  {
   "ename": "restclient",
-  "commit": "59303304fe1f724596245556dd90f6afffba425d",
-  "sha256": "0wzp8i89a4hwm7qyxvdk10frknbqcni0isnp8k63nhq7c30s7md4",
+  "commit": "a601f758f1820c811a9ce8bac81dacb76e01c60c",
+  "sha256": "0fnwk58djicbqb5g9gd1qx9gd8iyq42vhxia8bnm8qza40kwqplc",
   "fetcher": "github",
-  "repo": "pashky/restclient.el",
+  "repo": "emacsorphanage/restclient",
   "unstable": {
    "version": [
-    20231010,
-    1327
+    20250705,
+    2050
    ],
-   "commit": "e2a2b13482d72634f8e49864cd9e5c907a5fe137",
-   "sha256": "1s7rkm1j08g64ymi5ayhkw9546av9rkyhnap6ndr0988dkpa7rfm"
+   "deps": [
+    "compat"
+   ],
+   "commit": "e7a54135233d66fc5bb0dbae315d673abdfb4146",
+   "sha256": "15hwxxrvla12i71039dz0a5p0fbdm7xx5a5yqn7mxkv0dr1vngxf"
   }
  },
  {
   "ename": "restclient-helm",
-  "commit": "59303304fe1f724596245556dd90f6afffba425d",
-  "sha256": "0cpf02ippfr9w6kiw3kng8smabv256ff388322hhn8a8icyjl24j",
+  "commit": "a601f758f1820c811a9ce8bac81dacb76e01c60c",
+  "sha256": "1zq8jg11vyavr9imdrlzg1kbi8gcjwarqcgjlpm6ni59r4vn4mdd",
   "fetcher": "github",
-  "repo": "pashky/restclient.el",
+  "repo": "emacsorphanage/restclient",
   "unstable": {
    "version": [
     20170314,
@@ -109191,21 +109442,21 @@
  },
  {
   "ename": "restclient-jq",
-  "commit": "34f6696a0015aafd44f48de4cd220f62130c4ccd",
-  "sha256": "0hkrwnq15kf2qnpkzpji47bhja9h0h54gxc6497ww5vkbmmrnidr",
+  "commit": "a601f758f1820c811a9ce8bac81dacb76e01c60c",
+  "sha256": "0d72immyxc24b0jylrv4591rby6fh7qw4q6kxlzkr5qqwxwz4gms",
   "fetcher": "github",
-  "repo": "pashky/restclient.el",
+  "repo": "emacsorphanage/restclient",
   "unstable": {
    "version": [
-    20220426,
-    1734
+    20250704,
+    2009
    ],
    "deps": [
     "jq-mode",
     "restclient"
    ],
-   "commit": "ae79e7dd283890072da69b8f48aeec1afd0d9442",
-   "sha256": "0hbxrwp8nqd12x9z9krddlcm9b9adjzp1az90ywyr1a30bdmv5sk"
+   "commit": "6ec11373492d1a489402161632a8ce59f079daf0",
+   "sha256": "14nkv63mzg1imdkwg5z2x6pvpw6jw88xr523rj3594hbwwl4in3i"
   }
  },
  {
@@ -109454,15 +109705,15 @@
   "repo": "SqrtMinusOne/reverso.el",
   "unstable": {
    "version": [
-    20240113,
-    2128
+    20250610,
+    1032
    ],
    "deps": [
     "request",
     "transient"
    ],
-   "commit": "7ae99550cd6076009560c4c7a3e4cdf101826041",
-   "sha256": "025nd01w5sagiz56bpn7mihc5n9zr0s6bn6g3fimb7b1697h9rlq"
+   "commit": "40ed3d83c4f04c39e05d69d84595761ae2956a64",
+   "sha256": "1agsscrkqnmz8shibfy8df5f34xwixiyfad381k04aibadh742yb"
   }
  },
  {
@@ -109557,15 +109808,15 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20241221,
-    1420
+    20250625,
+    2009
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "50d42b1395d6381fef66ff8aae4b0d171f7e5b36",
-   "sha256": "1l293zd0rbd5yh0v0r6raq7nqnx5r4j63q2pd7a7s1rcg02w1ywh"
+   "commit": "7611852b5517212a4f0fdab9cd9ecb0cf3995f08",
+   "sha256": "0vwqwc0ajcrjd20zdynhmwcir5jzj018ihbk8db8lb8ar7yviinz"
   },
   "stable": {
    "version": [
@@ -110192,8 +110443,8 @@
   "repo": "LaurenceWarne/rom-party.el",
   "unstable": {
    "version": [
-    20240830,
-    1225
+    20250627,
+    838
    ],
    "deps": [
     "async",
@@ -110204,8 +110455,8 @@
     "ht",
     "s"
    ],
-   "commit": "60da757070d23c5f33b89b787ee01a280539c4f1",
-   "sha256": "1z8k983ibdn4vdakjyf2nj0y4pfsshbrpkaidblp1di1hifn2ng8"
+   "commit": "3664be5a15431c54f1bf04d2597ca546956edb6f",
+   "sha256": "0fymc3bc7idam0vi28aywg53gdrd1jlk32kdbyaqzjrgb2vg8fz7"
   },
   "stable": {
    "version": [
@@ -110788,10 +111039,10 @@
  },
  {
   "ename": "ruby-refactor",
-  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
-  "sha256": "0zz913v8hwc97qpz1c910adrhcj5ca7s72ixjnr32xq4qscmw9x2",
+  "commit": "c6894d0eec73eb0b05e1fabb5a046f33f5816a7b",
+  "sha256": "0lf6msz2hi3c5nhqf6ljnfjh1ka84s697ppi2nxhj5nj8hlf1kqr",
   "fetcher": "github",
-  "repo": "ajvargo/ruby-refactor",
+  "repo": "vargonaut/ruby-refactor",
   "unstable": {
    "version": [
     20160214,
@@ -110988,11 +111239,11 @@
   "repo": "ideasman42/emacs-run-stuff",
   "unstable": {
    "version": [
-    20240421,
-    807
+    20250707,
+    1237
    ],
-   "commit": "518ffa247bc71e31514d9e90257107da32f94939",
-   "sha256": "0rcdsia5kvmw1fxrydg18yg976axm1ki7vsg80binafb1p47s6rm"
+   "commit": "67776282c7277e1a288c7654f3ced5284d6cd46b",
+   "sha256": "1kgn2ph21h4r1rldnv1yrdhf66sqp1yanpaxvmz2qzhji1ykyj53"
   }
  },
  {
@@ -111127,11 +111378,11 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20250423,
-    15
+    20250705,
+    1444
    ],
-   "commit": "25d91cff281909e9b7cb84e31211c4e7b0480f94",
-   "sha256": "1dhacxmhjgwjyplaqivhv0v9wsk4dclbj2d9slwzib6s4dcgki87"
+   "commit": "f7334861bfc1d3dbcfbde464751837be2ec09ef3",
+   "sha256": "0cw03vbjq7wdkvpbc31lf9ppndc9yfgzx3mb1hzymzbjdp3g66pm"
   },
   "stable": {
    "version": [
@@ -111174,8 +111425,8 @@
   "repo": "emacs-rustic/rustic",
   "unstable": {
    "version": [
-    20250514,
-    156
+    20250630,
+    1332
    ],
    "deps": [
     "dash",
@@ -111188,8 +111439,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "194f15c91ace0c3e95a81d315d2a481480d80a3e",
-   "sha256": "0i0fclbip38wbnnrapbaj0mq991hnjhs6j3wwddc8vmzwgrn29ml"
+   "commit": "bfff139f260c386f60d581edef6df1a0d109a131",
+   "sha256": "0z59fw0rvb6sk62sd393kgk0j65xlkn4xrxs6nhd06vdzx6kjrgv"
   },
   "stable": {
    "version": [
@@ -111667,20 +111918,20 @@
   "repo": "nicolaisingh/saveplace-pdf-view",
   "unstable": {
    "version": [
-    20250207,
-    1811
+    20250625,
+    1437
    ],
-   "commit": "79e76562bc5ef94c12837035fe504f07be8a8f25",
-   "sha256": "15799sqw8h2iasnlkcwnjdjmj9ssa9a9pvpyr6fqj0dw4g7056m5"
+   "commit": "dc1e0b28a5ed8319a0b6725abaffba7c2fa8c730",
+   "sha256": "03kqxi1f5idq7140f7h7ck5f56p1yvz5vb19dq5bz65iwgdrx6xy"
   },
   "stable": {
    "version": [
     1,
     0,
-    8
+    9
    ],
-   "commit": "79e76562bc5ef94c12837035fe504f07be8a8f25",
-   "sha256": "15799sqw8h2iasnlkcwnjdjmj9ssa9a9pvpyr6fqj0dw4g7056m5"
+   "commit": "dc1e0b28a5ed8319a0b6725abaffba7c2fa8c730",
+   "sha256": "03kqxi1f5idq7140f7h7ck5f56p1yvz5vb19dq5bz65iwgdrx6xy"
   }
  },
  {
@@ -111844,6 +112095,21 @@
   }
  },
  {
+  "ename": "scallop-mode",
+  "commit": "6e2359917cdc08e41237119fb00d2c1f352d6bf9",
+  "sha256": "0xgkpjy1zmgki8kqbd6az6hiic085ajzn80j05nnf4nfna3lpwvm",
+  "fetcher": "github",
+  "repo": "taquangtrung/emacs-scallop-mode",
+  "unstable": {
+   "version": [
+    20250522,
+    1432
+   ],
+   "commit": "ba416989c3ec64369fe2fe1dafc521ca6821b23d",
+   "sha256": "0gqbkllp5jcmw0n0ipk5vq252xnckkkgdqhr720axmgx5a4sh42j"
+  }
+ },
+ {
   "ename": "scf-mode",
   "commit": "376be7f8903dbea69643600ae14e934ee5e2a11b",
   "sha256": "0acbrw94q6cr9b29mz1wcbwi1g90pbm7ly2xbaqb2g8081r5rgg0",
@@ -111994,14 +112260,14 @@
   "repo": "technomancy/scpaste",
   "unstable": {
    "version": [
-    20250125,
-    453
+    20250706,
+    1759
    ],
    "deps": [
     "htmlize"
    ],
-   "commit": "7d4f9d5f392e05877ba3865c08a8f04892da3705",
-   "sha256": "04mndh337x4dm3giz59c0impgq439dzn9m41sbc8r95z2y5pak5w"
+   "commit": "5203d3625c34e51433435dc466853aa36f4ebe21",
+   "sha256": "1bp935khc2dsi6sm5bky4nmp9fs144crbyxsyiv45ngnnwdr5i35"
   },
   "stable": {
    "version": [
@@ -112195,11 +112461,11 @@
   "repo": "ideasman42/emacs-scroll-on-jump",
   "unstable": {
    "version": [
-    20250113,
-    923
+    20250706,
+    1124
    ],
-   "commit": "1badf2f909871d30b0256c41cf2252716a4b5da1",
-   "sha256": "0svqxl48vgdlk50c34l0yx3hv01gaa8jwq7nkj6fjbf9vn4xw9yd"
+   "commit": "00522ba63218b7f8ea3be7da97c7be05a108f3ce",
+   "sha256": "032chba2nqj64cshc8iwsfkfgwnn2zxbf55148wdhdy827mp8kjd"
   }
  },
  {
@@ -112825,15 +113091,15 @@
   "repo": "emacsmirror/semi",
   "unstable": {
    "version": [
-    20250519,
-    1830
+    20250621,
+    1330
    ],
    "deps": [
     "apel",
     "flim"
    ],
-   "commit": "e9e3282f40a6c1d0c71d62fe98a67cf6c83a66cb",
-   "sha256": "1qfzkly53d22dmw8y366yc1jqfqwqlc2yyah59cixvn2m7pshd3m"
+   "commit": "a9ef04a4693015aa1d8259f804b83eee5e42f9ec",
+   "sha256": "1iqlcj2fcdykhcy7047ykyys0qky0dfv0zrl7dvdwgmz2c5k2220"
   }
  },
  {
@@ -113437,11 +113703,11 @@
   "repo": "Shopify/shadowenv.el",
   "unstable": {
    "version": [
-    20210512,
-    1625
+    20250604,
+    2048
    ],
-   "commit": "dbcef650b906fec62608d5e4e3075bf251e675e1",
-   "sha256": "0qnqp06vb2ikkwy0p10x3s7mil6c948w42mx4c72cdz36m116zc0"
+   "commit": "2b8383b54cac9edf8204050d2a8d70a0e6f0d972",
+   "sha256": "0b3289jm7rsm3wnxmb6975vwmhzlhb4v5ak6a9imr82h31pj18ga"
   }
  },
  {
@@ -113617,11 +113883,11 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20250523,
-    1343
+    20250702,
+    1116
    ],
-   "commit": "b55e2e8d28f1c0ecac1d45b4a299ddddc42f479f",
-   "sha256": "1qak305c7wxqshi6mfryqf3y2cnjwb35kvcnfgnfy8q3ya1q6y0i"
+   "commit": "3a88d3b909b4fbe3baa37a71e1245327adb845f8",
+   "sha256": "1941jyyg8wv5ajpr83s8bwmpdmcqcz0vqqzsj6yf91xsf60v7gwb"
   },
   "stable": {
    "version": [
@@ -113879,14 +114145,14 @@
   "repo": "purcell/emacs-shfmt",
   "unstable": {
    "version": [
-    20240104,
-    1218
+    20250610,
+    1538
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "1a747c53eab1c0cd4d2708e5ffb953f9761ca7fb",
-   "sha256": "1a288nq4ig9ydcbkys4x4dm5hx98jw784h0fm6mgs9p7byf5agdc"
+   "commit": "61b790405b0198f72db99df235c184eb86ffe405",
+   "sha256": "14zcj69gwvspnnzgcaddjm9njwrh426bzhmfy9sjmg7hq626a42j"
   },
   "stable": {
    "version": [
@@ -113908,11 +114174,11 @@
   "repo": "ideasman42/emacs-shift-number",
   "unstable": {
    "version": [
-    20250528,
-    143
+    20250610,
+    34
    ],
-   "commit": "15166f36a6847a32fe2df7be6ce14449a7324c82",
-   "sha256": "0fz4grp3vs05g4rp1wm050njlimmi56gf7vspbxx57gxmkm90nqr"
+   "commit": "d0d852ea302db96942938960a1022f943d863130",
+   "sha256": "02pci1x1lq3xbdxhnf2gb5lqpxj67b83q51m1rv78rzbh6zwz7mi"
   },
   "stable": {
    "version": [
@@ -113950,11 +114216,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20250306,
-    131
+    20250702,
+    658
    ],
-   "commit": "7a817d45d354f576bdd1e6f54baed1e628073f8a",
-   "sha256": "1f35bsdx6k489s5bi97p18pchhkxwqwszyv114vdqf03xy3zhvdp"
+   "commit": "bf3315747a469ef2692ebf57fcd2c4f853392c24",
+   "sha256": "1fnwqfryz3nxrsh816c9a5j8lq3c7afx5cwqkqw4wfdipp0azk4y"
   }
  },
  {
@@ -114419,11 +114685,11 @@
   "repo": "ideasman42/emacs-sidecar-locals",
   "unstable": {
    "version": [
-    20240421,
-    655
+    20250611,
+    320
    ],
-   "commit": "3daf8c07fac7c4ada7a02a1edad2f64894463614",
-   "sha256": "1jzsc1vxkxyvh66s6xz064s252jh2s6jrh157gi3rzkfkc7gcdwz"
+   "commit": "332c2c0d2e6c4c07f9b4fa91f5900e648f153212",
+   "sha256": "14dv8bz5z0am0wgsr34xfcqdikgmbw7q9skbbxv23sg86z7j8zl2"
   }
  },
  {
@@ -114464,15 +114730,15 @@
   "repo": "emacs-sideline/sideline-blame",
   "unstable": {
    "version": [
-    20250101,
-    857
+    20250704,
+    251
    ],
    "deps": [
     "sideline",
     "vc-msg"
    ],
-   "commit": "872c232b7f5d3805bde24607bd0050fc9464f8d6",
-   "sha256": "1815l3i4acwhfyf0hdna9fg32jmkzk34b336viiswpmi00h1j4nb"
+   "commit": "33b0699a5c9843a03b76cf6de19b5860738a9ac5",
+   "sha256": "071irj2nbr213j7n726avkj9ar0nphbnhrxpxini6l93rdxyp6kk"
   },
   "stable": {
    "version": [
@@ -115025,6 +115291,30 @@
   }
  },
  {
+  "ename": "simply-annotate",
+  "commit": "89ce06ff307a32fd8031f6f59b25c5bef66edae2",
+  "sha256": "1aqyiqxlzlagvfzk9i5gby9b6ry3h5hb7c5sxsqhlwdjwd44lxlx",
+  "fetcher": "github",
+  "repo": "captainflasmr/simply-annotate",
+  "unstable": {
+   "version": [
+    20250703,
+    2055
+   ],
+   "commit": "7fbeb4d76fd242ec0cdadca20857af5c43e2da5e",
+   "sha256": "1cxacx0nbqihnydxvzlj5i75nhdm7635qzlka5vzkjgrdzficy1q"
+  },
+  "stable": {
+   "version": [
+    0,
+    5,
+    1
+   ],
+   "commit": "0ace6e048d26e580ee02f614fde578c288c765fc",
+   "sha256": "11irqfqk2rrsncaxm4dggxd639p4ljzcpvibv6g4qpvnzpdihjc8"
+  }
+ },
+ {
   "ename": "sink",
   "commit": "9f6b09154d54b3bfbc16ef606fc7dfefb4762014",
   "sha256": "0wqxm6qs736q856w4niy7zfi2bvb31dg8zw24xr42qr07irk4x84",
@@ -115077,8 +115367,8 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20250401,
-    1807
+    20250601,
+    1100
    ],
    "deps": [
     "compat",
@@ -115086,14 +115376,14 @@
     "llama",
     "magit"
    ],
-   "commit": "e3f6ea4b720ed384c3ba34fa047bb66280906fad",
-   "sha256": "1mdslx756828ljhbnmqr1hvcbw0pislqisnlsw1y38c535hwns0f"
+   "commit": "d8b2130cd3aaa4e6b604cdb6fc0262152e5aa55f",
+   "sha256": "0z885k44nyvr2p41652xbpb8awyxjsnp20nps8c2xllam2pa80rl"
   },
   "stable": {
    "version": [
     0,
     2,
-    3
+    4
    ],
    "deps": [
     "compat",
@@ -115101,8 +115391,8 @@
     "llama",
     "magit"
    ],
-   "commit": "e3f6ea4b720ed384c3ba34fa047bb66280906fad",
-   "sha256": "1mdslx756828ljhbnmqr1hvcbw0pislqisnlsw1y38c535hwns0f"
+   "commit": "d8b2130cd3aaa4e6b604cdb6fc0262152e5aa55f",
+   "sha256": "0z885k44nyvr2p41652xbpb8awyxjsnp20nps8c2xllam2pa80rl"
   }
  },
  {
@@ -115345,8 +115635,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20250528,
-    1400
+    20250708,
+    2121
    ],
    "deps": [
     "alert",
@@ -115358,8 +115648,8 @@
     "ts",
     "websocket"
    ],
-   "commit": "8a3942671ac7c349377e84f43e9d8b959bf38e1c",
-   "sha256": "1s8mg4zwbf5zsqamn8zgadg6r4r7gwwag6vwlfc3v6k35jrwq7fb"
+   "commit": "761daa69cff3bf7bb44df19f38a61ca88663bbc1",
+   "sha256": "1jkpchh4ckiqxa6iakchx9r5krw1c03jarwpfa3gkfy9r1g05qll"
   }
  },
  {
@@ -115417,14 +115707,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20250520,
-    44
+    20250706,
+    1422
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "4ab2b36227c600b909bd03052d12a0713116515a",
-   "sha256": "0b0f9b5l550q75232r3ca65ahwinhz2m66ddjx1skvyhrsmi9cgg"
+   "commit": "5e234b45c6fcc3fc99ff75a62f489163e59f42bc",
+   "sha256": "1wb1axpvi5adfqq39dw3wqlnyjfmd5wjk7fg1af92isza2lcxxrr"
   },
   "stable": {
    "version": [
@@ -115588,6 +115878,56 @@
   }
  },
  {
+  "ename": "slothbar",
+  "commit": "3ff8bacb688fd0e01462c27f1a1d9fbe68ccfcf8",
+  "sha256": "1lkdb17j70qc6a0m7drr75hvknk6432c8rd52z8q2pnkpcdikq9f",
+  "fetcher": "codeberg",
+  "repo": "agnes-li/slothbar",
+  "unstable": {
+   "version": [
+    20250707,
+    137
+   ],
+   "deps": [
+    "all-the-icons",
+    "backlight",
+    "compat",
+    "dash",
+    "f",
+    "fontsloth",
+    "log4e",
+    "nerd-icons",
+    "s",
+    "volume",
+    "xelb"
+   ],
+   "commit": "f8066074a93dd6e2be54c4a5e503df9f78178a3e",
+   "sha256": "07ygh76mjmxpsqbska9r4yg0yhjhf82n89qkg7w5yk0ficyap4nl"
+  },
+  "stable": {
+   "version": [
+    0,
+    30,
+    1
+   ],
+   "deps": [
+    "all-the-icons",
+    "backlight",
+    "compat",
+    "dash",
+    "f",
+    "fontsloth",
+    "log4e",
+    "nerd-icons",
+    "s",
+    "volume",
+    "xelb"
+   ],
+   "commit": "f8066074a93dd6e2be54c4a5e503df9f78178a3e",
+   "sha256": "07ygh76mjmxpsqbska9r4yg0yhjhf82n89qkg7w5yk0ficyap4nl"
+  }
+ },
+ {
   "ename": "slovak-holidays",
   "commit": "d5c6b2208ef209dfe57c2c137a88ce08a4eae475",
   "sha256": "1dcw8pa3r9b7n7dc8fgzijz7ywwxb3nlfg7n0by8dnvpjq2c30bg",
@@ -115669,11 +116009,11 @@
   "repo": "vilij/slurpbarf-elcute",
   "unstable": {
    "version": [
-    20250325,
-    1442
+    20250707,
+    823
    ],
-   "commit": "97b4c3b0bd3e22d4d4b1a9aed3435b5a58b09259",
-   "sha256": "098wr42lra37f9hy35y8sb6x1zbj0gvvcnchy1f2nb57wh6xy9r2"
+   "commit": "3f1c0befad5a70cf51ca38131cfa1f6fa287cbf6",
+   "sha256": "02swww902hj2kp3d9njs48iiz486vs4984nn1bv0giy7mwxvmwjw"
   }
  },
  {
@@ -116226,14 +116566,14 @@
   "repo": "Fuco1/smartparens",
   "unstable": {
    "version": [
-    20250511,
-    2354
+    20250612,
+    1050
    ],
    "deps": [
     "dash"
    ],
-   "commit": "603325ab3d1186fb10da5c2a7ec1afb88018d792",
-   "sha256": "1d242visiid2fcshja4vw6ri94bla3wssc1hz993g3zdjzzcz78f"
+   "commit": "b629b4e893ba21ba5a381f6c0054bb72f8e96df2",
+   "sha256": "1nfd10kxd1l8bmxhaghhxphl424yg5qn6xcqaligwc3b406b566w"
   },
   "stable": {
    "version": [
@@ -116756,11 +117096,11 @@
   "repo": "mrBliss/snapshot-timemachine",
   "unstable": {
    "version": [
-    20161221,
-    929
+    20250612,
+    1320
    ],
-   "commit": "99efcebab309b11ed512a8dc62555d3834df5efb",
-   "sha256": "18qibcyqxjwpvphmpghppb8ky1xcch1dd4pz91qj5f4h42684ips"
+   "commit": "88af8c045e5274b06ddd6ca5e8c6a746cef776e0",
+   "sha256": "1i2irgjgd4j231b9af18xy6bwkicj99lnlapm7ia6q9gc6ah3260"
   }
  },
  {
@@ -117356,11 +117696,11 @@
   "repo": "mssola/soria",
   "unstable": {
    "version": [
-    20240603,
-    903
+    20250703,
+    508
    ],
-   "commit": "c6dbabc1b4f956e19c7e80f16e69f3d6c57b84b4",
-   "sha256": "1zsazml4qsbvnqb418fiknpj3zcnicl6m6x65i29ipwrjsi41i6j"
+   "commit": "65581530155b097fc314a19b2851a7dffcfd3790",
+   "sha256": "0142sa6dxlj77f629xp8724fja1378hjqp2k5mw7zkmjfj2finj4"
   },
   "stable": {
    "version": [
@@ -117760,11 +118100,11 @@
   "repo": "nashamri/spacemacs-theme",
   "unstable": {
    "version": [
-    20241101,
-    1030
+    20250613,
+    2113
    ],
-   "commit": "6c74684c4d55713c8359bedf1936e429918a8c33",
-   "sha256": "0ijpgaa9p971r2gvrad0p52wz7x3ry2245g0vsmwds3lpahkyiwr"
+   "commit": "2ffca41e6e9aa55d8de5c40c6fb61e0d47763b5d",
+   "sha256": "05p7p4q2p1bx2xqiha1qga5drlj6fn2757zdcdxplb88a9zx606r"
   },
   "stable": {
    "version": [
@@ -117968,15 +118308,14 @@
   "repo": "dakra/speed-type",
   "unstable": {
    "version": [
-    20250518,
-    1325
+    20250701,
+    2208
    ],
    "deps": [
-    "compat",
-    "dash"
+    "compat"
    ],
-   "commit": "357e6abb2ccf41a09f80c3b1a7605540203a7626",
-   "sha256": "0xjnqdn4gkz1n48zsq2ad6z99kqlb1bymjjq79yj5mbjrmk7axpv"
+   "commit": "b4dbaac540d924a431969417b77ea09ea817cf4d",
+   "sha256": "18x5zpq3m8zr5d3bb4kaj9s7xik337z16hjhdqy0knzpdyqs8k3f"
   },
   "stable": {
    "version": [
@@ -118454,19 +118793,19 @@
   "repo": "jterk/sql-impala",
   "unstable": {
    "version": [
-    20181218,
-    410
+    20250616,
+    110
    ],
-   "commit": "466e7c0c789ec3e5e8a276c8f6754f91bb584c3e",
-   "sha256": "02psgbm06wivdm2cmjnj2vy05lnljxn44hj2arw2fr7x2qwn9r35"
+   "commit": "8968be95e493da3a3cc445e44a852186fa37df6b",
+   "sha256": "1lmgzp4dz7yqlnl0ybd137cfxbvjsiwkpvf5nd92cp0xaw2wd3sg"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
-   "commit": "466e7c0c789ec3e5e8a276c8f6754f91bb584c3e",
-   "sha256": "02psgbm06wivdm2cmjnj2vy05lnljxn44hj2arw2fr7x2qwn9r35"
+   "commit": "8968be95e493da3a3cc445e44a852186fa37df6b",
+   "sha256": "1lmgzp4dz7yqlnl0ybd137cfxbvjsiwkpvf5nd92cp0xaw2wd3sg"
   }
  },
  {
@@ -118698,11 +119037,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20250510,
-    121
+    20250609,
+    2346
    ],
-   "commit": "f1f8451476fa0cee6b8d06c7a540af5ed469b6b4",
-   "sha256": "1fcl7hr4q0zwfxfnjsm9rslia0431hkqk8rnwxhbs57h4r6w3jh9"
+   "commit": "0b0f58f1cdeaf631017bc7593b81c8343d459b58",
+   "sha256": "0vd9b0nkjql2ghgmrsxa1kbd12zcl8a6j9vx100lmpp7gx8n0afp"
   },
   "stable": {
    "version": [
@@ -118820,30 +119159,6 @@
    ],
    "commit": "d0596f5fbeab3d2c3c30eb83527316403bc5b2f7",
    "sha256": "1xs9ixp2bgbn2whjpj7l1n15fklivfh7544sgai61225jprckyak"
-  }
- },
- {
-  "ename": "ssh-deploy",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "1ys3cc5fz8y4rsiq3daqgcpa14ssv1q4cw0pqbfscql6mps0mjdm",
-  "fetcher": "github",
-  "repo": "cjohansson/emacs-ssh-deploy",
-  "unstable": {
-   "version": [
-    20241117,
-    1850
-   ],
-   "commit": "dc8882d1806c0fdd635bc625b109179dfa3c929c",
-   "sha256": "022q31z4ybcrvp1wa16h623nyp2qcn0xrsrlzi0djfm1rxg80dx3"
-  },
-  "stable": {
-   "version": [
-    3,
-    1,
-    16
-   ],
-   "commit": "95fb076c9b657c5f1bfad3ee5bf1f8691c50d428",
-   "sha256": "0iwciwnlkpbasnwdvvip5g39jq4qc8srfw0s07ljb3c3njg3jhsg"
   }
  },
  {
@@ -119172,11 +119487,11 @@
   "repo": "stacked-git/stgit",
   "unstable": {
    "version": [
-    20250412,
-    2135
+    20250701,
+    356
    ],
-   "commit": "92abf02d077bcbec00ba39d9b9bf30c089a3b586",
-   "sha256": "0hnla60x0jhmrwpg5qc0gdxgry73hjzp5cpdhqyv7r6ipn3jd8yx"
+   "commit": "f88c7f0e375e069ea35f7db1294d1408d69e7a1d",
+   "sha256": "0lz88v4qny6l9fnxykaz7ys5cb7fds0y5b589gvqdqzjw3ijkd8j"
   },
   "stable": {
    "version": [
@@ -119454,11 +119769,11 @@
   "repo": "akicho8/string-inflection",
   "unstable": {
    "version": [
-    20240816,
-    523
+    20250630,
+    555
    ],
-   "commit": "4cc92e1ecd3d165b55235b51ae65ac09a0364958",
-   "sha256": "10jiabaxzvcpnqskai0jacj5n9h4ni5yr0rc8j2w0q35wfi78vmn"
+   "commit": "02ab7b2ea8530c63c20556c1afb795924e08dfca",
+   "sha256": "1hzjmiz3ybqpd8wla92pf5sx32cpq5b04iiy3sg0zax4wvyr8v8g"
   },
   "stable": {
    "version": [
@@ -119932,30 +120247,32 @@
   "repo": "kiyoka/Sumibi",
   "unstable": {
    "version": [
-    20250530,
-    1422
+    20250705,
+    2349
    ],
    "deps": [
     "deferred",
+    "mozc",
     "popup",
     "unicode-escape"
    ],
-   "commit": "006e7e21d81ad3a4c4d3ff251e68bbc8fdc30eaa",
-   "sha256": "1jnmy5w19a1jdhc8dm9d2vv33dkvxzrhxpcsnpmqbr9xzfslqg5j"
+   "commit": "af6c53ed79f6df61e77d40207f942190cf6459e6",
+   "sha256": "1xl961k1kq4cnd1vyhcx8ndxl54dyr07sx62zzq8vvbyg2v5vrch"
   },
   "stable": {
    "version": [
+    3,
     2,
-    4,
     0
    ],
    "deps": [
     "deferred",
+    "mozc",
     "popup",
     "unicode-escape"
    ],
-   "commit": "006e7e21d81ad3a4c4d3ff251e68bbc8fdc30eaa",
-   "sha256": "1jnmy5w19a1jdhc8dm9d2vv33dkvxzrhxpcsnpmqbr9xzfslqg5j"
+   "commit": "af6c53ed79f6df61e77d40207f942190cf6459e6",
+   "sha256": "1xl961k1kq4cnd1vyhcx8ndxl54dyr07sx62zzq8vvbyg2v5vrch"
   }
  },
  {
@@ -120463,26 +120780,26 @@
   "repo": "swift-emacs/swift-mode",
   "unstable": {
    "version": [
-    20250524,
-    530
+    20250615,
+    1001
    ],
    "deps": [
     "seq"
    ],
-   "commit": "839e46d1621a60ed79e3cfe01266dc27721654bd",
-   "sha256": "18khhvs9r1wafh25y4l0i8frqw2nyg05xmzsgh4b00vvs77b3c86"
+   "commit": "fc7df7bd906a2bb04aac6e0de47fc7acf33ceed3",
+   "sha256": "1z9ybkjwbdayk8yfclwp0irfy0mn15p6m1mfvv4vrn6ami2wvrsv"
   },
   "stable": {
    "version": [
     9,
-    3,
+    4,
     0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "e30b9d46e031fd25e794f00f23b6427f44f7d221",
-   "sha256": "0m4w29fhpzraixqlz36z9b0nl5g5mrvq1iasv56gcjsi0g2m1irp"
+   "commit": "fc7df7bd906a2bb04aac6e0de47fc7acf33ceed3",
+   "sha256": "1z9ybkjwbdayk8yfclwp0irfy0mn15p6m1mfvv4vrn6ami2wvrsv"
   }
  },
  {
@@ -121002,11 +121319,11 @@
   "repo": "KeyWeeUsr/emacs-syncthing",
   "unstable": {
    "version": [
-    20250528,
-    2346
+    20250612,
+    206
    ],
-   "commit": "c650aa6ce2c6f594deb7e89645f1de6295de953c",
-   "sha256": "1zbdv6gaklxi86f3ni5bhl8pnsx1jyi9zmb7rxkgjw46wdyi3c2d"
+   "commit": "eac37ecf5458b6d554544b1ddb76e3c6fbe3cb2f",
+   "sha256": "1b5zd0ah5habw2771wpn9h03mwmrpza19d6rzgb0741sq36jfd40"
   },
   "stable": {
    "version": [
@@ -122171,25 +122488,25 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20250316,
-    1016
+    20250620,
+    1157
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f52a99ebf6ee52a30d435ef1583dc8df3e5f2ca5",
-   "sha256": "1dlrcdyj0l4hbk0xhb3yj88naq4m76n5hfd180qqwjpc83g9fqs3"
+   "commit": "9fa2c59660fe9473429a51872d3c00e1b95cab86",
+   "sha256": "104wifdqglk6hxs6z3gr6rmxf3hdqsl3y9bvcp3wwm10yqkpnmkx"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f52a99ebf6ee52a30d435ef1583dc8df3e5f2ca5",
-   "sha256": "1dlrcdyj0l4hbk0xhb3yj88naq4m76n5hfd180qqwjpc83g9fqs3"
+   "commit": "9fa2c59660fe9473429a51872d3c00e1b95cab86",
+   "sha256": "104wifdqglk6hxs6z3gr6rmxf3hdqsl3y9bvcp3wwm10yqkpnmkx"
   }
  },
  {
@@ -122611,11 +122928,11 @@
   "repo": "davidshepherd7/terminal-here",
   "unstable": {
    "version": [
-    20241231,
-    1234
+    20250706,
+    1136
    ],
-   "commit": "dad595abd278a89f14e9f0231bb96ed089822245",
-   "sha256": "0c41ymawgipxg3y8slmsw8nh5n546xy1iyki827jrfdr3767a84h"
+   "commit": "bcdd467b8689001be3c2249859a68a8784f2db74",
+   "sha256": "0qllaf39yq2x6lpmfd8rdca6k0gfv10y5895j5yyvznmfr91cayz"
   },
   "stable": {
    "version": [
@@ -122652,11 +122969,11 @@
   "repo": "milanglacier/termint.el",
   "unstable": {
    "version": [
-    20250428,
-    1400
+    20250627,
+    25
    ],
-   "commit": "156af0ecd08b7ae26a516a7d20721659621b78dc",
-   "sha256": "07sqc5c4nq5mp5rhpmp8rymjyazg3m427zdjbgkrckg4snh3jkxq"
+   "commit": "eb9e63e15f8b03a51ef114fb0ec73b6f3b9b4ace",
+   "sha256": "1qkdk9gacg6qknhcfj3fxrp6dh82mhk6ir09xc2mmx9p7hhyx37g"
   }
  },
  {
@@ -122916,15 +123233,15 @@
   "repo": "johannes-mueller/test-cockpit.el",
   "unstable": {
    "version": [
-    20250216,
-    1832
+    20250615,
+    1258
    ],
    "deps": [
     "projectile",
     "toml"
    ],
-   "commit": "75711b58b9d087b15ebc6c6a754d6e1289e02e72",
-   "sha256": "1vr0ab29lgh4fw2nawq31nja438lpwdpfa46r7pmviz4mjyck63h"
+   "commit": "6a8527a495fb4611d569c85d06eb06154f8cfe5e",
+   "sha256": "1hhqx05crc5pfd2q66f6c3d03gb1x6w1lc7w5hyd94v078hjr2zh"
   },
   "stable": {
    "version": [
@@ -123207,11 +123524,11 @@
   "repo": "GongYiLiao/theme-anchor",
   "unstable": {
    "version": [
-    20250530,
-    1449
+    20250620,
+    13
    ],
-   "commit": "dbe2263e797aa4d1d7c698afc7515c514390fef7",
-   "sha256": "12q2b4gdn9kzdjgvs6dwpfldbrvb69pbqlm0i71j8v4sv6r1ik6n"
+   "commit": "a9143dbd6a073a6538f011d4095432152de127b7",
+   "sha256": "146pj02pj9pgqnqqnfi63v6pgcgzzasay9fx3an85q2wippxn38g"
   }
  },
  {
@@ -123416,21 +123733,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20250526,
-    125
+    20250707,
+    1302
    ],
-   "commit": "f5ed8492bafa87cbf2c5d444bda1dd0dcf11af1e",
-   "sha256": "06f91bf1nfmzjdhkpsn2z3kvarlxfg1kgwmgjpfs9hx6r0qz79an"
+   "commit": "0f0cd92a6e051e7a5980182d60941e3da492f634",
+   "sha256": "0hl3cf7hvrn7kjn12a40abkslijp509qgqrcdcqpczjscm5m172v"
   },
   "stable": {
    "version": [
     2025,
-    5,
-    26,
+    7,
+    7,
     0
    ],
-   "commit": "f5ed8492bafa87cbf2c5d444bda1dd0dcf11af1e",
-   "sha256": "06f91bf1nfmzjdhkpsn2z3kvarlxfg1kgwmgjpfs9hx6r0qz79an"
+   "commit": "0f0cd92a6e051e7a5980182d60941e3da492f634",
+   "sha256": "0hl3cf7hvrn7kjn12a40abkslijp509qgqrcdcqpczjscm5m172v"
   }
  },
  {
@@ -123474,32 +123791,32 @@
  },
  {
   "ename": "tidal",
-  "commit": "16a26659a16199b5bb066be6e5c4a40419bda018",
-  "sha256": "0im0qbavpykacrwww3y0mlbhf5yfx8afcyvsq5pmjjp0aw245w6a",
-  "fetcher": "github",
-  "repo": "tidalcycles/Tidal",
+  "commit": "80de57f3a04938bbd9c8c765bc640c6ebbb3168c",
+  "sha256": "0mg1fgjfc4i96r05jdfd4f47vy512cm2y72sm87z7w8jq84xvaj3",
+  "fetcher": "codeberg",
+  "repo": "uzu/tidal",
   "unstable": {
    "version": [
-    20250120,
-    1406
+    20250628,
+    806
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "d1023afe4703c2d43cc9b5ab20897c31d02b46f3",
-   "sha256": "18z7cds0mhlx9bi19jl8irk2pb9nv674w7rxvvxr6hhww5pqkdgp"
+   "commit": "7b1624ac83177ecf4ceead7dc50448258988af8b",
+   "sha256": "0cl7mr58sm7x4rx3lb7ss6yk0rxbwxgk09zgmbzvpq7h3r0blbs5"
   },
   "stable": {
    "version": [
     1,
-    9,
-    5
+    10,
+    0
    ],
    "deps": [
     "haskell-mode"
    ],
-   "commit": "88f09edf6bef2228d5f530dea872b08a9d803066",
-   "sha256": "1r1d5hl49vdbwg5fcbfd0r0kwnc36knbfbr8fii4j73icm1g3frd"
+   "commit": "433ed7f8524f2ec00f626146830537bd897eb08f",
+   "sha256": "0sy9kc0rchj5ilkg3sz5f94p4bslymq7rq1a17fgn6zynl3b3f7g"
   }
  },
  {
@@ -124316,25 +124633,26 @@
   "repo": "nagy/tokei.el",
   "unstable": {
    "version": [
-    20220823,
-    2058
+    20250621,
+    1500
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "86fbca422f580a95eb30247e46891184f3ac5c18",
-   "sha256": "0nn8v9x0dczw0ingibclc1v8fnhjiwl14vm1qjcng9dcr2pbp7mq"
+   "commit": "b16b05c9bbddd046300725d0eb4f45b38677b2fb",
+   "sha256": "0x9ayvd8fvgnyp2zgck3dnhs2ib3lrcwbgcdypzq6mhzfs1a2651"
   },
   "stable": {
    "version": [
     0,
-    2
+    2,
+    1
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "181021cd881eecd604a546d4a717866a81c7a511",
-   "sha256": "0gcjlcfxd4bg123gjf7d0vfvfd6zpd0da8svynglca1qhp77jkx1"
+   "commit": "b16b05c9bbddd046300725d0eb4f45b38677b2fb",
+   "sha256": "0x9ayvd8fvgnyp2zgck3dnhs2ib3lrcwbgcdypzq6mhzfs1a2651"
   }
  },
  {
@@ -124441,20 +124759,20 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20250408,
-    1812
+    20250628,
+    1608
    ],
-   "commit": "f5e18450e1d1f10dcc5a607f0e3fe82339755992",
-   "sha256": "0sanaq38q5kdpkbaq738izlgqq5rqnf9y4imz0b36vcgfay3qykb"
+   "commit": "d15dc91f99aa30fbe570f29fe689d49727ee248d",
+   "sha256": "105zxj6w9ipjhfzv19br66iicp21fq62la4rf17qsqy75kfqrj9z"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    2
    ],
-   "commit": "6be1f422f2388a8b39945a1823030d080ed10290",
-   "sha256": "1qzaygdxhnaqbv7impmh4vli8k7nzk2r0giv4yacd0waq3flqmj6"
+   "commit": "d15dc91f99aa30fbe570f29fe689d49727ee248d",
+   "sha256": "105zxj6w9ipjhfzv19br66iicp21fq62la4rf17qsqy75kfqrj9z"
   }
  },
  {
@@ -124624,11 +124942,11 @@
   "repo": "phf-1/total-recall",
   "unstable": {
    "version": [
-    20250511,
-    614
+    20250622,
+    1434
    ],
-   "commit": "e37874a7b78d172ad8c777cb11b16b2c134015c4",
-   "sha256": "0a6pa09s083mcy89lx28drbr22cjbjlj2pn0ziida6y3c28izf4h"
+   "commit": "dba59b6f10829d5a3373f1ad6fc4b4a73134180b",
+   "sha256": "0l9ljacx6v1xs4bp8hdhwmfavn9y9mw98yj7py4azxh18jcai6fs"
   }
  },
  {
@@ -124940,11 +125258,11 @@
   "repo": "cuspymd/tramp-term.el",
   "unstable": {
    "version": [
-    20220725,
-    1441
+    20250628,
+    823
    ],
-   "commit": "ed75189122737d301f716a30a8013205aa3736f1",
-   "sha256": "1629qsl2xsz5qwmvwl2wdfnlj6wlhvrb34wc33dd11n8szrvbk6h"
+   "commit": "4af42a379bfdbb6549d52a7c3460ba59264f19da",
+   "sha256": "06n3inymla5nw2gfg435wm713iid2j97cx8h7wg799fn86ivcaa4"
   }
  },
  {
@@ -125016,28 +125334,28 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20250530,
-    2040
+    20250701,
+    1223
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "b710423225373bad8c2517d741d911a1b4468514",
-   "sha256": "075vl86jgg80c9vw8bw68m3j68hgm66h42sy4h690dvqjfbykkdv"
+   "commit": "49bbb29fd34b807948d4f2b91f61587c12a595f0",
+   "sha256": "0iqxb0njhfi025w3mmzjh67wg35wk3cfgjd5f11hxxp81akqnxp2"
   },
   "stable": {
    "version": [
     0,
-    8,
-    8
+    9,
+    3
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "25b994a565ce8035330b0a3071ee430c0282349e",
-   "sha256": "0m780p5g2jgnbkk3yqs6sbr27gpz0pc2xm13k9cpglclssircg86"
+   "commit": "49bbb29fd34b807948d4f2b91f61587c12a595f0",
+   "sha256": "0iqxb0njhfi025w3mmzjh67wg35wk3cfgjd5f11hxxp81akqnxp2"
   }
  },
  {
@@ -125313,28 +125631,28 @@
   "repo": "tarsius/tray",
   "unstable": {
    "version": [
-    20250509,
-    1455
+    20250601,
+    1101
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "e5a3a52d0bc821aca7aaf01e4d6f7adc052d0c32",
-   "sha256": "159r0ln2zfdsdpnh6cmhjlcfi2i6l15cq6dwmlciqm09dq9w0pyq"
+   "commit": "aa71423330a6562effa2cc6bae8c96f3d4efaaf5",
+   "sha256": "1bkv2sfh4x37b25829fi5adya6ibzyibm2qwv0m2i2p3y3i63nzc"
   },
   "stable": {
    "version": [
     0,
     1,
-    5
+    6
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "68d6fa2f2cd7d40c82af6c78b7647a585755c1d1",
-   "sha256": "1cp9fs2ijnjvf2f409i4wabzk062wl3hv9mc6ipkjgrka1rnvp93"
+   "commit": "aa71423330a6562effa2cc6bae8c96f3d4efaaf5",
+   "sha256": "1bkv2sfh4x37b25829fi5adya6ibzyibm2qwv0m2i2p3y3i63nzc"
   }
  },
  {
@@ -125492,26 +125810,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20250518,
-    1107
+    20250706,
+    1346
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "3aa35be257d8716d3614166fabdef12ef04e816e",
-   "sha256": "09jlpg96glzz554wngvr7f8vb6zzp1km1ii43zlab5fv7f5kc0sj"
+   "commit": "b9339dcce36c58140fda64c71fe36886475d954c",
+   "sha256": "0n6wi5s3qny65yx366l5hnbvb1mzkbz7kgiyv016bhh7jw77lk7v"
   },
   "stable": {
    "version": [
     0,
     12,
-    280
+    290
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "78bf29e1959772b1f989e23cbd5de06c7e84149b",
-   "sha256": "1nwmw1ifphkliadaa3kjmpav2av434r497klhlriys7qbivd9r8m"
+   "commit": "b9339dcce36c58140fda64c71fe36886475d954c",
+   "sha256": "0n6wi5s3qny65yx366l5hnbvb1mzkbz7kgiyv016bhh7jw77lk7v"
   }
  },
  {
@@ -125588,8 +125906,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20250529,
-    1243
+    20250707,
+    2001
    ],
    "deps": [
     "ace-window",
@@ -125601,8 +125919,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "2fbaa00e0eec392def549436552410ee6210f66d",
-   "sha256": "0x4ig7bsj3swlv495srnj9h2n99cxrsjf823fzx6lblzi7kdsl00"
+   "commit": "246d9505edf86c25a08cfbd131c441c8d402f8c3",
+   "sha256": "0x9zp2dd9l79lp2pcj7a9x4a0h6kp6x5cyaiw4h8cw6ym3pym5lc"
   },
   "stable": {
    "version": [
@@ -126619,14 +126937,15 @@
   "repo": "deadblackclover/twtxt-el",
   "unstable": {
    "version": [
-    20250306,
-    1612
+    20250604,
+    516
    ],
    "deps": [
-    "request"
+    "request",
+    "visual-fill-column"
    ],
-   "commit": "d5767d7775757b592fbdc2f4c45b32caf142c7b3",
-   "sha256": "19c9l9rchpvmq4j0i62pvkshn1xqrcql6hmdn9mhhwkpdcxal8k6"
+   "commit": "290d81bb944a20784f0c466fc4eebafb0b34dbe3",
+   "sha256": "18k5jhahm97kdya6gdsy5m1s7qhzmh7c28qgvizlnkrqliagb68i"
   }
  },
  {
@@ -126726,21 +127045,6 @@
   }
  },
  {
-  "ename": "typing-game",
-  "commit": "e6ced22932f0462c77d121a631c494c01a0a4eaa",
-  "sha256": "0k85j9bcqp0gbzdh44q5a9wlkv5mc0g0m42ziq1bzmp6993wkmy2",
-  "fetcher": "github",
-  "repo": "lujun9972/el-typing-game",
-  "unstable": {
-   "version": [
-    20160426,
-    1220
-   ],
-   "commit": "616435a5270274f4c7b698697674dbb2039049a4",
-   "sha256": "0dkrnn9fzqv793wvd3nc7dbslayj37q5na1w1g63g32z2s8aq09j"
-  }
- },
- {
   "ename": "typit",
   "commit": "d17d019155e19c156f123dcd702f18cfba488701",
   "sha256": "05m7ymcq6fgbhh93ninrf3qi7csdnf2ahhf01mkm8gxxyaqq6m4n",
@@ -126774,17 +127078,17 @@
  },
  {
   "ename": "typo",
-  "commit": "855ea20024b606314f8590129259747cac0bcc97",
-  "sha256": "1p8is1n525lmzq588hj6vazmhl9wi6rairnfx1g1p6g6ijdycd4h",
-  "fetcher": "github",
-  "repo": "jorgenschaefer/typoel",
+  "commit": "11e080fa5a065ca4c2a3eff1203f80d7d1b1c597",
+  "sha256": "0aarir50ffgy2pk7jz6s8ivqhin9siy56x2hmhc9ky2va5qpnm8m",
+  "fetcher": "codeberg",
+  "repo": "pkal/typo.el",
   "unstable": {
    "version": [
-    20200706,
-    1714
+    20230725,
+    2003
    ],
-   "commit": "173ebe4fc7ac38f344b16e6eaf41f79e38f20d57",
-   "sha256": "09835zlfzxby5lpz9njl705nqc2n2h2f7a4vpcyx89f5rb9qhy68"
+   "commit": "f5920481422460837572646656f8ad2307e70c58",
+   "sha256": "0hc873mhwwmwgscrjsq00zs0r61ngvwcirpm6zm0na2c3q9qrvbn"
   },
   "stable": {
    "version": [
@@ -127234,11 +127538,11 @@
   "repo": "ideasman42/emacs-undo-fu",
   "unstable": {
    "version": [
-    20241206,
-    219
+    20250611,
+    2331
    ],
-   "commit": "399cc12f907f81a709f9014b6fad0205700d5772",
-   "sha256": "1d4ff3y67fy1zrs1qcbwh4grnw0jw9gvnrwrsripyav5w7bd03sw"
+   "commit": "545e29459e71a9aca81c96c1385d43a5696e27e9",
+   "sha256": "0kalasgpd0ss2rj17zz8n089jbzjing9znqg4405jp3zdff7m5m2"
   }
  },
  {
@@ -127249,11 +127553,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20241212,
-    40
+    20250611,
+    332
    ],
-   "commit": "d90d42ddba8fa42ef5dc109196545caeabb42b75",
-   "sha256": "167y0hjpcgg2g6pf69kgimk0mx9afki53q1prwrl89ph5w7lf6db"
+   "commit": "99d1b5099f432123577c51b6a67210b0c37716e6",
+   "sha256": "0sbijq1gac6dzrv2n2s6pwn96n3gx7bq8d5zsd71nq0635ffbkdq"
   }
  },
  {
@@ -127646,14 +127950,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20250526,
-    811
+    20250706,
+    1924
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "59c241853ef54c67634ab2cfb7e1ca94eaff65f8",
-   "sha256": "1r75xd460j6vcj4sxfl3l1dh97cdmwkr0shdkl7i8582x9066y45"
+   "commit": "475912a831ffb41b5b25d1eec79afb7a2279d9e3",
+   "sha256": "0xdij41clradmgjp1gzx163y8qdkdkjn3s5ivn3fjzq8307cxpna"
   }
  },
  {
@@ -127772,26 +128076,26 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20240429,
-    1525
+    20250704,
+    342
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "e16f5974c77e7126cd5c9b7448116ee94a6a1e72",
-   "sha256": "0n0ndahcamfqz9wrj1l43xr8q5lc03k204ny95mwlnahq27z9qsm"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   }
  },
  {
@@ -127802,26 +128106,26 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20240428,
-    1852
+    20250704,
+    342
    ],
    "deps": [
     "citeproc"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
     "citeproc"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   }
  },
  {
@@ -127832,21 +128136,21 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20240428,
-    1852
+    20250704,
+    342
    ],
    "deps": [
     "bibtex-completion",
     "elfeed",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
@@ -127854,8 +128158,8 @@
     "elfeed",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   }
  },
  {
@@ -127866,21 +128170,21 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20240428,
-    1852
+    20250704,
+    342
    ],
    "deps": [
     "elfeed",
     "elfeed-score",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
@@ -127888,8 +128192,8 @@
     "elfeed-score",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   }
  },
  {
@@ -127900,28 +128204,28 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20240428,
-    1852
+    20250704,
+    342
    ],
    "deps": [
     "org-roam",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
     "org-roam",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   }
  },
  {
@@ -128304,11 +128608,11 @@
   "repo": "jcs-elpa/use-ttf",
   "unstable": {
    "version": [
-    20250101,
-    1013
+    20250624,
+    1031
    ],
-   "commit": "78a0a55a036cce9442ffb3aae1bb00a2e1e4a78c",
-   "sha256": "1kvpfw8gblyiy9vymvi52d9967xz7544dskx3qs9x4djcc95ayqh"
+   "commit": "762a10f270430b278d48fd290100f0b899e5b9f5",
+   "sha256": "0cj11hs5nlv8hcxsb1m8dwwidw4xf7czw6gclg3f15qq87aw18wj"
   },
   "stable": {
    "version": [
@@ -128445,14 +128749,14 @@
   "repo": "z80dev/uv-mode",
   "unstable": {
    "version": [
-    20250130,
-    537
+    20250703,
+    1540
    ],
    "deps": [
     "pythonic"
    ],
-   "commit": "cc5ba6e560fdad565f108b769cb77d4bc5046da5",
-   "sha256": "162ih95360anpj3jsjirn9qw6x0m0y2lhk41zfkc4aar487ly47x"
+   "commit": "7e7f9b90832210b65823c3d58e3255cd164394b7",
+   "sha256": "1a8vk5shnbhapx5n95vd38gjdbxyr8q46kwn21yd3lpvlrg9zkds"
   }
  },
  {
@@ -128658,11 +128962,11 @@
   "url": "https://git.systemreboot.net/varuga/",
   "unstable": {
    "version": [
-    20241006,
-    2204
+    20250618,
+    2103
    ],
-   "commit": "b88ea762f7f0c321176ffd0d5d47c89d6971faf7",
-   "sha256": "0qpybhhndrj8hd6wy7kqrc3csx3y2xiy9j7447fkfq2zxp8d26cx"
+   "commit": "f055e8572b2e4d7a700392b8a71bacbfdc8e442a",
+   "sha256": "1x7jzvg1dxv381qlqdsa3knj3i4xcv6gy16834wzpfkfz6jb0240"
   },
   "stable": {
    "version": [
@@ -129237,8 +129541,8 @@
   "repo": "gmlarumbe/verilog-ext",
   "unstable": {
    "version": [
-    20250318,
-    1344
+    20250708,
+    1347
    ],
    "deps": [
     "ag",
@@ -129247,14 +129551,13 @@
     "flycheck",
     "hydra",
     "lsp-mode",
-    "outshine",
     "ripgrep",
     "verilog-mode",
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "028bac2b106079c147dddfc361e60b644b449426",
-   "sha256": "0sfv0ilakg2rgycfw6ab9mp2afcfw7cfirdwlp8pxmjj653sv45v"
+   "commit": "98f6ddc228449eb53cf425613887e44f46f3549f",
+   "sha256": "1mf04506zxl884w88cm3z0181nh92awn1r50f8dk5yzhfjwibqmm"
   },
   "stable": {
    "version": [
@@ -129287,14 +129590,14 @@
   "repo": "gmlarumbe/verilog-ts-mode",
   "unstable": {
    "version": [
-    20250320,
-    1821
+    20250623,
+    1457
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "7f5682603de99ff8922f108ab42066a48ba85b6a",
-   "sha256": "1plczm4pdivqjxj905z5k8k974p1hxwx6018j1ba3jnqlw3ig4q7"
+   "commit": "34f0dc244eb54d84346afa7e914e12d41b3c109a",
+   "sha256": "046d1lzwvnw78kaihh9f7k2s30a7gz58kamysq151mffjmk9sinv"
   },
   "stable": {
    "version": [
@@ -129395,25 +129698,25 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20250527,
-    1813
+    20250702,
+    1403
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f104ac4e2ae890555f6a77b1e741fc9b75914f43",
-   "sha256": "0lnqm2mdqimzlf2fa2q74mr9236spkxfayfpfasyxqh3bm3p68xl"
+   "commit": "d8dc49a3520ab908c2b0f62a4a8ae32ca23f2726",
+   "sha256": "1zrbhm5hm225xs5h54wyfniz8w4mp34ksmknmdsnpgqpfjqpq45p"
   },
   "stable": {
    "version": [
     2,
-    2
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "bb6abf63cc439601cd65682cfd549e4b6d63d409",
-   "sha256": "15zf0kj12an9dmdi55ghpkxj053bqzm50fwlhpga4sjzx7qmv5q8"
+   "commit": "fcab88ad878e16356c392c99a64f172e7541dd65",
+   "sha256": "089ngnx3avqs0xlf25hmpp2sximdc9wxkq9fvmjf87viiz175k1y"
   }
  },
  {
@@ -129660,20 +129963,20 @@
   "repo": "jamescherti/vim-tab-bar.el",
   "unstable": {
    "version": [
-    20250522,
-    1315
+    20250629,
+    344
    ],
-   "commit": "44b216ad4e48ef60e7b0e581f66e85082956ffed",
-   "sha256": "1air63q4wn4y54l9qjw46wvgpyzy4irnn6qw78xvmw6vfnfri5mz"
+   "commit": "abf7fb4f83c0dd87fa247c776c5d91963fb785e0",
+   "sha256": "126p9363dqciar2gxj12ipr7gqjbr3l4j0mglaxyk5lbmg98xji6"
   },
   "stable": {
    "version": [
     1,
     0,
-    7
+    8
    ],
-   "commit": "4d101f14bd388ddc6264c276013eac9760559b0f",
-   "sha256": "0dhkzbcr2dc0pq9g15ggx3vryik8xchlw2kknznsr8x1b2jg2kmq"
+   "commit": "abf7fb4f83c0dd87fa247c776c5d91963fb785e0",
+   "sha256": "126p9363dqciar2gxj12ipr7gqjbr3l4j0mglaxyk5lbmg98xji6"
   }
  },
  {
@@ -129794,6 +130097,21 @@
    ],
    "commit": "b0c2ac4a9d625b5f4f329bbab879ad86cd7056bd",
    "sha256": "052djdwlg2bx0smy4xbcniqb48q0nwfbigf98s2330ngpjk7112a"
+  }
+ },
+ {
+  "ename": "virtual-ring",
+  "commit": "d35bebbc4c94e581289c2f449fc59cd4026a4a54",
+  "sha256": "0sx3drafv3h0qbkwam8ljizfq9d3jfdzj2sb8fprrn512rlj565l",
+  "fetcher": "github",
+  "repo": "countvajhula/virtual-ring",
+  "unstable": {
+   "version": [
+    20250522,
+    1957
+   ],
+   "commit": "138afec2ce1176ebcf18124294b21428487245de",
+   "sha256": "01cvxng298ln6k071f0l8ggky70z0460sslx3v764jyia9lxkrc6"
   }
  },
  {
@@ -130098,21 +130416,6 @@
    ],
    "commit": "050d3e6d2543a6771a13f95612055864679b6301",
    "sha256": "1vyl13swx82njqlfzmaj9c4vbdpdsj4m9f8v32a9kycdhbm9x90z"
-  }
- },
- {
-  "ename": "votd",
-  "commit": "97bc76fa5779c6be203d9f8f492969ec576771f8",
-  "sha256": "16yil98znnvryrfihpkyjj02xwwhzm5aj6ykiq7mbp5hdg18b7lz",
-  "fetcher": "github",
-  "repo": "kristjoc/votd",
-  "unstable": {
-   "version": [
-    20250424,
-    1603
-   ],
-   "commit": "2a8e2348714f4aaf3edec20d47bbec12e6603141",
-   "sha256": "1g0ln9gh22zhc2j13bnw5j12gyahf7myz696nmqn0z7r87ji83hd"
   }
  },
  {
@@ -130455,14 +130758,14 @@
   "repo": "embed-me/vunit-mode",
   "unstable": {
    "version": [
-    20230913,
-    1754
+    20250707,
+    1741
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "a2126892f17a48c857682b6455f963a3fb7e07f0",
-   "sha256": "07r0mk0cb5l8q1z830j4vfy7p17f5wva73lmm74d1m3vqmvlxrn9"
+   "commit": "e730a771355dd02c92dedfe3aaea1889d523c198",
+   "sha256": "1nrqiwyrngpr60c5i6438fghywgs7wf4yyb4h6a7zmih4q76z8rs"
   }
  },
  {
@@ -130829,16 +131132,16 @@
   "repo": "emacsmirror/wanderlust",
   "unstable": {
    "version": [
-    20250519,
-    1830
+    20250629,
+    2048
    ],
    "deps": [
     "apel",
     "flim",
     "semi"
    ],
-   "commit": "4b11121dec2dd2928cfa4cddcd776c0b2ec4c7af",
-   "sha256": "1hxg5rsg1yq2jkvjnxy00hp5hj2a16ps6hd00s6kqyklsl0iimlv"
+   "commit": "b7d2e84bf3260ea2de7903eab8330538b3423a6e",
+   "sha256": "036jxcb999kgypg52rqd4s0nw5na1vp2r8ksafw1y2w8srky6mms"
   }
  },
  {
@@ -131147,11 +131450,11 @@
   "repo": "fxbois/web-mode",
   "unstable": {
    "version": [
-    20241227,
-    530
+    20250619,
+    1334
    ],
-   "commit": "be2d59c8fa02b1a45ae54ce4079e502e659cefe6",
-   "sha256": "0v1yq3lk0lvvc3yjs38lsmipa8x5lkz38pdm0v30npsi0dmh1h5r"
+   "commit": "994cb350bceeebb031406112cf6da119e066ef8e",
+   "sha256": "08w8r1hs4kf733ghlipfmixgl5xccd0qmsrd6m65r2cw7mf0wv4r"
   },
   "stable": {
    "version": [
@@ -132165,6 +132468,21 @@
   }
  },
  {
+  "ename": "wilson-ng-theme",
+  "commit": "dfc9db7856c7e25814846a8458bc6f4e7fcd736d",
+  "sha256": "1x2vw1i05cmycgypypn4w19g0g8m551lvzh3nz200v4cckcas2dl",
+  "fetcher": "github",
+  "repo": "levindue/emacs-wilson-theme",
+  "unstable": {
+   "version": [
+    20250621,
+    1426
+   ],
+   "commit": "81ddb3a2a8d3d69b03fe008fee96ffe99201c1f3",
+   "sha256": "0sc3ljbdkgf6nxhi3jxlfbj05iyxfr65i6qp84bysd3di4qd9i7k"
+  }
+ },
+ {
   "ename": "wilt",
   "commit": "eea4f2ca8b4f9ea93cc02151fdda6cfee5b68b70",
   "sha256": "0nw6zr06zq60j72qfjmbqrxyz022fnisb0bsh6xmlnd1k1kqlrz6",
@@ -132582,26 +132900,26 @@
   "repo": "magit/with-editor",
   "unstable": {
    "version": [
-    20250521,
-    1531
+    20250531,
+    2230
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e39137ed0add2fb2cb7e4db1d9fab10ee1ebd682",
-   "sha256": "0dxmvifsxdbrsbwaag9r5brydx6dj0g2mncaw8b1czi533v2y2qf"
+   "commit": "f32cd7b09d518b629bfaa3eeb92b539891c6b9bc",
+   "sha256": "18nz4830pc15lrlyj61rh3df17mss7v12b54f5037cg1ym4jrqm7"
   },
   "stable": {
    "version": [
     3,
     4,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "ca902ae02972bdd6919a902be2593d8cb6bd991b",
-   "sha256": "0h21qs60qihv4p72x5wbmc0xly4g74wc25qj8m9slfbc4am9mwys"
+   "commit": "f32cd7b09d518b629bfaa3eeb92b539891c6b9bc",
+   "sha256": "18nz4830pc15lrlyj61rh3df17mss7v12b54f5037cg1ym4jrqm7"
   }
  },
  {
@@ -132884,28 +133202,28 @@
   "repo": "swflint/emacs-universal-sidecar",
   "unstable": {
    "version": [
-    20240428,
-    1852
+    20250704,
+    342
    ],
    "deps": [
     "compat",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   },
   "stable": {
    "version": [
     1,
-    6,
+    7,
     0
    ],
    "deps": [
     "compat",
     "universal-sidecar"
    ],
-   "commit": "4c78015d10caba9c700e6e6b582004ae1c1d5344",
-   "sha256": "0s48sbvqchaakz3nyn8qjwdy4yjdfq6wbjshwdp6ix1ykm5xd0h4"
+   "commit": "c7f17d5377c8d97a72f6548a82d6b259dfc8fc07",
+   "sha256": "0pjvqrjmb616x9jc1zzwvrnlnsyws6acm1c4z6hs2c6nlh18ypnk"
   }
  },
  {
@@ -132985,10 +133303,10 @@
  },
  {
   "ename": "wordsmith-mode",
-  "commit": "3b5fda506e5b388cd6824d433b89032ed46858dc",
-  "sha256": "0s6b6dfqn31jdcgs2mlmvwgpr5a4zs4xi8m002ly11c6sn035xb1",
+  "commit": "4012a91c1c40276c2290b6b3cec4f735bce116e2",
+  "sha256": "12032chydsqkg13277zhv2izyr1ffiqdjhadmx8i17ixp5bgjfgm",
   "fetcher": "github",
-  "repo": "istib/wordsmith-mode",
+  "repo": "emacsattic/wordsmith-mode",
   "unstable": {
    "version": [
     20210715,
@@ -134215,20 +134533,20 @@
   "repo": "emacsorphanage/yafolding",
   "unstable": {
    "version": [
-    20250523,
-    1216
+    20250601,
+    2133
    ],
-   "commit": "7247f48503b116eb10a61de55afc0866716b2f87",
-   "sha256": "12fbpxlmjdykf1yyl8i67dg7q5zlphvvfxajavzw8c8fb3h210fj"
+   "commit": "77d36147a07d82a558788b180e4f0a983a3ed906",
+   "sha256": "0820bvw6bsryhrmgqk9gxi56x6r4qn8albhcm95q31siiq5f5dkb"
   },
   "stable": {
    "version": [
     0,
     4,
-    1
+    2
    ],
-   "commit": "4c1888ae45f9241516519ae0ae3a899f2efa05ba",
-   "sha256": "1bb763lx5cs5z06irjllip8z9c61brjsamfcjajibi24wcajkprx"
+   "commit": "77d36147a07d82a558788b180e4f0a983a3ed906",
+   "sha256": "0820bvw6bsryhrmgqk9gxi56x6r4qn8albhcm95q31siiq5f5dkb"
   }
  },
  {
@@ -134449,11 +134767,11 @@
   "repo": "Kungsgeten/yankpad",
   "unstable": {
    "version": [
-    20240926,
-    2114
+    20250609,
+    1121
    ],
-   "commit": "85cfa3242abb64018eb944271460bd533588d9c1",
-   "sha256": "0zi3j677dg0qw4dbwh2rcq2d0x7b8fw22jp1mc15ml3xyizgaqq9"
+   "commit": "55891dde4c9d83b86f94764e7a1990084e66ee53",
+   "sha256": "060vyy0l6y2mjyhk4xys28c85jhqrm8dilrzx4xdmlnd2x4nm1al"
   },
   "stable": {
    "version": [
@@ -134596,14 +134914,14 @@
   "repo": "joaotavora/yasnippet",
   "unstable": {
    "version": [
-    20250403,
-    1926
+    20250602,
+    1342
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "2384fe1655c60e803521ba59a34c0a7e48a25d06",
-   "sha256": "118iv62izrdrwvhndhfq5ywgdrv2gsl53623sqw69w1gln17v31h"
+   "commit": "dd570a6b22364212fff9769cbf4376bdbd7a63c5",
+   "sha256": "1s7zsdw83v5v7alsnzzrrr3m177qnm7x4hr8w7f84a4lamd0h6s3"
   },
   "stable": {
    "version": [
@@ -134837,14 +135155,14 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20250225,
-    1735
+    20250612,
+    2131
    ],
    "deps": [
     "compat"
    ],
-   "commit": "eb76b1d644170f2a685882a207e4644c399bb668",
-   "sha256": "05n56s56xpiy47f88an1qm30y0dcjiz5ah7almz5mnc0fsb4qsrn"
+   "commit": "b46fff22e7381444b5362d8bc175acad3c5d61f8",
+   "sha256": "1zf0y2f0ygx6mrfcpgdyjcd2x6yaj7d9bsqpsb6f1y32rd4migl4"
   },
   "stable": {
    "version": [
@@ -135686,14 +136004,14 @@
   "repo": "ziglang/zig-mode",
   "unstable": {
    "version": [
-    20241104,
-    1624
+    20250618,
+    1627
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "f0b4a487530146f99230f4a5ff67e8d56c8f3f80",
-   "sha256": "1cm4wvddvqyjhlp7wngls1lapsiq1n14qgi1ygiq3w2vryg96s1v"
+   "commit": "9f86fded13e28c6c9ccf56d417276547bac7e54e",
+   "sha256": "0n6h9k03s7nbpabda0xds5x6g1rhr7jg2igjgs476rzi60pfgcxs"
   }
  },
  {

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -119,6 +119,11 @@ in
         url = "https://git.savannah.gnu.org/cgit/emacs.git/patch/?id=53a5dada413662389a17c551a00d215e51f5049f";
         hash = "sha256-AEvsQfpdR18z6VroJkWoC3sBoApIYQQgeF/P2DprPQ8=";
       })
+      (fetchpatch {
+        # bug#76573
+        url = "https://git.savannah.gnu.org/cgit/emacs.git/patch/?id=05ecb2b8f0216aa3f391ee661aad4d61fd6aed0e";
+        hash = "sha256-fvnHMvuqwQseVrDpVpnzSaoWfXrR5tsjIib7+lhRGII=";
+      })
     ];
   });
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- emacs-overlay commit: 5a64a848253e773d14dffe72e95bf302932e6d02
- [hydra](https://hydra.nix-community.org/eval/504466?filter=x86_64-linux.unstable.packages.)
- new failed toplevel builds:
  - [x] [emacs-casual-avy-20241217.1931](https://hydra.nix-community.org/build/6419232)
  - [x] [emacs-casual-suite-20241022.3](https://hydra.nix-community.org/build/6419234)
  - [x] [emacs-casual-symbol-overlay-20241021.2358](https://hydra.nix-community.org/build/6419233)
  - [x] [emacs-casual-20250707.2046](https://hydra.nix-community.org/build/6419231): reported to https://github.com/kickingvegas/casual/issues/262
  - [X] [emacs-daselt-20250627.1245](https://hydra.nix-community.org/build/6364455)
  - [x] [emacs-doom-modeline-now-playing-20250707.950](https://hydra.nix-community.org/build/6417920): reported in https://github.com/elken/doom-modeline-now-playing/issues/5
  - [X] [emacs-git-commit-insert-issue-20230512.1416](https://hydra.nix-community.org/build/6410023)
  - [X] [emacs-gitlab-pipeline-20241101.356](https://hydra.nix-community.org/build/6410025)
  - [X] [emacs-gnosis-20250702.651](https://hydra.nix-community.org/build/6390123)
  - [X] [emacs-magit-gitlab-20240707.1506](https://hydra.nix-community.org/build/6410212)
  - [X] [emacs-vc-jj-0.3](https://hydra.nix-community.org/build/6297036)
  - [X] [emacs-graphviz-dot-mode-20250708.1125](https://hydra.nix-community.org/build/6420632)
  - [x] [emacs-vdirel-20230906.1844](https://hydra.nix-community.org/build/6420779): reported in https://github.com/pinoaffe/org-vcard/issues/49


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
