### PR TITLE
python3Packages.pyopensprinkler: init at 0.7.15, home-assistant-custom-components.hass-opensprinkler: init at 1.5.1

### DIFF
--- a/pkgs/development/python-modules/pyopensprinkler/default.nix
+++ b/pkgs/development/python-modules/pyopensprinkler/default.nix
@@ -5,8 +5,6 @@
   setuptools,
   aiohttp,
   backoff,
-  pytestCheckHook,
-  pytest-asyncio,
 }:
 
 buildPythonPackage rec {
@@ -28,10 +26,10 @@ buildPythonPackage rec {
     backoff
   ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-    pytest-asyncio
-  ];
+  # There are no unit tests upstream. The existing tests are unmaintained
+  # integration tests that run against a docker container.
+  # See <https://github.com/vinteo/py-opensprinkler/issues/4>.
+  doCheck = false;
 
   pythonImportsCheck = [ "pyopensprinkler" ];
 

--- a/pkgs/development/python-modules/pyopensprinkler/default.nix
+++ b/pkgs/development/python-modules/pyopensprinkler/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  backoff,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage rec {
+  pname = "pyopensprinkler";
+  version = "0.7.15";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "vinteo";
+    repo = "py-opensprinkler";
+    rev = version;
+    hash = "sha256-OfC3YYP2GeoiJh+3Ti35dmjtjg4xpN7KXPy/5BA3pPs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    backoff
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "pyopensprinkler" ];
+
+  meta = {
+    changelog = "https://github.com/vinteo/py-opensprinkler/releases/tag/${version}";
+    homepage = "https://github.com/vinteo/py-opensprinkler";
+    maintainers = with lib.maintainers; [ jfly ];
+    license = lib.licenses.mit;
+    description = "Python module for OpenSprinker API";
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/hass-opensprinkler/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/hass-opensprinkler/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  pyopensprinkler,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "vinteo";
+  domain = "opensprinkler";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "vinteo";
+    repo = "hass-opensprinkler";
+    tag = "v${version}";
+    hash = "sha256-cq9BCN/lvEZ5xPt4cLOFwNP36S+u0hQr4o2gGFz0IGo=";
+  };
+
+  dependencies = [
+    pyopensprinkler
+  ];
+
+  meta = {
+    changelog = "https://github.com/vinteo/hass-opensprinkler/releases/tag/${src.tag}";
+    description = "OpenSprinkler Integration for Home Assistant";
+    homepage = "https://github.com/vinteo/hass-opensprinkler";
+    maintainers = with lib.maintainers; [ jfly ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13340,6 +13340,8 @@ self: super: with self; {
 
   pyopengltk = callPackage ../development/python-modules/pyopengltk { };
 
+  pyopensprinkler = callPackage ../development/python-modules/pyopensprinkler { };
+
   pyopenssl = callPackage ../development/python-modules/pyopenssl { };
 
   pyopenuv = callPackage ../development/python-modules/pyopenuv { };


### PR DESCRIPTION
See title.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
