### PR TITLE
game-music-emu: clean up & 0.6.3 -> 0.6.4

### DIFF
--- a/pkgs/by-name/ga/game-music-emu/package.nix
+++ b/pkgs/by-name/ga/game-music-emu/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   cmake,
   removeReferencesTo,
   zlib,
@@ -11,10 +11,13 @@ stdenv.mkDerivation rec {
   version = "0.6.3";
   pname = "game-music-emu";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/mpyne/game-music-emu/downloads/${pname}-${version}.tar.xz";
-    sha256 = "07857vdkak306d9s5g6fhmjyxk7vijzjhkmqb15s7ihfxx9lx8xb";
+  src = fetchFromGitHub {
+    owner = "libgme";
+    repo = "game-music-emu";
+    tag = version;
+    hash = "sha256-XmPcFfKsEe07hH7f0xMs9hRJshOO/p58Zm9fYsmCCoA=";
   };
+
   cmakeFlags = [ "-DENABLE_UBSAN=OFF" ];
   nativeBuildInputs = [
     cmake
@@ -31,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://bitbucket.org/mpyne/game-music-emu/wiki/Home";
+    homepage = "https://github.com/libgme/game-music-emu/wiki";
     description = "Collection of video game music file emulators";
     license = licenses.lgpl21Plus;
     platforms = platforms.all;

--- a/pkgs/by-name/ga/game-music-emu/package.nix
+++ b/pkgs/by-name/ga/game-music-emu/package.nix
@@ -8,14 +8,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "0.6.3";
+  version = "0.6.4";
   pname = "game-music-emu";
 
   src = fetchFromGitHub {
     owner = "libgme";
     repo = "game-music-emu";
     tag = finalAttrs.version;
-    hash = "sha256-XmPcFfKsEe07hH7f0xMs9hRJshOO/p58Zm9fYsmCCoA=";
+    hash = "sha256-qGNWFFUUjv2R5e/nQrriAyDJCARISqNB8e5/1zEJ3fk=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/ga/game-music-emu/package.nix
+++ b/pkgs/by-name/ga/game-music-emu/package.nix
@@ -3,41 +3,28 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  removeReferencesTo,
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "0.6.3";
   pname = "game-music-emu";
 
   src = fetchFromGitHub {
     owner = "libgme";
     repo = "game-music-emu";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-XmPcFfKsEe07hH7f0xMs9hRJshOO/p58Zm9fYsmCCoA=";
   };
 
-  cmakeFlags = [ "-DENABLE_UBSAN=OFF" ];
-  nativeBuildInputs = [
-    cmake
-    removeReferencesTo
-  ];
+  nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib ];
 
-  # It used to reference it, in the past, but thanks to the postFixup hook, now
-  # it doesn't.
-  disallowedReferences = [ stdenv.cc.cc ];
-
-  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-    remove-references-to -t ${stdenv.cc.cc} "$(readlink -f $out/lib/libgme.so)"
-  '';
-
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/libgme/game-music-emu/wiki";
     description = "Collection of video game music file emulators";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ ];
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ];
   };
-}
+})

--- a/pkgs/by-name/ga/game-music-emu/package.nix
+++ b/pkgs/by-name/ga/game-music-emu/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   zlib,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,6 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/libgme/game-music-emu/wiki";


### PR DESCRIPTION
From the original wiki page:
> This repository is closed and archived in favor of the GitHub repository, where development will continue.
> Repository has been moved to a new place here:
> - https://github.com/libgme/game-music-emu

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
