### PR TITLE
python3Packages.datasketch: init at 1.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12748,7 +12748,7 @@
     email = "jokatzke@fastmail.com";
     github = "jokatzke";
     githubId = 46931073;
-    name = "Jonas Katzke";
+    name = "Josefine Katzke";
   };
   joko = {
     email = "ioannis.koutras@gmail.com";

--- a/pkgs/development/python-modules/datasketch/default.nix
+++ b/pkgs/development/python-modules/datasketch/default.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build
+  hatchling,
+  # runtime
+  cassandra-driver,
+  motor,
+  numpy,
+  pybloomfilter3,
+  redis,
+  scipy,
+  # check
+  pytestCheckHook,
+  aiounittest,
+  mock,
+  pymongo,
+  pytest-asyncio,
+  pytest-rerunfailures,
+
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "datasketch";
+  version = "1.9.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ekzhu";
+    repo = "datasketch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ijBkbY6OioK5RP8zAeCnwlbrwE0OHa4tbEnCOabLTqs=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "--cov-report=xml" ""
+  '';
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    numpy
+    scipy
+  ];
+
+  optional-dependencies = rec {
+    cassandra = [ cassandra-driver ];
+    redis = [ redis ];
+    experimental_aio = [
+      motor
+      aiounittest
+    ];
+    bloom = [ pybloomfilter3 ];
+    all = cassandra ++ redis ++ experimental_aio ++ bloom;
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    cassandra-driver
+    mock
+    motor
+    redis
+    pybloomfilter3
+    pymongo
+    pytest-rerunfailures
+    pytest-asyncio
+  ];
+
+  disabledTestPaths = [
+    # these tests import mockredis, which has been abandoned for many years
+    "test/test_lsh.py"
+    "test/test_lshensemble.py"
+  ];
+  disabledTests = [
+    # flaky
+    "test_soft_remove_and_pop_and_clean"
+  ];
+
+  meta = {
+    changelog = "https://github.com/ekzhu/datasketch/releases/tag/v${finalAttrs.version}";
+    description = "MinHash, LSH, LSH Forest, Weighted MinHash, HyperLogLog, HyperLogLog++, LSH Ensemble and HNSW";
+    homepage = "https://ekzhu.com/datasketch/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jokatzke ];
+  };
+})

--- a/pkgs/development/python-modules/pybloomfilter3/default.nix
+++ b/pkgs/development/python-modules/pybloomfilter3/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build
+  setuptools,
+  cython,
+  # check
+  pytest,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pybloomfilter3";
+  version = "0.7.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cavoq";
+    repo = "pybloomfiltermmap3";
+    rev = "237631c181423c42043ba8003a305dd1d8e0b700"; # repo has no tags or branches
+    hash = "sha256-vUaU0U5Smmm+k+i54uKu/R2qpoCbdq3LrjU4/BBEMq8=";
+  };
+
+  build-system = [
+    setuptools
+    cython
+  ];
+
+  # tests are not discovered by pytestCheckHook
+  nativeCheckInputs = [ pytest ];
+  checkPhase = ''
+    runHook preCheck
+    python -m unittest discover -s tests -p "*.py"
+    runHook postCheck
+  '';
+
+  meta = {
+    changelog = "https://github.com/prashnts/pybloomfilter3/blob/${finalAttrs.src.rev}/CHANGELOG";
+    description = "Fast Python Bloom Filter using Mmap";
+    homepage = "https://github.com/prashnts/pybloomfilter3";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jokatzke ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13130,6 +13130,8 @@ self: super: with self; {
 
   pybloom-live = callPackage ../development/python-modules/pybloom-live { };
 
+  pybloomfilter3 = callPackage ../development/python-modules/pybloomfilter3 { };
+
   pyblu = callPackage ../development/python-modules/pyblu { };
 
   pybluez = callPackage ../development/python-modules/pybluez { inherit (pkgs) bluez; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3605,6 +3605,8 @@ self: super: with self; {
 
   datashaper = callPackage ../development/python-modules/datashaper { };
 
+  datasketch = callPackage ../development/python-modules/datasketch { };
+
   datauri = callPackage ../development/python-modules/datauri { };
 
   datefinder = callPackage ../development/python-modules/datefinder { };


### PR DESCRIPTION
Add datasketch, a Python library that implements "MinHash, LSH, LSH Forest, Weighted MinHash, HyperLogLog, HyperLogLog++, LSH Ensemble and HNSW".

Homepage: https://ekzhu.github.io/datasketch
GitHub: https://github.com/ekzhu/datasketch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
