### PR TITLE
_1password-gui{,-beta}: 8.10.82 -> 8.11.0, 8.11.0-25.BETA -> 8.11.2-18.BETA

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.10.82",
+      "version": "8.11.0",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.82.x64.tar.gz",
-          "hash": "sha256-/mpp+HRQO7Xu+faYUzq00LxFrDRTod7Wvro3IoVGFAg="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.11.0.x64.tar.gz",
+          "hash": "sha256-aE7AQPzgMNZh++HOFduT4c7qipEvjUdQ9sBH8epuXeE="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.82.arm64.tar.gz",
-          "hash": "sha256-DiZVlq0xVGeCh6x5Bt8KP7B0iC15prvQrd9dnAmjWCI="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.11.0.arm64.tar.gz",
+          "hash": "sha256-5jmMolrISZaoqsGEYhsTxlKgAZk+RdVUOBMQDIn9nFM="
         }
       }
     },
     "darwin": {
-      "version": "8.10.82",
+      "version": "8.11.0",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.82-x86_64.zip",
-          "hash": "sha256-LATm0OcX+i02X3byaKQA32PpOXDyQFzyJVOgNzgtfYM="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.0-x86_64.zip",
+          "hash": "sha256-bZoX7mxh7JqYKgPQGUjrWEFYKGjl7dzhpL/CIt5IY00="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.10.82-aarch64.zip",
-          "hash": "sha256-uXtXDfCE+CFaOXqpSEKh2x7lzeYOhrHoH017NzNS2p8="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.0-aarch64.zip",
+          "hash": "sha256-I88nfsb1xsErgafmo0qqSHcalhTMkGH9m0bMWAGlad8="
         }
       }
     }

--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -29,31 +29,30 @@
   },
   "beta": {
     "linux": {
-      "version": "8.11.0-25.BETA",
+      "version": "8.11.2-18.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.11.0-25.BETA.x64.tar.gz",
-          "hash": "sha256-TMVquYVZPxJGxn7vEwhSsD5eebM+9xovdBB/5/y2ygc="
+          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.11.2-18.BETA.x64.tar.gz",
+          "hash": "sha256-/8sXdF1JmJX3kFOn9SCRz6Cr/ZldzHfhvq1oJlV19v8="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.11.0-25.BETA.arm64.tar.gz",
-          "hash": "sha256-eV6gTKbTWkC1Kg5vyGf4tgiBxOQ5ZOKha03PSTGVE9Q="
+          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.11.2-18.BETA.arm64.tar.gz",
+          "hash": "sha256-bDRJAU6LgkoHp1Fi/KQPm/Fe/BkGt7V+dGVnLh9awcs="
         }
       }
     },
     "darwin": {
-      "version": "8.11.0-25.BETA",
+      "version": "8.11.2-18.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.0-25.BETA-x86_64.zip",
-          "hash": "sha256-9cE31VdYoxFnxsO0jOLQsXA2SEBUdy7ABvUIfsGEE04="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.2-18.BETA-x86_64.zip",
+          "hash": "sha256-oZqrNB49SR8UWh8qXnKi/xlT/b2YUxPCLpz2tjwzzuw="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.11.0-25.BETA-aarch64.zip",
-          "hash": "sha256-bxBoJZSt7znOhiIu20Nuq5MzNyS1HzLkNyt/cgY1dBg="
+          "url": "https://downloads.1password.com/mac/1Password-8.11.2-18.BETA-aarch64.zip",
+          "hash": "sha256-+EXrqEe3cDp9Ez8iug53HhSTtz0tDYsUXHAsXtRHGH4="
         }
       }
     }
   }
 }
-


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
