### PR TITLE
nixos/pihole-ftl: fix openFirewall ports

### DIFF
--- a/nixos/modules/services/networking/pihole-ftl.md
+++ b/nixos/modules/services/networking/pihole-ftl.md
@@ -22,6 +22,7 @@ Example configuration:
 {
   services.pihole-ftl = {
     enable = true;
+    openFirewallDNS = true;
     openFirewallDHCP = true;
     queryLogDeleter.enable = true;
     lists = [

--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -56,6 +56,12 @@ in
       example = "3";
     };
 
+    openFirewallDNS = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Open ports in the firewall for pihole-FTL's DNS server.";
+    };
+
     openFirewallDHCP = mkOption {
       type = types.bool;
       default = false;
@@ -434,6 +440,11 @@ in
     };
 
     networking.firewall = lib.mkMerge [
+      (mkIf cfg.openFirewallDNS {
+        allowedUDPPorts = [ 53 ];
+        allowedTCPPorts = [ 53 ];
+      })
+
       (mkIf cfg.openFirewallDHCP {
         allowedUDPPorts = [ 67 ];
       })

--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -435,8 +435,7 @@ in
 
     networking.firewall = lib.mkMerge [
       (mkIf cfg.openFirewallDHCP {
-        allowedUDPPorts = [ 53 ];
-        allowedTCPPorts = [ 53 ];
+        allowedUDPPorts = [ 67 ];
       })
 
       (mkIf cfg.openFirewallWebserver {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`openFirewallDHCP` opened port 53 in the firewall, this is the DNS port. I fixed it to correctly open port 67 on UDP and added the option `openFirewallDNS` to open port 53 on UDP and TCP.

I also updated the docs example to add the `openFirewallDHCP` option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
---

Maintainer ping @averyvigolo

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
