### PR TITLE
python3Packages.pgpy: Fix build again

### DIFF
--- a/pkgs/development/python-modules/pgpy/Fix-compat-with-current-cryptography.patch
+++ b/pkgs/development/python-modules/pgpy/Fix-compat-with-current-cryptography.patch
@@ -1,0 +1,49 @@
+From 5cdda87f74bcbb1dd7d29bb49b6a0ee67e41a7ce Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 10 Jul 2025 17:51:02 +0200
+Subject: [PATCH] pgpy/_curves.py: Fix compat with current cryptography
+
+Curves must now specify their group_order.
+---
+ pgpy/_curves.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/pgpy/_curves.py b/pgpy/_curves.py
+index 14f2528..91e7dbb 100644
+--- a/pgpy/_curves.py
++++ b/pgpy/_curves.py
+@@ -75,26 +75,31 @@ else:
+     class BrainpoolP256R1(ec.EllipticCurve):
+         name = 'brainpoolP256r1'
+         key_size = 256
++        group_order = 0xa9fb57dba1eea9bc3e660a909d838d718c397aa3b561a6f7901e0e82974856a7
+ 
+ 
+     class BrainpoolP384R1(ec.EllipticCurve):  # noqa: E303
+         name = 'brainpoolP384r1'
+         key_size = 384
++        group_order = 0x8cb91e82a3386d280f5d6f7e50e641df152f7109ed5456b31f166e6cac0425a7cf3ab6af6b7fc3103b883202e9046565
+ 
+ 
+     class BrainpoolP512R1(ec.EllipticCurve):  # noqa: E303
+         name = 'brainpoolP512r1'
+         key_size = 512
++        group_order = 0xaadd9db8dbe9c48b3fd4e6ae33c9fc07cb308db3b3c9d20ed6639cca70330870553e5c414ca92619418661197fac10471db1d381085ddaddb58796829ca90069
+ 
+ 
+     class X25519(ec.EllipticCurve):  # noqa: E303
+         name = 'X25519'
+         key_size = 256
++        group_order = 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed
+ 
+ 
+     class Ed25519(ec.EllipticCurve):  # noqa: E303
+         name = 'ed25519'
+         key_size = 256
++        group_order = 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed
+ 
+ 
+ # add these curves to the _CURVE_TYPES list
+-- 
+2.49.0
+

--- a/pkgs/development/python-modules/pgpy/default.nix
+++ b/pkgs/development/python-modules/pgpy/default.nix
@@ -34,6 +34,9 @@ buildPythonPackage rec {
   patches = [
     # https://github.com/SecurityInnovation/PGPy/issues/462
     ./pr-443.patch
+
+    # https://github.com/SecurityInnovation/PGPy/pull/474
+    ./Fix-compat-with-current-cryptography.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
Closes #421534

Applies https://github.com/SecurityInnovation/PGPy/pull/474 to fix compat with our version of `python3Packages.cryptography`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
