### PR TITLE
audit: 4.0.5 -> 4.1.0

### DIFF
--- a/pkgs/by-name/au/audit/musl.patch
+++ b/pkgs/by-name/au/audit/musl.patch
@@ -1,0 +1,76 @@
+From 87c782153deb10bd8c3345723a8bcee343826e78 Mon Sep 17 00:00:00 2001
+From: Grimmauld <Grimmauld@grimmauld.de>
+Date: Thu, 10 Jul 2025 18:58:31 +0200
+Subject: [PATCH 1/2] lib/audit_logging.h: fix includes for musl
+
+`sys/types.h` is indirectly included with `glibc`,
+but needs to be specified explicitly on musl.
+---
+ lib/audit_logging.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/audit_logging.h b/lib/audit_logging.h
+index 9082a2720..c58861b1e 100644
+--- a/lib/audit_logging.h
++++ b/lib/audit_logging.h
+@@ -25,6 +25,7 @@
+ 
+ // Next include is to pick up the function attribute macros
+ #include <features.h>
++#include <sys/types.h>
+ #include <audit-records.h>
+ 
+ #ifdef __cplusplus
+
+From 98adfcc4bfa66ac25db0b609d7172d7d40c4f85f Mon Sep 17 00:00:00 2001
+From: Grimmauld <Grimmauld@grimmauld.de>
+Date: Fri, 11 Jul 2025 08:11:21 +0200
+Subject: [PATCH 2/2] Guard __attr_dealloc_free seperately from __attr_dealloc
+
+Otherwise, header include order matters when building against a libc that
+does not itself define __attr_dealloc_free, such as musl.
+---
+ auparse/auparse.h   | 2 ++
+ lib/audit_logging.h | 2 ++
+ lib/libaudit.h      | 2 ++
+ 3 files changed, 6 insertions(+)
+
+diff --git a/auparse/auparse.h b/auparse/auparse.h
+index 48375e2c7..ba5139625 100644
+--- a/auparse/auparse.h
++++ b/auparse/auparse.h
+@@ -31,6 +31,8 @@
+ #endif
+ #ifndef __attr_dealloc
+ # define __attr_dealloc(dealloc, argno)
++#endif
++#ifndef __attr_dealloc_free
+ # define __attr_dealloc_free
+ #endif
+ #ifndef __attribute_malloc__
+diff --git a/lib/audit_logging.h b/lib/audit_logging.h
+index c58861b1e..fab7e75d1 100644
+--- a/lib/audit_logging.h
++++ b/lib/audit_logging.h
+@@ -40,6 +40,8 @@ extern "C" {
+ #endif
+ #ifndef __attr_dealloc
+ # define __attr_dealloc(dealloc, argno)
++#endif
++#ifndef __attr_dealloc_free
+ # define __attr_dealloc_free
+ #endif
+ // Warn unused result
+diff --git a/lib/libaudit.h b/lib/libaudit.h
+index 2c51853b7..cce5dc493 100644
+--- a/lib/libaudit.h
++++ b/lib/libaudit.h
+@@ -43,6 +43,8 @@
+ // malloc and free assignments
+ #ifndef __attr_dealloc
+ # define __attr_dealloc(dealloc, argno)
++#endif
++#ifndef __attr_dealloc_free
+ # define __attr_dealloc_free
+ #endif
+ #ifndef __attribute_malloc__

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   autoreconfHook,
   bash,
   buildPackages,
@@ -21,31 +20,18 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "audit";
-  version = "4.0.5";
+  version = "4.1.0";
 
   src = fetchFromGitHub {
     owner = "linux-audit";
     repo = "audit-userspace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SgMt1MmcH7r7O6bmJCetRg3IdoZXAXjVJyeu0HRfyf8=";
+    hash = "sha256-MWlHaGue7Ca8ks34KNg74n4Rfj8ivqAhLOJHeyE2Q04=";
   };
 
   patches = [
-    # nix configures most stuff by symlinks, e.g. in /etc
-    # thus, for plugins to be picked up, symlinks must be allowed
-    # https://github.com/linux-audit/audit-userspace/pull/467
-    (fetchpatch {
-      url = "https://github.com/linux-audit/audit-userspace/pull/467/commits/dbefc642b3bd0cafe599fcd18c6c88cb672397ee.patch?full_index=1";
-      hash = "sha256-Ksn/qKBQYFAjvs1OVuWhgWCdf4Bdp9/a+MrhyJAT+Bw=";
-    })
-    (fetchpatch {
-      url = "https://github.com/linux-audit/audit-userspace/pull/467/commits/50094f56fefc0b9033ef65e8c4f108ed52ef5de5.patch?full_index=1";
-      hash = "sha256-CJKDLdlpsCd+bG6j5agcnxY1+vMCImHwHGN6BXURa4c=";
-    })
-    (fetchpatch {
-      url = "https://github.com/linux-audit/audit-userspace/pull/467/commits/5e75091abd297807b71b3cfe54345c2ef223939a.patch?full_index=1";
-      hash = "sha256-LPpO4PH/3MyCJq2xhmhhcnFeK3yh7LK6Mjypuvhacu4=";
-    })
+    # https://github.com/linux-audit/audit-userspace/pull/476
+    ./musl.patch
   ];
 
   postPatch = ''
@@ -53,6 +39,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "/usr/include/linux/audit.h" \
                      "${linuxHeaders}/include/linux/audit.h"
   '';
+
+  # https://github.com/linux-audit/audit-userspace/issues/474
+  # building databuf_test fails otherwise, as that uses hidden symbols only available in the static builds
+  dontDisableStatic = true;
 
   outputs = [
     "bin"


### PR DESCRIPTION
Changelog: https://github.com/linux-audit/audit-userspace/releases/tag/v4.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-linux (musl)
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
