### PR TITLE
pyprojectize: init at 1a6

### DIFF
--- a/pkgs/by-name/py/pyprojectize/package.nix
+++ b/pkgs/by-name/py/pyprojectize/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "pyprojectize";
+  version = "1a6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hroncok";
+    repo = "pyprojectize";
+    tag = version;
+    hash = "sha256-NW74IoGdghtX2Wlxocosx8zb3Htfqq6zN9iNpICdffs=";
+  };
+
+  build-system = with python3.pkgs; [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = with python3.pkgs; [
+    packaging
+    specfile
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pyprojectize" ];
+
+  meta = {
+    description = "Tool to convert a RPM spec file from %py3_build etc. macros to pyproject";
+    homepage = "https://github.com/hroncok/pyprojectize";
+    changelog = "https://github.com/hroncok/pyprojectize/releases/tag/${src.tag}";
+    license = lib.licenses.mit0;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "pyprojectize";
+  };
+}

--- a/pkgs/development/python-modules/specfile/default.nix
+++ b/pkgs/development/python-modules/specfile/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flexmock,
+  git,
+  pytestCheckHook,
+  rpm,
+  setuptools-scm,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "specfile";
+  version = "0.36.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "packit";
+    repo = "specfile";
+    tag = version;
+    hash = "sha256-P15ilAK/LaSmDRviftTdj1bzoNqL3B0ESCHb6/avT2A=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [ rpm ];
+
+  nativeCheckInputs = [
+    git
+    flexmock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "specfile" ];
+
+  disabledTests = [
+    # AssertionError
+    "test_update_tag"
+    "test_shell_expansions"
+  ];
+
+  meta = {
+    description = "Library for parsing and manipulating RPM spec files";
+    homepage = "https://github.com/packit/specfile";
+    changelog = "https://github.com/packit/specfile/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16705,6 +16705,8 @@ self: super: with self; {
 
   speaklater3 = callPackage ../development/python-modules/speaklater3 { };
 
+  specfile = callPackage ../development/python-modules/specfile { };
+
   spectra = callPackage ../development/python-modules/spectra { };
 
   spectral-cube = callPackage ../development/python-modules/spectral-cube { };


### PR DESCRIPTION
Tool to convert a RPM spec file from %py3_build etc. macros to pyproject

https://github.com/hroncok/pyprojectize

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
