### PR TITLE
slack: 4.42.120 -> 4.44.65

### DIFF
--- a/pkgs/by-name/sl/slack/package.nix
+++ b/pkgs/by-name/sl/slack/package.nix
@@ -46,14 +46,14 @@ let
 
   pname = "slack";
 
-  x86_64-darwin-version = "4.42.120";
-  x86_64-darwin-sha256 = "17sam5z3f1x75ay9vm34is64r18h26lr03qrdw5ajvcgdvdqyanp";
+  x86_64-darwin-version = "4.44.65";
+  x86_64-darwin-sha256 = "14y33ds3ncgxwlcb0gvi8pfxm7ppfipzalg63x5vnj05q9wn8lby";
 
-  x86_64-linux-version = "4.42.120";
-  x86_64-linux-sha256 = "1wmxd7z742z3xvq85293kwr99vvdvczv6q32l7mrm2vp9gjyr0pz";
+  x86_64-linux-version = "4.44.65";
+  x86_64-linux-sha256 = "ca6ce66685e5897db0b19a79275e9c244693ebaf64a6b2f12a79a2b442d5be47";
 
-  aarch64-darwin-version = "4.42.120";
-  aarch64-darwin-sha256 = "0cry2f2pwkyn6rhdh7q9lfxcibz6izlwfhif3pqjv8pishn21afp";
+  aarch64-darwin-version = "4.44.65";
+  aarch64-darwin-sha256 = "1gdvvz2dd06din31qparwhnghjcxmvrc2zll09b3lfhr11im7888";
 
   version =
     {


### PR DESCRIPTION
Changelog: https://slack.com/release-notes

The latest Mac release notes mention a security update, but the latest Linux changelog still sits at `4.43.52` :shrug:. The `.deb` is already available for the newer version.

Tested working on `x86_64-linux` on wayland (sway).

Closes: https://github.com/NixOS/nixpkgs/pull/404906

Hashes for darwin versions obtained manually using:
```
nix-prefetch-url https://downloads.slack-edge.com/desktop-releases/mac/universal/4.44.65/Slack-4.44.65-macOS.dmg

nix-prefetch-url https://downloads.slack-edge.com/desktop-releases/mac/arm64/4.44.65/Slack-4.44.65-macOS.dmg
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
