### PR TITLE
python3Packages.conda: 25.1.0 -> 25.5.1

### DIFF
--- a/pkgs/development/python-modules/conda-libmamba-solver/default.nix
+++ b/pkgs/development/python-modules/conda-libmamba-solver/default.nix
@@ -5,6 +5,7 @@
   hatchling,
   hatch-vcs,
   boltons,
+  libmambapy,
 }:
 buildPythonPackage rec {
   pname = "conda-libmamba-solver";
@@ -26,6 +27,7 @@ buildPythonPackage rec {
 
   dependencies = [
     boltons
+    libmambapy
   ];
 
   # this package depends on conda for the import to run successfully, but conda depends on this package to execute.

--- a/pkgs/development/python-modules/conda/0001-conda_exe.patch
+++ b/pkgs/development/python-modules/conda/0001-conda_exe.patch
@@ -1,15 +1,17 @@
+diff --git a/conda/base/context.py b/conda/base/context.py
+index 34a5e6495..ac017f48b 100644
 --- a/conda/base/context.py
 +++ b/conda/base/context.py
-@@ -754,7 +754,7 @@
-
+@@ -826,7 +826,7 @@ class Context(Configuration):
+ 
      @property
-     def conda_prefix(self):
+     def conda_prefix(self) -> PathType:
 -        return abspath(sys.prefix)
 +        return expand("~/.conda")
-
+ 
      @property
      @deprecated(
-@@ -787,27 +787,17 @@
+@@ -858,25 +858,17 @@ class Context(Configuration):
          The vars can refer to each other if necessary since the dict is ordered.
          None means unset it.
          """
@@ -26,12 +28,10 @@
 -            }
 -        else:
 -            exe = "conda.exe" if on_win else "conda"
--            # I was going to use None to indicate a variable to unset, but that gets tricky with
--            # error-on-undefined.
 -            return {
 -                "CONDA_EXE": os.path.join(sys.prefix, BIN_DIRECTORY, exe),
--                "_CE_M": "",
--                "_CE_CONDA": "",
+-                "_CE_M": None,
+-                "_CE_CONDA": None,
 -                "CONDA_PYTHON_EXE": sys.executable,
 -            }
 +        import sys
@@ -45,6 +45,6 @@
 +            "_CE_CONDA": "conda",
 +            "CONDA_PYTHON_EXE": sys.executable,
 +        }
-
+ 
      @memoizedproperty
-     def channel_alias(self):
+     def channel_alias(self) -> Channel:

--- a/pkgs/development/python-modules/conda/default.nix
+++ b/pkgs/development/python-modules/conda/default.nix
@@ -28,7 +28,7 @@
 buildPythonPackage rec {
   __structuredAttrs = true;
   pname = "conda";
-  version = "25.1.0";
+  version = "25.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "conda";
     repo = "conda";
     tag = version;
-    hash = "sha256-dFj9ob9RRmeaaVDJeDOVLe06fBkCGEWhavLFKytJ8Mo=";
+    hash = "sha256-BHy0t+5jz1WdSElCQBgFh5VJC3iIYelS01iQeQByr+0=";
   };
 
   build-system = [


### PR DESCRIPTION
Closes #423863

Diff: https://github.com/conda/conda/compare/25.1.0..25.5.1

Conda 25.1.0 is incompatible with python3.13, so I have bumped it and updated the patch.

There was also a warning about `conda-libmamba-solver` missing a dep, so I have added it:
```
Error while loading conda entry point: conda-libmamba-solver (No module named 'libmambapy')
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
