### PR TITLE
haskellPackages.mkDerivation: Add `env` argument

### DIFF
--- a/doc/languages-frameworks/haskell.section.md
+++ b/doc/languages-frameworks/haskell.section.md
@@ -223,6 +223,10 @@ If `null` (which is the default value), the one included in `src` is used.
 `editedCabalFile`
 : `sha256` hash of the cabal file identified by `revision` or `null`.
 
+`env`
+: Extra environment variables to set during the build.
+These will also be set inside the [development environment defined by the `passthru.env` attribute in the returned derivation](#haskell-development-environments), but will not be set inside a development environment built with [`shellFor`](#haskell-shellFor) that includes this package.
+
 `configureFlags`
 : Extra flags passed when executing the `configure` command of `Setup.hs`.
 

--- a/pkgs/test/haskell/default.nix
+++ b/pkgs/test/haskell/default.nix
@@ -3,6 +3,7 @@
 lib.recurseIntoAttrs {
   cabalSdist = callPackage ./cabalSdist { };
   documentationTarball = callPackage ./documentationTarball { };
+  env = callPackage ./env { };
   ghcWithPackages = callPackage ./ghcWithPackages { };
   incremental = callPackage ./incremental { };
   setBuildTarget = callPackage ./setBuildTarget { };

--- a/pkgs/test/haskell/env/default.nix
+++ b/pkgs/test/haskell/env/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  haskellPackages,
+}:
+
+let
+  withEnv =
+    env:
+    haskellPackages.mkDerivation {
+      pname = "puppy";
+      version = "1.0.0";
+      src = null;
+      license = null;
+
+      inherit env;
+    };
+
+  failures = lib.runTests {
+    testCanSetEnv = {
+      expr =
+        (withEnv {
+          PUPPY = "DOGGY";
+        }).drvAttrs.PUPPY;
+      expected = "DOGGY";
+    };
+
+    testCanSetEnvMultiple = {
+      expr =
+        let
+          env =
+            (withEnv {
+              PUPPY = "DOGGY";
+              SILLY = "GOOFY";
+            }).drvAttrs;
+        in
+        {
+          inherit (env) PUPPY SILLY;
+        };
+      expected = {
+        PUPPY = "DOGGY";
+        SILLY = "GOOFY";
+      };
+    };
+
+    testCanSetEnvPassthru = {
+      expr =
+        (withEnv {
+          PUPPY = "DOGGY";
+        }).passthru.env.PUPPY;
+      expected = "DOGGY";
+    };
+  };
+in
+# TODO: Use `lib.debug.throwTestFailures`: https://github.com/NixOS/nixpkgs/pull/416207
+lib.optional (failures != [ ]) (throw "${lib.generators.toPretty { } failures}")


### PR DESCRIPTION
Previously, setting environment variables in a Haskell package build required using `.overrideAttrs`, which (I think?) breaks later invocations of `haskell.lib.overrideCabal`.

This patch adds an `env` argument to `haskellPackages.mkDerivation`, which can be used to set environment variables during Haskell package builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
