### PR TITLE
python3Packages.plotly: 6.2.0 -> 6.2.0

### DIFF
--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -38,14 +38,14 @@
 
 buildPythonPackage rec {
   pname = "plotly";
-  version = "6.1.2";
+  version = "6.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "plotly";
     repo = "plotly.py";
     tag = "v${version}";
-    hash = "sha256-+vIq//pDLaaTmRGW+oytho3TfMmLCtuIoHeFenLVcek=";
+    hash = "sha256-Vfj5jG0AkBjivExOx7oMoocTopWl0yMc1INpEbtlgTc=";
   };
 
   postPatch = ''


### PR DESCRIPTION

### Automatic Update for `python3Packages.plotly`
- **Old version**: `6.2.0`
- **New version**: `6.2.0`
- This PR was generated by a GitHub Actions workflow.
