### PR TITLE
treewide: specify that mebibytes are used when it's ambiguous

### DIFF
--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -145,14 +145,14 @@ Similarly, if you encounter errors similar to `Error_Protocol ("certificate has 
 
 `diskSize` (Number; _optional_)
 
-: Controls the disk size (in megabytes) of the VM used to run the script specified in `runAsRoot`.
+: Controls the disk size in MiB (1024x1024 bytes) of the VM used to run the script specified in `runAsRoot`.
   This attribute is ignored if `runAsRoot` is `null`.
 
   _Default value:_ 1024.
 
 `buildVMMemorySize` (Number; _optional_)
 
-: Controls the amount of memory (in megabytes) provisioned for the VM used to run the script specified in `runAsRoot`.
+: Controls the amount of memory in MiB (1024x1024 bytes) provisioned for the VM used to run the script specified in `runAsRoot`.
   This attribute is ignored if `runAsRoot` is `null`.
 
   _Default value:_ 512.

--- a/doc/build-helpers/images/makediskimage.section.md
+++ b/doc/build-helpers/images/makediskimage.section.md
@@ -108,6 +108,6 @@ make-disk-image {
   diskSize = "auto";
   additionalSpace = "0M"; # Defaults to 512M.
   copyChannel = false;
-  memSize = 2048; # Qemu VM memory size in megabytes. Defaults to 1024M.
+  memSize = 2048; # Qemu VM memory size in MiB (1024*1024 bytes). Defaults to 1024M.
 }
 ```

