### PR TITLE
nixosTests.systemd-initrd-networkd: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1364,7 +1364,7 @@ in
   systemd-initrd-luks-tpm2 = runTest ./systemd-initrd-luks-tpm2.nix;
   systemd-initrd-luks-unl0kr = runTest ./systemd-initrd-luks-unl0kr.nix;
   systemd-initrd-modprobe = runTest ./systemd-initrd-modprobe.nix;
-  systemd-initrd-networkd = handleTest ./systemd-initrd-networkd.nix { };
+  systemd-initrd-networkd = import ./systemd-initrd-networkd.nix { inherit runTest; };
   systemd-initrd-networkd-ssh = runTest ./systemd-initrd-networkd-ssh.nix;
   systemd-initrd-networkd-openvpn = handleTestOn [
     "x86_64-linux"

--- a/nixos/tests/systemd-initrd-networkd.nix
+++ b/nixos/tests/systemd-initrd-networkd.nix
@@ -1,61 +1,80 @@
-{
-  system ? builtins.currentSystem,
-  config ? { },
-  pkgs ? import ../.. { inherit system config; },
-  lib ? pkgs.lib,
-}:
-
-with import ../lib/testing-python.nix { inherit system pkgs; };
+{ runTest }:
 
 let
-  inherit (lib.maintainers) elvishjerricco;
-
-  common = {
-    boot.initrd.systemd = {
-      enable = true;
-      network.wait-online.timeout = 10;
-      network.wait-online.anyInterface = true;
-      targets.network-online.requiredBy = [ "initrd.target" ];
-      services.systemd-networkd-wait-online.requiredBy = [ "network-online.target" ];
-      initrdBin = [
-        pkgs.iproute2
-        pkgs.iputils
-        pkgs.gnugrep
-      ];
+  common =
+    { pkgs, ... }:
+    {
+      boot.initrd.systemd = {
+        enable = true;
+        network.wait-online.timeout = 10;
+        network.wait-online.anyInterface = true;
+        targets.network-online.requiredBy = [ "initrd.target" ];
+        services.systemd-networkd-wait-online.requiredBy = [ "network-online.target" ];
+        initrdBin = [
+          pkgs.iproute2
+          pkgs.iputils
+          pkgs.gnugrep
+        ];
+      };
+      testing.initrdBackdoor = true;
+      boot.initrd.network.enable = true;
     };
-    testing.initrdBackdoor = true;
-    boot.initrd.network.enable = true;
-  };
 
   mkFlushTest =
     flush: script:
-    makeTest {
-      name = "systemd-initrd-network-${lib.optionalString (!flush) "no-"}flush";
-      meta.maintainers = [ elvishjerricco ];
+    runTest (
+      { lib, ... }:
+      {
+        name = "systemd-initrd-network-${lib.optionalString (!flush) "no-"}flush";
+        meta.maintainers = with lib.maintainers; [ elvishjerricco ];
 
-      nodes.machine = {
-        imports = [ common ];
+        nodes.machine =
+          { pkgs, ... }:
+          {
+            imports = [ common ];
 
-        boot.initrd.network.flushBeforeStage2 = flush;
-        systemd.services.check-flush = {
-          requiredBy = [ "multi-user.target" ];
-          before = [
-            "network-pre.target"
-            "multi-user.target"
-            "shutdown.target"
-          ];
-          conflicts = [ "shutdown.target" ];
-          wants = [ "network-pre.target" ];
-          unitConfig.DefaultDependencies = false;
-          serviceConfig.Type = "oneshot";
-          path = [
-            pkgs.iproute2
-            pkgs.iputils
-            pkgs.gnugrep
-          ];
-          inherit script;
-        };
-      };
+            boot.initrd.network.flushBeforeStage2 = flush;
+            systemd.services.check-flush = {
+              requiredBy = [ "multi-user.target" ];
+              before = [
+                "network-pre.target"
+                "multi-user.target"
+                "shutdown.target"
+              ];
+              conflicts = [ "shutdown.target" ];
+              wants = [ "network-pre.target" ];
+              unitConfig.DefaultDependencies = false;
+              serviceConfig.Type = "oneshot";
+              path = [
+                pkgs.iproute2
+                pkgs.iputils
+                pkgs.gnugrep
+              ];
+              inherit script;
+            };
+          };
+
+        testScript = ''
+          machine.wait_for_unit("network-online.target")
+          machine.succeed(
+              "ip addr | grep 10.0.2.15",
+              "ping -c1 10.0.2.2",
+          )
+          machine.switch_root()
+
+          machine.wait_for_unit("multi-user.target")
+        '';
+      }
+    );
+in
+{
+  basic = runTest (
+    { lib, ... }:
+    {
+      name = "systemd-initrd-network";
+      meta.maintainers = with lib.maintainers; [ elvishjerricco ];
+
+      nodes.machine = common;
 
       testScript = ''
         machine.wait_for_unit("network-online.target")
@@ -65,33 +84,14 @@ let
         )
         machine.switch_root()
 
+        # Make sure the systemd-network user was set correctly in initrd
         machine.wait_for_unit("multi-user.target")
+        machine.succeed("[ $(stat -c '%U,%G' /run/systemd/netif/links) = systemd-network,systemd-network ]")
+        machine.succeed("ip addr show >&2")
+        machine.succeed("ip route show >&2")
       '';
-    };
-
-in
-{
-  basic = makeTest {
-    name = "systemd-initrd-network";
-    meta.maintainers = [ elvishjerricco ];
-
-    nodes.machine = common;
-
-    testScript = ''
-      machine.wait_for_unit("network-online.target")
-      machine.succeed(
-          "ip addr | grep 10.0.2.15",
-          "ping -c1 10.0.2.2",
-      )
-      machine.switch_root()
-
-      # Make sure the systemd-network user was set correctly in initrd
-      machine.wait_for_unit("multi-user.target")
-      machine.succeed("[ $(stat -c '%U,%G' /run/systemd/netif/links) = systemd-network,systemd-network ]")
-      machine.succeed("ip addr show >&2")
-      machine.succeed("ip route show >&2")
-    '';
-  };
+    }
+  );
 
   doFlush = mkFlushTest true ''
     if ip addr | grep 10.0.2.15; then


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on 2fcd5fed (master) and dde4a38d (this PR) and compare outputs, note that the derivations are the same.

```
nix eval --read-only .#nixosTests.systemd-initrd-networkd
```

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
