### PR TITLE
clickhouse: 25.3.5.42 → 25.7.4.11

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -113,6 +113,10 @@
 
 - `fetchgit`: Add `rootDir` argument to limit the resulting source to one subdirectory of the whole Git repository. Corresponding `--root-dir` option added to `nix-prefetch-git`.
 
+- The `clickhouse` package now track the stable upstream version per [upstream's
+  recommendation](https://clickhouse.com/docs/faq/operations/production). Users
+  can continue to use the `clickhouse-lts` package if desired.
+
 ## Nixpkgs Library {#sec-nixpkgs-release-25.11-lib}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -333,7 +333,14 @@ in
   cinnamon-wayland = runTest ./cinnamon-wayland.nix;
   cjdns = runTest ./cjdns.nix;
   clatd = runTest ./clatd.nix;
-  clickhouse = import ./clickhouse { inherit runTest; };
+  clickhouse = import ./clickhouse {
+    inherit runTest;
+    package = pkgs.clickhouse;
+  };
+  clickhouse-lts = import ./clickhouse {
+    inherit runTest;
+    package = pkgs.clickhouse-lts;
+  };
   cloud-init = runTest ./cloud-init.nix;
   cloud-init-hostname = runTest ./cloud-init-hostname.nix;
   cloudlog = runTest ./cloudlog.nix;

--- a/nixos/tests/clickhouse/base.nix
+++ b/nixos/tests/clickhouse/base.nix
@@ -1,7 +1,10 @@
 { pkgs, package, ... }:
 {
   name = "clickhouse";
-  meta.maintainers = with pkgs.lib.maintainers; [ jpds ];
+  meta.maintainers = with pkgs.lib.maintainers; [
+    jpds
+    thevar1able
+  ];
 
   nodes.machine = {
     services.clickhouse = {

--- a/nixos/tests/clickhouse/base.nix
+++ b/nixos/tests/clickhouse/base.nix
@@ -1,10 +1,13 @@
-{ pkgs, ... }:
+{ pkgs, package, ... }:
 {
   name = "clickhouse";
   meta.maintainers = with pkgs.lib.maintainers; [ jpds ];
 
   nodes.machine = {
-    services.clickhouse.enable = true;
+    services.clickhouse = {
+      enable = true;
+      inherit package;
+    };
     virtualisation.memorySize = 4096;
   };
 

--- a/nixos/tests/clickhouse/default.nix
+++ b/nixos/tests/clickhouse/default.nix
@@ -1,8 +1,31 @@
-{ runTest }:
+{
+  runTest,
+  package,
+}:
 
 {
-  base = runTest ./base.nix;
-  kafka = runTest ./kafka.nix;
-  keeper = runTest ./keeper.nix;
-  s3 = runTest ./s3.nix;
+  base = runTest {
+    imports = [ ./base.nix ];
+    _module.args = {
+      inherit package;
+    };
+  };
+  kafka = runTest {
+    imports = [ ./kafka.nix ];
+    _module.args = {
+      inherit package;
+    };
+  };
+  keeper = runTest {
+    imports = [ ./keeper.nix ];
+    _module.args = {
+      inherit package;
+    };
+  };
+  s3 = runTest {
+    imports = [ ./s3.nix ];
+    _module.args = {
+      inherit package;
+    };
+  };
 }

--- a/nixos/tests/clickhouse/kafka.nix
+++ b/nixos/tests/clickhouse/kafka.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, package, ... }:
 
 let
   kafkaNamedCollectionConfig = ''
@@ -38,7 +38,10 @@ in
         };
       };
 
-      services.clickhouse.enable = true;
+      services.clickhouse = {
+        enable = true;
+        inherit package;
+      };
       virtualisation.memorySize = 4096;
     };
 

--- a/nixos/tests/clickhouse/kafka.nix
+++ b/nixos/tests/clickhouse/kafka.nix
@@ -28,7 +28,10 @@ let
 in
 {
   name = "clickhouse-kafka";
-  meta.maintainers = with pkgs.lib.maintainers; [ jpds ];
+  meta.maintainers = with pkgs.lib.maintainers; [
+    jpds
+    thevar1able
+  ];
 
   nodes = {
     clickhouse = {

--- a/nixos/tests/clickhouse/keeper.nix
+++ b/nixos/tests/clickhouse/keeper.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  lib,
+  pkgs,
+  package,
+  ...
+}:
 rec {
   name = "clickhouse-keeper";
   meta.maintainers = with pkgs.lib.maintainers; [ jpds ];
@@ -94,7 +99,10 @@ rec {
           9444
         ];
 
-        services.clickhouse.enable = true;
+        services.clickhouse = {
+          enable = true;
+          inherit package;
+        };
 
         systemd.services.clickhouse = {
           after = [ "network-online.target" ];

--- a/nixos/tests/clickhouse/keeper.nix
+++ b/nixos/tests/clickhouse/keeper.nix
@@ -6,7 +6,10 @@
 }:
 rec {
   name = "clickhouse-keeper";
-  meta.maintainers = with pkgs.lib.maintainers; [ jpds ];
+  meta.maintainers = with pkgs.lib.maintainers; [
+    jpds
+    thevar1able
+  ];
 
   nodes =
     let

--- a/nixos/tests/clickhouse/s3.nix
+++ b/nixos/tests/clickhouse/s3.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, package, ... }:
 
 let
   s3 = {
@@ -50,7 +50,10 @@ in
         };
       };
 
-      services.clickhouse.enable = true;
+      services.clickhouse = {
+        enable = true;
+        inherit package;
+      };
       virtualisation.diskSize = 15 * 1024;
       virtualisation.memorySize = 4 * 1024;
     };

--- a/nixos/tests/clickhouse/s3.nix
+++ b/nixos/tests/clickhouse/s3.nix
@@ -40,7 +40,10 @@ let
 in
 {
   name = "clickhouse-s3";
-  meta.maintainers = with pkgs.lib.maintainers; [ jpds ];
+  meta.maintainers = with pkgs.lib.maintainers; [
+    jpds
+    thevar1able
+  ];
 
   nodes = {
     clickhouse = {

--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -1,4 +1,10 @@
 {
+  lts ? false,
+  version,
+  hash,
+}:
+
+{
   lib,
   stdenv,
   llvmPackages_19,
@@ -20,16 +26,16 @@
 }:
 
 llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
-  pname = "clickhouse";
-  version = "25.3.5.42";
+  pname = "clickhouse" + lib.optionalString lts "-lts";
+  inherit version;
 
   src = fetchFromGitHub rec {
     owner = "ClickHouse";
     repo = "ClickHouse";
-    tag = "v${finalAttrs.version}-lts";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     name = "clickhouse-${tag}.tar.gz";
-    hash = "sha256-LvGl9XJK6Emt7HnV/Orp7qEmJSr3TBJZtApL6GrWIMg=";
+    inherit hash;
     postFetch = ''
       # delete files that make the source too big
       rm -rf $out/contrib/llvm-project/llvm/test

--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -112,6 +112,7 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags =
     [
+      "-DENABLE_CHDIG=OFF"
       "-DENABLE_TESTS=OFF"
       "-DENABLE_DELTA_KERNEL_RS=0"
       "-DCOMPILER_CACHE=disabled"

--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -2,6 +2,7 @@
   lts ? false,
   version,
   hash,
+  nixUpdateExtraArgs ? [ ],
 }:
 
 {
@@ -23,6 +24,7 @@
   rustc,
   cargo,
   rustPlatform,
+  nix-update-script,
 }:
 
 llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
@@ -156,7 +158,13 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   # Builds in 7+h with 2 cores, and ~20m with a big-parallel builder.
   requiredSystemFeatures = [ "big-parallel" ];
 
-  passthru.tests.clickhouse = nixosTests.clickhouse;
+  passthru = {
+    tests.clickhouse = nixosTests.clickhouse;
+
+    updateScript = nix-update-script {
+      extraArgs = nixUpdateExtraArgs;
+    };
+  };
 
   meta = with lib; {
     homepage = "https://clickhouse.com";

--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -63,63 +63,60 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   };
 
   strictDeps = true;
-  nativeBuildInputs =
-    [
-      cmake
-      ninja
-      python3
-      perl
-      llvmPackages_19.lld
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isx86_64 [
-      nasm
-      yasm
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      llvmPackages_19.bintools
-      findutils
-      darwin.bootstrap_cmds
-    ]
-    ++ lib.optionals rustSupport [
-      rustc
-      cargo
-      rustPlatform.cargoSetupHook
-    ];
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+    perl
+    llvmPackages_19.lld
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+    nasm
+    yasm
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages_19.bintools
+    findutils
+    darwin.bootstrap_cmds
+  ]
+  ++ lib.optionals rustSupport [
+    rustc
+    cargo
+    rustPlatform.cargoSetupHook
+  ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   dontCargoSetupPostUnpack = true;
 
-  postPatch =
-    ''
-      patchShebangs src/
-      patchShebangs utils/
+  postPatch = ''
+    patchShebangs src/ utils/
 
-      sed -i 's|/usr/bin/env perl|"${lib.getExe perl}"|' contrib/openssl-cmake/CMakeLists.txt
+    sed -i 's|/usr/bin/env perl|"${lib.getExe perl}"|' contrib/openssl-cmake/CMakeLists.txt
 
-      substituteInPlace src/Storages/System/StorageSystemLicenses.sh utils/list-licenses/list-licenses.sh \
-        --replace-fail '$(git rev-parse --show-toplevel)' "$NIX_BUILD_TOP/$sourceRoot"
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace cmake/tools.cmake \
-        --replace-fail 'gfind' 'find' \
-        --replace-fail 'ggrep' 'grep' \
-        --replace-fail '--ld-path=''${LLD_PATH}' '-fuse-ld=lld'
-    ''
-    + lib.optionalString rustSupport ''
-      cargoSetupPostPatchHook() { true; }
-    '';
+    substituteInPlace src/Storages/System/StorageSystemLicenses.sh utils/list-licenses/list-licenses.sh \
+      --replace-fail '$(git rev-parse --show-toplevel)' "$NIX_BUILD_TOP/$sourceRoot"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace cmake/tools.cmake \
+      --replace-fail 'gfind' 'find' \
+      --replace-fail 'ggrep' 'grep' \
+      --replace-fail '--ld-path=''${LLD_PATH}' '-fuse-ld=lld'
+  ''
+  # Rust is handled by cmake
+  + lib.optionalString rustSupport ''
+    cargoSetupPostPatchHook() { true; }
+  '';
 
-  cmakeFlags =
-    [
-      "-DENABLE_CHDIG=OFF"
-      "-DENABLE_TESTS=OFF"
-      "-DENABLE_DELTA_KERNEL_RS=0"
-      "-DCOMPILER_CACHE=disabled"
-    ]
-    ++ lib.optional (
-      stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64
-    ) "-DNO_ARMV81_OR_HIGHER=1";
+  cmakeFlags = [
+    "-DENABLE_CHDIG=OFF"
+    "-DENABLE_TESTS=OFF"
+    "-DENABLE_DELTA_KERNEL_RS=0"
+    "-DCOMPILER_CACHE=disabled"
+  ]
+  ++ lib.optional (
+    stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64
+  ) "-DNO_ARMV81_OR_HIGHER=1";
 
   env = {
     CARGO_HOME = "$PWD/../.cargo/";
@@ -137,19 +134,16 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [ "fortify" ];
 
   postInstall = ''
-    rm -rf $out/share/clickhouse-test
-
     sed -i -e '\!<log>/var/log/clickhouse-server/clickhouse-server\.log</log>!d' \
       $out/etc/clickhouse-server/config.xml
     substituteInPlace $out/etc/clickhouse-server/config.xml \
-      --replace-fail "<errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>" "<console>1</console>"
-    substituteInPlace $out/etc/clickhouse-server/config.xml \
+      --replace-fail "<errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>" "<console>1</console>" \
       --replace-fail "<level>trace</level>" "<level>warning</level>"
   '';
 
   # Basic smoke test
   doCheck = true;
-  checkPhase = ''
+  checkPhase = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $NIX_BUILD_TOP/$sourceRoot/build/programs/clickhouse local --query 'SELECT 1' | grep 1
   '';
 

--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -159,7 +159,7 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   requiredSystemFeatures = [ "big-parallel" ];
 
   passthru = {
-    tests.clickhouse = nixosTests.clickhouse;
+    tests.clickhouse = if lts then nixosTests.clickhouse-lts else nixosTests.clickhouse;
 
     updateScript = nix-update-script {
       extraArgs = nixUpdateExtraArgs;

--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -63,65 +63,62 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   };
 
   strictDeps = true;
-  nativeBuildInputs = [
-    cmake
-    ninja
-    python3
-    perl
-    llvmPackages_19.lld
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isx86_64 [
-    nasm
-    yasm
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    llvmPackages_19.bintools
-    findutils
-    darwin.bootstrap_cmds
-  ]
-  ++ lib.optionals rustSupport [
-    rustc
-    cargo
-    rustPlatform.cargoSetupHook
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      ninja
+      python3
+      perl
+      llvmPackages_19.lld
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+      nasm
+      yasm
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      llvmPackages_19.bintools
+      findutils
+      darwin.bootstrap_cmds
+    ]
+    ++ lib.optionals rustSupport [
+      rustc
+      cargo
+      rustPlatform.cargoSetupHook
+    ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   dontCargoSetupPostUnpack = true;
 
-  postPatch = ''
-    patchShebangs src/
-    patchShebangs utils/
+  postPatch =
+    ''
+      patchShebangs src/
+      patchShebangs utils/
 
-    sed -i 's|/usr/bin/env perl|"${lib.getExe perl}"|' contrib/openssl-cmake/CMakeLists.txt
+      sed -i 's|/usr/bin/env perl|"${lib.getExe perl}"|' contrib/openssl-cmake/CMakeLists.txt
 
-    substituteInPlace src/Storages/System/StorageSystemLicenses.sh \
-      --replace-fail '$(git rev-parse --show-toplevel)' "$NIX_BUILD_TOP/$sourceRoot"
-    substituteInPlace utils/check-style/check-ungrouped-includes.sh \
-      --replace-fail '$(git rev-parse --show-toplevel)' "$NIX_BUILD_TOP/$sourceRoot"
-    substituteInPlace utils/list-licenses/list-licenses.sh \
-      --replace-fail '$(git rev-parse --show-toplevel)' "$NIX_BUILD_TOP/$sourceRoot"
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    sed -i 's|gfind|find|' cmake/tools.cmake
-    sed -i 's|ggrep|grep|' cmake/tools.cmake
+      substituteInPlace src/Storages/System/StorageSystemLicenses.sh utils/list-licenses/list-licenses.sh \
+        --replace-fail '$(git rev-parse --show-toplevel)' "$NIX_BUILD_TOP/$sourceRoot"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace cmake/tools.cmake \
+        --replace-fail 'gfind' 'find' \
+        --replace-fail 'ggrep' 'grep' \
+        --replace-fail '--ld-path=''${LLD_PATH}' '-fuse-ld=lld'
+    ''
+    + lib.optionalString rustSupport ''
+      cargoSetupPostPatchHook() { true; }
+    '';
 
-    # Make sure Darwin invokes lld.ld64 not lld.
-    substituteInPlace cmake/tools.cmake \
-      --replace '--ld-path=''${LLD_PATH}' '-fuse-ld=lld'
-  ''
-  + lib.optionalString rustSupport ''
-    cargoSetupPostPatchHook() { true; }
-  '';
-
-  cmakeFlags = [
-    "-DENABLE_TESTS=OFF"
-    "-DENABLE_DELTA_KERNEL_RS=0"
-    "-DCOMPILER_CACHE=disabled"
-  ]
-  ++ lib.optional (
-    stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64
-  ) "-DNO_ARMV81_OR_HIGHER=1";
+  cmakeFlags =
+    [
+      "-DENABLE_TESTS=OFF"
+      "-DENABLE_DELTA_KERNEL_RS=0"
+      "-DCOMPILER_CACHE=disabled"
+    ]
+    ++ lib.optional (
+      stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64
+    ) "-DNO_ARMV81_OR_HIGHER=1";
 
   env = {
     CARGO_HOME = "$PWD/../.cargo/";

--- a/pkgs/by-name/cl/clickhouse/generic.nix
+++ b/pkgs/by-name/cl/clickhouse/generic.nix
@@ -94,8 +94,12 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
 
     sed -i 's|/usr/bin/env perl|"${lib.getExe perl}"|' contrib/openssl-cmake/CMakeLists.txt
 
-    substituteInPlace src/Storages/System/StorageSystemLicenses.sh utils/list-licenses/list-licenses.sh \
+    substituteInPlace utils/list-licenses/list-licenses.sh \
       --replace-fail '$(git rev-parse --show-toplevel)' "$NIX_BUILD_TOP/$sourceRoot"
+  ''
+  + lib.optionalString (lib.versions.majorMinor version <= "25.6") ''
+    substituteInPlace src/Storages/System/StorageSystemLicenses.sh \
+       --replace-fail '$(git rev-parse --show-toplevel)' "$NIX_BUILD_TOP/$sourceRoot"
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace cmake/tools.cmake \

--- a/pkgs/by-name/cl/clickhouse/lts.nix
+++ b/pkgs/by-name/cl/clickhouse/lts.nix
@@ -2,4 +2,10 @@ import ./generic.nix {
   version = "25.3.5.42-lts";
   hash = "sha256-LvGl9XJK6Emt7HnV/Orp7qEmJSr3TBJZtApL6GrWIMg=";
   lts = true;
+  nixUpdateExtraArgs = [
+    "--version-regex"
+    "^v?(.*-lts)$"
+    "--override-filename"
+    "pkgs/by-name/cl/clickhouse/lts.nix"
+  ];
 }

--- a/pkgs/by-name/cl/clickhouse/lts.nix
+++ b/pkgs/by-name/cl/clickhouse/lts.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.3.5.42-lts";
-  hash = "sha256-LvGl9XJK6Emt7HnV/Orp7qEmJSr3TBJZtApL6GrWIMg=";
+  version = "25.3.6.56-lts";
+  hash = "sha256-wpC6uw811IWImLWAatYbghp3aZ+esEEBFng6AHIesK4=";
   lts = true;
   nixUpdateExtraArgs = [
     "--version-regex"

--- a/pkgs/by-name/cl/clickhouse/lts.nix
+++ b/pkgs/by-name/cl/clickhouse/lts.nix
@@ -1,0 +1,5 @@
+import ./generic.nix {
+  version = "25.3.5.42-lts";
+  hash = "sha256-LvGl9XJK6Emt7HnV/Orp7qEmJSr3TBJZtApL6GrWIMg=";
+  lts = true;
+}

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,0 +1,5 @@
+import ./generic.nix {
+  version = "25.5.6.14-stable";
+  hash = "sha256-gaKozR/QvvyZ3v21XEZLHV2YrhEStKuuAdOjjkd3+uc";
+  lts = false;
+}

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.7.1.3997-stable";
-  hash = "sha256-XEVAQrANEIXim1MlOAYEmfwyomGrvsS/mbSKggMkr1k=";
+  version = "25.7.2.54-stable";
+  hash = "sha256-WwrElYPSgcQGGpJ0gUqVrynLQx/kQHHmrTsckiRFm4w=";
   lts = false;
   nixUpdateExtraArgs = [
     "--version-regex"

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.7.2.54-stable";
-  hash = "sha256-WwrElYPSgcQGGpJ0gUqVrynLQx/kQHHmrTsckiRFm4w=";
+  version = "25.7.4.11-stable";
+  hash = "sha256-SKDnnBdl9Rwc+ONH1chXAOFIwRmVG2l5cPEwpaDogzU=";
   lts = false;
   nixUpdateExtraArgs = [
     "--version-regex"

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.5.6.14-stable";
-  hash = "sha256-gaKozR/QvvyZ3v21XEZLHV2YrhEStKuuAdOjjkd3+uc";
+  version = "25.6.3.116-stable";
+  hash = "sha256-gWvlVhW9RtSj50+Mzlvk0aTNdl0hS9vHzveocTvuazc=";
   lts = false;
   nixUpdateExtraArgs = [
     "--version-regex"

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -2,4 +2,10 @@ import ./generic.nix {
   version = "25.5.6.14-stable";
   hash = "sha256-gaKozR/QvvyZ3v21XEZLHV2YrhEStKuuAdOjjkd3+uc";
   lts = false;
+  nixUpdateExtraArgs = [
+    "--version-regex"
+    "^v?(.*-stable)$"
+    "--override-filename"
+    "pkgs/by-name/cl/clickhouse/package.nix"
+  ];
 }

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.6.3.116-stable";
-  hash = "sha256-gWvlVhW9RtSj50+Mzlvk0aTNdl0hS9vHzveocTvuazc=";
+  version = "25.6.4.12-stable";
+  hash = "sha256-37huf+eOMOUJg7pyoFPzCTlUilI3wnq8D6tcrhC0NUE=";
   lts = false;
   nixUpdateExtraArgs = [
     "--version-regex"

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.6.4.12-stable";
-  hash = "sha256-37huf+eOMOUJg7pyoFPzCTlUilI3wnq8D6tcrhC0NUE=";
+  version = "25.6.5.41-stable";
+  hash = "sha256-NIt5JCKXSnJRSjCZskMvRhN8qwCB0aKinOCKXqq5DF0=";
   lts = false;
   nixUpdateExtraArgs = [
     "--version-regex"

--- a/pkgs/by-name/cl/clickhouse/package.nix
+++ b/pkgs/by-name/cl/clickhouse/package.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
-  version = "25.6.5.41-stable";
-  hash = "sha256-NIt5JCKXSnJRSjCZskMvRhN8qwCB0aKinOCKXqq5DF0=";
+  version = "25.7.1.3997-stable";
+  hash = "sha256-XEVAQrANEIXim1MlOAYEmfwyomGrvsS/mbSKggMkr1k=";
   lts = false;
   nixUpdateExtraArgs = [
     "--version-regex"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2637,6 +2637,8 @@ with pkgs;
 
   ckb-next = libsForQt5.callPackage ../tools/misc/ckb-next { };
 
+  clickhouse-lts = callPackage ../by-name/cl/clickhouse/lts.nix { };
+
   cmdpack = callPackages ../tools/misc/cmdpack { };
 
   cocoapods = callPackage ../development/tools/cocoapods { };


### PR DESCRIPTION
Init `clickhouse-stable` at `25.5.6.14`, enable `nix-update-script`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
