### PR TITLE
qt6.qtwebengine: fix build

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -7,6 +7,7 @@
   buildPackages,
   bison,
   coreutils,
+  fetchpatch2,
   flex,
   git,
   gperf,
@@ -100,20 +101,30 @@ qtModule {
   # which cannot be set at the same time as -Wformat-security
   hardeningDisable = [ "format" ];
 
-  patches = [
-    # Don't assume /usr/share/X11, and also respect the XKB_CONFIG_ROOT
-    # environment variable, since NixOS relies on it working.
-    # See https://github.com/NixOS/nixpkgs/issues/226484 for more context.
-    ./xkb-includes.patch
+  patches =
+    [
+      # Don't assume /usr/share/X11, and also respect the XKB_CONFIG_ROOT
+      # environment variable, since NixOS relies on it working.
+      # See https://github.com/NixOS/nixpkgs/issues/226484 for more context.
+      ./xkb-includes.patch
 
-    ./link-pulseaudio.patch
+      ./link-pulseaudio.patch
 
-    # Override locales install path so they go to QtWebEngine's $out
-    ./locales-path.patch
+      # Override locales install path so they go to QtWebEngine's $out
+      ./locales-path.patch
 
-    # Reproducibility QTBUG-136068
-    ./gn-object-sorted.patch
-  ];
+      # Reproducibility QTBUG-136068
+      ./gn-object-sorted.patch
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      # https://chromium-review.googlesource.com/c/chromium/src/+/6445471
+      (fetchpatch2 {
+        url = "https://github.com/chromium/chromium/commit/f8f21fb4aa01f75acbb12abf5ea8c263c6817141.patch?full_index=1";
+        stripLen = 1;
+        extraPrefix = "src/3rdparty/chromium/";
+        hash = "sha256-wcby9uD8xb4re9+s+rdl1hcpxDcHxuI68vUNAC7Baas=";
+      })
+    ];
 
   postPatch =
     ''


### PR DESCRIPTION
This backports a upstream patch: https://chromium-review.googlesource.com/c/chromium/src/+/6445471

Related hydra jobs:
- failed aarch64-darwin build: https://hydra.nixos.org/build/300503841/nixlog/2
- x86_64-linux build with warnings: https://hydra.nixos.org/build/300075625/nixlog/1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
