### PR TITLE
factorio: allow configuring mod-list.json

### DIFF
--- a/nixos/modules/services/games/factorio.nix
+++ b/nixos/modules/services/games/factorio.nix
@@ -46,7 +46,7 @@ let
     lib.optionalString (
       list != [ ]
     ) "--${name}=${pkgs.writeText "${name}.json" (builtins.toJSON list)}";
-  modDir = pkgs.factorio-utils.mkModDirDrv cfg.mods cfg.mods-dat;
+  modDir = pkgs.factorio-utils.mkModDirDrv cfg.mods cfg.mods-dat cfg.mods-list;
 in
 {
   options = {
@@ -194,6 +194,14 @@ in
           Mods settings can be changed by specifying a dat file, in the [mod
           settings file
           format](https://wiki.factorio.com/Mod_settings_file_format).
+        '';
+      };
+      mods-list = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          Mods can be enabled and disabled by specifying a mod-list.json file.
+          Useful for disabling built-in mods.
         '';
       };
       game-name = lib.mkOption {

--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -21,6 +21,7 @@
   wayland,
 
   mods-dat ? null,
+  mods-list ? null,
   versionsJson ? ./versions.json,
   username ? "",
   token ? "", # get/reset token at https://factorio.com/profile
@@ -185,7 +186,7 @@ let
     fi
   '';
 
-  modDir = factorio-utils.mkModDirDrv mods mods-dat;
+  modDir = factorio-utils.mkModDirDrv mods mods-dat mods-list;
 
   base = with actual; {
     # remap -expansion to -space-age to better match the attr name in nixpkgs.

--- a/pkgs/by-name/fa/factorio/utils.nix
+++ b/pkgs/by-name/fa/factorio/utils.nix
@@ -15,7 +15,7 @@ let
 in
 {
   mkModDirDrv =
-    mods: modsDatFile: # a list of mod derivations
+    mods: modsDatFile: modsListFile: # a list of mod derivations
     let
       recursiveDeps = modDrv: [ modDrv ] ++ map recursiveDeps modDrv.deps;
       modDrvs = unique (flatten (map recursiveDeps mods));
@@ -34,6 +34,9 @@ in
         ''
         + (optionalString (modsDatFile != null) ''
           cp ${modsDatFile} $out/mod-settings.dat
+        '')
+        + (optionalString (modsListFile != null) ''
+          cp ${modsListFile} $out/mod-list.json
         '');
     };
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/392183 by adding an option to the factorio NixOS module to specify a custom `mod-list.json` file. This is particularly helpful for disabling built-in mods like `space-age` when playing with others without the DLC, or when using incompatible mods like Pyanodon's. 
```nix
  services.factorio = {
    # ...
    mods =
      let
        inherit (pkgs) lib;
        modDir = /home/username/factorio-mods;
        modList = lib.pipe modDir [
          builtins.readDir
          (lib.filterAttrs (k: v: v == "regular"))
          (lib.mapAttrsToList (k: v: k))
          (builtins.filter (lib.hasSuffix ".zip"))
        ];
        modToDrv = modFileName:
          pkgs.runCommand "copy-factorio-mods" {} ''
            mkdir $out
            cp ${modDir + "/${modFileName}"} $out/${modFileName}
          ''
          // { deps = []; };
      in
        builtins.map modToDrv modList;
    mods-dat = builtins.path {
      path = "/home/username/factorio-mods/mod-settings.dat";
      name = "mod-settings.dat";
    };
    # NEW:
    mods-list = builtins.path {
      path = "/home/username/factorio-mods/mod-list.json";
      name = "mod-list.json";
    };
  };
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
