### PR TITLE
genei-fonts: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -199,6 +199,11 @@
     github = "2hexed";
     githubId = 54501296;
   };
+  _34j = {
+    name = "34j";
+    github = "34j";
+    githubId = 55338215;
+  };
   _360ied = {
     name = "Brian Zhu";
     email = "therealbarryplayer@gmail.com";

--- a/pkgs/data/fonts/genei-fonts/default.nix
+++ b/pkgs/data/fonts/genei-fonts/default.nix
@@ -1,0 +1,151 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  symlinkJoin,
+}:
+
+let
+  fonts = {
+    # Sometimes "a" in version is missing in the URL
+    koburimin = {
+      version = "6.1a";
+      url = "https://okoneya.jp/font/GenEiKoburiMin_v6.1.zip";
+      hash = "sha256-pLgCiK+o6tssPoZnxbKsSfYV4J7bHfz12hynuC3zC2g=";
+    };
+    chikumin = {
+      version = "3.1a";
+      url = "https://okoneya.jp/font/GenEiChikuMin_v3.1.zip";
+      hash = "sha256-WqWB5bVErd0I8QDEipDxzd5PbZ08NsLnBLXygLTcC2I=";
+    };
+    antique = {
+      version = "5.1";
+      url = "https://okoneya.jp/font/GenEiAntique_v5.1.zip";
+      hash = "sha256-1HUbD4tBWp17+rF8+XqQ9FngazRnfe6kpId/mjyNX10=";
+    };
+    eimgothic = {
+      version = "2.0";
+      url = "https://okoneya.jp/font/GenEiMGothic_v2.0.zip";
+      hash = "sha256-AdZcvR2NAc1BBWGAzrZQNiRIqGVVjUSK7Zr9sIbWW2Q=";
+    };
+    pople = {
+      version = "1.0";
+      url = "https://okoneya.jp/font/GenEiPOPle_v1.0.zip";
+      hash = "sha256-DZ2rVoEdUwnxXRxFs0wmQOovBBeQt/iSUNYCou9Stuc=";
+    };
+    kiwamigo = {
+      version = "1.2";
+      url = "https://okoneya.jp/font/GenEiKiwamiGo_v1.2.zip";
+      hash = "sha256-F8L5MkpRjKgXBE3TaKY9PcKCrEpecL0QIoEVTAWBGNg=";
+    };
+    monogothic = {
+      version = "1.0";
+      url = "https://okoneya.jp/font/GenEiMonoGothic_v1.0.zip";
+      hash = "sha256-4cNoLihaO4xLf3z2o+8pgwQ0sJ+T+wJsOG9N5oyxOVY=";
+    };
+    nugothic-eb = {
+      version = "1.1";
+      url = "https://okoneya.jp/font/GenEiNuGothic-EB_v1.1.zip";
+      hash = "sha256-hzUAp4sYuuGnCD0ZSdxRodWBWx6kh024fHadJ5z5wik=";
+    };
+    latin = {
+      version = "2.1";
+      url = "https://okoneya.jp/font/GenEiLatin-Separate_v2.1.zip";
+      hash = "sha256-pLgCiK+o6tssPoZnxbKsSfYV4J7bHfz12hynuC3zC2g=";
+    };
+    universans = {
+      version = "1.1";
+      url = "https://okoneya.jp/font/GenEiUniverSans-1.1.zip";
+      hash = "sha256-B+1tFzJhVgGP3auwF6h/t6RU78xomI68MNu9wFxuUVk=";
+    };
+    webhonmon = {
+      version = "1.0";
+      url = "https://okoneya.jp/font/GenEiWebHonmon_v1.0.zip";
+      hash = "sha256-uNm39uHbcFYyKAtmf+kr5WlJWazYL0A92jjg1oTCsQg=";
+    };
+    nombre = {
+      version = "2.0";
+      url = "https://okoneya.jp/font/GenEiNombre_v2.0.zip";
+      hash = "sha256-dNftKdwp6+JmFri09I2AuqucH6nTPlkOq86lKMNow4Q=";
+    };
+    brice = {
+      version = "1.1";
+      url = "https://okoneya.jp/font/GenEiBrice_v1.1.zip";
+      hash = "sha256-HzFrN3VmLyVtZ18e+Hz/6/Y3yfHJB3WVx67JQciujx4=";
+    };
+    romannotes = {
+      version = "1.0";
+      url = "https://okoneya.jp/font/GenEiRomanNotes-1.0.zip";
+      hash = "sha256-QCDIunaVo8ppl/P2nC/iwj0yLOm45igQLT4GM18ARGI=";
+    };
+    bizenantique = {
+      version = "1.0";
+      url = "https://okoneya.jp/font/BIZenAntique.zip";
+      hash = "sha256-x9navGNGlPY0p7o+6wNQx8QZwNHMUKQMHja0wZk1V24=";
+    };
+    togemarugothic = {
+      version = "1.0";
+      url = "https://okoneya.jp/font/TogeMaruGothic_v1.0.zip";
+      hash = "sha256-L3Q3sMJYUXJYL/eOmAreRSjqdyDDH/h82dQhZlCv/KQ=";
+    };
+    satsukigendaimincho = {
+      version = "1.04";
+      url = "https://okoneya.jp/font/SatsukiGendaiMincho_v1.04.zip";
+      hash = "sha256-SgJfX/Jd2n/mbM0xYRbNuivRILjv1Wu7Jxx8VSpvbtw=";
+    };
+    gothicall = {
+      version = "1.1a";
+      url = "https://okoneya.jp/font/GenEiGothicAll-1.1a.zip";
+      hash = "sha256-Vgk3XTHNYxYxtBtuRWqs7t/hGjPGcRUquV4sB/N6JFc=";
+    };
+    gothickl = {
+      version = "1.3";
+      url = "https://okoneya.jp/font/GenEiGothicKL-1.3.zip";
+      hash = "sha256-1YpFMjd6NFR0lv8GkJv78T+Uxw/sgekyHFCAHBWV10c=";
+    };
+  };
+
+  mkpkg =
+    pname:
+    {
+      version,
+      url,
+      hash,
+    }:
+    stdenvNoCC.mkDerivation rec {
+      inherit pname version;
+
+      src = fetchzip {
+        inherit hash url;
+      };
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/share/{fonts/opentype,fonts/truetype,doc/genei-${pname}}
+        find . -type f -name "*.otf" -exec cp -v {} $out/share/fonts/opentype/ \;
+        find . -type f -name "*.ttf" -exec cp -v {} $out/share/fonts/truetype/ \;
+        find . -type f -name "*.txt" -exec cp -v {} $out/share/doc/genei-${pname}/ \;
+
+        runHook postInstall
+      '';
+
+      meta = {
+        homepage = "https://okoneya.jp/font/";
+        description = "Japanese text fonts modified from Source Han Sans JP";
+        license = lib.licenses.ofl;
+        platforms = lib.platforms.linux;
+        maintainers = with lib.maintainers; [
+          _34j
+        ];
+      };
+    };
+  packages = lib.mapAttrs mkpkg fonts;
+in
+packages
+// {
+  full = symlinkJoin {
+    name = "full";
+    paths = builtins.filter lib.isDerivation (lib.attrValues packages);
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16652,4 +16652,6 @@ with pkgs;
   davis = callPackage ../by-name/da/davis/package.nix {
     php = php83; # https://github.com/tchapi/davis/issues/195
   };
+
+  genei-fonts = callPackages ../data/fonts/genei-fonts { };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds Japanese open source (SIL) fonts in https://okoneya.jp/font as a package set.

Continues #424024 (@liberodark)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
