### PR TITLE
apacheHttpd: 2.6.62 -> 2.6.65

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -33,11 +33,11 @@
 
 stdenv.mkDerivation rec {
   pname = "apache-httpd";
-  version = "2.4.62";
+  version = "2.4.65";
 
   src = fetchurl {
     url = "mirror://apache/httpd/httpd-${version}.tar.bz2";
-    hash = "sha256-Z0GI579EztgtqNtSLalGhJ4iCA1z0WyT9/TfieJXKew=";
+    hash = "sha256-WLi+l9mUDsF/dlbAxrn0G2GKrEaLiUtTQUjjKWxTuLM=";
   };
 
   patches = [


### PR DESCRIPTION
Fixes CVE-2025-53020, CVE-2025-49812, CVE-2025-49630, CVE-2025-23048, CVE-2024-47252, CVE-2024-43204 and CVE-2024-42516.

https://dlcdn.apache.org/httpd/CHANGES_2.4.64
https://dlcdn.apache.org/httpd/CHANGES_2.4.65


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 424369`
Commit: `29b0c5917810b65a71c6cb75960dac182a7bdeec`

---
### `aarch64-linux`
<details>
  <summary>:x: 3 packages failed to build:</summary>
  <ul>
    <li>apacheHttpdPackages.mod_python (apacheHttpdPackages_2_4.mod_python)</li>
    <li>perl538Packages.libapreq2</li>
    <li>perl540Packages.libapreq2</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 82 packages built:</summary>
  <ul>
    <li>apacheHttpd (apacheHttpdPackages.apacheHttpd, apacheHttpdPackages_2_4.apacheHttpd, apacheHttpd_2_4)</li>
    <li>apacheHttpd.dev (apacheHttpdPackages.apacheHttpd.dev, apacheHttpdPackages_2_4.apacheHttpd.dev, apacheHttpd_2_4.dev)</li>
    <li>apacheHttpd.doc (apacheHttpdPackages.apacheHttpd.doc, apacheHttpdPackages_2_4.apacheHttpd.doc, apacheHttpd_2_4.doc)</li>
    <li>apacheHttpd.man (apacheHttpdPackages.apacheHttpd.man, apacheHttpdPackages_2_4.apacheHttpd.man, apacheHttpd_2_4.man)</li>
    <li>apacheHttpdPackages.mod_auth_mellon (apacheHttpdPackages_2_4.mod_auth_mellon)</li>
    <li>apacheHttpdPackages.mod_ca (apacheHttpdPackages_2_4.mod_ca)</li>
    <li>apacheHttpdPackages.mod_crl (apacheHttpdPackages_2_4.mod_crl)</li>
    <li>apacheHttpdPackages.mod_cspnonce (apacheHttpdPackages_2_4.mod_cspnonce)</li>
    <li>apacheHttpdPackages.mod_csr (apacheHttpdPackages_2_4.mod_csr)</li>
    <li>apacheHttpdPackages.mod_dnssd (apacheHttpdPackages_2_4.mod_dnssd)</li>
    <li>apacheHttpdPackages.mod_fastcgi (apacheHttpdPackages_2_4.mod_fastcgi)</li>
    <li>apacheHttpdPackages.mod_itk (apacheHttpdPackages_2_4.mod_itk)</li>
    <li>apacheHttpdPackages.mod_jk (apacheHttpdPackages_2_4.mod_jk)</li>
    <li>apacheHttpdPackages.mod_mbtiles (apacheHttpdPackages_2_4.mod_mbtiles)</li>
    <li>apacheHttpdPackages.mod_ocsp (apacheHttpdPackages_2_4.mod_ocsp)</li>
    <li>apacheHttpdPackages.mod_perl (apacheHttpdPackages_2_4.mod_perl)</li>
    <li>apacheHttpdPackages.mod_pkcs12 (apacheHttpdPackages_2_4.mod_pkcs12)</li>
    <li>apacheHttpdPackages.mod_scep (apacheHttpdPackages_2_4.mod_scep)</li>
    <li>apacheHttpdPackages.mod_spkac (apacheHttpdPackages_2_4.mod_spkac)</li>
    <li>apacheHttpdPackages.mod_tile (apacheHttpdPackages_2_4.mod_tile)</li>
    <li>apacheHttpdPackages.mod_timestamp (apacheHttpdPackages_2_4.mod_timestamp)</li>
    <li>apacheHttpdPackages.mod_wsgi3 (apacheHttpdPackages_2_4.mod_wsgi3)</li>
    <li>apacheHttpdPackages.subversion (apacheHttpdPackages_2_4.subversion)</li>
    <li>apacheHttpdPackages.subversion.dev (apacheHttpdPackages_2_4.subversion.dev)</li>
    <li>apacheHttpdPackages.subversion.man (apacheHttpdPackages_2_4.subversion.man)</li>
    <li>budgie-control-center</li>
    <li>budgie-control-center.debug</li>
    <li>cinnamon-gsettings-overrides</li>
    <li>code-nautilus</li>
    <li>collision</li>
    <li>eiciel</li>
    <li>eiciel.nautilusExtension</li>
    <li>file-roller</li>
    <li>gnome-control-center</li>
    <li>gnome-control-center.debug</li>
    <li>gnome-terminal</li>
    <li>gnome-user-share</li>
    <li>gnomeExtensions.gtk4-desktop-icons-ng-ding</li>
    <li>haxe (haxe_4_3)</li>
    <li>haxePackages.format</li>
    <li>haxePackages.heaps</li>
    <li>haxePackages.hlopenal</li>
    <li>haxePackages.hlsdl</li>
    <li>hxcpp (haxePackages.hxcpp)</li>
    <li>haxePackages.hxcs</li>
    <li>haxePackages.hxjava</li>
    <li>haxePackages.hxnodejs_4</li>
    <li>haxe_4_0</li>
    <li>haxe_4_1</li>
    <li>mapcache</li>
    <li>mate.mate-user-share</li>
    <li>modsecurity_standalone</li>
    <li>modsecurity_standalone.nginx</li>
    <li>nautilus</li>
    <li>nautilus-open-any-terminal</li>
    <li>nautilus-open-any-terminal.dist</li>
    <li>nautilus-open-in-blackbox</li>
    <li>nautilus-python</li>
    <li>nautilus-python.dev</li>
    <li>nautilus-python.devdoc</li>
    <li>nautilus-python.doc</li>
    <li>nautilus.dev</li>
    <li>nautilus.devdoc</li>
    <li>neko</li>
    <li>nemo-fileroller</li>
    <li>nemo-with-extensions</li>
    <li>pantheon.file-roller-contract</li>
    <li>papers</li>
    <li>papers.dev</li>
    <li>papers.devdoc</li>
    <li>perl538Packages.GoferTransporthttp</li>
    <li>perl538Packages.GoferTransporthttp.devdoc</li>
    <li>perl538Packages.mod_perl2</li>
    <li>perl538Packages.mod_perl2.devdoc</li>
    <li>perl540Packages.GoferTransporthttp</li>
    <li>perl540Packages.GoferTransporthttp.devdoc</li>
    <li>perl540Packages.mod_perl2</li>
    <li>perl540Packages.mod_perl2.devdoc</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>themechanger</li>
    <li>xsecurelock</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `aarch64-linux`</summary>
<details>
<summary>apacheHttpdPackages.mod_python</summary>
<pre>config.status: creating scripts/mod_python
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
build flags: SHELL=/nix/store/fkxvlai6grfi6nngzgp0vahi235nhkq3-bash-5.2p37/bin/bash
make[1]: Entering directory '/build/source/src'

Building mod_python.so.

/nix/store/1kq40scv7l461wq0m0bnyyvl6y9a6kjl-apache-httpd-2.4.65-dev/bin/apxs -I/build/source/src/include -I/nix/store/chgczp3c2zsr14bxkx9vfwsywajbgbgg-python3-3.13.5/include/python3.13 -I/nix/store/chgczp3c2zsr14bxkx9vfwsywajbgbgg-python3-3.13.5/include/python3.13   -c mod_python.c _apachemodule.c requestobject.c tableobject.c util.c serverobject.c connobject.c filterobject.c hlist.c hlistobject.c finfoobject.c version.c include/_apachemodule.h  include/filterobject.h  include/hlist.h include/mod_python.h  include/psp_flex.h include/psp_parser.h include/requestobject.h include/tableobject.h include/connobject.h include/finfoobject.h include/hlistobject.h include/mp_version.h include/_pspmodule.h  include/psp_string.h  include/serverobject.h include/util.h -L/nix/store/chgczp3c2zsr14bxkx9vfwsywajbgbgg-python3-3.13.5/lib -lpython3.13 -ldl -L/nix/store/xyh4yq0vxrs03d3jlc5n6v1a9szcvnjc-libxcrypt-4.4.38/lib -lm   
/nix/store/8r152axzcb35ssb0pm4jwyi2yij51mlc-apr-1.7.6-dev/share/build/libtool --silent --mode=compile gcc -prefer-pic   -DLINUX -D_REENTRANT -D_GNU_SOURCE -g -O2 -I/nix/store/1kq40scv7l461wq0m0bnyyvl6y9a6kjl-apache-httpd-2.4.65-dev/include  -I/nix/store/8r152axzcb35ssb0pm4jwyi2yij51mlc-apr-1.7.6-dev/include   -I/nix/store/1y1hbs88vgz1zjjsibaj5jhmwl5590r4-apr-util-1.6.3-dev/include -I/nix/store/5i2b3p7l3q2g12arpdjfknbng9l9wjif-openssl-3.5.1-dev/include -I/nix/store/zcwp4ssa70qfjiilnlai62gdhyyxgwf1-db-5.3.28-dev/include -I/nix/store/hzdy6fb258gp4xqz3s8m8d48yw2yi9m7-expat-2.7.1-dev/include -I/build/source/src/include -I/nix/store/chgczp3c2zsr14bxkx9vfwsywajbgbgg-python3-3.13.5/include/python3.13 -I/nix/store/chgczp3c2zsr14bxkx9vfwsywajbgbgg-python3-3.13.5/include/python3.13  -c -o mod_python.lo mod_python.c && touch mod_python.slo
/nix/store/8r152axzcb35ssb0pm4jwyi2yij51mlc-apr-1.7.6-dev/share/build/libtool --silent --mode=compile gcc -prefer-pic   -DLINUX -D_REENTRANT -D_GNU_SOURCE -g -O2 -I/nix/store/1kq40scv7l461wq0m0bnyyvl6y9a6kjl-apache-httpd-2.4.65-dev/include  -I/nix/store/8r152axzcb35ssb0pm4jwyi2yij51mlc-apr-1.7.6-dev/include   -I/nix/store/1y1hbs88vgz1zjjsibaj5jhmwl5590r4-apr-util-1.6.3-dev/include -I/nix/store/5i2b3p7l3q2g12arpdjfknbng9l9wjif-openssl-3.5.1-dev/include -I/nix/store/zcwp4ssa70qfjiilnlai62gdhyyxgwf1-db-5.3.28-dev/include -I/nix/store/hzdy6fb258gp4xqz3s8m8d48yw2yi9m7-expat-2.7.1-dev/include -I/build/source/src/include -I/nix/store/chgczp3c2zsr14bxkx9vfwsywajbgbgg-python3-3.13.5/include/python3.13 -I/nix/store/chgczp3c2zsr14bxkx9vfwsywajbgbgg-python3-3.13.5/include/python3.13  -c -o _apachemodule.lo _apachemodule.c && touch _apachemodule.slo
_apachemodule.c: In function '_apache_module_init':
_apachemodule.c:857:5: error: implicit declaration of function '_PyImport_FixupExtensionObject' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.3.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
  857 |     _PyImport_FixupExtensionObject(m, name, name
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
apxs:Error: Command failed with rc=65536
.
make[1]: *** [Makefile:57: mod_python.so] Error 1
make[1]: Leaving directory '/build/source/src'
make: *** [Makefile:34: do_dso] Error 2</pre>
</details>
<details>
<summary>perl538Packages.libapreq2</summary>
<pre>/nix/store/fkxvlai6grfi6nngzgp0vahi235nhkq3-bash-5.2p37/bin/bash ../../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I../../include  -I/nix/store/1kq40scv7l461wq0m0bnyyvl6y9a6kjl-apache-httpd-2.4.65-dev/include  -I/nix/store/8r152axzcb35ssb0pm4jwyi2yij51mlc-apr-1.7.6-dev/include  -I/nix/store/1y1hbs88vgz1zjjsibaj5jhmwl5590r4-apr-util-1.6.3-dev/include -I/nix/store/5i2b3p7l3q2g12arpdjfknbng9l9wjif-openssl-3.5.1-dev/include -I/nix/store/zcwp4ssa70qfjiilnlai62gdhyyxgwf1-db-5.3.28-dev/include -I/nix/store/hzdy6fb258gp4xqz3s8m8d48yw2yi9m7-expat-2.7.1-dev/include -DLINUX -D_REENTRANT -D_GNU_SOURCE  -g -O2 -c -o handle.lo handle.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../../include -I/nix/store/1kq40scv7l461wq0m0bnyyvl6y9a6kjl-apache-httpd-2.4.65-dev/include -I/nix/store/8r152axzcb35ssb0pm4jwyi2yij51mlc-apr-1.7.6-dev/include -I/nix/store/1y1hbs88vgz1zjjsibaj5jhmwl5590r4-apr-util-1.6.3-dev/include -I/nix/store/5i2b3p7l3q2g12arpdjfknbng9l9wjif-openssl-3.5.1-dev/include -I/nix/store/zcwp4ssa70qfjiilnlai62gdhyyxgwf1-db-5.3.28-dev/include -I/nix/store/hzdy6fb258gp4xqz3s8m8d48yw2yi9m7-expat-2.7.1-dev/include -DLINUX -D_REENTRANT -D_GNU_SOURCE -g -O2 -c handle.c  -fPIC -DPIC -o .libs/handle.o
/nix/store/fkxvlai6grfi6nngzgp0vahi235nhkq3-bash-5.2p37/bin/bash ../../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I../../include  -I/nix/store/1kq40scv7l461wq0m0bnyyvl6y9a6kjl-apache-httpd-2.4.65-dev/include  -I/nix/store/8r152axzcb35ssb0pm4jwyi2yij51mlc-apr-1.7.6-dev/include  -I/nix/store/1y1hbs88vgz1zjjsibaj5jhmwl5590r4-apr-util-1.6.3-dev/include -I/nix/store/5i2b3p7l3q2g12arpdjfknbng9l9wjif-openssl-3.5.1-dev/include -I/nix/store/zcwp4ssa70qfjiilnlai62gdhyyxgwf1-db-5.3.28-dev/include -I/nix/store/hzdy6fb258gp4xqz3s8m8d48yw2yi9m7-expat-2.7.1-dev/include -DLINUX -D_REENTRANT -D_GNU_SOURCE  -g -O2 -c -o filter.lo filter.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../../include -I/nix/store/1kq40scv7l461wq0m0bnyyvl6y9a6kjl-apache-httpd-2.4.65-dev/include -I/nix/store/8r152axzcb35ssb0pm4jwyi2yij51mlc-apr-1.7.6-dev/include -I/nix/store/1y1hbs88vgz1zjjsibaj5jhmwl5590r4-apr-util-1.6.3-dev/include -I/nix/store/5i2b3p7l3q2g12arpdjfknbng9l9wjif-openssl-3.5.1-dev/include -I/nix/store/zcwp4ssa70qfjiilnlai62gdhyyxgwf1-db-5.3.28-dev/include -I/nix/store/hzdy6fb258gp4xqz3s8m8d48yw2yi9m7-expat-2.7.1-dev/include -DLINUX -D_REENTRANT -D_GNU_SOURCE -g -O2 -c filter.c  -fPIC -DPIC -o .libs/filter.o
/nix/store/fkxvlai6grfi6nngzgp0vahi235nhkq3-bash-5.2p37/bin/bash ../../libtool  --tag=CC   --mode=link gcc  -g -O2 -export-dynamic -module -avoid-version `/build/libapreq2-2.17/apreq2-config --link-libtool --libs`  /nix/store/h2qyrcp5kjna53kg75rss0j7wxj52ssm-apr-1.7.6/lib/libapr-1.la /nix/store/wqikwcjjxjmlxhp4hap3g9jxipprgkyx-apr-util-1.6.3/lib/libaprutil-1.la  -o mod_apreq2.la -rpath `apxs -q LIBEXECDIR` handle.lo filter.lo  
/build/libapreq2-2.17/apreq2-config: line 33: grep: not found
libtool: link: ( cd ".libs" && rm -f "mod_apreq2.la" && ln -s "../mod_apreq2.la" "mod_apreq2.la" )
make[2]: Leaving directory '/build/libapreq2-2.17/module/apache2'
make[2]: Entering directory '/build/libapreq2-2.17/module'
gcc -DHAVE_CONFIG_H -I. -I../include  -I/nix/store/8r152axzcb35ssb0pm4jwyi2yij51mlc-apr-1.7.6-dev/include  -I/nix/store/1y1hbs88vgz1zjjsibaj5jhmwl5590r4-apr-util-1.6.3-dev/include -I/nix/store/5i2b3p7l3q2g12arpdjfknbng9l9wjif-openssl-3.5.1-dev/include -I/nix/store/zcwp4ssa70qfjiilnlai62gdhyyxgwf1-db-5.3.28-dev/include -I/nix/store/hzdy6fb258gp4xqz3s8m8d48yw2yi9m7-expat-2.7.1-dev/include -DLINUX -D_REENTRANT -D_GNU_SOURCE  -g -O2 -c -o test_cgi.o test_cgi.c
/nix/store/fkxvlai6grfi6nngzgp0vahi235nhkq3-bash-5.2p37/bin/bash ../libtool  --tag=CC   --mode=link gcc  -g -O2 `/build/libapreq2-2.17/apreq2-config --link-libtool`  -L/nix/store/wqikwcjjxjmlxhp4hap3g9jxipprgkyx-apr-util-1.6.3/lib -laprutil-1 -L/nix/store/nxgc9iw2hpd4djf68qg4bpvxx1kjbm3y-openssl-3.5.1/lib -L/nix/store/f265cd2rav3q0xcyymrwnv54m2bnn9zd-db-5.3.28/lib -L/nix/store/6bkandddyycyc9yb8h91vqfww4ixrmh4-expat-2.7.1/lib -L/nix/store/h2qyrcp5kjna53kg75rss0j7wxj52ssm-apr-1.7.6/lib -lapr-1  -o test_cgi test_cgi.o  
/build/libapreq2-2.17/apreq2-config: line 33: grep: not found
libtool: link: gcc -g -O2 -o .libs/test_cgi test_cgi.o  /build/libapreq2-2.17/library/.libs/libapreq2.so -lpthread /nix/store/6bkandddyycyc9yb8h91vqfww4ixrmh4-expat-2.7.1/lib/libexpat.so -L/nix/store/wqikwcjjxjmlxhp4hap3g9jxipprgkyx-apr-util-1.6.3/lib /nix/store/wqikwcjjxjmlxhp4hap3g9jxipprgkyx-apr-util-1.6.3/lib/libaprutil-1.so -L/nix/store/nxgc9iw2hpd4djf68qg4bpvxx1kjbm3y-openssl-3.5.1/lib -L/nix/store/f265cd2rav3q0xcyymrwnv54m2bnn9zd-db-5.3.28/lib -L/nix/store/6bkandddyycyc9yb8h91vqfww4ixrmh4-expat-2.7.1/lib -L/nix/store/h2qyrcp5kjna53kg75rss0j7wxj52ssm-apr-1.7.6/lib /nix/store/h2qyrcp5kjna53kg75rss0j7wxj52ssm-apr-1.7.6/lib/libapr-1.so
/nix/store/5lx6wcf1i09vywwbg2rp4ig1dqikjii6-binutils-2.44/bin/ld: cannot find /build/libapreq2-2.17/library/.libs/libapreq2.so: No such file or directory
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:411: test_cgi] Error 1
make[2]: Leaving directory '/build/libapreq2-2.17/module'
make[1]: *** [Makefile:461: all-recursive] Error 1
make[1]: Leaving directory '/build/libapreq2-2.17/module'
make: *** [Makefile:500: all-recursive] Error 1</pre>
</details>
</details>

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 424369`
Commit: `29b0c5917810b65a71c6cb75960dac182a7bdeec`

---
### `x86_64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>apacheHttpdPackages.mod_python</li>
    <li>apacheHttpdPackages.mod_tile</li>
    <li>perl538Packages.libapreq2</li>
    <li>perl540Packages.libapreq2</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 84 packages built:</summary>
  <ul>
    <li>apacheHttpd</li>
    <li>apacheHttpd.dev</li>
    <li>apacheHttpd.doc</li>
    <li>apacheHttpd.man</li>
    <li>apacheHttpdPackages.mod_auth_mellon</li>
    <li>apacheHttpdPackages.mod_ca</li>
    <li>apacheHttpdPackages.mod_crl</li>
    <li>apacheHttpdPackages.mod_cspnonce</li>
    <li>apacheHttpdPackages.mod_csr</li>
    <li>apacheHttpdPackages.mod_dnssd</li>
    <li>apacheHttpdPackages.mod_fastcgi</li>
    <li>apacheHttpdPackages.mod_itk</li>
    <li>apacheHttpdPackages.mod_jk</li>
    <li>apacheHttpdPackages.mod_mbtiles</li>
    <li>apacheHttpdPackages.mod_ocsp</li>
    <li>apacheHttpdPackages.mod_perl</li>
    <li>apacheHttpdPackages.mod_pkcs12</li>
    <li>apacheHttpdPackages.mod_scep</li>
    <li>apacheHttpdPackages.mod_spkac</li>
    <li>apacheHttpdPackages.mod_timestamp</li>
    <li>apacheHttpdPackages.mod_wsgi3</li>
    <li>apacheHttpdPackages.subversion</li>
    <li>apacheHttpdPackages.subversion.dev</li>
    <li>apacheHttpdPackages.subversion.man</li>
    <li>budgie-control-center</li>
    <li>budgie-control-center.debug</li>
    <li>cinnamon-gsettings-overrides</li>
    <li>code-nautilus</li>
    <li>collision</li>
    <li>dropbox-cli</li>
    <li>dropbox-cli.nautilusExtension</li>
    <li>eiciel</li>
    <li>eiciel.nautilusExtension</li>
    <li>file-roller</li>
    <li>gnome-control-center</li>
    <li>gnome-control-center.debug</li>
    <li>gnome-terminal</li>
    <li>gnome-user-share</li>
    <li>gnomeExtensions.gtk4-desktop-icons-ng-ding</li>
    <li>haxe</li>
    <li>haxePackages.format</li>
    <li>haxePackages.heaps</li>
    <li>haxePackages.hlopenal</li>
    <li>haxePackages.hlsdl</li>
    <li>haxePackages.hxcpp</li>
    <li>haxePackages.hxcs</li>
    <li>haxePackages.hxjava</li>
    <li>haxePackages.hxnodejs_4</li>
    <li>haxe_4_0</li>
    <li>haxe_4_1</li>
    <li>insync-nautilus</li>
    <li>mapcache</li>
    <li>mate.mate-user-share</li>
    <li>modsecurity_standalone</li>
    <li>modsecurity_standalone.nginx</li>
    <li>nautilus</li>
    <li>nautilus-open-any-terminal</li>
    <li>nautilus-open-any-terminal.dist</li>
    <li>nautilus-open-in-blackbox</li>
    <li>nautilus-python</li>
    <li>nautilus-python.dev</li>
    <li>nautilus-python.devdoc</li>
    <li>nautilus-python.doc</li>
    <li>nautilus.dev</li>
    <li>nautilus.devdoc</li>
    <li>neko</li>
    <li>nemo-fileroller</li>
    <li>nemo-with-extensions</li>
    <li>pantheon.file-roller-contract</li>
    <li>papers</li>
    <li>papers.dev</li>
    <li>papers.devdoc</li>
    <li>perl538Packages.GoferTransporthttp</li>
    <li>perl538Packages.GoferTransporthttp.devdoc</li>
    <li>perl538Packages.mod_perl2</li>
    <li>perl538Packages.mod_perl2.devdoc</li>
    <li>perl540Packages.GoferTransporthttp</li>
    <li>perl540Packages.GoferTransporthttp.devdoc</li>
    <li>perl540Packages.mod_perl2</li>
    <li>perl540Packages.mod_perl2.devdoc</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>themechanger</li>
    <li>xsecurelock</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>apacheHttpdPackages.mod_python</summary>
<pre>config.status: creating scripts/mod_python
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
build flags: SHELL=/nix/store/p79bgyzmmmddi554ckwzbqlavbkw07zh-bash-5.2p37/bin/bash
make[1]: Entering directory '/build/source/src'

Building mod_python.so.

/nix/store/l991dpw43yi6vqxqj9ijcyc6gcxf6rv6-apache-httpd-2.4.65-dev/bin/apxs -I/build/source/src/include -I/nix/store/djck7mx6jad1w0yy6zings96dyxanls6-python3-3.13.5/include/python3.13 -I/nix/store/djck7mx6jad1w 
/nix/store/dcmjhviarj3fy56bcd57f54zhjb4mjks-apr-1.7.6-dev/share/build/libtool --silent --mode=compile gcc -prefer-pic   -DLINUX -D_REENTRANT -D_GNU_SOURCE -g -O2 -I/nix/store/l991dpw43yi6vqxqj9ijcyc6gcxf6rv6-apao
/nix/store/dcmjhviarj3fy56bcd57f54zhjb4mjks-apr-1.7.6-dev/share/build/libtool --silent --mode=compile gcc -prefer-pic   -DLINUX -D_REENTRANT -D_GNU_SOURCE -g -O2 -I/nix/store/l991dpw43yi6vqxqj9ijcyc6gcxf6rv6-apao
_apachemodule.c: In function '_apache_module_init':
_apachemodule.c:857:5: error: implicit declaration of function '_PyImport_FixupExtensionObject' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.3.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplic]
  857 |     _PyImport_FixupExtensionObject(m, name, name
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
apxs:Error: Command failed with rc=65536
.
make[1]: *** [Makefile:57: mod_python.so] Error 1
make[1]: Leaving directory '/build/source/src'
make: *** [Makefile:34: do_dso] Error 2</pre>
</details>
<details>
<summary>apacheHttpdPackages.mod_tile</summary>
<pre>21/25 Test #19: status_and_dirty_webp ............   Passed    3.37 sec
      Start 20: remove_tile_webp
22/25 Test #20: remove_tile_webp .................   Passed    0.01 sec
      Start 23: stop_renderd
23/25 Test #23: stop_renderd .....................   Passed    0.11 sec
      Start 24: stop_httpd
24/25 Test #24: stop_httpd .......................   Passed    0.03 sec
      Start 25: clear_dirs
25/25 Test #25: clear_dirs .......................   Passed    0.07 sec

88% tests passed, 3 tests failed out of 25

Total Test time (real) = 211.27 sec

The following tests FAILED:
	  6 - render_expired (Timeout)
	  7 - render_list (Timeout)
	  8 - render_old (Timeout)
Errors while running CTest
make: *** [Makefile:91: test] Error 8</pre>
</details>
<details>
<summary>perl538Packages.libapreq2</summary>
<pre>/nix/store/p79bgyzmmmddi554ckwzbqlavbkw07zh-bash-5.2p37/bin/bash ../../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I../../include  -I/nix/store/l991dpw43yi6vqxqj9ijcyc6gcxf6rv6-apache-httpd-c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../../include -I/nix/store/l991dpw43yi6vqxqj9ijcyc6gcxf6rv6-apache-httpd-2.4.65-dev/include -I/nix/store/dcmjhviarj3fy56bcd57f54zhjb4mjks-apr-1.7.6-dev/include -I/nixo
/nix/store/p79bgyzmmmddi554ckwzbqlavbkw07zh-bash-5.2p37/bin/bash ../../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I../../include  -I/nix/store/l991dpw43yi6vqxqj9ijcyc6gcxf6rv6-apache-httpd-2.4.6c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../../include -I/nix/store/l991dpw43yi6vqxqj9ijcyc6gcxf6rv6-apache-httpd-2.4.65-dev/include -I/nix/store/dcmjhviarj3fy56bcd57f54zhjb4mjks-apr-1.7.6-dev/include -I/nixo
/nix/store/p79bgyzmmmddi554ckwzbqlavbkw07zh-bash-5.2p37/bin/bash ../../libtool  --tag=CC   --mode=link gcc  -g -O2 -export-dynamic -module -avoid-version `/build/libapreq2-2.17/apreq2-config --link-libtool --lib 
/build/libapreq2-2.17/apreq2-config: line 33: grep: not found
libtool: link: ( cd ".libs" && rm -f "mod_apreq2.la" && ln -s "../mod_apreq2.la" "mod_apreq2.la" )
make[2]: Leaving directory '/build/libapreq2-2.17/module/apache2'
make[2]: Entering directory '/build/libapreq2-2.17/module'
gcc -DHAVE_CONFIG_H -I. -I../include  -I/nix/store/dcmjhviarj3fy56bcd57f54zhjb4mjks-apr-1.7.6-dev/include  -I/nix/store/bb2c3d2lq849i68m76zjm60hinvcj46y-apr-util-1.6.3-dev/include -I/nix/store/jyi9ix8mpg6zb22d14c
/nix/store/p79bgyzmmmddi554ckwzbqlavbkw07zh-bash-5.2p37/bin/bash ../libtool  --tag=CC   --mode=link gcc  -g -O2 `/build/libapreq2-2.17/apreq2-config --link-libtool`  -L/nix/store/j5qgnj70q499mxqvkd1fayv09s847lai 
/build/libapreq2-2.17/apreq2-config: line 33: grep: not found
libtool: link: gcc -g -O2 -o .libs/test_cgi test_cgi.o  /build/libapreq2-2.17/library/.libs/libapreq2.so -lpthread /nix/store/4ciq67pdwyc43a5y1h63wcipl54f938w-expat-2.7.1/lib/libexpat.so -L/nix/store/j5qgnj70q49o
/nix/store/x7w0rmkaam7aikclyhwdbn8wmmq29ma6-binutils-2.44/bin/ld: cannot find /build/libapreq2-2.17/library/.libs/libapreq2.so: No such file or directory
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:411: test_cgi] Error 1
make[2]: Leaving directory '/build/libapreq2-2.17/module'
make[1]: *** [Makefile:461: all-recursive] Error 1
make[1]: Leaving directory '/build/libapreq2-2.17/module'
make: *** [Makefile:500: all-recursive] Error 1</pre>
</details>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
