### PR TITLE
parlatype: 4.2 -> 4.3

### DIFF
--- a/pkgs/by-name/pa/parlatype/package.nix
+++ b/pkgs/by-name/pa/parlatype/package.nix
@@ -6,6 +6,7 @@
   desktop-file-utils,
   gettext,
   glib,
+  gobject-introspection,
   gst_all_1,
   gtk4,
   hicolor-icon-theme,
@@ -16,25 +17,27 @@
   meson,
   ninja,
   pkg-config,
+  pocketsphinx,
   python3,
   wrapGAppsHook4,
 }:
 
 stdenv.mkDerivation rec {
   pname = "parlatype";
-  version = "4.2";
+  version = "4.3";
 
   src = fetchFromGitHub {
     owner = "gkarsay";
     repo = "parlatype";
-    rev = "v${version}";
-    sha256 = "1wi9f23zgvsa98xcxgghm53jlafnr3pan1zl4gkn0yd8b2d6avhk";
+    tag = "v${version}";
+    sha256 = "1kjsbwr08k1kzaan555zjk37r3l5qhpgrvjb1p57dnygk2g3hsm2";
   };
 
   nativeBuildInputs = [
     appstream-glib
     desktop-file-utils
     gettext
+    gobject-introspection
     itstool
     libxml2
     meson
@@ -56,11 +59,17 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme
     isocodes
     libadwaita
+    pocketsphinx
   ];
 
   postPatch = ''
     patchShebangs libparlatype/tests/data/generate_config_data
   '';
+
+  mesonFlags = [
+    "-Dgir=true"
+    "-Dpocketsphinx=true"
+  ];
 
   doCheck = false;
 


### PR DESCRIPTION
Changelog: brief at <https://github.com/gkarsay/parlatype/commit/93b8d4eb0ea308807252f989708bfc29a2e730f7>, more extensive at <https://www.parlatype.xyz/2025/07/01/v4.3.html>. Support for pocketsphinx 5, MPRIS improvements, translation updates.

On the Nixpkgs side, I’ve reenabled the pocketsphinx integration, which was removed together with pocketsphinx itself for lack of Python 3 support, and the gobject-introspection integration, which did not work in the early days of the Gtk 4 port in Parlatype 4.0 for reasons I do not remember, but seems to work now.

closes #421710 and supersedes it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
