### PR TITLE
rundeck-cli: fix missing `java.logging` module

### DIFF
--- a/pkgs/by-name/ru/rundeck-cli/package.nix
+++ b/pkgs/by-name/ru/rundeck-cli/package.nix
@@ -11,6 +11,9 @@
 let
   jre11_minimal_headless = jre11_minimal.override {
     jdk = jdk11_headless;
+    modules = [
+      "java.logging"
+    ];
   };
 in
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
A couple of days ago, a PR has been merged to reduce the closure size of `rundeck-cli` by using `jre11_minimal`, see https://github.com/NixOS/nixpkgs/pull/422077.

Now, running `rundeck-cli` end up with:

```
❯ ./result/bin/rd run --follow -i {$JOB_ID} -- -Project {$PROJECT} -AppName {$APPNAME} -Limit {$LIMIT} -Version {$VERSION}
Exception in thread "main" java.lang.NoClassDefFoundError: java/util/logging/Logger
        at okhttp3.internal.concurrent.TaskRunner.<clinit>(TaskRunner.kt:311)
        at okhttp3.ConnectionPool.<init>(ConnectionPool.kt:41)
        at okhttp3.ConnectionPool.<init>(ConnectionPool.kt:47)
        at okhttp3.OkHttpClient$Builder.<init>(OkHttpClient.kt:471)
        at org.rundeck.client.RundeckClient$Builder.<init>(RundeckClient.java:87)
        at org.rundeck.client.RundeckClient.builder(RundeckClient.java:430)
        at org.rundeck.client.tool.Main.createClient(Main.java:495)
        at org.rundeck.client.tool.Main.createClient(Main.java:467)
        at org.rundeck.client.tool.Main$Rd.getClient(Main.java:394)
        at org.rundeck.client.tool.Main$Rd.getClient(Main.java:359)
        at org.rundeck.client.tool.commands.RdToolImpl.getClient(RdToolImpl.java:60)
        at org.rundeck.client.tool.commands.Run.call(Run.java:89)
        at org.rundeck.client.tool.commands.Run.call(Run.java:46)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.rundeck.client.tool.Main.main(Main.java:155)
Caused by: java.lang.ClassNotFoundException: java.util.logging.Logger
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
        ... 22 more
``` 

It looks like the `rundeck-cli` app require the `java.logging` module. Adding this module fix the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
