### PR TITLE
Netdata make package upstream aligned

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -292,6 +292,7 @@ in
       };
     };
 
+    # nix repackaged variant of https://github.com/netdata/netdata/blob/826d60df4287c0e3b2798c456c103f024d8c46c3/system/systemd/netdata.service.in
     systemd.services.netdata = {
       description = "Real time performance monitoring";
       after = [
@@ -342,21 +343,20 @@ in
           NETDATA_CLAIM_TOKEN="$(cat "$CREDENTIALS_DIRECTORY/token")"
           echo "Loaded NETDATA_CLAIM_TOKEN into env"
         '')
-        "exec netdata -P /run/netdata/netdata.pid -D -c /etc/netdata/netdata.conf"
+        "exec netdata -D"
       ];
       serviceConfig = {
+        LogNamespace = lib.optionalAttrs (cfg.package.withSystemdJournal) "netdata";
         ExecReload = "${pkgs.util-linux}/bin/kill -s HUP -s USR1 -s USR2 $MAINPID";
-        ExecStartPost = pkgs.writeShellScript "wait-for-netdata-up" ''
-          while [ "$(${cfg.package}/bin/netdatacli ping)" != pong ]; do sleep 0.5; done
-        '';
-
         TimeoutStopSec = cfg.deadlineBeforeStopSec;
+        CPUSchedulingPolicy = "batch";
         Restart = "on-failure";
         # User and group
         User = cfg.user;
         Group = cfg.group;
         # Performance
         LimitNOFILE = "30000";
+        Nice = 0;
         # Runtime directory and mode
         RuntimeDirectory = "netdata";
         RuntimeDirectoryMode = "0750";
@@ -399,6 +399,20 @@ in
         PrivateTmp = true;
         ProtectControlGroups = true;
         PrivateMounts = true;
+        ReadWriteDirectories = lib.optional config.services.postfix.enable [
+          "-/var/spool/postfix/maildrop"
+        ];
+        # https://github.com/netdata/netdata/issues/14238
+        BindReadOnlyPaths = map (p: "-/proc/" + p) [
+          "cpuinfo"
+          "diskstats"
+          "loadavg"
+          "meminfo"
+          "slabinfo"
+          "stat"
+          "swapsstat"
+          "uptime"
+        ];
       }
       // (lib.optionalAttrs (cfg.claimTokenFile != null) {
         LoadCredential = [ "token:${cfg.claimTokenFile}" ];


### PR DESCRIPTION
Working on #424409 I've noticed some potential improvements to the module


* `wait-for-netdata-up` is not completely implemented, it would run unnecessarily long for a unit that failed because systemd doesn't provide a method to only run `ExecStartPost` only if `ExecStart` was successful -> maybe it's worth using the same settings as netdata upstream there, so this PR removes https://github.com/NixOS/nixpkgs/pull/181976 @wmertens. If you have other systemd services depending on netdata it's best if they use `ExecStartPre` with a similar command.
* include more systemd settings of netdata upstream systemd service
   * a bit unsure about the journal namespace as this would require people to use `sudo journalctl --namespace netdata -f` instead of `journalctl -fu netdata`, not sure why netdata did that in their default service
* improve default type as there are more possible options allowed by systemd -> generally the `TimeoutStopSec` should maybe not be a config option as users can always use `systemd.services.netdata.ServiceConfig.TimeoutStopSec = "200s";` to change the desired
* remove unused `PIDFILE` this is not needed when using `-D`
* remove passing default config options

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
