### PR TITLE
python3Packages.optree: 0.14.1 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/optree/default.nix
+++ b/pkgs/development/python-modules/optree/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "optree";
-  version = "0.14.1";
+  version = "0.16.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "metaopt";
     repo = "optree";
     tag = "v${version}";
-    hash = "sha256-5PIe/mXPNohwM0oNT/zSPmNUycjXuujtIFCki5t7V1I=";
+    hash = "sha256-KfR3j4I2+muoRFl7l7B9i2QhsJKWsGO7AOkYIMhQv/Q=";
   };
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION

### Automatic Update for `python3Packages.optree`
- **Old version**: `0.14.1`
- **New version**: `0.16.0`
- This PR was generated by a GitHub Actions workflow.
