### PR TITLE
netexec: use python 3.12

### DIFF
--- a/pkgs/by-name/ne/netexec/package.nix
+++ b/pkgs/by-name/ne/netexec/package.nix
@@ -2,11 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python3,
+  python312,
   writableTmpDirAsHomeHook,
 }:
 let
-  python = python3.override {
+  python = python312.override {
     self = python;
     packageOverrides = self: super: {
       impacket = super.impacket.overridePythonAttrs {


### PR DESCRIPTION
Some dependencies are not yet compatible with Python 3.13. I opened a PR to fix ldapdomaindump (#418520). pynfsclient does not yet support it (https://github.com/CharmingYang0/NfsClient/issues/11).

@vncsb 