### PR TITLE
shader-slang: 2025.8.1 -> 2025.10.3

### DIFF
--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shader-slang";
-  version = "2025.8.1";
+  version = "2025.10.3";
 
   src = fetchFromGitHub {
     owner = "shader-slang";
     repo = "slang";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PScbMkJJ4rh8I8ID709GKtLmd5+4Z2x2BlFEdWpoesI=";
+    hash = "sha256-eiXfudPF4FeDIFAxPBuh3M0Kiv8ZWlWux8A2mHTgtXs=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upgrades shader-slang from 2025.8.1 to 2025.10.3

At first I tried to fix up #416790 to get all the way to the latest version, but I failed. It seems like the only issue was that `pkgs/by-name/sh/shader-slang/1-find-packages.patch` was out of date, so I fixed that:

<details>
<summary>Updated patch for v2025.10.4 through v2025.12.1</summary>

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 549e465ac..546c94607 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,8 @@ advanced_option(
     "Build using system unordered dense"
     OFF
 )
+advanced_option(SLANG_USE_SYSTEM_SPIRV_TOOLS "Build using system SPIR-V tools library" OFF)
+advanced_option(SLANG_USE_SYSTEM_GLSLANG "Build using system glslang library" OFF)
 
 option(
     SLANG_SPIRV_HEADERS_INCLUDE_DIR
@@ -404,6 +406,34 @@ if(${SLANG_USE_SYSTEM_UNORDERED_DENSE})
     find_package(unordered_dense CONFIG QUIET)
 endif()
 
+if(${SLANG_USE_SYSTEM_MINIZ})
+    find_package(miniz REQUIRED)
+    add_library(miniz ALIAS miniz::miniz)
+endif()
+
+if(${SLANG_USE_SYSTEM_LZ4})
+    find_package(lz4 REQUIRED)
+    add_library(lz4_static ALIAS LZ4::lz4)
+endif()
+
+if(${SLANG_USE_SYSTEM_VULKAN_HEADERS})
+    find_package(VulkanHeaders REQUIRED)
+endif()
+
+if(${SLANG_USE_SYSTEM_SPIRV_HEADERS})
+    find_package(SPIRV-Headers REQUIRED)
+    add_library(SPIRV-Headers ALIAS SPIRV-Headers::SPIRV-Headers)
+endif()
+
+if(${SLANG_USE_SYSTEM_SPIRV_TOOLS})
+    find_package(SPIRV-Tools REQUIRED)
+endif()
+
+if(${SLANG_USE_SYSTEM_GLSLANG})
+    find_package(glslang REQUIRED)
+    add_library(glslang ALIAS glslang::glslang)
+endif()
+
 add_subdirectory(external)
 
 # webgpu_dawn is only available as a fetched shared library, since Dawn's nested source
diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
index 801cae4d6..d45150118 100644
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -133,6 +133,7 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
         )
     endif()
 
+if(NOT ${SLANG_USE_SYSTEM_SPIRV_TOOLS})
     # SPIRV-Tools
     set(SPIRV_TOOLS_BUILD_STATIC ON)
     set(SPIRV_WERROR OFF)
@@ -148,11 +149,14 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
             ${system}
         )
     endif()
+endif()
 
+if(NOT ${SLANG_USE_SYSTEM_GLSLANG})
     # glslang
     set(SKIP_GLSLANG_INSTALL ON)
     set(ENABLE_OPT ON)
     set(ENABLE_PCH OFF)
+    set(ALLOW_EXTERNAL_SPIRV_TOOLS ${SLANG_USE_SYSTEM_SPIRV_TOOLS})
     if(NOT SLANG_OVERRIDE_GLSLANG_PATH)
         add_subdirectory(glslang EXCLUDE_FROM_ALL ${system})
     else()
@@ -164,6 +168,7 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
         )
     endif()
 endif()
+endif()
 
 # imgui
 add_library(imgui INTERFACE)
```

</details>

But after doing that, I started getting these weird build errors at the very end:

```
error: cycle detected in build of '/nix/store/vg64rlbv3xmaxqa6084is11mz8wsqpi2-shader-slang-2025.10.4.drv' in the references of output 'dev' from output 'out'
```

```
error: cycle detected in build of '/nix/store/9w3c9pips513k31969r7gxlzwhqz49zd-shader-slang-2025.12.1.drv' in the references of output 'dev' from output 'out'
```

I couldn't figure out how to fix them, so that's why for now I gave up and opened this PR for a month-old version instead. However, I did do a little more delta debugging: it turns out that the reference cycle is caused by shader-slang/slang#7382, since it is absent when building from the previous commit shader-slang/slang@4ae6e9d8b7790d827ca9edd729ad94f38a0c73de.

cc @niklaskorz

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
