### PR TITLE
lima, lima-additional-guestagents: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/by-name/li/lima-additional-guestagents/package.nix
+++ b/pkgs/by-name/li/lima-additional-guestagents/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "lima-additional-guestagents";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "lima-vm";
     repo = "lima";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vmn5AQpFbugFOmeiPUNMkPkgV1cZSR3nli90tdFmF0A";
+    hash = "sha256-vrYsIYikoN4D3bxu/JTb9lMRcL5k9S6T473dl58SDW0=";
   };
 
-  vendorHash = "sha256-1+jWEZ4VvVjJ7tSL4vlkCrWxCoSu8hiXefKSm3GExNs=";
+  vendorHash = "sha256-8S5tAL7GY7dxNdyC+WOrOZ+GfTKTSX84sG8WcSec2Os=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     apple-sdk_15

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -22,16 +22,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "lima";
-  version = "1.1.1";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "lima-vm";
     repo = "lima";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vmn5AQpFbugFOmeiPUNMkPkgV1cZSR3nli90tdFmF0A";
+    hash = "sha256-vrYsIYikoN4D3bxu/JTb9lMRcL5k9S6T473dl58SDW0=";
   };
 
-  vendorHash = "sha256-1+jWEZ4VvVjJ7tSL4vlkCrWxCoSu8hiXefKSm3GExNs=";
+  vendorHash = "sha256-8S5tAL7GY7dxNdyC+WOrOZ+GfTKTSX84sG8WcSec2Os=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
Diff: https://github.com/lima-vm/lima/compare/v1.1.1...v1.2.0
Release Note: https://github.com/lima-vm/lima/releases/tag/v1.2.0

As far as I know, there are two notable changes for nixpkgs users.

- nix-darwin: Fix https://github.com/NixOS/nixpkgs/issues/419596
- NixOS: Suppress `Unsupported option "gssapiauthentication"`: https://github.com/lima-vm/lima/issues/3198 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

<details><summary>tree diff</summary>

`lima-additional-guestagents` was not changed.

`lima` has been changed as below.

```diff
diff --git a/dev/fd/63 b/dev/fd/62
--- a/dev/fd/63
+++ b/dev/fd/62
@@ -1,4 +1,4 @@
-/nix/store/897fbzlz57m3lcpbdi21ylq2jkja2mpl-lima-1.1.1
+./result
 ├── bin
 │   ├── apptainer.lima
 │   ├── docker.lima
@@ -21,6 +21,7 @@
     │       ├── _default
     │       │   ├── mounts.yaml
     │       ├── _images
+    │       │   ├── almalinux-10.yaml
     │       │   ├── almalinux-8.yaml
     │       │   ├── almalinux-9.yaml
     │       │   ├── almalinux-kitten-10.yaml
@@ -37,6 +38,7 @@
     │       │   ├── opensuse-leap.yaml
     │       │   ├── oraclelinux-8.yaml
     │       │   ├── oraclelinux-9.yaml
+    │       │   ├── rocky-10.yaml
     │       │   ├── rocky-8.yaml
     │       │   ├── rocky-9.yaml
     │       │   ├── ubuntu-20.04.yaml
@@ -46,6 +48,7 @@
     │       │   ├── ubuntu-25.04.yaml
     │       │   ├── ubuntu-lts.yaml
     │       │   ├── ubuntu.yaml
+    │       ├── almalinux-10.yaml
     │       ├── almalinux-8.yaml
     │       ├── almalinux-9.yaml
     │       ├── almalinux-kitten-10.yaml
@@ -68,11 +71,15 @@
     │       ├── docker.yaml
     │       ├── experimental
     │       │   ├── alsa.yaml
+    │       │   ├── debian-13.yaml
     │       │   ├── debian-sid.yaml
+    │       │   ├── debian-testing.yaml
     │       │   ├── gentoo.yaml
     │       │   ├── opensuse-tumbleweed.yaml
     │       │   ├── rke2.yaml
     │       │   ├── u7s.yaml
+    │       │   ├── ubuntu-25.10.yaml
+    │       │   ├── ubuntu-next.yaml
     │       │   ├── vnc.yaml
     │       │   ├── wsl2.yaml
     │       ├── faasd.yaml
@@ -89,6 +96,7 @@
     │       ├── oraclelinux.yaml
     │       ├── podman-rootful.yaml
     │       ├── podman.yaml
+    │       ├── rocky-10.yaml
     │       ├── rocky-8.yaml
     │       ├── rocky-9.yaml
     │       ├── rocky.yaml
@@ -103,4 +111,4 @@
         ├── site-functions
             ├── _limactl
 
-14 directories, 90 files
+14 directories, 98 files
```

