### PR TITLE
pkgs/flameshot: 12.1.0-unstable-2025-05-04 → 12.1.0-unstable-2025-07-10

### DIFF
--- a/pkgs/by-name/fl/flameshot/0001-NixOS-dependency-injection.patch
+++ b/pkgs/by-name/fl/flameshot/0001-NixOS-dependency-injection.patch
@@ -1,0 +1,41 @@
+From 8ca703efdb1129d97d27f78b0bbd1d21056a9501 Mon Sep 17 00:00:00 2001
+From: hustlerone <nine-ball@tutanota.com>
+Date: Thu, 10 Jul 2025 18:13:32 +0200
+Subject: [PATCH] NixOS dependency injection
+
+---
+ CMakeLists.txt | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8df544bc..62bccb8b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,8 +48,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+ FetchContent_Declare(
+     qtColorWidgets
+-    GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
+-    GIT_TAG 352bc8f99bf2174d5724ee70623427aa31ddc26a
++    SOURCE_DIR "${CMAKE_SOURCE_DIR}/tmp/qtColorWidgets"
+ )
+ 
+ #Workaround for duplicate GUID in windows WIX installer
+@@ -129,12 +128,8 @@ if (USE_KDSINGLEAPPLICATION)
+   set(KDSingleApplication_EXAMPLES OFF CACHE BOOL "Don't build the examples")
+   set(KDSingleApplication_STATIC ON CACHE BOOL "Build static versions of the libraries")
+ 
+-  FetchContent_Declare(
+-      kdsingleApplication
+-      GIT_REPOSITORY https://github.com/KDAB/KDSingleApplication.git
+-      GIT_TAG v1.2.0
+-  )
+-  FetchContent_MakeAvailable(KDSingleApplication)
++  find_package(KDSingleApplication-qt6)
++  add_library(kdsingleapplication ALIAS KDAB::kdsingleapplication)
+ endif()
+ 
+ # ToDo: Check if this is used anywhere
+-- 
+2.49.0
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR is a work in progress. It compiles but flameshot will error with `qt.core.qobject.connect: QObject::connect: No such signal QPlatformNativeInterface::systemTrayWindowChanged(QScreen*)`.

It also disregards Darwin. It'll be rectified by the time It's complete and the package works as it should.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
