### PR TITLE
Nagstamon: add missing dependency and add myself as maintainer

### DIFF
--- a/pkgs/by-name/na/nagstamon/package.nix
+++ b/pkgs/by-name/na/nagstamon/package.nix
@@ -61,6 +61,7 @@ python3Packages.buildPythonApplication rec {
     maintainers = with lib.maintainers; [
       pSub
       liberodark
+      videl
     ];
     mainProgram = "nagstamon.py";
     # NameError: name 'bdist_rpm_options' is not defined. Did you mean: 'bdist_mac_options'?

--- a/pkgs/by-name/na/nagstamon/package.nix
+++ b/pkgs/by-name/na/nagstamon/package.nix
@@ -45,6 +45,7 @@ python3Packages.buildPythonApplication rec {
     python-dateutil
     requests
     requests-kerberos
+    setuptools
   ];
 
   nativeCheckInputs = with python3Packages; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I noticed I had this issue when installing the package:

```
❯ nagstamon.py
[Errno 2] No such file or directory: '/home/videl/.nagstamon/nagstamon.pid'
qt.multimedia.symbolsresolver: Couldn't load pipewire-0.3 library
qt.multimedia.symbolsresolver: Couldn't resolve pipewire-0.3 symbols
Traceback (most recent call last):
  File "/nix/store/3mam50xd1hp1a5gak8dgp672d6qrygz7-nagstamon-3.16.2/bin/.nagstamon.py-wrapped", line 46, in <module>
    from Nagstamon.QUI import (APP,
  File "/nix/store/3mam50xd1hp1a5gak8dgp672d6qrygz7-nagstamon-3.16.2/lib/python3.12/site-packages/Nagstamon/QUI/__init__.py", line 53, in <module>
    from Nagstamon.Servers import (SERVER_TYPES,
  File "/nix/store/3mam50xd1hp1a5gak8dgp672d6qrygz7-nagstamon-3.16.2/lib/python3.12/site-packages/Nagstamon/Servers/__init__.py", line 41, in <module>
    from Nagstamon.Servers.ZabbixProblemBased import ZabbixProblemBasedServer
  File "/nix/store/3mam50xd1hp1a5gak8dgp672d6qrygz7-nagstamon-3.16.2/lib/python3.12/site-packages/Nagstamon/Servers/ZabbixProblemBased.py", line 7, in <module>
    from pkg_resources import parse_version
ModuleNotFoundError: No module named 'pkg_resources'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
