### PR TITLE
wuffs: init at 0.4.0-alpha.9

### DIFF
--- a/pkgs/by-name/wu/wuffs/package.nix
+++ b/pkgs/by-name/wu/wuffs/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildGoModule,
+  makeBinaryWrapper,
+  replaceVars,
+  testers,
+}:
+let
+  compiler =
+    if stdenv.cc.isClang then
+      "clang"
+    else if stdenv.cc.isGNU then
+      "gcc"
+    else
+      throw "unsupported compiler";
+in
+buildGoModule (finalAttrs: {
+  pname = "wuffs";
+  version = "0.4.0-alpha.9";
+
+  outputs = [
+    "out"
+    "dev"
+    "lib"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "wuffs";
+    tag = "v" + finalAttrs.version;
+    hash = "sha256-XbupK4QYnPudUlO5tRWrQRncGHITzJL//Yk/E7WNxYk=";
+  };
+
+  vendorHash = null;
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  subPackages = [
+    "cmd/wuffs-c"
+    "cmd/wuffs"
+  ];
+
+  # There are no checks
+  doCheck = false;
+
+  postInstall =
+    let
+      pkgconfig = replaceVars ./wuffs.pc {
+        LIB = placeholder "lib";
+        DEV = placeholder "dev";
+        DESCRIPTION = finalAttrs.meta.description;
+        VERSION = finalAttrs.version;
+      };
+    in
+    ''
+      wrapProgram "$out/bin/wuffs" \
+        --prefix PATH : "$out/bin"
+
+      "$out/bin/wuffs" gen std/...
+      "$out/bin/wuffs" genlib -ccompilers=${compiler}
+
+      install -Dm444 -t "$lib/lib" gen/lib/c/${compiler}-dynamic/libwuffs.*
+
+      install -Dm444 release/c/wuffs-unsupported-snapshot.c "$dev/include/wuffs/wuffs-v0.4.c"
+
+      install -Dm444 ${pkgconfig} "$dev/lib/pkgconfig/wuffs.pc"
+    '';
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = {
+    homepage = "https://github.com/google/wuffs";
+    description = "memory-safe programming language and standard library for wrangling untrusted data";
+    mainProgram = "wuffs";
+    pkgConfigModules = [ "wuffs" ];
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [
+      RossSmyth
+    ];
+  };
+})

--- a/pkgs/by-name/wu/wuffs/wuffs.pc
+++ b/pkgs/by-name/wu/wuffs/wuffs.pc
@@ -1,0 +1,13 @@
+prefix=@LIB@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=@DEV@/include/wuffs
+
+Name: wuffs
+Description: @DESCRIPTION@
+Version: @VERSION@
+Requires:
+Conflicts:
+Libs: -L${libdir} -lwuffs
+Libs.private:
+Cflags: -I${includedir}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Package Wuffs the toolchain
2. Package Wuffs the library
3. Add a pkgconfig file

The install phase essentially acts as an installCheck because it generates the standard library.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
