### PR TITLE
workflows/build: be clearer about what is being built

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,20 @@ jobs:
           - runner: ubuntu-24.04
             system: x86_64-linux
             builds: [shell, manual-nixos, lib-tests]
+            desc: shell, docs, lib
           - runner: ubuntu-24.04-arm
             system: aarch64-linux
             builds: [shell, manual-nixos, manual-nixpkgs, manual-nixpkgs-tests]
+            desc: shell, docs
           - runner: macos-13
             system: x86_64-darwin
             builds: [shell]
+            desc: shell
           - runner: macos-14
             system: aarch64-darwin
             builds: [shell]
-    name: ${{ matrix.system }}
+            desc: shell
+    name: '${{ matrix.system }}: ${{ matrix.desc }}'
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
People could get the false impression from, e.g., `PR / Build / aarch64-linux` that this workflow builds the packages changed in the current PR. If a committer had this misunderstanding, it could pair poorly with the "enable auto-merge" button, once that's enabled (i.e. they could think, wrongly, that the PR will not be merged unless the packages it changes build).

Definitely open to suggestions for the contents of the `desc` fields, especially if they would make them shorter!

Tested on my fork.