### PR TITLE
python3Packages.datadog: 0.51.0 -> 0.52.0

### DIFF
--- a/pkgs/development/python-modules/datadog/default.nix
+++ b/pkgs/development/python-modules/datadog/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenvNoCC,
   buildPythonPackage,
   fetchFromGitHub,
   pythonAtLeast,
@@ -22,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "datadog";
-  version = "0.51.0";
+  version = "0.52.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "DataDog";
     repo = "datadogpy";
     tag = "v${version}";
-    hash = "sha256-DIuKawqOzth8XYF+M3fYm2kMeo3UbfS34/Qa4Y9V1h8=";
+    hash = "sha256-CmSUbqctElk9sCyQAL+SKqJBpT1vlpmp6mEX6HWN8Po=";
   };
 
   build-system = [ hatchling ];
@@ -65,10 +66,17 @@ buildPythonPackage rec {
       "test_timed"
       "test_timed_in_ms"
       "test_timed_start_stop_calls"
+
+      # OSError: AF_UNIX path too long
+      "test_socket_connection"
     ]
     ++ lib.optionals (pythonAtLeast "3.13") [
       # https://github.com/DataDog/datadogpy/issues/880
       "test_timed_coroutine"
+    ]
+    ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+      # PermissionError: [Errno 1] Operation not permitted
+      "test_dedicated_uds_telemetry_dest"
     ];
 
   pythonImportsCheck = [ "datadog" ];
@@ -76,7 +84,7 @@ buildPythonPackage rec {
   meta = {
     description = "Datadog Python library";
     homepage = "https://github.com/DataDog/datadogpy";
-    changelog = "https://github.com/DataDog/datadogpy/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/DataDog/datadogpy/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.sarahec ];
   };


### PR DESCRIPTION
changelog: https://github.com/DataDog/datadogpy/releases/tag/v0.52.0
diff: https://github.com/DataDog/datadogpy/compare/v0.51.0...v0.52.0

Supersedes #423756 by disabling a broken test (`OSError: AF_UNIX path too long` due to the `build-dir` relocation in the Darwin builder).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
