### PR TITLE
.gitattributes: manage CRLF handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,11 +30,11 @@ ci/OWNERS linguist-language=CODEOWNERS
 # - `text=auto` means "Git should try to work out if this file is a text file.
 #   If it is, it should do the line-ending munging as for `text`, and if it
 #   isn't, it should leave the file alone."
-# - `eol=lf` or `eol=crlf` means "Ignore any local configuration about how line
+# - `eol=lf` means "Ignore any local configuration about how line
 #   endings normally work on this platform. This file should always and only
 #   have LF line endings in the repo (so if there's a CR in the repo, it's
 #   meant to be there in addition to any end-of-line mark), and the selected
-#   attribute is how the file should appear in the working directory.
+#   attribute is how the file should appear in the working directory."
 #
 # See https://github.com/NixOS/nixpkgs/issues/423762 for historical context.
 * text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,28 @@ nixos/modules/module-list.nix merge=union
 # pkgs/top-level/all-packages.nix merge=union
 
 ci/OWNERS linguist-language=CODEOWNERS
+
+# Avoid munging line endings when using Git for Windows, and instead keep files
+# using LF line endings.  This particularly affects scripts committed in the
+# nixpkgs repository.
+#
+# - `text` without `=auto` would mean "Git should always munge line endings on
+#   this file so there will never be a CRLF in the repository, and the line
+#   endings in the working directory should respect the local Git
+#   configuration."
+# - `text=auto` means "Git should try to work out if this file is a text file.
+#   If it is, it should do the line-ending munging as for `text`, and if it
+#   isn't, it should leave the file alone."
+# - `eol=lf` or `eol=crlf` means "Ignore any local configuration about how line
+#   endings normally work on this platform. This file should always and only
+#   have LF line endings in the repo (so if there's a CR in the repo, it's
+#   meant to be there in addition to any end-of-line mark), and the selected
+#   attribute is how the file should appear in the working directory.
+#
+# See https://github.com/NixOS/nixpkgs/issues/423762 for historical context.
+* text=auto eol=lf
+
+# Don't force LF line endings for diff/patch files, as they might be correctly
+# patching CRLF line endings from an upstream source package.
+*.diff !text !eol
+*.patch !text !eol


### PR DESCRIPTION
In certain circumstances, Git will munge line endings when it checks out and commits files.  This can result in difficult-to-debug errors when files are changed when they're checked out.  To avoid that problem, set .gitattributes such that Git will always use LF line endings for files it detects as text files.

*.diff and *.patch files are excluded, as committed patch files may need to patch upstream source code that intentionally uses CRLF line endings.

For the few other files that have been committed with CRLF line endings, normalise them to LF for consistency, having confirmed with `nixpkgs-review` that this doesn't result in any new build failures. (Although #424329 removes those few remaining files anyway...)

Fixes #423762.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
