### PR TITLE
maintainers: drop kanielrkirby

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12985,12 +12985,6 @@
     githubId = 56224949;
     name = "Mia Kanashi";
   };
-  kanielrkirby = {
-    email = "kanielrkirby@runbox.com";
-    github = "kanielrkirby";
-    githubId = 77940607;
-    name = "Kaniel Kirby";
-  };
   karantan = {
     name = "Gasper Vozel";
     email = "karantan@gmail.com";

--- a/pkgs/by-name/la/lazysql/package.nix
+++ b/pkgs/by-name/la/lazysql/package.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
     description = "Cross-platform TUI database management tool written in Go";
     homepage = "https://github.com/jorgerojas26/lazysql";
     license = licenses.mit;
-    maintainers = with maintainers; [ kanielrkirby ];
+    maintainers = with maintainers; [ ];
     mainProgram = "lazysql";
   };
 }


### PR DESCRIPTION
Added lazysql in April/June 2024 and became a maintainer for it. Never joined the nixos org and never interacted with any of the 13 update PRs.

Dropping according to https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#how-to-lose-maintainer-status.

@kanielrkirby if you'd like to stay maintainer please say so. In that case, please also consider asking for the invite to the nixos org again, so that you can be pinged for reviews properly: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#tools-for-maintainers

Will wait a week before merging according to the contribution guidelines.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