</details>

## Things done

<details><summary>package test</summary>

```console
> nix-build --attr pkgs.lima.passthru.tests
these 8 derivations will be built:
  /nix/store/9kiw43yarxiv3iwbry5h965ya6szr5js-actual.drv
  /nix/store/k5xw1wq3ya88b9yad2vrn3nw6xv4kns1-expected.drv
  /nix/store/a21qvls0qxarb06fjvymbdc4ll9i21ha-equal-contents-limactl-only-detects-host-s-architecture-guest-agent-by-default.drv
  /nix/store/y58ryrx5abi7r97vbc0lw0d6768ir71p-expected.drv
  /nix/store/di8fy3c44s24f68l54r6xzl49qza7z1y-lima-additional-guestagents-1.2.0.drv
  /nix/store/p9wjis4yksjzsw4lyc91c579l04l1dxk-lima-1.2.0.drv
  /nix/store/ys26gvwpxs27m7rjm747g2spzlfwvgzb-actual.drv
  /nix/store/cn6411lih3qj4nslmxqggg7s6fv5rrjm-equal-contents-limactl-also-detects-additional-guest-agents-if-specified.drv
these 38 paths will be fetched (24.26 MiB download, 190.03 MiB unpacked):
  /nix/store/792nxrcpxvln7jr6lpb49g8ffn24z5zz-binutils-2.44
  /nix/store/3m5zzshkd928px0p79xn5jlnly41q6sf-binutils-2.44-lib
  /nix/store/1ffrj6w0ndg32kfbc1p1m065a3lkbqcl-colordiff-1.0.21
  /nix/store/jchdjkygals5ddk90yrh2fhkgfjdnjqf-cpio-2.15
  /nix/store/qw6yic79mcsf20j5crzn9ipv74h53ymi-db-5.3.28-bin
  /nix/store/9wghpnrvmkc5x4p35cw5c9mkfv3sqbpr-diffoscope-300
  /nix/store/aqhi6hraraxfkk3pxhw45r78cdnybd4s-fontforge-20230101
  /nix/store/qdvys4b94hsb3d2aw2s7102m2p06d526-html2text-2.3.0
  /nix/store/dvy119mx8ab0yjxblaaippb2js6nbzkn-jq-1.8.0-dev
  /nix/store/izmkmf96697pgrva6ni1jwrizizfkh2g-libxmlb-0.3.22
  /nix/store/jhhb30d82n7p710bxrlhffrqdyb80l9v-lua-5.4.7
  /nix/store/k2kpv2qjf5qb03q0z6xcvg0lyz23ckdy-lz4-1.10.0
  /nix/store/vj2sww9iy2il07h6qhvd48sy44q9kq3p-lzip-1.25
  /nix/store/vlhqhr4wcskya525py22larjazcdz7r5-netpbm-11.10.5
  /nix/store/16l722rl0bv7jkzf2scm17xqfdgvx7b9-pgpdump-0.36
  /nix/store/f2f6frj5v9v2plxz1s1lh3mdkmib3lid-python3-3.13.4-env
  /nix/store/i7g4pgv2wb3zan6gnwj4vcccagrk1qzs-python3.13-defusedxml-0.8.0rc2
  /nix/store/dllh900xk2d7g2sy5gpg9gl8l40fhhhj-python3.13-editorconfig-0.17.0
  /nix/store/8rxhmsnh58hvqargi4kwsj4sgn5l4d90-python3.13-jsbeautifier-1.15.4
  /nix/store/0aagxw8rqa9jka1af08zmjbrznpv8vgn-python3.13-jsondiff-2.2.1
  /nix/store/q7y4h8z7xv35g5qcwkmsjc9f5rdsfny3-python3.13-libarchive-c-5.1
  /nix/store/0mq1sflvcb0ljw7v782v4mlcc1d3kxw1-python3.13-progressbar33-2.4
  /nix/store/48gdmwwkrwjvxkwdx0rdb1qf16k0hdan-python3.13-pypdf-5.7.0
  /nix/store/vs77nwl7y2gvrbksv81lwaj03p99ciif-python3.13-python-debian-1.0.1
  /nix/store/xcx9x2hnbx5mv1zdsj1ynigdb3vnkm03-python3.13-python-magic-0.4.27
  /nix/store/2mmpkyzl8fn2v21lp7b0lrn14jqm015z-python3.13-pyxattr-0.8.1
  /nix/store/1zn2d2igcz3a584xj769millwz58bccl-python3.13-pyyaml-6.0.2
  /nix/store/1jzascxfclrgksjdj84bf99c2m56jzk2-python3.13-setuptools-80.7.1
  /nix/store/y16ycpa0rm7j78xv7yf156clbryv573r-python3.13-six-1.17.0
  /nix/store/krc9kcwl8jlah8hy0v1m1hhbf3wqrqbh-python3.13-tlsh-3.19.1
  /nix/store/52p2ndxyljxlp6xq55g54k3mvplnlsha-rpm-4.20.1
  /nix/store/89d3hpw6zaji5i3g3x8r7r6fhrr8sn49-rpm-sequoia-1.8.0
  /nix/store/8das79p513b6j85yss3g4ambzr6wm3yh-sng-1.1.1
  /nix/store/zyznvm2c0f8y1ymw8y5dn2b0dcna09ah-squashfs-4.6.1
  /nix/store/s79p9a0g83askxqsq601lwh3464ps0hm-tinyxxd-1.3.7
  /nix/store/a22alszy3k7frx0cifv77qq99g9lnyc2-unzip-6.0
  /nix/store/zw4cxd8454p535xba1rpnx5xmrf3fvgb-xxd-tinyxxd-1.3.7
  /nix/store/a6yg470k2x5s9jzjv1n9hmb7kgn8c9l9-zip-3.0
building '/nix/store/k5xw1wq3ya88b9yad2vrn3nw6xv4kns1-expected.drv'...
building '/nix/store/y58ryrx5abi7r97vbc0lw0d6768ir71p-expected.drv'...
copying path '/nix/store/3m5zzshkd928px0p79xn5jlnly41q6sf-binutils-2.44-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/1ffrj6w0ndg32kfbc1p1m065a3lkbqcl-colordiff-1.0.21' from 'https://cache.nixos.org'...
copying path '/nix/store/jchdjkygals5ddk90yrh2fhkgfjdnjqf-cpio-2.15' from 'https://cache.nixos.org'...
copying path '/nix/store/qw6yic79mcsf20j5crzn9ipv74h53ymi-db-5.3.28-bin' from 'https://cache.nixos.org'...
copying path '/nix/store/qdvys4b94hsb3d2aw2s7102m2p06d526-html2text-2.3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/izmkmf96697pgrva6ni1jwrizizfkh2g-libxmlb-0.3.22' from 'https://cache.nixos.org'...
copying path '/nix/store/k2kpv2qjf5qb03q0z6xcvg0lyz23ckdy-lz4-1.10.0' from 'https://cache.nixos.org'...
copying path '/nix/store/vj2sww9iy2il07h6qhvd48sy44q9kq3p-lzip-1.25' from 'https://cache.nixos.org'...
copying path '/nix/store/16l722rl0bv7jkzf2scm17xqfdgvx7b9-pgpdump-0.36' from 'https://cache.nixos.org'...
copying path '/nix/store/i7g4pgv2wb3zan6gnwj4vcccagrk1qzs-python3.13-defusedxml-0.8.0rc2' from 'https://cache.nixos.org'...
copying path '/nix/store/dllh900xk2d7g2sy5gpg9gl8l40fhhhj-python3.13-editorconfig-0.17.0' from 'https://cache.nixos.org'...
copying path '/nix/store/0mq1sflvcb0ljw7v782v4mlcc1d3kxw1-python3.13-progressbar33-2.4' from 'https://cache.nixos.org'...
copying path '/nix/store/q7y4h8z7xv35g5qcwkmsjc9f5rdsfny3-python3.13-libarchive-c-5.1' from 'https://cache.nixos.org'...
copying path '/nix/store/48gdmwwkrwjvxkwdx0rdb1qf16k0hdan-python3.13-pypdf-5.7.0' from 'https://cache.nixos.org'...
copying path '/nix/store/vs77nwl7y2gvrbksv81lwaj03p99ciif-python3.13-python-debian-1.0.1' from 'https://cache.nixos.org'...
copying path '/nix/store/xcx9x2hnbx5mv1zdsj1ynigdb3vnkm03-python3.13-python-magic-0.4.27' from 'https://cache.nixos.org'...
building '/nix/store/di8fy3c44s24f68l54r6xzl49qza7z1y-lima-additional-guestagents-1.2.0.drv'...
copying path '/nix/store/dvy119mx8ab0yjxblaaippb2js6nbzkn-jq-1.8.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/jhhb30d82n7p710bxrlhffrqdyb80l9v-lua-5.4.7' from 'https://cache.nixos.org'...
copying path '/nix/store/vlhqhr4wcskya525py22larjazcdz7r5-netpbm-11.10.5' from 'https://cache.nixos.org'...
Running phase: unpackPhase
unpacking source archive /nix/store/3fb5l9s7c2qzdsw64hw2ask7yg2r1mx4-source
copying path '/nix/store/2mmpkyzl8fn2v21lp7b0lrn14jqm015z-python3.13-pyxattr-0.8.1' from 'https://cache.nixos.org'...
copying path '/nix/store/1zn2d2igcz3a584xj769millwz58bccl-python3.13-pyyaml-6.0.2' from 'https://cache.nixos.org'...
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
copying path '/nix/store/1jzascxfclrgksjdj84bf99c2m56jzk2-python3.13-setuptools-80.7.1' from 'https://cache.nixos.org'...
copying path '/nix/store/y16ycpa0rm7j78xv7yf156clbryv573r-python3.13-six-1.17.0' from 'https://cache.nixos.org'...
copying path '/nix/store/0aagxw8rqa9jka1af08zmjbrznpv8vgn-python3.13-jsondiff-2.2.1' from 'https://cache.nixos.org'...
copying path '/nix/store/krc9kcwl8jlah8hy0v1m1hhbf3wqrqbh-python3.13-tlsh-3.19.1' from 'https://cache.nixos.org'...
copying path '/nix/store/89d3hpw6zaji5i3g3x8r7r6fhrr8sn49-rpm-sequoia-1.8.0' from 'https://cache.nixos.org'...
copying path '/nix/store/zyznvm2c0f8y1ymw8y5dn2b0dcna09ah-squashfs-4.6.1' from 'https://cache.nixos.org'...
copying path '/nix/store/s79p9a0g83askxqsq601lwh3464ps0hm-tinyxxd-1.3.7' from 'https://cache.nixos.org'...
copying path '/nix/store/a22alszy3k7frx0cifv77qq99g9lnyc2-unzip-6.0' from 'https://cache.nixos.org'...
copying path '/nix/store/a6yg470k2x5s9jzjv1n9hmb7kgn8c9l9-zip-3.0' from 'https://cache.nixos.org'...
copying path '/nix/store/8rxhmsnh58hvqargi4kwsj4sgn5l4d90-python3.13-jsbeautifier-1.15.4' from 'https://cache.nixos.org'...
copying path '/nix/store/zw4cxd8454p535xba1rpnx5xmrf3fvgb-xxd-tinyxxd-1.3.7' from 'https://cache.nixos.org'...
building '/nix/store/9kiw43yarxiv3iwbry5h965ya6szr5js-actual.drv'...
copying path '/nix/store/f2f6frj5v9v2plxz1s1lh3mdkmib3lid-python3-3.13.4-env' from 'https://cache.nixos.org'...
copying path '/nix/store/52p2ndxyljxlp6xq55g54k3mvplnlsha-rpm-4.20.1' from 'https://cache.nixos.org'...
copying path '/nix/store/8das79p513b6j85yss3g4ambzr6wm3yh-sng-1.1.1' from 'https://cache.nixos.org'...
WARN[0000] unable to determine host timezone, falling back to default value
Running phase: buildPhase
WARN[0000] unable to determine host timezone, falling back to default value
make: git: No such file or directory
cp config.mk .config
make: git: No such file or directory
Guestagents are unzipped each time to check the build configuration; they may be gunzipped afterward.
copying path '/nix/store/aqhi6hraraxfkk3pxhw45r78cdnybd4s-fontforge-20230101' from 'https://cache.nixos.org'...
mkdir -p _output/share/lima
CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.0"  -o _output/share/lima/lima-guestagent.Linux-aarch64 ./cmd/lima-guestagent
copying path '/nix/store/792nxrcpxvln7jr6lpb49g8ffn24z5zz-binutils-2.44' from 'https://cache.nixos.org'...
copying path '/nix/store/9wghpnrvmkc5x4p35cw5c9mkfv3sqbpr-diffoscope-300' from 'https://cache.nixos.org'...
building '/nix/store/a21qvls0qxarb06fjvymbdc4ll9i21ha-equal-contents-limactl-only-detects-host-s-architecture-guest-agent-by-default.drv'...
Checking:
limactl only detects host's architecture guest agent by default
expected /nix/store/76d03nv2w28zgfzrxnnafv4d9n8c5fca-expected and actual /nix/store/lnig8q8qfckpcpv9yp1vpnr43wjw4fzb-actual match.
OK
chmod 644 _output/share/lima/lima-guestagent.Linux-aarch64
+ gzip _output/share/lima/lima-guestagent.Linux-aarch64
CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.0"  -o _output/share/lima/lima-guestagent.Linux-armv7l ./cmd/lima-guestagent
chmod 644 _output/share/lima/lima-guestagent.Linux-armv7l
+ gzip _output/share/lima/lima-guestagent.Linux-armv7l
CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.0"  -o _output/share/lima/lima-guestagent.Linux-ppc64le ./cmd/lima-guestagent
chmod 644 _output/share/lima/lima-guestagent.Linux-ppc64le
+ gzip _output/share/lima/lima-guestagent.Linux-ppc64le
CGO_ENABLED=0 GOOS=linux GOARCH=riscv64 go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.0"  -o _output/share/lima/lima-guestagent.Linux-riscv64 ./cmd/lima-guestagent
chmod 644 _output/share/lima/lima-guestagent.Linux-riscv64
+ gzip _output/share/lima/lima-guestagent.Linux-riscv64
CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.0"  -o _output/share/lima/lima-guestagent.Linux-s390x ./cmd/lima-guestagent
chmod 644 _output/share/lima/lima-guestagent.Linux-s390x
+ gzip _output/share/lima/lima-guestagent.Linux-s390x
buildPhase completed in 5 minutes 1 seconds
Running phase: checkPhase
/nix/store/nlqc1vm5psq2jjr5df6z25gkxkfqbvxx-stdenv-linux/setup: line 1766: getGoDirs: command not found
Running phase: installPhase
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/kawq03wfrqb2rkls0aq7q69nig3gq2m5-lima-additional-guestagents-1.2.0
checking for references to /build/ in /nix/store/kawq03wfrqb2rkls0aq7q69nig3gq2m5-lima-additional-guestagents-1.2.0...
patching script interpreter paths in /nix/store/kawq03wfrqb2rkls0aq7q69nig3gq2m5-lima-additional-guestagents-1.2.0
Running phase: installCheckPhase
building '/nix/store/p9wjis4yksjzsw4lyc91c579l04l1dxk-lima-1.2.0.drv'...
Using versionCheckHook
Running phase: unpackPhase
unpacking source archive /nix/store/3fb5l9s7c2qzdsw64hw2ask7yg2r1mx4-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: buildPhase
make: git: No such file or directory
cp config.mk .config
make: git: No such file or directory
Guestagents are unzipped each time to check the build configuration; they may be gunzipped afterward.
rm -rf _output
CGO_ENABLED=1 GOOS="linux" GOARCH="amd64" CC="cc" go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.0"  -o _output/bin/limactl ./cmd/limactl
cp -a cmd/lima _output/bin/lima
cp -a cmd/nerdctl.lima _output/bin/nerdctl.lima
cp -a cmd/apptainer.lima _output/bin/apptainer.lima
cp -a cmd/docker.lima _output/bin/docker.lima
cp -a cmd/podman.lima _output/bin/podman.lima
cp -a cmd/kubectl.lima _output/bin/kubectl.lima
mkdir -p _output/share/lima
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s=true -w -X github.com/lima-vm/lima/pkg/version.Version=v1.2.0"  -o _output/share/lima/lima-guestagent.Linux-x86_64 ./cmd/lima-guestagent
chmod 644 _output/share/lima/lima-guestagent.Linux-x86_64
+ gzip _output/share/lima/lima-guestagent.Linux-x86_64
mkdir -p _output/share/lima/templates
cp -aL templates/README.md _output/share/lima/templates/README.md
cp -aL templates/_default _output/share/lima/templates/_default
cp -aL templates/_images _output/share/lima/templates/_images
cp -aL templates/almalinux-10.yaml _output/share/lima/templates/almalinux-10.yaml
cp -aL templates/almalinux-8.yaml _output/share/lima/templates/almalinux-8.yaml
cp -aL templates/almalinux-9.yaml _output/share/lima/templates/almalinux-9.yaml
cp -aL templates/almalinux-kitten-10.yaml _output/share/lima/templates/almalinux-kitten-10.yaml
cp -aL templates/almalinux-kitten.yaml _output/share/lima/templates/almalinux-kitten.yaml
cp -aL templates/almalinux.yaml _output/share/lima/templates/almalinux.yaml
cp -aL templates/alpine-iso.yaml _output/share/lima/templates/alpine-iso.yaml
cp -aL templates/alpine.yaml _output/share/lima/templates/alpine.yaml
cp -aL templates/apptainer-rootful.yaml _output/share/lima/templates/apptainer-rootful.yaml
cp -aL templates/apptainer.yaml _output/share/lima/templates/apptainer.yaml
cp -aL templates/archlinux.yaml _output/share/lima/templates/archlinux.yaml
cp -aL templates/buildkit.yaml _output/share/lima/templates/buildkit.yaml
cp -aL templates/centos-stream-10.yaml _output/share/lima/templates/centos-stream-10.yaml
cp -aL templates/centos-stream-9.yaml _output/share/lima/templates/centos-stream-9.yaml
cp -aL templates/centos-stream.yaml _output/share/lima/templates/centos-stream.yaml
cp -aL templates/debian-11.yaml _output/share/lima/templates/debian-11.yaml
cp -aL templates/debian-12.yaml _output/share/lima/templates/debian-12.yaml
cp -aL templates/debian.yaml _output/share/lima/templates/debian.yaml
cp -aL templates/default.yaml _output/share/lima/templates/default.yaml
cp -aL templates/docker-rootful.yaml _output/share/lima/templates/docker-rootful.yaml
cp -aL templates/docker.yaml _output/share/lima/templates/docker.yaml
cp -aL templates/faasd.yaml _output/share/lima/templates/faasd.yaml
cp -aL templates/fedora-41.yaml _output/share/lima/templates/fedora-41.yaml
cp -aL templates/fedora-42.yaml _output/share/lima/templates/fedora-42.yaml
cp -aL templates/fedora.yaml _output/share/lima/templates/fedora.yaml
cp -aL templates/k3s.yaml _output/share/lima/templates/k3s.yaml
cp -aL templates/k8s.yaml _output/share/lima/templates/k8s.yaml
cp -aL templates/linuxbrew.yaml _output/share/lima/templates/linuxbrew.yaml
cp -aL templates/opensuse-leap.yaml _output/share/lima/templates/opensuse-leap.yaml
cp -aL templates/opensuse.yaml _output/share/lima/templates/opensuse.yaml
cp -aL templates/oraclelinux-8.yaml _output/share/lima/templates/oraclelinux-8.yaml
cp -aL templates/oraclelinux-9.yaml _output/share/lima/templates/oraclelinux-9.yaml
cp -aL templates/oraclelinux.yaml _output/share/lima/templates/oraclelinux.yaml
cp -aL templates/podman-rootful.yaml _output/share/lima/templates/podman-rootful.yaml
cp -aL templates/podman.yaml _output/share/lima/templates/podman.yaml
cp -aL templates/rocky-10.yaml _output/share/lima/templates/rocky-10.yaml
cp -aL templates/rocky-8.yaml _output/share/lima/templates/rocky-8.yaml
cp -aL templates/rocky-9.yaml _output/share/lima/templates/rocky-9.yaml
cp -aL templates/rocky.yaml _output/share/lima/templates/rocky.yaml
cp -aL templates/ubuntu-20.04.yaml _output/share/lima/templates/ubuntu-20.04.yaml
cp -aL templates/ubuntu-22.04.yaml _output/share/lima/templates/ubuntu-22.04.yaml
cp -aL templates/ubuntu-24.04.yaml _output/share/lima/templates/ubuntu-24.04.yaml
cp -aL templates/ubuntu-24.10.yaml _output/share/lima/templates/ubuntu-24.10.yaml
cp -aL templates/ubuntu-25.04.yaml _output/share/lima/templates/ubuntu-25.04.yaml
cp -aL templates/ubuntu-lts.yaml _output/share/lima/templates/ubuntu-lts.yaml
cp -aL templates/ubuntu.yaml _output/share/lima/templates/ubuntu.yaml
mkdir -p _output/share/lima/templates/experimental
cp -aL templates/experimental/alsa.yaml _output/share/lima/templates/experimental/alsa.yaml
cp -aL templates/experimental/debian-13.yaml _output/share/lima/templates/experimental/debian-13.yaml
cp -aL templates/experimental/debian-sid.yaml _output/share/lima/templates/experimental/debian-sid.yaml
cp -aL templates/experimental/debian-testing.yaml _output/share/lima/templates/experimental/debian-testing.yaml
cp -aL templates/experimental/gentoo.yaml _output/share/lima/templates/experimental/gentoo.yaml
cp -aL templates/experimental/opensuse-tumbleweed.yaml _output/share/lima/templates/experimental/opensuse-tumbleweed.yaml
cp -aL templates/experimental/rke2.yaml _output/share/lima/templates/experimental/rke2.yaml
cp -aL templates/experimental/u7s.yaml _output/share/lima/templates/experimental/u7s.yaml
cp -aL templates/experimental/ubuntu-25.10.yaml _output/share/lima/templates/experimental/ubuntu-25.10.yaml
cp -aL templates/experimental/ubuntu-next.yaml _output/share/lima/templates/experimental/ubuntu-next.yaml
cp -aL templates/experimental/vnc.yaml _output/share/lima/templates/experimental/vnc.yaml
cp -aL templates/experimental/wsl2.yaml _output/share/lima/templates/experimental/wsl2.yaml
buildPhase completed in 1 minutes 33 seconds
Running phase: checkPhase
/nix/store/nlqc1vm5psq2jjr5df6z25gkxkfqbvxx-stdenv-linux/setup: line 1766: getGoDirs: command not found
Running phase: installPhase
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/fx00r6l57dgsyavw93s7n20dryy5s461-lima-1.2.0
shrinking /nix/store/fx00r6l57dgsyavw93s7n20dryy5s461-lima-1.2.0/bin/.limactl-wrapped
checking for references to /build/ in /nix/store/fx00r6l57dgsyavw93s7n20dryy5s461-lima-1.2.0...
patching script interpreter paths in /nix/store/fx00r6l57dgsyavw93s7n20dryy5s461-lima-1.2.0
stripping (with command strip and flags -S -p) in  /nix/store/fx00r6l57dgsyavw93s7n20dryy5s461-lima-1.2.0/bin
Running phase: installCheckPhase
Executing versionCheckPhase
Successfully managed to find version 1.2.0 in the output of the command /nix/store/fx00r6l57dgsyavw93s7n20dryy5s461-lima-1.2.0/bin/limactl --version
limactl version 1.2.0
Finished versionCheckPhase
WARN[0000] unable to determine host timezone, falling back to default value
INFO[0000] "templates/default.yaml": OK
building '/nix/store/ys26gvwpxs27m7rjm747g2spzlfwvgzb-actual.drv'...
WARN[0000] unable to determine host timezone, falling back to default value
WARN[0000] unable to determine host timezone, falling back to default value
building '/nix/store/cn6411lih3qj4nslmxqggg7s6fv5rrjm-equal-contents-limactl-also-detects-additional-guest-agents-if-specified.drv'...
Checking:
limactl also detects additional guest agents if specified
expected /nix/store/sgzpwlm5zf4qjqy0m7qjnfx2k8mha3z4-expected and actual /nix/store/30rlv3ykgg21gycpyi9nnsgfm72gi33m-actual match.
OK
/nix/store/sch0ixcydbghsx184nn1afhv8k6jksag-equal-contents-limactl-also-detects-additional-guest-agents-if-specified
/nix/store/9qwwq56mc05zid0g8wibjb6pyqx2wydl-equal-contents-limactl-only-detects-host-s-architecture-guest-agent-by-default
```

</details>

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @AkinoKaede

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc