### PR TITLE
emacsPackages.holo-layer: init at 0-unstable-2025-06-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24966,6 +24966,12 @@
     githubId = 5404976;
     name = "Tyler Hardin";
   };
+  thattemperature = {
+    name = "That Temperature";
+    email = "2719023332@qq.com";
+    github = "thattemperature";
+    githubId = 125476238;
+  };
   thblt = {
     name = "Thibault Polge";
     email = "thibault@thb.lt";

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/holo-layer/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/holo-layer/package.nix
@@ -1,0 +1,74 @@
+{
+  # Basic
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  # Python dependency
+  python3,
+  # Emacs dependencies
+  markdown-mode,
+  posframe,
+  # Updater
+  unstableGitUpdater,
+}:
+
+let
+
+  pythonPkgs =
+    ps: with ps; [
+      epc
+      inflect
+      pyqt6
+      pyqt6-sip
+      sexpdata
+      six
+      xlib
+    ];
+  pythonEnv = python3.withPackages pythonPkgs;
+
+in
+
+melpaBuild {
+
+  pname = "holo-layer";
+  version = "0-unstable-2025-06-13";
+
+  src = fetchFromGitHub {
+    owner = "manateelazycat";
+    repo = "holo-layer";
+    rev = "464b6996268a81fa3b524ced02a60fcc266f8965";
+    hash = "sha256-uTxfnhtDybWx+Na4fj5TJuZh+tKoNuSZ03IR9ErvI7s=";
+  };
+
+  packageRequires = [
+    markdown-mode
+    posframe
+  ];
+
+  postPatch = ''
+    substituteInPlace holo-layer.el \
+      --replace-fail "\"python3\"" \
+                     "\"${pythonEnv.interpreter}\""
+  '';
+
+  files = ''
+    ("*.el"
+     "*.py"
+     "icon_cache"
+     "plugin"
+     "resources"
+     "swaymsg-treefetch")
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Display and animation extension for Emacs";
+    homepage = "https://github.com/manateelazycat/holo-layer";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      thattemperature
+    ];
+  };
+
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
