### PR TITLE
pythonPackages.tree-sitter: staging-next fixes

### DIFF
--- a/pkgs/development/python-modules/lsp-tree-sitter/default.nix
+++ b/pkgs/development/python-modules/lsp-tree-sitter/default.nix
@@ -45,5 +45,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/neomutt/lsp-tree-sitter";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ doronbehar ];
+    # https://github.com/neomutt/lsp-tree-sitter/issues/4
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -101,5 +101,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/Textualize/textual/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ gepbird ];
+    # https://github.com/Textualize/textual/issues/5868
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/tree-sitter/default.nix
+++ b/pkgs/development/python-modules/tree-sitter/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "tree-sitter";
-  version = "0.24.0";
+  version = "0.24.0-unstable-2025-06-02";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -23,8 +23,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "tree-sitter";
     repo = "py-tree-sitter";
-    tag = "v${version}";
-    hash = "sha256-ZDt/8suteaAjGdk71l8eej7jDkkVpVDBIZS63SA8tsU=";
+    rev = "9c78f3b8d10f81b97fbb2181c9333323d6375480";
+    hash = "sha256-jPqTraGrYFXBlci4Zaleyp/NTQhvuI39tYWRckjnV2E=";
     fetchSubmodules = true;
   };
 
@@ -56,11 +56,21 @@ buildPythonPackage rec {
     "test_dot_graphs"
   ];
 
-  meta = {
-    description = "Python bindings to the Tree-sitter parsing library";
-    homepage = "https://github.com/tree-sitter/py-tree-sitter";
-    changelog = "https://github.com/tree-sitter/py-tree-sitter/releases/tag/${src.tag}";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fab ];
-  };
+  meta =
+    let
+      # for an -unstable version, we grab the release notes for the last tagged
+      # version it is based upon
+      lastTag = lib.pipe version [
+        lib.splitVersion
+        (lib.take 3)
+        (lib.concatStringsSep ".")
+      ];
+    in
+    {
+      description = "Python bindings to the Tree-sitter parsing library";
+      homepage = "https://github.com/tree-sitter/py-tree-sitter";
+      changelog = "https://github.com/tree-sitter/py-tree-sitter/releases/tag/v${lastTag}";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ fab ];
+    };
 }


### PR DESCRIPTION
Adresses https://github.com/NixOS/nixpkgs/pull/414233#issuecomment-3056281422

Fixes a hydra failure directly, so I think this should go into staging-next

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
