### PR TITLE
python3Packages.astropy-helpers: fix build for py312+; python3Packages.astroquery: fix build

### DIFF
--- a/pkgs/development/python-modules/astropy-helpers/default.nix
+++ b/pkgs/development/python-modules/astropy-helpers/default.nix
@@ -2,8 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  isPy3k,
-  pythonAtLeast,
   setuptools,
 }:
 
@@ -12,14 +10,17 @@ buildPythonPackage rec {
   version = "4.0.1";
   pyproject = true;
 
-  disabled = !isPy3k || pythonAtLeast "3.12";
-
   src = fetchFromGitHub {
     owner = "astropy";
     repo = "astropy-helpers";
     tag = "v${version}";
     hash = "sha256-MjL/I+ApyoyoD2NmKuKWpDbyuEgvBb2OBhxqj/w/3lk=";
   };
+
+  patches = [
+    # Fixes build with Python 3.12+
+    ./python-imp.patch
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/astropy-helpers/default.nix
+++ b/pkgs/development/python-modules/astropy-helpers/default.nix
@@ -1,30 +1,34 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   isPy3k,
   pythonAtLeast,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "astropy-helpers";
   version = "4.0.1";
-  format = "setuptools";
+  pyproject = true;
 
-  # ModuleNotFoundError: No module named 'imp'
   disabled = !isPy3k || pythonAtLeast "3.12";
 
-  doCheck = false; # tests requires sphinx-astropy
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "f1096414d108778218d6bea06d4d9c7b2ff7c83856a451331ac194e74de9f413";
+  src = fetchFromGitHub {
+    owner = "astropy";
+    repo = "astropy-helpers";
+    tag = "v${version}";
+    hash = "sha256-MjL/I+ApyoyoD2NmKuKWpDbyuEgvBb2OBhxqj/w/3lk=";
   };
 
-  meta = with lib; {
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "astropy_helpers" ];
+
+  meta = {
     description = "Utilities for building and installing Astropy, Astropy affiliated packages, and their respective documentation";
     homepage = "https://github.com/astropy/astropy-helpers";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.smaret ];
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.smaret ];
   };
 }

--- a/pkgs/development/python-modules/astropy-helpers/python-imp.patch
+++ b/pkgs/development/python-modules/astropy-helpers/python-imp.patch
@@ -1,0 +1,63 @@
+diff --git a/astropy_helpers/tests/test_git_helpers.py b/astropy_helpers/tests/test_git_helpers.py
+index 6b826fc..3fb3a29 100644
+--- a/astropy_helpers/tests/test_git_helpers.py
++++ b/astropy_helpers/tests/test_git_helpers.py
+@@ -1,5 +1,5 @@
+ import glob
+-import imp
++import importlib as imp
+ import os
+ import pkgutil
+ import re
+diff --git a/astropy_helpers/utils.py b/astropy_helpers/utils.py
+index 115c915..0cfc9e3 100644
+--- a/astropy_helpers/utils.py
++++ b/astropy_helpers/utils.py
+@@ -1,12 +1,12 @@
+ # Licensed under a 3-clause BSD style license - see LICENSE.rst
+ 
+ import contextlib
+-import imp
+ import os
+ import sys
+ import glob
+ 
+ from importlib import machinery as import_machinery
++from importlib import util as importlib_util
+ 
+ 
+ # Note: The following Warning subclasses are simply copies of the Warnings in
+@@ -54,9 +54,9 @@ def get_numpy_include_path():
+     import builtins
+     if hasattr(builtins, '__NUMPY_SETUP__'):
+         del builtins.__NUMPY_SETUP__
+-    import imp
++    import importlib
+     import numpy
+-    imp.reload(numpy)
++    importlib.reload(numpy)
+ 
+     try:
+         numpy_include = numpy.get_include()
+@@ -208,8 +208,6 @@ def import_file(filename, name=None):
+     # generates an underscore-separated name which is more likely to
+     # be unique, and it doesn't really matter because the name isn't
+     # used directly here anyway.
+-    mode = 'r'
+-
+     if name is None:
+         basename = os.path.splitext(filename)[0]
+         name = '_'.join(os.path.relpath(basename).split(os.sep)[1:])
+@@ -221,8 +219,10 @@ def import_file(filename, name=None):
+         loader = import_machinery.SourceFileLoader(name, filename)
+         mod = loader.load_module()
+     else:
+-        with open(filename, mode) as fd:
+-            mod = imp.load_module(name, fd, filename, ('.py', mode, 1))
++        importlib_util
++        spec = importlib_util.spec_from_file_location(name, filename)
++        mod = importlib_util.module_from_spec(spec)
++        spec.loader.exec_module(mod)
+ 
+     return mod
+ 

--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -2,7 +2,9 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   astropy,
+  boto3,
   requests,
   keyring,
   beautifulsoup4,
@@ -31,6 +33,15 @@ buildPythonPackage rec {
     hash = "sha256-5pNKV+XNfUQca7WoWboVphXffzyVIHCmfxwr4nBMaEk=";
   };
 
+  patches = [
+    # https://github.com/astropy/astroquery/pull/3311
+    (fetchpatch2 {
+      name = "setuptools-package-index.patch";
+      url = "https://github.com/astropy/astroquery/commit/9d43beb4b7bea424d73fff0b602ca90026155519.patch";
+      hash = "sha256-3QdOwP1rlWeScGxHT9ZVPmffE7S1XE0cbtnQ8T4bIYw=";
+    })
+  ];
+
   build-system = [
     astropy-helpers
     setuptools
@@ -53,6 +64,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   checkInputs = [
+    boto3
     matplotlib
     pillow
     pytest

--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -1,7 +1,7 @@
 {
-  pkgs,
+  lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   astropy,
   requests,
   keyring,
@@ -17,33 +17,32 @@
   pyvo,
   astropy-helpers,
   setuptools,
-  isPy3k,
 }:
 
 buildPythonPackage rec {
   pname = "astroquery";
   version = "0.4.10";
-  format = "pyproject";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-6s2R6do3jmQXQPvDEjhQ2qg7oJJqb/9MQMy/XcbVpAY=";
+  src = fetchFromGitHub {
+    owner = "astropy";
+    repo = "astroquery";
+    tag = "v${version}";
+    hash = "sha256-5pNKV+XNfUQca7WoWboVphXffzyVIHCmfxwr4nBMaEk=";
   };
 
-  disabled = !isPy3k;
+  build-system = [
+    astropy-helpers
+    setuptools
+  ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     astropy
     requests
     keyring
     beautifulsoup4
     html5lib
     pyvo
-  ];
-
-  nativeBuildInputs = [
-    astropy-helpers
-    setuptools
   ];
 
   # Disable automatic update of the astropy-helper module
@@ -77,10 +76,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "astroquery" ];
 
-  meta = with pkgs.lib; {
+  meta = {
     description = "Functions and classes to access online data resources";
     homepage = "https://astroquery.readthedocs.io/";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.smaret ];
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.smaret ];
   };
 }


### PR DESCRIPTION
Closes #424288

Fixed python 3.12+ build for python3Packages.astropy-helpers. Noticed that build for astroquery was also failing due to the removal of setuptools.package_index and fixed it.

Also modernized both.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
