### PR TITLE
conftest: 0.59.0 -> 0.62.0

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -24,6 +24,8 @@
 
 - `gnome-keyring` no longer ships with an SSH agent anymore because it has been deprecated upstream. You should use `gcr_4` instead, which provides the same features. More information on why this was done can be found on [the relevant GCR upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67).
 
+- `conftest` since `0.60.0` has moved to use rego `v1` as default. To continue using `v0` use `--rego-version v0`. For more information about upgrading to Rego v1 syntax, see the [upstream docs](https://www.openpolicyagent.org/docs/latest/v0-upgrade/).
+
 - `tooling-language-server` has been renamed to `deputy` (both the package and binary), following the rename of the upstream project.
 
 - `lima` package now only includes the guest agent for the host's architecture by default. If your guest VM's architecture differs from your Lima host's, you'll need to enable the `lima-additional-guestagents` package by setting `withAdditionalGuestAgents = true` when overriding lima with this input.

--- a/pkgs/by-name/co/conftest/package.nix
+++ b/pkgs/by-name/co/conftest/package.nix
@@ -9,15 +9,15 @@
 
 buildGoModule (finalAttrs: {
   pname = "conftest";
-  version = "0.59.0";
+  version = "0.62.0";
 
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "conftest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bmZp1cPNTm6m30YxjlWdnfv2437nDXH+taDNFZ0OKIY=";
+    hash = "sha256-6LEzWvnTMSNdMzoStS8cfJxiYCo752e0Js185PGa0y4=";
   };
-  vendorHash = "sha256-aPvGbtAucb9OdcydO4dMLJrrM3XretPI7zyJULlm1fg=";
+  vendorHash = "sha256-Jf9Ui7iHyUZyDLuhI2tjFFawUfKLdcAJUlk79yAqckg=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/co/conftest/package.nix
+++ b/pkgs/by-name/co/conftest/package.nix
@@ -13,6 +13,8 @@ buildGoModule (finalAttrs: {
   pname = "conftest";
   version = "0.62.0";
 
+  __darwinAllowLocalNetworking = true; # required for tests
+
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "conftest";

--- a/pkgs/by-name/co/conftest/package.nix
+++ b/pkgs/by-name/co/conftest/package.nix
@@ -1,10 +1,12 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
   versionCheckHook,
   writableTmpDirAsHomeHook,
+  buildPackages,
 }:
 
 buildGoModule (finalAttrs: {
@@ -29,12 +31,20 @@ buildGoModule (finalAttrs: {
     installShellFiles
   ];
 
-  postInstall = ''
-    installShellCompletion --cmd conftest \
-      --bash <($out/bin/conftest completion bash) \
-      --fish <($out/bin/conftest completion fish) \
-      --zsh <($out/bin/conftest completion zsh)
-  '';
+  postInstall =
+    let
+      conftest =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          placeholder "out"
+        else
+          buildPackages.conftest;
+    in
+    ''
+      installShellCompletion --cmd conftest \
+        --bash <(${conftest}/bin/conftest completion bash) \
+        --fish <(${conftest}/bin/conftest completion fish) \
+        --zsh <(${conftest}/bin/conftest completion zsh)
+    '';
 
   nativeCheckInputs = [
     writableTmpDirAsHomeHook


### PR DESCRIPTION


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

conftest: 0.59.0 -> 0.62.0

Diff: https://github.com/open-policy-agent/conftest/compare/refs/tags/v0.59.0...refs/tags/v0.62.0

Changelog: https://github.com/open-policy-agent/conftest/releases/tag/v0.62.0

also allow for building completions when cross-compiling**

closes #405740

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
