### PR TITLE
[Backport release-25.05]  opencode: 0.0.46 -> 0.2.33

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5944,6 +5944,14 @@
     github = "deinferno";
     githubId = 14363193;
   };
+  delafthi = {
+    name = "Thierry Delafontaine";
+    email = "delafthi@pm.me";
+    matrix = "@delafthi:matrix.org";
+    github = "delafthi";
+    githubId = 50531499;
+    keys = [ { fingerprint = "6DBB 0BB9 AEE6 2C2A 8059  7E1C 0092 6686 9818 63CB"; } ];
+  };
   delehef = {
     name = "Franklin Delehelle";
     email = "nix@odena.eu";

--- a/pkgs/by-name/op/opencode/fix-models-macro.patch
+++ b/pkgs/by-name/op/opencode/fix-models-macro.patch
@@ -1,0 +1,8 @@
+--- a/packages/opencode/src/provider/models-macro.ts
++++ b/packages/opencode/src/provider/models-macro.ts
+@@ -1,4 +1,3 @@
+ export async function data() {
+-  const json = await fetch("https://models.dev/api.json").then((x) => x.text())
+-  return json
++  return process.env.MODELS_JSON || '{}';
+ }

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -49,7 +49,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Powerful terminal-based AI assistant providing intelligent coding assistance";
-    homepage = "https://github.com/opencode-ai/opencode";
+    homepage = "https://github.com/sst/opencode";
     changelog = "https://github.com/sst/opencode/releases/tag/v${finalAttrs.version}";
     mainProgram = "opencode";
     license = lib.licenses.mit;

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -2,20 +2,28 @@
   lib,
   fetchFromGitHub,
   buildGoModule,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "opencode";
-  version = "0.0.46";
+  version = "0.0.52";
 
   src = fetchFromGitHub {
-    owner = "opencode-ai";
+    owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Q7ArUsFMpe0zayUMBJd+fC1K4jTGElIFep31Qa/L1jY=";
+    hash = "sha256-wniGu8EXOI2/sCI7gv2luQgODRdes7tt1CoJ6Gs09ig=";
   };
 
-  vendorHash = "sha256-MVpluFTF/2S6tRQQAXE3ujskQZ3njBkfve0RQgk3IkQ=";
+  vendorHash = "sha256-pnev0o2/jirTqG67amCeI49XUdMCCulpGq/jYqGqzRY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/sst/opencode/internal/version.Version=${finalAttrs.version}"
+  ];
 
   checkFlags =
     let
@@ -24,13 +32,25 @@ buildGoModule (finalAttrs: {
         "TestBashTool_Run"
         "TestSourcegraphTool_Run"
         "TestLsTool_Run"
+
+        # Difference with snapshot
+        "TestGetContextFromPaths"
       ];
     in
     [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
 
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Powerful terminal-based AI assistant providing intelligent coding assistance";
     homepage = "https://github.com/opencode-ai/opencode";
+    changelog = "https://github.com/sst/opencode/releases/tag/v${finalAttrs.version}";
     mainProgram = "opencode";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -26,12 +26,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.2.27";
+  version = "0.2.33";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nVjvcPL4s6xvlyR3NMXISl2Kaypwjk8QdvBnLc7c/E0=";
+    hash = "sha256-l/V9YHwuIPN73ieMT++enL1O5vecA9L0qBDGr8eRVxY=";
   };
 
   tui = buildGoModule {
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) version;
     src = "${finalAttrs.src}/packages/tui";
 
-    vendorHash = "sha256-5PG81ca/MPLdYbiQu6tj7DL+4HSEgHpwi4zekOnbf/c=";
+    vendorHash = "sha256-0vf4fOk32BLF9/904W8g+5m0vpe6i6tUFRXqDHVcMIQ=";
 
     subPackages = [ "cmd/opencode" ];
 

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -26,12 +26,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.2.20";
+  version = "0.2.23";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QONFC5HP5+mA/p7irEskJb8fN/uOnQ4VoB6mjP9v32k=";
+    hash = "sha256-rfYhlbSiSgpbbJazZf7P+bOiugVO+sYt+xFuYjBcBhY=";
   };
 
   tui = buildGoModule {
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) version;
     src = "${finalAttrs.src}/packages/tui";
 
