### PR TITLE
nixos/espanso: provide required capabilities for espanso-wayland

### DIFF
--- a/nixos/modules/services/desktops/espanso.nix
+++ b/nixos/modules/services/desktops/espanso.nix
@@ -32,7 +32,6 @@ in
       source = lib.getExe (
         pkgs.espanso-wayland.override { securityWrapperPath = config.security.wrapperDir; }
       );
-
     };
     systemd.user.services.espanso = {
       description = "Espanso daemon";

--- a/nixos/modules/services/desktops/espanso.nix
+++ b/nixos/modules/services/desktops/espanso.nix
@@ -25,10 +25,24 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    security.wrappers.espanso = lib.mkIf (cfg.package.waylandSupport or false) {
+      capabilities = "cap_dac_override+p";
+      owner = "root";
+      group = "root";
+      source = lib.getExe (
+        pkgs.espanso-wayland.override { securityWrapperPath = config.security.wrapperDir; }
+      );
+
+    };
     systemd.user.services.espanso = {
       description = "Espanso daemon";
       serviceConfig = {
-        ExecStart = "${lib.getExe cfg.package} daemon";
+        ExecStart = "${
+          if (cfg.package.waylandSupport or false) then
+            "${config.security.wrapperDir}/espanso"
+          else
+            lib.getExe cfg.package
+        } daemon";
         Restart = "on-failure";
       };
       wantedBy = [ "default.target" ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -523,6 +523,10 @@ in
   ergo = runTest ./ergo.nix;
   ergochat = runTest ./ergochat.nix;
   ersatztv = handleTest ./ersatztv.nix { };
+  espanso = import ./espanso.nix {
+    inherit (pkgs) lib;
+    inherit runTest;
+  };
   esphome = runTest ./esphome.nix;
   etc = pkgs.callPackage ../modules/system/etc/test.nix { inherit evalMinimalConfig; };
   etcd = import ./etcd/default.nix { inherit pkgs runTest; };

--- a/nixos/tests/espanso.nix
+++ b/nixos/tests/espanso.nix
@@ -1,0 +1,86 @@
+{ lib, runTest }:
+let
+  makeTest =
+    conf:
+    runTest {
+      name = "espanso";
+      meta.maintainers = with lib.maintainers; [ n8henrie ];
+
+      nodes.machine =
+        let
+          base =
+            { pkgs, config, ... }:
+            {
+              imports = [ ./common/user-account.nix ];
+              services.espanso.enable = true;
+              system.activationScripts.espanso-config = {
+                deps = [ "users" ];
+                text =
+                  let
+                    confdir = "${config.users.users.alice.home}/.config/espanso";
+                    espanso_conf =
+                      let
+                        settingsFormat = pkgs.formats.yaml { };
+                      in
+                      settingsFormat.generate "base.yaml" {
+                        matches = [
+                          {
+                            trigger = ":nixostest";
+                            replace = "My NixOS Test Passed!";
+                          }
+                        ];
+                      };
+                  in
+                  ''
+                    mkdir -p ${confdir}/{config,match}
+                    touch ${confdir}/config/default.yml
+                    cp ${espanso_conf} ${confdir}/match/base.yml
+                    chown -R ${config.users.users.alice.name} ${confdir}
+                  '';
+              };
+            };
+        in
+        lib.mkMerge [
+          base
+          conf
+        ];
+
+      enableOCR = true;
+      testScript = ''
+        machine.wait_for_unit("graphical.target")
+        machine.wait_for_text("Espanso is running!")
+        machine.send_chars(":nixostest")
+        machine.wait_for_text("My NixOS Test Passed!")
+      '';
+    };
+in
+{
+  x11 = makeTest {
+    imports = [ ./common/x11.nix ];
+    test-support.displayManager.auto.user = "alice";
+    users.users.alice.extraGroups = [ "input" ];
+  };
+  wayland = makeTest (
+    { pkgs, config, ... }:
+    {
+      programs.sway.enable = true;
+      services = {
+        greetd =
+          let
+            initial_session = {
+              user = config.users.users.alice.name;
+              command = lib.getExe pkgs.sway;
+            };
+          in
+          {
+            enable = true;
+            settings = {
+              inherit initial_session;
+              default_session = initial_session;
+            };
+          };
+        espanso.package = pkgs.espanso-wayland;
+      };
+    }
+  );
+}

--- a/pkgs/by-name/es/espanso/package.nix
+++ b/pkgs/by-name/es/espanso/package.nix
@@ -123,6 +123,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       '';
 
   passthru = {
+    inherit waylandSupport;
     tests.version = testers.testVersion {
       package = finalAttrs.finalPackage;
       inherit (finalAttrs) version;


### PR DESCRIPTION
On wayland, espanso relies on capabilities for its worker process to function.

Unfortunately it forks itself using `current_exe()` to find the binary, which resolves to the capability-lacking binary in the store instead of a wrapped binary provided by `security.wrappers`.

Extensive discussion of the problem and alternative solutions in https://github.com/NixOS/nixpkgs/pull/328890.

As compared to that PR, which has not made much progress, this is a dramatically simpler approach that seems to work well.

Happy to incorporate constructive criticism, as I am not terribly familiar with `security.wrappers` and suspect there may be better ways to e.g. find the wrapped espanso, test for `pkgs.espanso-wayland`, etc.

Fixes https://github.com/NixOS/nixpkgs/issues/249364

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
