### PR TITLE
foks: init at 0.1.7

### DIFF
--- a/pkgs/by-name/fo/foks-server/package.nix
+++ b/pkgs/by-name/fo/foks-server/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  foks,
+  pcsclite,
+  pkg-config,
+  stdenv,
+  buildPackages,
+}:
+let
+  templFoks = buildPackages.templ.overrideAttrs (old: {
+    pname = "templ-foks";
+    version = "0.3.833";
+    src = old.src.override {
+      hash = "sha256-4K1MpsM3OuamXRYOllDsxxgpMRseFGviC4RJzNA7Cu8=";
+    };
+    vendorHash = "sha256-OPADot7Lkn9IBjFCfbrqs3es3F6QnWNjSOHxONjG4MM=";
+  });
+in
+buildGoModule (finalAttrs: {
+  pname = "foks-server";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "foks-proj";
+    repo = "go-foks";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UZ4BZ2/S44hnG+uLHtWR/qqQtr6tbbQbQOgIrN4ciT0=";
+  };
+
+  vendorHash = "sha256-+ysHa5KNhoxtoXPgOWC9ZDJKYqF+84s7oyxRib2S6a8=";
+
+  postPatch = ''
+    cd ./server/web/templates
+    templ generate
+    cd -
+  '';
+  postInstall = ''
+    ln -s $out/bin/{foks-server,git-remote-foks}
+  '';
+
+  subPackages = [ "server/foks-server" ];
+  excludedPackages = [ "server" ];
+
+  buildInputs = lib.optionals (stdenv.hostPlatform.isLinux) [ pcsclite ];
+  nativeBuildInputs = [
+    pkg-config
+    templFoks
+    foks
+  ];
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Federated key management and distribution system";
+    homepage = "https://foks.pub";
+    downloadPage = "https://github.com/foks-proj/go-foks";
+    changelog = "https://github.com/foks-proj/go-foks/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ poptart ];
+    mainProgram = "foks";
+  };
+})

--- a/pkgs/by-name/fo/foks/package.nix
+++ b/pkgs/by-name/fo/foks/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pcsclite,
+  pkg-config,
+  stdenv,
+  templ,
+  buildPackages,
+}:
+let
+  templFoks = buildPackages.templ.overrideAttrs (old: {
+    pname = "templ-foks";
+    version = "0.3.833";
+    src = old.src.override {
+      hash = "sha256-4K1MpsM3OuamXRYOllDsxxgpMRseFGviC4RJzNA7Cu8=";
+    };
+    vendorHash = "sha256-OPADot7Lkn9IBjFCfbrqs3es3F6QnWNjSOHxONjG4MM=";
+  });
+in
+buildGoModule (finalAttrs: {
+  pname = "foks";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "foks-proj";
+    repo = "go-foks";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UZ4BZ2/S44hnG+uLHtWR/qqQtr6tbbQbQOgIrN4ciT0=";
+  };
+
+  vendorHash = "sha256-+ysHa5KNhoxtoXPgOWC9ZDJKYqF+84s7oyxRib2S6a8=";
+
+  postPatch = ''
+    cd ./server/web/templates
+    ${templFoks}/bin/templ generate
+    cd -
+  '';
+  postInstall = ''
+    ln -s $out/bin/{foks,git-remote-foks}
+  '';
+
+  subPackages = [ "client/foks" ];
+  excludedPackages = [ "server" ];
+
+  buildInputs = lib.optionals (stdenv.hostPlatform.isLinux) [ pcsclite ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Federated key management and distribution system";
+    homepage = "https://foks.pub";
+    downloadPage = "https://github.com/foks-proj/go-foks";
+    changelog = "https://github.com/foks-proj/go-foks/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ poptart ];
+    mainProgram = "foks";
+  };
+})


### PR DESCRIPTION
Adds the `foks` package. This package is the client component of the foks federated cryptographic key managed and distribution system.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