-    vendorHash = "sha256-ujDTUdQLpWMFcmbabg4je6ZHFmUEyjaGt6BDucnC6mg=";
+    vendorHash = "sha256-PRPJlLjzcxKpVSKKLc9fOEh41QZz2AH7vsLb1P5/tvg=";
 
     subPackages = [ "cmd/opencode" ];
 

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -26,12 +26,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.2.6";
+  version = "0.2.13";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-k1eDQPZKV+X7I1gDPpAKTQBhWMjvXfOyZV4w+UIqLbU=";
+    hash = "sha256-Sh7FEn34iL4iZuusmghLCvKHfx/CMjOogBwnT+enz4g=";
   };
 
   tui = buildGoModule {
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) version;
     src = "${finalAttrs.src}/packages/tui";
 
-    vendorHash = "sha256-i7nFthcJOT1rCMsu4b3nzKjWnErGJJkWcGF1BFw58ZE=";
+    vendorHash = "sha256-Qvn59PU95TniPy7JaZDJhn/wUCfFYM+7bzav1jxNv34=";
 
     subPackages = [ "cmd/opencode" ];
 

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -26,12 +26,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.2.13";
+  version = "0.2.20";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Sh7FEn34iL4iZuusmghLCvKHfx/CMjOogBwnT+enz4g=";
+    hash = "sha256-QONFC5HP5+mA/p7irEskJb8fN/uOnQ4VoB6mjP9v32k=";
   };
 
   tui = buildGoModule {
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) version;
     src = "${finalAttrs.src}/packages/tui";
 
-    vendorHash = "sha256-Qvn59PU95TniPy7JaZDJhn/wUCfFYM+7bzav1jxNv34=";
+    vendorHash = "sha256-ujDTUdQLpWMFcmbabg4je6ZHFmUEyjaGt6BDucnC6mg=";
 
     subPackages = [ "cmd/opencode" ];
 

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -144,7 +144,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
     install -Dm755 opencode $out/bin/opencode
 
     runHook postInstall

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -26,12 +26,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.2.5";
+  version = "0.2.6";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eeB0M95APRLS5sJ49ubrUTga71Sy5UHUbR3Ps7oWYzo=";
+    hash = "sha256-k1eDQPZKV+X7I1gDPpAKTQBhWMjvXfOyZV4w+UIqLbU=";
   };
 
   tui = buildGoModule {
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) version;
     src = "${finalAttrs.src}/packages/tui";
 
-    vendorHash = "sha256-hLXOcZKGx56Q4BaWC0Y1/38Uo/soGbvqFSqoznYwoOo=";
+    vendorHash = "sha256-i7nFthcJOT1rCMsu4b3nzKjWnErGJJkWcGF1BFw58ZE=";
 
     subPackages = [ "cmd/opencode" ];
 

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -25,12 +25,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.1.182";
+  version = "0.1.185";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XTVh/lq9Ma6FATH1SPuLveig8MD/uJ/34EQzfuPAnxI=";
+    hash = "sha256-UCYfme9l7F3oBt+3sQE37+PwsmeTbnUFarbqVlb1f0I=";
   };
 
   tui = buildGoModule {
@@ -49,6 +49,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       "-w"
       "-X=main.Version=${finalAttrs.version}"
     ];
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 $GOPATH/bin/opencode $out/bin/tui
+
+      runHook postInstall
+    '';
   };
 
   node_modules = stdenvNoCC.mkDerivation {
@@ -77,9 +85,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     '';
 
     installPhase = ''
-      mkdir -p $out/node_modules
+      runHook preInstall
 
+      mkdir -p $out/node_modules
       cp -R ./node_modules $out
+
+      runHook postInstall
     '';
 
     # Required else we get errors that our fixed-output derivation references store paths
@@ -118,7 +129,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --target=${bun-target.${stdenvNoCC.hostPlatform.system}} \
       --outfile=opencode \
       ./packages/opencode/src/index.ts \
-      ${finalAttrs.tui}/bin/opencode
+      ${finalAttrs.tui}/bin/tui
 
     runHook postBuild
   '';
@@ -129,7 +140,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/bin
-    cp opencode $out/bin/opencode
+    install -Dm755 opencode $out/bin/opencode
 
     runHook postInstall
   '';

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -26,12 +26,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.2.25";
+  version = "0.2.27";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eZCWBnFfC4WSprhr+MXnJLuOyY3bEEfWwc89kc9VBs4=";
+    hash = "sha256-nVjvcPL4s6xvlyR3NMXISl2Kaypwjk8QdvBnLc7c/E0=";
   };
 
   tui = buildGoModule {
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) version;
     src = "${finalAttrs.src}/packages/tui";
 
