### PR TITLE
cloudflare-warp: add headless variant

### DIFF
--- a/pkgs/by-name/cl/cloudflare-warp/package.nix
+++ b/pkgs/by-name/cl/cloudflare-warp/package.nix
@@ -20,6 +20,7 @@
   jq,
   ripgrep,
   common-updater-scripts,
+  headless ? false,
 }:
 
 let
@@ -38,7 +39,7 @@ in
 stdenv.mkDerivation rec {
   inherit version;
 
-  pname = "cloudflare-warp";
+  pname = "cloudflare-warp" + lib.optionalString headless "-headless";
 
   src =
     sources.${stdenv.hostPlatform.system}
@@ -49,20 +50,24 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
     versionCheckHook
     makeWrapper
+  ]
+  ++ lib.optionals (!headless) [
     copyDesktopItems
     desktop-file-utils
   ];
 
   buildInputs = [
     dbus
-    gtk3
     libpcap
     openssl
     nss
     (lib.getLib stdenv.cc.cc)
+  ]
+  ++ lib.optionals (!headless) [
+    gtk3
   ];
 
-  desktopItems = [
+  desktopItems = lib.optionals (!headless) [
     (makeDesktopItem {
       name = "com.cloudflare.WarpCli";
       desktopName = "Cloudflare Zero Trust Team Enrollment";
@@ -93,22 +98,35 @@ stdenv.mkDerivation rec {
     mv lib/systemd/system $out/lib/systemd/
     substituteInPlace $out/lib/systemd/system/warp-svc.service \
       --replace-fail "ExecStart=" "ExecStart=$out"
-    substituteInPlace $out/lib/systemd/user/warp-taskbar.service \
-      --replace-fail "ExecStart=" "ExecStart=$out" \
-      --replace-fail "BindsTo=" "PartOf="
+    ${lib.optionalString (!headless) ''
+      substituteInPlace $out/lib/systemd/user/warp-taskbar.service \
+        --replace-fail "ExecStart=" "ExecStart=$out" \
+        --replace-fail "BindsTo=" "PartOf="
 
-    cat >>$out/lib/systemd/user/warp-taskbar.service <<EOF
+      cat >>$out/lib/systemd/user/warp-taskbar.service <<EOF
 
-    [Service]
-    BindReadOnlyPaths=$out:/usr:
-    EOF
+      [Service]
+      BindReadOnlyPaths=$out:/usr:
+      EOF
+    ''}
+    ${lib.optionalString headless ''
+      # For headless version, remove GUI components
+      rm $out/bin/warp-taskbar
+      rm -r $out/lib/systemd/user
+      rm -r $out/etc
+      rm -r $out/share/applications
+      rm -r $out/share/icons
+      rm -r $out/share/warp
+    ''}
 
     runHook postInstall
   '';
 
   postInstall = ''
     wrapProgram $out/bin/warp-svc --prefix PATH : ${lib.makeBinPath [ nftables ]}
-    wrapProgram $out/bin/warp-cli --prefix PATH : ${lib.makeBinPath [ desktop-file-utils ]}
+    ${lib.optionalString (!headless) ''
+      wrapProgram $out/bin/warp-cli --prefix PATH : ${lib.makeBinPath [ desktop-file-utils ]}
+    ''}
   '';
 
   doInstallCheck = true;
@@ -146,7 +164,9 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "Replaces the connection between your device and the Internet with a modern, optimized, protocol";
+    description =
+      "Replaces the connection between your device and the Internet with a modern, optimized, protocol"
+      + lib.optionalString headless " (headless version)";
     homepage = "https://pkg.cloudflareclient.com/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;


### PR DESCRIPTION
Add a `headless` variant of `cloudflare-warp`, which is useful for server environments that do not need the GUI components and dependencies.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
