### PR TITLE
nixosTests.suwayomi-server: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1324,7 +1324,10 @@ in
   sudo-rs = runTest ./sudo-rs.nix;
   sunshine = runTest ./sunshine.nix;
   suricata = runTest ./suricata.nix;
-  suwayomi-server = handleTest ./suwayomi-server.nix { };
+  suwayomi-server = import ./suwayomi-server.nix {
+    inherit (pkgs) lib;
+    inherit runTest;
+  };
   swap-file-btrfs = runTest ./swap-file-btrfs.nix;
   swap-partition = runTest ./swap-partition.nix;
   swap-random-encryption = runTest ./swap-random-encryption.nix;

--- a/nixos/tests/suwayomi-server.nix
+++ b/nixos/tests/suwayomi-server.nix
@@ -1,22 +1,9 @@
-{
-  system ? builtins.currentSystem,
-  pkgs,
-  lib ? pkgs.lib,
-}:
-let
-  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
-  inherit (lib) recursiveUpdate;
+{ lib, runTest }:
 
+let
   baseTestConfig = {
     meta.maintainers = with lib.maintainers; [ ratcornu ];
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        services.suwayomi-server = {
-          enable = true;
-          settings.server.port = 1234;
-        };
-      };
+
     testScript = ''
       machine.wait_for_unit("suwayomi-server.service")
       machine.wait_for_open_port(1234)
@@ -26,14 +13,23 @@ let
 in
 
 {
-  without-auth = makeTest (
-    recursiveUpdate baseTestConfig {
+  without-auth = runTest (
+    baseTestConfig
+    // {
       name = "suwayomi-server-without-auth";
+
+      nodes.machine = {
+        services.suwayomi-server = {
+          enable = true;
+          settings.server.port = 1234;
+        };
+      };
     }
   );
 
-  with-auth = makeTest (
-    recursiveUpdate baseTestConfig {
+  with-auth = runTest (
+    baseTestConfig
+    // {
       name = "suwayomi-server-with-auth";
 
       nodes.machine =


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on 2fcd5fed (master) and dda9d6e8 (this PR) and compare outputs, note that the derivations are the same.

```
nix eval --read-only .#nixosTests.suwayomi-server
```

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