-    vendorHash = "sha256-PRPJlLjzcxKpVSKKLc9fOEh41QZz2AH7vsLb1P5/tvg=";
+    vendorHash = "sha256-5PG81ca/MPLdYbiQu6tj7DL+4HSEgHpwi4zekOnbf/c=";
 
     subPackages = [ "cmd/opencode" ];
 

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -25,12 +25,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.1.181";
+  version = "0.1.182";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hANFrs0ihOwVbrFS0PyHyexLawpH+VzfwjG4FrOuYac=";
+    hash = "sha256-XTVh/lq9Ma6FATH1SPuLveig8MD/uJ/34EQzfuPAnxI=";
   };
 
   tui = buildGoModule {

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -25,12 +25,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.1.185";
+  version = "0.1.189";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UCYfme9l7F3oBt+3sQE37+PwsmeTbnUFarbqVlb1f0I=";
+    hash = "sha256-vQZE1b+/B3NV9wEp/T1ayP5pEuxmv37XRXx95XtUK9M=";
   };
 
   tui = buildGoModule {
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) version;
     src = "${finalAttrs.src}/packages/tui";
 
-    vendorHash = "sha256-/gDzGBCRapDBpEV9x1pB3QsOX9yua2RFY3i4OAjaIqc=";
+    vendorHash = "sha256-cDQ2ElnpGIqbTt13OY8QKhey9CsI/DoClHQrEUkXBMk=";
 
     subPackages = [ "cmd/opencode" ];
 

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -10,12 +10,12 @@
 }:
 
 let