--- a/doc/build-helpers/special/vm-tools.section.md
+++ b/doc/build-helpers/special/vm-tools.section.md
@@ -23,7 +23,7 @@ If the build fails and Nix is run with the `-K/--keep-failed` option, a script `
 ### Attributes {#vm-tools-runInLinuxVM-attributes}
 
 * `preVM` (optional). Shell command to be evaluated *before* the VM is started (i.e., on the host).
-* `memSize` (optional, default `512`). The memory size of the VM in MiB.
+* `memSize` (optional, default `512`). The memory size of the VM in MiB (1024×1024 bytes).
 * `diskImage` (optional). A file system image to be attached to `/dev/sda`.
   Note that currently we expect the image to contain a filesystem, not a full disk image with a partition table etc.
 

--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -92,7 +92,7 @@ There are a few special NixOS options for test VMs:
 
 `virtualisation.memorySize`
 
-:   The memory of the VM in megabytes.
+:   The memory of the VM in MiB (1024×1024 bytes).
 
 `virtualisation.vlans`
 

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -96,7 +96,7 @@
   # The NixOS configuration to be installed onto the disk image.
   config,
 
-  # The size of the disk, in megabytes.
+  # The size of the disk, in MiB (1024*1024 bytes).
   # if "auto" size is calculated based on the contents copied to it and
   #   additionalSpace is taken into account.
   diskSize ? "auto",
@@ -152,7 +152,7 @@
   # Shell code executed after the VM has finished.
   postVM ? "",
 
-  # Guest memory size
+  # Guest memory size in MiB (1024*1024 bytes)
   memSize ? 1024,
 
   # Copy the contents of the Nix store to the root of the image and

--- a/nixos/lib/make-multi-disk-zfs-image.nix
+++ b/nixos/lib/make-multi-disk-zfs-image.nix
@@ -30,10 +30,10 @@
   # The NixOS configuration to be installed onto the disk image.
   config,
 
-  # size of the FAT boot disk, in megabytes.
+  # size of the FAT boot disk in MiB (1024*1024 bytes)
   bootSize ? 1024,
 
-  # The size of the root disk, in megabytes.
+  # The size of the root disk in MiB (1024*1024 bytes)
   rootSize ? 2048,
 
   # The name of the ZFS pool
@@ -74,7 +74,7 @@
   # Shell code executed after the VM has finished.
   postVM ? "",
 
-  # Guest memory size
+  # Guest memory size in MiB (1024*1024 bytes)
   memSize ? 1024,
 
   name ? "nixos-disk-image",

--- a/nixos/lib/make-single-disk-zfs-image.nix
+++ b/nixos/lib/make-single-disk-zfs-image.nix
@@ -19,13 +19,13 @@
   # The NixOS configuration to be installed onto the disk image.
   config,
 
-  # size of the FAT partition, in megabytes.
-  bootSize ? 1024
+  # size of the FAT partition, in MiB (1024x1024 bytes).
+  bootSize ? 1024,
 
-  , # memory allocated for virtualized build instance
+  # memory allocated for virtualized build instance, in MiB (1024x1024 bytes).
   memSize ? 1024,
 
-  # The size of the root partition, in megabytes.
+  # The size of the root partition, in MiB (1024x1024 bytes).
   rootSize ? 2048,
 
   # The name of the ZFS pool

--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -121,7 +121,7 @@ let
           description = ''
             If this option is set, ‘device’ is interpreted as the
             path of a swapfile that will be created automatically
-            with the indicated size (in megabytes).
+            with the indicated size in MiB (1024×1024 bytes).
           '';
         };
 

--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -80,8 +80,7 @@ in
       type = types.int;
       default = 8;
       description = ''
-        Gap in front of the /boot/firmware partition, in mebibytes (1024×1024
-        bytes).
+        Gap in front of the /boot/firmware partition, in MiB (1024×1024 bytes).
         Can be increased to make more space for boards requiring to dd u-boot
         SPL before actual partitions.
 

--- a/nixos/modules/profiles/nix-builder-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vm.nix
@@ -48,13 +48,13 @@ in
       default = 20 * 1024;
       type = types.int;
       example = 30720;
-      description = "The maximum disk space allocated to the runner in MB";
+      description = "The maximum disk space allocated to the runner in MiB (1024×1024 bytes).";
     };
     memorySize = mkOption {
       default = 3 * 1024;
       type = types.int;
       example = 8192;
-      description = "The runner's memory in MB";
+      description = "The runner's memory in MiB (1024×1024 bytes).";
     };
     min-free = mkOption {
       default = 1024 * 1024 * 1024;

--- a/nixos/modules/services/databases/memcached.nix
+++ b/nixos/modules/services/databases/memcached.nix
@@ -44,7 +44,7 @@ in
       maxMemory = lib.mkOption {
         type = lib.types.ints.unsigned;
         default = 64;
-        description = "The maximum amount of memory to use for storage, in megabytes.";
+        description = "The maximum amount of memory to use for storage, in MiB (1024×1024 bytes).";
       };
 
       maxConnections = lib.mkOption {

--- a/nixos/modules/virtualisation/disk-size-option.nix
+++ b/nixos/modules/virtualisation/disk-size-option.nix
@@ -18,7 +18,7 @@ in
       default = if config.virtualisation.diskSizeAutoSupported then "auto" else 1024;
       defaultText = lib.literalExpression "if virtualisation.diskSizeAutoSupported then \"auto\" else 1024";
       description = ''
-        The disk size in megabytes of the virtual machine.
+        The disk size in MiB (1024×1024 bytes) of the virtual machine.
       '';
     };
   };

--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -71,7 +71,7 @@ with lib;
         type = types.ints.positive;
         default = 1024;
         description = ''
-          Guest memory in MB
+          Guest memory in MiB (1024×1024 bytes)
         '';
       };
       bios = mkOption {

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -391,7 +391,7 @@ in
       type = types.ints.positive;
       default = 1024;
       description = ''
-        The memory size in megabytes of the virtual machine.
+        The memory size of the virtual machine in MiB (1024×1024 bytes).
       '';
     };
 
@@ -457,7 +457,7 @@ in
       default = [ ];
       description = ''
         Additional disk images to provide to the VM. The value is
-        a list of size in megabytes of each disk. These disks are
+        a list of size in MiB (1024×1024 bytes) of each disk. These disks are
         writeable by the VM.
       '';
     };
@@ -1098,7 +1098,7 @@ in
         {
           assertion = pkgs.stdenv.hostPlatform.is32bit -> cfg.memorySize < 2047;
           message = ''
-            virtualisation.memorySize is above 2047, but qemu is only able to allocate 2047MB RAM on 32bit max.
+            virtualisation.memorySize is above 2047, but qemu is only able to allocate 2047 MiB RAM on 32bit max.
           '';
         }
         {

--- a/nixos/modules/virtualisation/waagent.nix
+++ b/nixos/modules/virtualisation/waagent.nix
@@ -174,7 +174,7 @@ let
           type = types.int;
           default = 0;
           description = ''
-            Specifies the size of the swap file in megabytes.
+            Specifies the size of the swap file in MiB (1024×1024 bytes).
 
             This configuration has no effect if resource disk is managed by cloud-init.
           '';

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -317,7 +317,7 @@ rec {
   # A bash script fragment that produces a disk image at `destination`.
   createEmptyImage =
     {
-      # Disk image size in MiB
+      # Disk image size in MiB (1024*1024 bytes)
       size,
       # Name that will be written to ${destination}/nix-support/full-name
       fullName,
@@ -358,11 +358,11 @@ rec {
     will build the derivation `patchelf' inside a VM.  The attribute
     `preVM' can optionally contain a shell command to be evaluated
     *before* the VM is started (i.e., on the host).  The attribute
-    `memSize' specifies the memory size of the VM in megabytes,
-    defaulting to 512.  The attribute `diskImage' can optionally
-    specify a file system image to be attached to /dev/sda.  (Note
-    that currently we expect the image to contain a filesystem, not a
-    full disk image with a partition table etc.)
+    `memSize' specifies the memory size of the VM in MiB (1024*1024
+    bytes), defaulting to 512.  The attribute `diskImage' can
+    optionally specify a file system image to be attached to /dev/sda.
+    (Note that currently we expect the image to contain a filesystem,
+    not a full disk image with a partition table etc.)
 
     If the build fails and Nix is run with the `-K' option, a script
     `run-vm' will be left behind in the temporary build directory
@@ -1230,7 +1230,7 @@ rec {
     `extraPackages' specifies the names of additional packages from
     the distribution that should be included in the image; `packages'
     allows the entire set of packages to be overridden; and `size'
-    sets the size of the disk in megabytes.  E.g.,
+    sets the size of the disk in MiB (1024*1024 bytes).  E.g.,
     `diskImageFuns.ubuntu1004x86_64 { extraPackages = ["firefox"];
     size = 8192; }' builds an 8 GiB image containing Firefox in
     addition to the default packages.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The definition of "megabytes" and "MB" is often ambiguous. Where necessary, rewrote previous uses of MB/megabytes as MiB/mebibytes, and provided a formula for calculating the amount of bytes in a mebibyte. Checked source code where necessary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
