### PR TITLE
gccNGPackages_15: fix gfortran & libstdcxx

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -726,6 +726,15 @@ stdenvNoCC.mkDerivation {
       echo "-isystem ${getDev libcxx}/include/c++/v1" >> $out/nix-support/libcxx-cxxflags
       echo "-stdlib=libc++" >> $out/nix-support/libcxx-ldflags
     ''
+    # GCC NG friendly libc++
+    + optionalString (libcxx != null && libcxx.isGNU or false) ''
+      for dir in ${getDev libcxx}/include/c++/*; do
+        echo "-isystem $dir" >> $out/nix-support/libcxx-cxxflags
+      done
+      for dir in ${getDev libcxx}/include/c++/*/${targetPlatform.config}; do
+        echo "-isystem $dir" >> $out/nix-support/libcxx-cxxflags
+      done
+    ''
 
     ##
     ## Initial CFLAGS

--- a/pkgs/development/compilers/gcc/ng/common/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/default.nix
@@ -131,6 +131,21 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libgcc}/lib"
           "-B${targetGccPackages.libssp}/lib"
           "-B${targetGccPackages.libatomic}/lib"
+          "-B${targetGccPackages.libgfortran}/lib/"
+        ];
+      };
+
+      gfortranNoLibgfortran = wrapCCWith rec {
+        cc = gccPackages.gfortran-unwrapped;
+        libcxx = targetGccPackages.libstdcxx;
+        bintools = binutils;
+        extraPackages = [
+          targetGccPackages.libgcc
+        ];
+        nixSupport.cc-cflags = [
+          "-B${targetGccPackages.libgcc}/lib"
+          "-B${targetGccPackages.libssp}/lib"
+          "-B${targetGccPackages.libatomic}/lib"
         ];
       };
 
@@ -211,7 +226,7 @@ makeScopeWithSplicing' {
 
       libgfortran = callPackage ./libgfortran {
         stdenv = overrideCC stdenv buildGccPackages.gcc;
-        inherit (buildGccPackages) gfortran;
+        gfortran = buildGccPackages.gfortranNoLibgfortran;
       };
 
       libstdcxx = callPackage ./libstdcxx {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Makes it possible to compile things with gfortran. I've tested by applying this diff:
```diff
diff --git a/pkgs/by-name/gf/gfortran/package.nix b/pkgs/by-name/gf/gfortran/package.nix
index 93b8c5a4906d..9129a89b5dfe 100644
--- a/pkgs/by-name/gf/gfortran/package.nix
+++ b/pkgs/by-name/gf/gfortran/package.nix
@@ -1,11 +1,2 @@
-{ wrapCC, gcc }:
-# Use the same GCC version as the one from stdenv by default
-wrapCC (
-  gcc.cc.override {
-    name = "gfortran";
-    langFortran = true;
-    langCC = false;
-    langC = false;
-    profiledCompiler = false;
-  }
-)
+{ gfortran15 }:
+gfortran15
diff --git a/pkgs/by-name/gf/gfortran15/package.nix b/pkgs/by-name/gf/gfortran15/package.nix
deleted file mode 100644
index 45b1581e0f9a..000000000000
--- a/pkgs/by-name/gf/gfortran15/package.nix
+++ /dev/null
@@ -1,10 +0,0 @@
-{ wrapCC, gcc15 }:
-wrapCC (
-  gcc15.cc.override {
-    name = "gfortran";
-    langFortran = true;
-    langCC = false;
-    langC = false;
-    profiledCompiler = false;
-  }
-)
diff --git a/pkgs/top-level/all-packages.nix b/pkgs/top-level/all-packages.nix
index 562775fe2f97..9e50112f0ed3 100644
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5007,8 +5007,11 @@ with pkgs;
       gccNGPackagesSet = recurseIntoAttrs (callPackages ../development/compilers/gcc/ng { });
       gccNGPackages_15 = gccNGPackagesSet."15";
       mkGCCNGPackages = gccNGPackagesSet.mkPackage;
+
+      gfortran15 = gccNGPackages_15.gfortran;
     })
     gccNGPackages_15
+    gfortran15
     mkGCCNGPackages
     ;
```

I then compiled `mela` and `pkgsLLVM.mela` and there is no breakage.

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