-  version = "0.1.169";
+  version = "0.1.176";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${version}";
-    hash = "sha256-XCtO89yj+ov+f1Quof4hCWxL8l4xcFkqRWFW808GiUs=";
+    hash = "sha256-AKC8nAOa+33nOGSNzlQdbw2ESy+fg0j1h0k29qCCzd8=";
   };
 
   opencode-tui = buildGoModule {
@@ -24,7 +24,7 @@ let
 
     sourceRoot = "source/packages/tui";
 
-    vendorHash = "sha256-jUxBlBP8eKyDXVvYIZhcrSMfUvGb8/mTPZiPxlCfwLs=";
+    vendorHash = "sha256-gkaxjMGoJfDX6QjDCn6SSyyO7/mRqYrh+IRhWeBzj48=";
 
     subPackages = [ "cmd/opencode" ];
 
@@ -38,10 +38,10 @@ let
   };
 
   opencode-node-modules-hash = {
-    "aarch64-darwin" = "sha256-5Y9bfzYaO1iwSgpkCwPuUCDRtG8uXwgKm98sq78HisI=";
-    "aarch64-linux" = "sha256-t7dcyPsWeqYJv4/DPP15bvVurVPGCXWXVPUfpk1+l1Q=";
-    "x86_64-darwin" = "sha256-qYljdz4iyl3aZBhVU+uIVx4ZsvY9ubTTLNxJ94TUkBo=";
-    "x86_64-linux" = "sha256-TYjcA7MTfOKkvTwGSK1SotMDIH9xag79dikf6hMF8us=";
+    "aarch64-darwin" = "sha256-ZI4wJvBeSejhHjyRsYqpfUvJ959WU01JCW+2HIBs3Cg=";
+    "aarch64-linux" = "sha256-g/IyhBxVyU39rh2R9SfmHwBi4oMS12bo60Apbay06v0=";
+    "x86_64-darwin" = "sha256-ckWsqrwJEpL1ejrOSp5wTGwQYsDapLH3imNnSOEHQSw=";
+    "x86_64-linux" = "sha256-Q3zlrS7kuyKJReuIFqsqG5yfDuwLwBoCm0hUpJo9hSU=";
   };
   node_modules = stdenv.mkDerivation {
     name = "opencode-${version}-node-modules";
@@ -57,11 +57,15 @@ let
     dontConfigure = true;
 
     buildPhase = ''
+
+      export HOME=$(mktemp -d)
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+
       bun install \
-        --no-cache \
-        --no-progress \
+        --filter=opencode \
+        --force \
         --frozen-lockfile \
-        --filter=opencode
+        --no-progress
     '';
 
     installPhase = ''
@@ -80,7 +84,7 @@ let
 
   modelsDevData = fetchurl {
     url = "https://models.dev/api.json";
-    sha256 = "sha256-+VpQjvOOtuoltE3n9MZn8d0srYDacOh6B4wM0RqBmBM=";
+    sha256 = "sha256-igxQOC+Hz2FnXIW/S4Px9WhRuBhcIQIHO+7U8jHU1TQ=";
   };
   bun-target = {
     "aarch64-darwin" = "bun-darwin-arm64";

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -1,60 +1,156 @@
 {
   lib,
-  fetchFromGitHub,
+  stdenv,
   buildGoModule,
-  versionCheckHook,
+  bun,
+  fetchFromGitHub,
+  fetchurl,
   nix-update-script,
+  testers,
 }:
 
-buildGoModule (finalAttrs: {
-  pname = "opencode";
-  version = "0.0.52";
-
+let
+  version = "0.1.169";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-wniGu8EXOI2/sCI7gv2luQgODRdes7tt1CoJ6Gs09ig=";
+    tag = "v${version}";
+    hash = "sha256-XCtO89yj+ov+f1Quof4hCWxL8l4xcFkqRWFW808GiUs=";
   };
 
-  vendorHash = "sha256-pnev0o2/jirTqG67amCeI49XUdMCCulpGq/jYqGqzRY=";
+  opencode-tui = buildGoModule {
+    pname = "opencode-tui";
+    inherit version src;
 
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/sst/opencode/internal/version.Version=${finalAttrs.version}"
-  ];
+    sourceRoot = "source/packages/tui";
 
-  checkFlags =
-    let
-      skippedTests = [
-        # permission denied
-        "TestBashTool_Run"
-        "TestSourcegraphTool_Run"
-        "TestLsTool_Run"
+    vendorHash = "sha256-jUxBlBP8eKyDXVvYIZhcrSMfUvGb8/mTPZiPxlCfwLs=";
 
-        # Difference with snapshot
-        "TestGetContextFromPaths"
-      ];
-    in
-    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
+    subPackages = [ "cmd/opencode" ];
 
-  nativeCheckInputs = [
-    versionCheckHook
-  ];
-  versionCheckProgramArg = "--version";
-  doInstallCheck = true;
+    env.CGO_ENABLED = 0;
 
-  passthru.updateScript = nix-update-script { };
+    ldflags = [
+      "-s"
+      "-w"
+      "-X=main.Version=${version}"
+    ];
+  };
+
+  opencode-node-modules-hash = {
+    "aarch64-darwin" = "sha256-5Y9bfzYaO1iwSgpkCwPuUCDRtG8uXwgKm98sq78HisI=";
+    "aarch64-linux" = "sha256-t7dcyPsWeqYJv4/DPP15bvVurVPGCXWXVPUfpk1+l1Q=";
+    "x86_64-darwin" = "sha256-qYljdz4iyl3aZBhVU+uIVx4ZsvY9ubTTLNxJ94TUkBo=";
+    "x86_64-linux" = "sha256-TYjcA7MTfOKkvTwGSK1SotMDIH9xag79dikf6hMF8us=";
+  };
+  node_modules = stdenv.mkDerivation {
+    name = "opencode-${version}-node-modules";
+    inherit version src;
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+
+    nativeBuildInputs = [ bun ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      bun install \
+        --no-cache \
+        --no-progress \
+        --frozen-lockfile \
+        --filter=opencode
+    '';
+
+    installPhase = ''
+      mkdir -p $out/node_modules
+
+      cp -R ./node_modules $out
+    '';
+
+    # Required else we get errors that our fixed-output derivation references store paths
+    dontFixup = true;
+
+    outputHash = opencode-node-modules-hash.${stdenv.hostPlatform.system};
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+  modelsDevData = fetchurl {
+    url = "https://models.dev/api.json";
+    sha256 = "sha256-+VpQjvOOtuoltE3n9MZn8d0srYDacOh6B4wM0RqBmBM=";
+  };
+  bun-target = {
+    "aarch64-darwin" = "bun-darwin-arm64";
+    "aarch64-linux" = "bun-linux-arm64";
+    "x86_64-darwin" = "bun-darwin-x64";
+    "x86_64-linux" = "bun-linux-x64";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "opencode";
+  inherit version src;
+
+  nativeBuildInputs = [ bun ];
+
+  patches = [ ./fix-models-macro.patch ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${node_modules}/node_modules .
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export MODELS_JSON="$(cat ${modelsDevData})"
+    bun build \
+      --define OPENCODE_VERSION="'${version}'" \
+      --compile \
+      --minify \
+      --target=${bun-target.${stdenv.hostPlatform.system}} \
+      --outfile=opencode \
+      ./packages/opencode/src/index.ts \
+      ${opencode-tui}/bin/opencode
+
+    runHook postBuild
+  '';
+
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp opencode $out/bin/opencode
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
-    description = "Powerful terminal-based AI assistant providing intelligent coding assistance";
+    description = "AI coding agent built for the terminal";
+    longDescription = ''
+      OpenCode is a terminal-based agent that can build anything.
+      It combines a TypeScript/JavaScript core with a Go-based TUI
+      to provide an interactive AI coding experience.
+    '';
     homepage = "https://github.com/sst/opencode";
-    changelog = "https://github.com/sst/opencode/releases/tag/v${finalAttrs.version}";
-    mainProgram = "opencode";
     license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       zestsystem
+      delafthi
     ];
+    mainProgram = "opencode";
   };
 })

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -113,7 +113,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ bun ];
 
-  patches = [ ./fix-models-macro.patch ];
+  patches = [
+    # Patch `packages/opencode/src/provider/models-macro.ts` to load the prefetched `models.dev/api.json`
+    # from the `MODELS_JSON` environment variable instead of fetching it at build time.
+    ./fix-models-macro.patch
+  ];
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -12,10 +12,10 @@
 
 let
   opencode-node-modules-hash = {
-    "aarch64-darwin" = "sha256-+eXXWskZg0CIY12+Ee4Y3uwpB5I92grDiZ600Whzx/I=";
-    "aarch64-linux" = "sha256-rxLPrYAIiKDh6de/GACPfcYXY7nIskqAu1Xi12y5DpU=";
-    "x86_64-darwin" = "sha256-LOz7N6gMRaZLPks+y5fDIMOuUCXTWpHIss1v0LHPnqw=";
-    "x86_64-linux" = "sha256-GKLR+T+lCa7GFQr6HqSisfa4uf8F2b79RICZmePmCBE=";
+    "aarch64-darwin" = "sha256-uk8HQfHCKTAW54rNHZ1Rr0piZzeJdx6i4o0+xKjfFZs=";
+    "aarch64-linux" = "sha256-gDQh8gfFKl0rAujtos1XsCUnxC2Vjyq9xH5FLZoNW5s=";
+    "x86_64-darwin" = "sha256-H5+qa7vxhwNYRXUo4v8IFUToVXtyXzU3veIqu4idAbU=";
+    "x86_64-linux" = "sha256-1ZxetDrrRdNNOfDOW2uMwMwpEs5S3BLF+SejWcRdtik=";
   };
   bun-target = {
     "aarch64-darwin" = "bun-darwin-arm64";
@@ -26,12 +26,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.1.194";
+  version = "0.2.5";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-51Mc0Qrg3C0JTpXl2OECKEUvle+6X+j9+/Blu8Nu9Ao=";
+    hash = "sha256-eeB0M95APRLS5sJ49ubrUTga71Sy5UHUbR3Ps7oWYzo=";
   };
 
   tui = buildGoModule {
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) version;
     src = "${finalAttrs.src}/packages/tui";
 
-    vendorHash = "sha256-hxtQHlaV2Em8CyTK3BNaoo/LgnGbMjj5XafbleF+p9I=";
+    vendorHash = "sha256-hLXOcZKGx56Q4BaWC0Y1/38Uo/soGbvqFSqoznYwoOo=";
 
     subPackages = [ "cmd/opencode" ];
 

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -26,12 +26,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "0.2.23";
+  version = "0.2.25";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rfYhlbSiSgpbbJazZf7P+bOiugVO+sYt+xFuYjBcBhY=";
+    hash = "sha256-eZCWBnFfC4WSprhr+MXnJLuOyY3bEEfWwc89kc9VBs4=";
   };
 
   tui = buildGoModule {


### PR DESCRIPTION
This PR cherry-picks all Opencode-related commits from the `master` branch to backport them to `release-25.05`. The update brings Opencode to the latest version to resolve confusion caused by the 25.05 release lacking the SST variant. For example, [x.com/bedesqui/status/1943047048867254365](https://x.com/bedesqui/status/1943047048867254365).

@GaetanLepage, what do you think? Should we use the most recent version for the backport, or would it be better to select a specific version instead?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
