### PR TITLE
action-validator: 0.6.0-unstable-2025-02-16 -> 0.7.1

### DIFF
--- a/pkgs/by-name/ac/action-validator/package.nix
+++ b/pkgs/by-name/ac/action-validator/package.nix
@@ -2,27 +2,24 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "action-validator";
-  version = "0.6.0-unstable-2025-02-16";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "mpalmer";
     repo = "action-validator";
-    rev = "2f8be1d2066eb3687496a156d00b4f1b3ea7b028";
-    hash = "sha256-QDnikgAfkrvn7/vnmgTQ5J8Ro2HZ6SVkp9cPUYgejqM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pqWowcc/3NHtVcNDZ+4opgtwttcKdUVoi4qkv56JvY4=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-FuJ5NzeZhfN312wK5Q1DgIXUAN6hqxu/1BhGqasbdS8=";
+  cargoHash = "sha256-w6qC4gJ06TfoQl2WD8lgOxSxUWyG6Z8ma9mUvvYlkTU=";
 
-  passthru.updateScript = unstableGitUpdater {
-    tagPrefix = "v";
-    branch = "main";
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Tool to validate GitHub Action and Workflow YAML files";
@@ -31,4 +28,4 @@ rustPlatform.buildRustPackage {
     mainProgram = "action-validator";
     maintainers = with lib.maintainers; [ thiagokokada ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/mpalmer/action-validator/compare/2f8be1d2066eb3687496a156d00b4f1b3ea7b028...v0.7.1

`unstableGitUpdater` doesn't update `cargoHash` by itself https://nixpkgs-update-logs.nix-community.org/action-validator/2025-07-06.log. I forgot to add the necessary logic while addressing https://github.com/NixOS/nixpkgs/pull/403812.

Adding `extraArgs = [ "--version=branch" ];` to the `nix-update-script` will fix this.
But the upstream repository frequently updates its versions in these days.
So, I'm switching back to the stable version in this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
