### PR TITLE
shader-slang: 2025.8.1 -> 2025.12.1

### DIFF
--- a/pkgs/by-name/sh/shader-slang/1-find-packages.patch
+++ b/pkgs/by-name/sh/shader-slang/1-find-packages.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a933d0ab64..fced38bc32 100644
+index 549e465ac..546c94607 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -160,6 +160,8 @@ advanced_option(
+@@ -175,6 +175,8 @@ advanced_option(
      "Build using system unordered dense"
      OFF
  )
@@ -11,7 +11,7 @@ index a933d0ab64..fced38bc32 100644
  
  option(
      SLANG_SPIRV_HEADERS_INCLUDE_DIR
-@@ -386,6 +388,34 @@ if(${SLANG_USE_SYSTEM_UNORDERED_DENSE})
+@@ -404,6 +406,34 @@ if(${SLANG_USE_SYSTEM_UNORDERED_DENSE})
      find_package(unordered_dense CONFIG QUIET)
  endif()
  
@@ -47,18 +47,18 @@ index a933d0ab64..fced38bc32 100644
  
  # webgpu_dawn is only available as a fetched shared library, since Dawn's nested source
 diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
-index 55d9e4941d..ff8a244651 100644
+index 801cae4d6..d45150118 100644
 --- a/external/CMakeLists.txt
 +++ b/external/CMakeLists.txt
-@@ -117,6 +117,7 @@ if(NOT ${SLANG_USE_SYSTEM_SPIRV_HEADERS})
- endif()
+@@ -133,6 +133,7 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
+         )
+     endif()
  
- if(SLANG_ENABLE_SLANG_GLSLANG)
 +if(NOT ${SLANG_USE_SYSTEM_SPIRV_TOOLS})
      # SPIRV-Tools
      set(SPIRV_TOOLS_BUILD_STATIC ON)
      set(SPIRV_WERROR OFF)
-@@ -138,11 +139,14 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
+@@ -148,11 +149,14 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
              ${system}
          )
      endif()
@@ -73,7 +73,7 @@ index 55d9e4941d..ff8a244651 100644
      if(NOT SLANG_OVERRIDE_GLSLANG_PATH)
          add_subdirectory(glslang EXCLUDE_FROM_ALL ${system})
      else()
-@@ -154,6 +158,7 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
+@@ -164,6 +168,7 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
          )
      endif()
  endif()

--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shader-slang";
-  version = "2025.8.1";
+  version = "2025.12.1";
 
   src = fetchFromGitHub {
     owner = "shader-slang";
     repo = "slang";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PScbMkJJ4rh8I8ID709GKtLmd5+4Z2x2BlFEdWpoesI=";
+    hash = "sha256-5M/sKoCFVGW4VcOPzL8dVhTuo+esjINPXw76fnO7OEw=";
     fetchSubmodules = true;
   };
 
@@ -130,6 +130,10 @@ stdenv.mkDerivation (finalAttrs: {
       "-DSLANG_USE_SYSTEM_GLSLANG=ON"
     ]
     ++ lib.optional (!withGlslang) "-DSLANG_ENABLE_SLANG_GLSLANG=OFF";
+
+  postInstall = ''
+    mv "$out/cmake" "$dev/cmake"
+  '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/slangc";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upgrades shader-slang from 2025.8.1 to 2025.12.1

This PR fixes up #416790 by applying the updated patch mentioned in #424144, and then "resolves" the reference cycle error by having the derivation be single-output; this was the only fix I could figure out at the moment with my limited Nix expertise. I don't have a good understanding of what the drawbacks are.

Changelogs:

- https://github.com/shader-slang/slang/releases/tag/v2025.12.1
- https://github.com/shader-slang/slang/releases/tag/v2025.12
- https://github.com/shader-slang/slang/releases/tag/v2025.11.1
- https://github.com/shader-slang/slang/releases/tag/v2025.11
- https://github.com/shader-slang/slang/releases/tag/v2025.10.5
- https://github.com/shader-slang/slang/releases/tag/v2025.10.4
- https://github.com/shader-slang/slang/releases/tag/v2025.10.3
- https://github.com/shader-slang/slang/releases/tag/v2025.10.2
- https://github.com/shader-slang/slang/releases/tag/v2025.10.1
- https://github.com/shader-slang/slang/releases/tag/v2025.10
- https://github.com/shader-slang/slang/releases/tag/v2025.9.2
- https://github.com/shader-slang/slang/releases/tag/v2025.9.1
- https://github.com/shader-slang/slang/releases/tag/v2025.9


cc @niklaskorz

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
