### PR TITLE
maintainers: drop vidister

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26514,12 +26514,6 @@
     githubId = 123554;
     name = "Thibaut Smith";
   };
-  vidister = {
-    email = "v@vidister.de";
-    github = "vidister";
-    githubId = 11413574;
-    name = "Fiona Weber";
-  };
   vieta = {
     email = "xyzVieta@gmail.com";
     github = "yVieta";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1256,7 +1256,6 @@ with lib.maintainers;
   wdz = {
     members = [
       n0emis
-      vidister
       johannwagner
       yuka
     ];

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "TUI display manager";
     license = lib.licenses.wtfpl;
     homepage = "https://codeberg.org/AnErrupTion/ly";
-    maintainers = [ lib.maintainers.vidister ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "ly";
   };


### PR DESCRIPTION
Inactive since 2023, dropping according to the contribution guidelines: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#how-to-lose-maintainer-status

Also renamed their GitHub profile to "unfokus" as can be seen by `gh api /user/11413574`.

@unfokus if you'd like to keep maintaining, please make sure to keep your maintainer data up to date.

Also requesting `teams.wdz` members for review due to removal from their team (and maybe to get in touch).