### PR TITLE
discord: fix krisp by using fhsEnv on linux

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -5,12 +5,11 @@
   meta,
   binaryName,
   desktopName,
-  autoPatchelfHook,
+  buildFHSEnv,
   makeDesktopItem,
   lib,
   stdenv,
-  wrapGAppsHook3,
-  makeShellWrapper,
+  writeScript,
   alsa-lib,
   at-spi2-atk,
   at-spi2-core,
@@ -44,18 +43,20 @@
   libxcb,
   libxshmfence,
   libgbm,
+  libxkbcommon,
+  mesa,
   nspr,
   nss,
   pango,
   systemd,
   libappindicator-gtk3,
   libdbusmenu,
-  writeScript,
   pipewire,
   python3,
   runCommand,
   speechd-minimal,
   wayland,
+  xorg,
   branch,
   withOpenASAR ? false,
   openasar,
@@ -88,132 +89,164 @@ let
         substituteAllInPlace $out/bin/disable-breaking-updates.py
         chmod +x $out/bin/disable-breaking-updates.py
       '';
-in
-stdenv.mkDerivation rec {
-  inherit
-    pname
-    version
-    src
-    meta
-    ;
 
-  nativeBuildInputs = [
-    alsa-lib
-    autoPatchelfHook
-    cups
-    libdrm
-    libuuid
-    libXdamage
-    libX11
-    libXScrnSaver
-    libXtst
-    libxcb
-    libxshmfence
-    libgbm
-    nss
-    wrapGAppsHook3
-    makeShellWrapper
-  ];
-
-  dontWrapGApps = true;
-
-  libPath = lib.makeLibraryPath (
-    [
-      libcxx
-      systemd
-      libpulseaudio
-      libdrm
-      libgbm
-      stdenv.cc.cc
-      alsa-lib
-      atk
-      at-spi2-atk
-      at-spi2-core
-      cairo
-      cups
-      dbus
-      expat
-      fontconfig
-      freetype
-      gdk-pixbuf
-      glib
-      gtk3
-      libglvnd
-      libnotify
-      libX11
-      libXcomposite
-      libuuid
-      libXcursor
-      libXdamage
-      libXext
-      libXfixes
-      libXi
-      libXrandr
-      libXrender
-      libXtst
-      nspr
-      libxcb
-      pango
-      pipewire
-      libXScrnSaver
-      libappindicator-gtk3
-      libdbusmenu
-      wayland
-    ]
-    ++ lib.optional withTTS speechd-minimal
-  );
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/{bin,opt/${binaryName},share/pixmaps,share/icons/hicolor/256x256/apps}
-    mv * $out/opt/${binaryName}
-
-    chmod +x $out/opt/${binaryName}/${binaryName}
-    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
-        $out/opt/${binaryName}/${binaryName}
-
-    wrapProgramShell $out/opt/${binaryName}/${binaryName} \
-        "''${gappsWrapperArgs[@]}" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
-        ${lib.strings.optionalString withTTS ''
-          --run 'if [[ "''${NIXOS_SPEECH:-default}" != "False" ]]; then NIXOS_SPEECH=True; else unset NIXOS_SPEECH; fi' \
-          --add-flags "\''${NIXOS_SPEECH:+--enable-speech-dispatcher}" \
-        ''} \
-        ${lib.strings.optionalString enableAutoscroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""} \
-        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-        --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/${binaryName} \
-        ${lib.strings.optionalString disableUpdates "--run ${lib.getExe disableBreakingUpdates}"} \
-        --add-flags ${lib.escapeShellArg commandLineArgs}
-
-    ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
-    # Without || true the install would fail on case-insensitive filesystems
-    ln -s $out/opt/${binaryName}/${binaryName} $out/bin/${lib.strings.toLower binaryName} || true
-
-    ln -s $out/opt/${binaryName}/discord.png $out/share/pixmaps/${pname}.png
-    ln -s $out/opt/${binaryName}/discord.png $out/share/icons/hicolor/256x256/apps/${pname}.png
-
-    ln -s "$desktopItem/share/applications" $out/share/
-
-    runHook postInstall
-  '';
-
-  postInstall =
-    lib.strings.optionalString withOpenASAR ''
-      cp -f ${openasar} $out/opt/${binaryName}/resources/app.asar
-    ''
-    + lib.strings.optionalString withVencord ''
-      mv $out/opt/${binaryName}/resources/app.asar $out/opt/${binaryName}/resources/_app.asar
-      mkdir $out/opt/${binaryName}/resources/app.asar
-      echo '{"name":"discord","main":"index.js"}' > $out/opt/${binaryName}/resources/app.asar/package.json
-      echo 'require("${vencord}/patcher.js")' > $out/opt/${binaryName}/resources/app.asar/index.js
-    ''
-    + lib.strings.optionalString withMoonlight ''
-      mv $out/opt/${binaryName}/resources/app.asar $out/opt/${binaryName}/resources/_app.asar
-      mkdir $out/opt/${binaryName}/resources/app
-      echo '{"name":"discord","main":"injector.js","private": true}' > $out/opt/${binaryName}/resources/app/package.json
-      echo 'require("${moonlight}/injector.js").inject(require("path").join(__dirname, "../_app.asar"));' > $out/opt/${binaryName}/resources/app/injector.js
+  # Create the Discord application directory
+  discordDir = stdenv.mkDerivation {
+    name = "${pname}-${version}-dir";
+    inherit src;
+    
+    # Disable automatic patching that could modify binaries
+    dontPatchELF = true;
+    dontStrip = true;
+    dontPatchShebangs = true;
+    
+    unpackPhase = ''
+      runHook preUnpack
+      
+      mkdir -p $out
+      cd $out
+      tar -xzf $src --strip-components=1
+      
+      runHook postUnpack
     '';
+    
+    dontBuild = true;
+    dontConfigure = true;
+    
+    installPhase = ''
+      runHook preInstall
+      
+      # Apply modifications (do NOT chmod the binary - it breaks Krisp checksum validation)
+      ${lib.optionalString withOpenASAR ''
+        cp -f ${openasar} resources/app.asar
+      ''}
+      ${lib.optionalString withVencord ''
+        mv resources/app.asar resources/_app.asar
+        mkdir resources/app.asar
+        echo '{"name":"discord","main":"index.js"}' > resources/app.asar/package.json
+        echo 'require("${vencord}/patcher.js")' > resources/app.asar/index.js
+      ''}
+      ${lib.optionalString withMoonlight ''
+        mv resources/app.asar resources/_app.asar
+        mkdir resources/app
+        echo '{"name":"discord","main":"injector.js","private": true}' > resources/app/package.json
+        echo 'require("${moonlight}/injector.js").inject(require("path").join(__dirname, "../_app.asar"));' > resources/app/injector.js
+      ''}
+      
+      runHook postInstall
+    '';
+  };
+
+  # FHS Environment with all necessary libraries
+  fhsEnv = buildFHSEnv {
+    name = "${pname}-fhs";
+    
+    targetPkgs = pkgs: [
+      # Core system libraries
+      pkgs.stdenv.cc.cc.lib
+      pkgs.glibc
+      
+      # Graphics and display
+      pkgs.libglvnd
+      pkgs.mesa
+      pkgs.libdrm
+      pkgs.libgbm
+      pkgs.wayland
+      
+      # X11 libraries
+      pkgs.xorg.libX11
+      pkgs.xorg.libXcomposite
+      pkgs.xorg.libXcursor
+      pkgs.xorg.libXdamage
+      pkgs.xorg.libXext
+      pkgs.xorg.libXfixes
+      pkgs.xorg.libXi
+      pkgs.xorg.libXrandr
+      pkgs.xorg.libXrender
+      pkgs.xorg.libXtst
+      pkgs.xorg.libXScrnSaver
+      pkgs.xorg.libxcb
+      pkgs.xorg.libxshmfence
+      
+      # GTK and desktop integration
+      pkgs.gtk3
+      pkgs.glib
+      pkgs.cairo
+      pkgs.pango
+      pkgs.gdk-pixbuf
+      pkgs.atk
+      pkgs.at-spi2-atk
+      pkgs.at-spi2-core
+      pkgs.libappindicator-gtk3
+      pkgs.libdbusmenu
+      
+      # Audio
+      pkgs.alsa-lib
+      pkgs.libpulseaudio
+      pkgs.pipewire
+      
+      # Other system libraries
+      pkgs.dbus
+      pkgs.systemd
+      pkgs.fontconfig
+      pkgs.freetype
+      pkgs.expat
+      pkgs.libuuid
+      pkgs.cups
+      pkgs.nspr
+      pkgs.nss
+      pkgs.libnotify
+      pkgs.libcxx
+      pkgs.libxkbcommon
+    ] ++ lib.optional withTTS pkgs.speechd-minimal;
+    
+    multiPkgs = pkgs: [
+      # Additional 32-bit libraries if needed
+      pkgs.alsa-lib
+      pkgs.libpulseaudio
+    ];
+    
+    # Set up the runtime environment
+    runScript = writeScript "${pname}-wrapper" ''
+      #!/bin/bash
+      
+      # Run the disable updates script if enabled
+      ${lib.optionalString disableUpdates ''
+        ${lib.getExe disableBreakingUpdates}
+      ''}
+      
+      # Set up environment variables
+      export XDG_DATA_DIRS="${gtk3}/share/gsettings-schemas/${gtk3.name}/:$XDG_DATA_DIRS"
+      
+      # Handle Wayland
+      if [[ -n "$NIXOS_OZONE_WL" && -n "$WAYLAND_DISPLAY" ]]; then
+        WAYLAND_FLAGS="--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true"
+      fi
+      
+      # Handle TTS
+      ${lib.optionalString withTTS ''
+        if [[ "''${NIXOS_SPEECH:-default}" != "False" ]]; then
+          export NIXOS_SPEECH=True
+          TTS_FLAGS="--enable-speech-dispatcher"
+        fi
+      ''}
+      
+      # Handle autoscroll
+      ${lib.optionalString enableAutoscroll ''
+        AUTOSCROLL_FLAGS="--enable-blink-features=MiddleClickAutoscroll"
+      ''}
+      
+      # Execute Discord
+      exec ${discordDir}/${binaryName} \
+        --no-sandbox \
+        --disable-gpu-sandbox \
+        $WAYLAND_FLAGS \
+        $TTS_FLAGS \
+        $AUTOSCROLL_FLAGS \
+        ${lib.escapeShellArg commandLineArgs} \
+        "$@"
+    '';
+  };
 
   desktopItem = makeDesktopItem {
     name = pname;
@@ -228,7 +261,36 @@ stdenv.mkDerivation rec {
     mimeTypes = [ "x-scheme-handler/discord" ];
     startupWMClass = "discord";
   };
-
+in
+stdenv.mkDerivation {
+  inherit pname version meta;
+  
+  dontUnpack = true;
+  dontBuild = true;
+  dontConfigure = true;
+  
+  installPhase = ''
+    runHook preInstall
+    
+    mkdir -p $out/bin
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/pixmaps
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+    
+    # Install the FHS wrapper
+    ln -s ${fhsEnv}/bin/${pname}-fhs $out/bin/${binaryName}
+    ln -s ${fhsEnv}/bin/${pname}-fhs $out/bin/${lib.strings.toLower binaryName}
+    
+    # Install icons
+    ln -s ${discordDir}/discord.png $out/share/pixmaps/${pname}.png
+    ln -s ${discordDir}/discord.png $out/share/icons/hicolor/256x256/apps/${pname}.png
+    
+    # Install desktop file
+    ln -s ${desktopItem}/share/applications/${pname}.desktop $out/share/applications/
+    
+    runHook postInstall
+  '';
+  
   passthru = {
     # make it possible to run disableBreakingUpdates standalone
     inherit disableBreakingUpdates;

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -100,22 +100,16 @@ let
     dontStrip = true;
     dontPatchShebangs = true;
     
-    unpackPhase = ''
-      runHook preUnpack
-      
-      mkdir -p $out
-      cd $out
-      tar -xzf $src --strip-components=1
-      
-      runHook postUnpack
-    '';
-    
     dontBuild = true;
     dontConfigure = true;
     
     installPhase = ''
       runHook preInstall
       
+      mkdir -p $out/opt/${binaryName}
+      mv * $out/opt/${binaryName}
+      cd $out/opt
+
       # Apply modifications (do NOT chmod the binary - it breaks Krisp checksum validation)
       ${lib.optionalString withOpenASAR ''
         cp -f ${openasar} resources/app.asar
@@ -141,63 +135,63 @@ let
   fhsEnv = buildFHSEnv {
     name = "${pname}-fhs";
     
-    targetPkgs = pkgs: [
+    targetPkgs = pkgs: with pkgs; [
       # Core system libraries
-      pkgs.stdenv.cc.cc.lib
-      pkgs.glibc
+      stdenv.cc.cc.lib
+      glibc
       
       # Graphics and display
-      pkgs.libglvnd
-      pkgs.mesa
-      pkgs.libdrm
-      pkgs.libgbm
-      pkgs.wayland
+      libglvnd
+      mesa
+      libdrm
+      libgbm
+      wayland
       
       # X11 libraries
-      pkgs.xorg.libX11
-      pkgs.xorg.libXcomposite
-      pkgs.xorg.libXcursor
-      pkgs.xorg.libXdamage
-      pkgs.xorg.libXext
-      pkgs.xorg.libXfixes
-      pkgs.xorg.libXi
-      pkgs.xorg.libXrandr
-      pkgs.xorg.libXrender
-      pkgs.xorg.libXtst
-      pkgs.xorg.libXScrnSaver
-      pkgs.xorg.libxcb
-      pkgs.xorg.libxshmfence
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libXScrnSaver
+      xorg.libxcb
+      xorg.libxshmfence
       
       # GTK and desktop integration
-      pkgs.gtk3
-      pkgs.glib
-      pkgs.cairo
-      pkgs.pango
-      pkgs.gdk-pixbuf
-      pkgs.atk
-      pkgs.at-spi2-atk
-      pkgs.at-spi2-core
-      pkgs.libappindicator-gtk3
-      pkgs.libdbusmenu
+      gtk3
+      glib
+      cairo
+      pango
+      gdk-pixbuf
+      atk
+      at-spi2-atk
+      at-spi2-core
+      libappindicator-gtk3
+      libdbusmenu
       
       # Audio
-      pkgs.alsa-lib
-      pkgs.libpulseaudio
-      pkgs.pipewire
+      alsa-lib
+      libpulseaudio
+      pipewire
       
       # Other system libraries
-      pkgs.dbus
-      pkgs.systemd
-      pkgs.fontconfig
-      pkgs.freetype
-      pkgs.expat
-      pkgs.libuuid
-      pkgs.cups
-      pkgs.nspr
-      pkgs.nss
-      pkgs.libnotify
-      pkgs.libcxx
-      pkgs.libxkbcommon
+      dbus
+      systemd
+      fontconfig
+      freetype
+      expat
+      libuuid
+      cups
+      nspr
+      nss
+      libnotify
+      libcxx
+      libxkbcommon
     ] ++ lib.optional withTTS pkgs.speechd-minimal;
     
     multiPkgs = pkgs: [
@@ -237,7 +231,7 @@ let
       ''}
       
       # Execute Discord
-      exec ${discordDir}/${binaryName} \
+      exec ${discordDir}/opt/${binaryName}/${binaryName} \
         --no-sandbox \
         --disable-gpu-sandbox \
         $WAYLAND_FLAGS \
@@ -282,8 +276,8 @@ stdenv.mkDerivation {
     ln -s ${fhsEnv}/bin/${pname}-fhs $out/bin/${lib.strings.toLower binaryName}
     
     # Install icons
-    ln -s ${discordDir}/discord.png $out/share/pixmaps/${pname}.png
-    ln -s ${discordDir}/discord.png $out/share/icons/hicolor/256x256/apps/${pname}.png
+    ln -s ${discordDir}/opt/${binaryName}/discord.png $out/share/pixmaps/${pname}.png
+    ln -s ${discordDir}/opt/${binaryName}/discord.png $out/share/icons/hicolor/256x256/apps/${pname}.png
     
     # Install desktop file
     ln -s ${desktopItem}/share/applications/${pname}.desktop $out/share/applications/


### PR DESCRIPTION
Fixes #195512

This fixes Krisp, which was broken since the binary was getting modified. By moving to using an fhsEnv instead of patchElf and not striping or modifying the binary in any way, the checksum passes.

Don't have a darwin machine to test this on ATM, and tbh don't even know if this is an issue there, so only made the change on the linux side

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
