### PR TITLE
temurin-{jdk, jre}: init

### DIFF
--- a/pkgs/development/compilers/temurin/default.nix
+++ b/pkgs/development/compilers/temurin/default.nix
@@ -1,0 +1,446 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  removeReferencesTo,
+  autoconf,
+  bash,
+  which,
+  zip,
+  unzip,
+  pkg-config,
+  cpio,
+  file,
+  openjdk11,
+  openjdk17,
+  openjdk21,
+  openjdk23,
+  openjdk24,
+  cups,
+  freetype,
+  alsa-lib,
+  libjpeg,
+  giflib,
+  libpng,
+  zlib,
+  lcms2,
+  fontconfig,
+  xorg,
+  cctools,
+  darwin,
+}:
+
+let
+  mkTemurinJDK =
+    {
+      featureVersion,
+      version,
+      build,
+      hash,
+    }:
+    let
+      bootstrapJdk =
+        if featureVersion == "11" then
+          openjdk11
+        else if lib.versionAtLeast featureVersion "24" then
+          openjdk24
+        else if lib.versionAtLeast featureVersion "23" then
+          openjdk23
+        else if lib.versionAtLeast featureVersion "21" then
+          openjdk21
+        else
+          openjdk17;
+
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      buildConfigMap = lib.genAttrs supportedSystems (
+        system:
+        let
+          parts = lib.strings.splitString "-" system;
+          arch = lib.elemAt parts 0;
+          os = lib.elemAt parts 1;
+          osPrefix =
+            {
+              linux = "linux";
+              darwin = "macosx";
+            }
+            .${os};
+          normalPart = if featureVersion == "11" then "-normal" else "";
+        in
+        "${osPrefix}-${arch}${normalPart}-server-release"
+      );
+
+      buildConfig = buildConfigMap.${stdenv.hostPlatform.system};
+
+    in
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "temurin-jdk-${featureVersion}";
+      version = "${version}+${build}";
+
+      src = fetchFromGitHub {
+        owner = "adoptium";
+        repo = "jdk${featureVersion}u";
+        tag = "jdk-${version}+${build}";
+        inherit hash;
+      };
+
+      nativeBuildInputs =
+        [
+          autoconf
+          bash
+          which
+          zip
+          unzip
+          pkg-config
+          cpio
+          file
+          bootstrapJdk
+        ]
+        ++ lib.optionals stdenv.isDarwin [
+          cctools
+          darwin.bootstrap_cmds
+          darwin.xattr
+          darwin.DarwinTools
+          darwin.sigtool
+        ];
+
+      buildInputs =
+        [
+          cups
+          freetype
+          libjpeg
+          giflib
+          libpng
+          zlib
+          lcms2
+          fontconfig
+        ]
+        ++ lib.optionals stdenv.isLinux [
+          alsa-lib
+          xorg.libX11
+          xorg.libXext
+          xorg.libXrender
+          xorg.libXrandr
+          xorg.libXtst
+          xorg.libXt
+          xorg.libXi
+          xorg.xorgproto
+        ];
+
+      configurePhase = ''
+        runHook preConfigure
+
+        if [ "${featureVersion}" = "21" ] || [ "${featureVersion}" = "23" ] || [ "${featureVersion}" = "24" ]; then
+          export SOURCE_DATE_EPOCH=315532802
+        fi
+
+        bash configure \
+          --with-boot-jdk=${bootstrapJdk} \
+          --with-version-opt="nixpkgs" \
+          --with-version-pre="" \
+          --with-version-build="${build}" \
+          --with-vendor-name="NixOS" \
+          --with-vendor-url="https://nixos.org/" \
+          --with-vendor-bug-url="https://github.com/NixOS/nixpkgs/issues" \
+          --enable-unlimited-crypto \
+          --with-native-debug-symbols=internal \
+          --with-freetype=system \
+          --with-libjpeg=system \
+          --with-giflib=system \
+          --with-libpng=system \
+          --with-zlib=system \
+          --with-lcms=system \
+          --with-cups=${cups.dev} \
+          --disable-warnings-as-errors
+
+        runHook postConfigure
+      '';
+
+      buildPhase = ''
+        runHook preBuild
+
+        make images
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        buildDir="build/${buildConfig}/images/jdk"
+
+        if [ ! -d "$buildDir" ]; then
+          exit 1
+        fi
+
+        mkdir -p $out
+        cp -r "$buildDir"/. "$out"/
+
+        mkdir -p $out/nix-support
+        echo 'if [ -z "''${JAVA_HOME-}" ]; then export JAVA_HOME='"$out"'; fi' > $out/nix-support/setup-hook
+
+        runHook postInstall
+      '';
+
+      dontStrip = true;
+      enableParallelBuilding = true;
+
+      passthru = {
+        home = finalAttrs.finalPackage;
+        jre = finalAttrs.finalPackage;
+      };
+
+      meta = {
+        description = "Eclipse Temurin ${featureVersion} JDK - Java Development Kit";
+        homepage = "https://adoptium.net/";
+        license = lib.licenses.gpl2Classpath;
+        maintainers = with lib.maintainers; [ liberodark ];
+        platforms = lib.platforms.linux;
+        mainProgram = "java";
+      };
+    });
+
+  mkTemurinJRE =
+    {
+      jdk,
+      featureVersion,
+      versionStr,
+      buildStr,
+    }:
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "temurin-jre-${featureVersion}";
+      version = "${versionStr}+${buildStr}";
+
+      dontUnpack = true;
+
+      nativeBuildInputs = [ removeReferencesTo ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        MODULES="java.base"
+        MODULES="$MODULES,java.compiler"
+        MODULES="$MODULES,java.datatransfer"
+        MODULES="$MODULES,java.desktop"
+        MODULES="$MODULES,java.instrument"
+        MODULES="$MODULES,java.logging"
+        MODULES="$MODULES,java.management"
+        MODULES="$MODULES,java.management.rmi"
+        MODULES="$MODULES,java.naming"
+        MODULES="$MODULES,java.net.http"
+        MODULES="$MODULES,java.prefs"
+        MODULES="$MODULES,java.rmi"
+        MODULES="$MODULES,java.scripting"
+        MODULES="$MODULES,java.se"
+        MODULES="$MODULES,java.security.jgss"
+        MODULES="$MODULES,java.security.sasl"
+        MODULES="$MODULES,java.smartcardio"
+        MODULES="$MODULES,java.sql"
+        MODULES="$MODULES,java.sql.rowset"
+        MODULES="$MODULES,java.transaction.xa"
+        MODULES="$MODULES,java.xml"
+        MODULES="$MODULES,java.xml.crypto"
+        MODULES="$MODULES,jdk.accessibility"
+        MODULES="$MODULES,jdk.charsets"
+        MODULES="$MODULES,jdk.crypto.cryptoki"
+        MODULES="$MODULES,jdk.dynalink"
+        MODULES="$MODULES,jdk.httpserver"
+        MODULES="$MODULES,jdk.internal.vm.ci"
+        MODULES="$MODULES,jdk.jdwp.agent"
+        MODULES="$MODULES,jdk.jfr"
+        MODULES="$MODULES,jdk.jsobject"
+        MODULES="$MODULES,jdk.localedata"
+        MODULES="$MODULES,jdk.management"
+        MODULES="$MODULES,jdk.management.agent"
+        MODULES="$MODULES,jdk.management.jfr"
+        MODULES="$MODULES,jdk.naming.dns"
+        MODULES="$MODULES,jdk.naming.rmi"
+        MODULES="$MODULES,jdk.net"
+        MODULES="$MODULES,jdk.sctp"
+        MODULES="$MODULES,jdk.security.auth"
+        MODULES="$MODULES,jdk.security.jgss"
+        MODULES="$MODULES,jdk.unsupported"
+        MODULES="$MODULES,jdk.xml.dom"
+        MODULES="$MODULES,jdk.zipfs"
+
+        ${lib.optionalString (featureVersion != "23" && featureVersion != "24") ''
+          MODULES="$MODULES,jdk.crypto.ec"
+        ''}
+
+        ${lib.optionalString (featureVersion == "23" || featureVersion == "24") ''
+          MODULES="$MODULES,jdk.graal.compiler"
+          MODULES="$MODULES,jdk.graal.compiler.management"
+        ''}
+
+        ${lib.optionalString (featureVersion != "23" && featureVersion != "24") ''
+          MODULES="$MODULES,jdk.internal.vm.compiler"
+          MODULES="$MODULES,jdk.internal.vm.compiler.management"
+        ''}
+
+        ${lib.optionalString (featureVersion == "11") ''
+          MODULES="$MODULES,jdk.naming.ldap"
+          MODULES="$MODULES,jdk.pack"
+          MODULES="$MODULES,jdk.scripting.nashorn"
+          MODULES="$MODULES,jdk.scripting.nashorn.shell"
+          MODULES="$MODULES,jdk.aot"
+          MODULES="$MODULES,jdk.internal.ed"
+          MODULES="$MODULES,jdk.internal.le"
+        ''}
+
+        ${lib.optionalString
+          (lib.elem featureVersion [
+            "17"
+            "21"
+            "23"
+            "24"
+          ])
+          ''
+            MODULES="$MODULES,jdk.nio.mapmode"
+            MODULES="$MODULES,jdk.incubator.vector"
+          ''
+        }
+
+        ${lib.optionalString (featureVersion == "17") ''
+          MODULES="$MODULES,jdk.incubator.foreign"
+        ''}
+
+          COMPRESS_OPT="--compress=2"
+        ${lib.optionalString
+          (lib.elem featureVersion [
+            "21"
+            "23"
+            "24"
+          ])
+          ''
+            COMPRESS_OPT="--compress zip-2"
+          ''
+        }
+
+        ${jdk}/bin/jlink \
+          --module-path ${jdk}/jmods \
+          --add-modules $MODULES \
+          --output jre \
+          --strip-debug \
+          --no-man-pages \
+          --no-header-files \
+          $COMPRESS_OPT \
+          --release-info ${jdk}/release
+
+          runHook postBuild
+      '';
+
+      installPhase = ''
+        mkdir -p $out
+        cp -r jre/* $out/
+
+        mkdir -p $out/nix-support
+        cat > $out/nix-support/setup-hook << 'EOF'
+        if [ -z "''${JAVA_HOME-}" ]; then
+          export JAVA_HOME=$out
+        fi
+        EOF
+      '';
+
+      preFixup = ''
+        find $out -type f -exec remove-references-to -t ${jdk} {} + || true
+      '';
+
+      passthru = {
+        home = finalAttrs.finalPackage;
+        jdk = jdk;
+      };
+
+      meta = jdk.meta // {
+        description = "Eclipse Temurin ${featureVersion} JRE - Java Runtime Environment";
+      };
+    });
+
+  versions = {
+    "11" = {
+      version = "11.0.26";
+      build = "4";
+      hash = "sha256-7yeyr2UbMntuOtEjRLdLoiyN0zC+fZZSGL9XxI2D7GU=";
+    };
+    "17" = {
+      version = "17.0.14";
+      build = "7";
+      hash = "sha256-Vc1+8xnKmNQkCzeHoW8Y2WuxU7G5IAfRYXMp8JrjFuQ=";
+    };
+    "21" = {
+      version = "21.0.6";
+      build = "7";
+      hash = "sha256-GOx8awClA96VFpUhACYV+wtFM1qD29X0s3utIWWY+Nc=";
+    };
+    "23" = {
+      version = "23.0.2";
+      build = "7";
+      hash = "sha256-zlL2DV6iOfV3hgq/Ci95gTwVrhcvz5MWsg4/+O2ntE8=";
+    };
+    "24" = {
+      version = "24.0.1";
+      build = "9";
+      hash = "sha256-vXZNi6whn0GpL02DBaGAp40vYOP6BkJrLOhhL9df2kA=";
+    };
+  };
+
+  jdks = lib.mapAttrs (
+    featureVersion: versionInfo:
+    mkTemurinJDK {
+      inherit featureVersion;
+      inherit (versionInfo) version build hash;
+    }
+  ) versions;
+
+in
+{
+  temurin-jdk-11 = jdks."11";
+  temurin-jdk-17 = jdks."17";
+  temurin-jdk-21 = jdks."21";
+  temurin-jdk-23 = jdks."23";
+  temurin-jdk-24 = jdks."24";
+
+  temurin-jre-11 = mkTemurinJRE {
+    jdk = jdks."11";
+    featureVersion = "11";
+    versionStr = versions."11".version;
+    buildStr = versions."11".build;
+  };
+  temurin-jre-17 = mkTemurinJRE {
+    jdk = jdks."17";
+    featureVersion = "17";
+    versionStr = versions."17".version;
+    buildStr = versions."17".build;
+  };
+  temurin-jre-21 = mkTemurinJRE {
+    jdk = jdks."21";
+    featureVersion = "21";
+    versionStr = versions."21".version;
+    buildStr = versions."21".build;
+  };
+  temurin-jre-23 = mkTemurinJRE {
+    jdk = jdks."23";
+    featureVersion = "23";
+    versionStr = versions."23".version;
+    buildStr = versions."23".build;
+  };
+  temurin-jre-24 = mkTemurinJRE {
+    jdk = jdks."24";
+    featureVersion = "24";
+    versionStr = versions."24".version;
+    buildStr = versions."24".build;
+  };
+
+  temurin = jdks."21";
+  temurin-jdk = jdks."21";
+  temurin-jre = mkTemurinJRE {
+    jdk = jdks."21";
+    featureVersion = "21";
+    versionStr = versions."21".version;
+    buildStr = versions."21".build;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4826,6 +4826,22 @@ with pkgs;
   temurin-bin = temurin-bin-21;
   temurin-jre-bin = temurin-jre-bin-21;
 
+  temurin = callPackage ../development/compilers/temurin { };
+  inherit (temurin)
+    temurin-jdk-11
+    temurin-jdk-17
+    temurin-jdk-21
+    temurin-jdk-23
+    temurin-jdk-24
+    temurin-jre-11
+    temurin-jre-17
+    temurin-jre-21
+    temurin-jre-23
+    temurin-jre-24
+    temurin-jdk
+    temurin-jre
+    ;
+
   semeru-bin-21 = javaPackages.compiler.semeru-bin.jdk-21;
   semeru-jre-bin-21 = javaPackages.compiler.semeru-bin.jre-21;
   semeru-bin-17 = javaPackages.compiler.semeru-bin.jdk-17;


### PR DESCRIPTION
This is Epic quest to add temurin-{jdk,jre} build from source.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
