### PR TITLE
{rundeck, rundeck-cli}: switch to jre

### DIFF
--- a/pkgs/by-name/ru/rundeck-cli/package.nix
+++ b/pkgs/by-name/ru/rundeck-cli/package.nix
@@ -3,16 +3,11 @@
   stdenv,
   fetchurl,
   makeBinaryWrapper,
-  jre11_minimal,
-  jdk11_headless,
+  temurin-jre-bin-11,
   versionCheckHook,
   nix-update-script,
 }:
-let
-  jre11_minimal_headless = jre11_minimal.override {
-    jdk = jdk11_headless;
-  };
-in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "rundeck-cli";
   version = "2.0.9";
@@ -23,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [ makeBinaryWrapper ];
-  buildInputs = [ jre11_minimal_headless ];
+  buildInputs = [ temurin-jre-bin-11 ];
 
   dontUnpack = true;
 
@@ -34,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp $src $out/share/rundeck-cli/rundeck-cli.jar
 
     mkdir -p $out/bin
-    makeWrapper ${lib.getExe jre11_minimal_headless} $out/bin/rd \
+    makeWrapper ${lib.getExe temurin-jre-bin-11} $out/bin/rd \
       --add-flags "-jar $out/share/rundeck-cli/rundeck-cli.jar"
 
     runHook postInstall

--- a/pkgs/by-name/ru/rundeck/package.nix
+++ b/pkgs/by-name/ru/rundeck/package.nix
@@ -2,8 +2,8 @@
   lib,
   stdenv,
   fetchurl,
-  makeWrapper,
-  jdk17,
+  makeBinaryWrapper,
+  temurin-jre-bin-17,
   which,
   coreutils,
   openssh,
@@ -19,8 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-RqyJ0/gZQ1gIYSPoYfGGN5VB5ubUMl00pHPlw6v6tBQ=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jdk17 ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
+  buildInputs = [ temurin-jre-bin-17 ];
 
   dontUnpack = true;
 
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp $src $out/share/rundeck/rundeck.war
 
     mkdir -p $out/bin
-    makeWrapper ${lib.getExe jdk17} $out/bin/rundeck \
+    makeWrapper ${lib.getExe temurin-jre-bin-17} $out/bin/rundeck \
       --add-flags "-jar $out/share/rundeck/rundeck.war" \
       --prefix PATH : ${
         lib.makeBinPath [


### PR DESCRIPTION
These are two non-graphical applications that initially use JRE.
Using OpenJDK was the default choice.
And using JRE significantly reduces the package size.

- Fix rundeck-cli issue with `jre_minimal`

Wait of this PR : https://github.com/NixOS/nixpkgs/pull/424105

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
