### PR TITLE
nixosTests.systemd-networkd-dhcpserver-static-leases: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1386,9 +1386,7 @@ in
   systemd-networkd = runTest ./systemd-networkd.nix;
   systemd-networkd-bridge = runTest ./systemd-networkd-bridge.nix;
   systemd-networkd-dhcpserver = runTest ./systemd-networkd-dhcpserver.nix;
-  systemd-networkd-dhcpserver-static-leases =
-    handleTest ./systemd-networkd-dhcpserver-static-leases.nix
-      { };
+  systemd-networkd-dhcpserver-static-leases = runTest ./systemd-networkd-dhcpserver-static-leases.nix;
   systemd-networkd-ipv6-prefix-delegation =
     handleTest ./systemd-networkd-ipv6-prefix-delegation.nix
       { };

--- a/nixos/tests/systemd-networkd-dhcpserver-static-leases.nix
+++ b/nixos/tests/systemd-networkd-dhcpserver-static-leases.nix
@@ -1,96 +1,94 @@
 # In contrast to systemd-networkd-dhcpserver, this test configures
 # the router with a static DHCP lease for the client's MAC address.
-import ./make-test-python.nix (
-  { lib, ... }:
-  {
-    name = "systemd-networkd-dhcpserver-static-leases";
-    meta = with lib.maintainers; {
-      maintainers = [ veehaitch ];
-    };
-    nodes = {
-      router = {
-        virtualisation.vlans = [ 1 ];
-        systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
-        networking = {
-          useNetworkd = true;
-          useDHCP = false;
-          firewall.enable = false;
-        };
-        systemd.network = {
-          networks = {
-            # systemd-networkd will load the first network unit file
-            # that matches, ordered lexiographically by filename.
-            # /etc/systemd/network/{40-eth1,99-main}.network already
-            # exists. This network unit must be loaded for the test,
-            # however, hence why this network is named such.
-            "01-eth1" = {
-              name = "eth1";
-              networkConfig = {
-                DHCPServer = true;
-                Address = "10.0.0.1/24";
-              };
-              dhcpServerStaticLeases = [
-                {
-                  MACAddress = "02:de:ad:be:ef:01";
-                  Address = "10.0.0.10";
-                }
-              ];
-            };
-          };
-        };
+{ lib, ... }:
+{
+  name = "systemd-networkd-dhcpserver-static-leases";
+  meta = with lib.maintainers; {
+    maintainers = [ veehaitch ];
+  };
+  nodes = {
+    router = {
+      virtualisation.vlans = [ 1 ];
+      systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+        firewall.enable = false;
       };
-
-      client = {
-        virtualisation.vlans = [ 1 ];
-        systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
-        systemd.network = {
-          enable = true;
-          links."10-eth1" = {
-            matchConfig.OriginalName = "eth1";
-            linkConfig.MACAddress = "02:de:ad:be:ef:01";
-          };
-          networks."40-eth1" = {
-            matchConfig.Name = "eth1";
+      systemd.network = {
+        networks = {
+          # systemd-networkd will load the first network unit file
+          # that matches, ordered lexiographically by filename.
+          # /etc/systemd/network/{40-eth1,99-main}.network already
+          # exists. This network unit must be loaded for the test,
+          # however, hence why this network is named such.
+          "01-eth1" = {
+            name = "eth1";
             networkConfig = {
-              DHCP = "ipv4";
-              IPv6AcceptRA = false;
+              DHCPServer = true;
+              Address = "10.0.0.1/24";
             };
-            # This setting is important to have the router assign the
-            # configured lease based on the client's MAC address. Also see:
-            # https://github.com/systemd/systemd/issues/21368#issuecomment-982193546
-            dhcpV4Config.ClientIdentifier = "mac";
-            linkConfig.RequiredForOnline = "routable";
+            dhcpServerStaticLeases = [
+              {
+                MACAddress = "02:de:ad:be:ef:01";
+                Address = "10.0.0.10";
+              }
+            ];
           };
-        };
-        networking = {
-          useDHCP = false;
-          firewall.enable = false;
-          interfaces.eth1 = lib.mkForce { };
         };
       };
     };
-    testScript = ''
-      start_all()
 
-      with subtest("check router network configuration"):
-        router.systemctl("start systemd-networkd-wait-online.service")
-        router.wait_for_unit("systemd-networkd-wait-online.service")
-        eth1_status = router.succeed("networkctl status eth1")
-        assert "Network File: /etc/systemd/network/01-eth1.network" in eth1_status, \
-          "The router interface eth1 is not using the expected network file"
-        assert "10.0.0.1" in eth1_status, "Did not find expected router IPv4"
+    client = {
+      virtualisation.vlans = [ 1 ];
+      systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+      systemd.network = {
+        enable = true;
+        links."10-eth1" = {
+          matchConfig.OriginalName = "eth1";
+          linkConfig.MACAddress = "02:de:ad:be:ef:01";
+        };
+        networks."40-eth1" = {
+          matchConfig.Name = "eth1";
+          networkConfig = {
+            DHCP = "ipv4";
+            IPv6AcceptRA = false;
+          };
+          # This setting is important to have the router assign the
+          # configured lease based on the client's MAC address. Also see:
+          # https://github.com/systemd/systemd/issues/21368#issuecomment-982193546
+          dhcpV4Config.ClientIdentifier = "mac";
+          linkConfig.RequiredForOnline = "routable";
+        };
+      };
+      networking = {
+        useDHCP = false;
+        firewall.enable = false;
+        interfaces.eth1 = lib.mkForce { };
+      };
+    };
+  };
+  testScript = ''
+    start_all()
 
-      with subtest("check client network configuration"):
-        client.systemctl("start systemd-networkd-wait-online.service")
-        client.wait_for_unit("systemd-networkd-wait-online.service")
-        eth1_status = client.succeed("networkctl status eth1")
-        assert "Network File: /etc/systemd/network/40-eth1.network" in eth1_status, \
-          "The client interface eth1 is not using the expected network file"
-        assert "10.0.0.10" in eth1_status, "Did not find expected client IPv4"
+    with subtest("check router network configuration"):
+      router.systemctl("start systemd-networkd-wait-online.service")
+      router.wait_for_unit("systemd-networkd-wait-online.service")
+      eth1_status = router.succeed("networkctl status eth1")
+      assert "Network File: /etc/systemd/network/01-eth1.network" in eth1_status, \
+        "The router interface eth1 is not using the expected network file"
+      assert "10.0.0.1" in eth1_status, "Did not find expected router IPv4"
 
-      with subtest("router and client can reach each other"):
-        client.wait_until_succeeds("ping -c 5 10.0.0.1")
-        router.wait_until_succeeds("ping -c 5 10.0.0.10")
-    '';
-  }
-)
+    with subtest("check client network configuration"):
+      client.systemctl("start systemd-networkd-wait-online.service")
+      client.wait_for_unit("systemd-networkd-wait-online.service")
+      eth1_status = client.succeed("networkctl status eth1")
+      assert "Network File: /etc/systemd/network/40-eth1.network" in eth1_status, \
+        "The client interface eth1 is not using the expected network file"
+      assert "10.0.0.10" in eth1_status, "Did not find expected client IPv4"
+
+    with subtest("router and client can reach each other"):
+      client.wait_until_succeeds("ping -c 5 10.0.0.1")
+      router.wait_until_succeeds("ping -c 5 10.0.0.10")
+  '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on 059f9f4c (master) and e9c1e2ef (this PR) and compare outputs, note that the derivations are the same.

```
nix eval --read-only .#nixosTests.systemd-networkd-dhcpserver-static-leases
```

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
