### PR TITLE
wasmtime: copy nested c-api header files

### DIFF
--- a/pkgs/by-name/wa/wasmtime/package.nix
+++ b/pkgs/by-name/wa/wasmtime/package.nix
@@ -59,14 +59,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       rm -r ''${!outputLib}/lib
 
       # copy the build.rs generated c-api headers
-      install -d -m0755 $dev/include/wasmtime
       # https://github.com/rust-lang/cargo/issues/9661
-      install -m0644 \
-        target/${cargoShortTarget}/release/build/wasmtime-c-api-impl-*/out/include/*.h \
-        $dev/include
-      install -m0644 \
-        target/${cargoShortTarget}/release/build/wasmtime-c-api-impl-*/out/include/wasmtime/*.h \
-        $dev/include/wasmtime
+      cp -r target/${cargoShortTarget}/release/build/wasmtime-c-api-impl-*/out/include $dev/include
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       install_name_tool -id \


### PR DESCRIPTION
Kind of a follow-up for #394859 discovered while working on #394870 (cherry picked from that PR).

There seem to be new header files in nested directories, which weren't copied with the previous `install` command:
```
/nix/store/pppaqaxlqk3hxs0cgmllqbla9kf453py-wasmtime-33.0.0-dev/include
├── wasmtime
│   ├── component
│   │   ├── component.h
│   │   ├── func.h
│   │   ├── instance.h
│   │   └── linker.h
│   ├── types
│   │   ├── export.hh
│   │   ├── extern.hh
│   │   ├── func.hh
│   │   ├── global.hh
│   │   ├── import.hh
│   │   ├── memory.hh
│   │   ├── table.hh
│   │   └── val.hh
│   ├── ...
```

Without these files compilation fails with
```
In file included from /nix/store/aqwddz62ih5ja7kh3dzs6n1qjpdhcvjx-wasmtime-33.0.0-dev/include/wasmtime.h:207,
                 from /build/source/lib/src/wasm_store.c:17:
/nix/store/aqwddz62ih5ja7kh3dzs6n1qjpdhcvjx-wasmtime-33.0.0-dev/include/wasmtime/component.h:4:10: fatal error: wasmtime/component/component.h: No such file or directory
    4 | #include <wasmtime/component/component.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
