### PR TITLE
kodiPackages.screensaver-asteroids: 22.0.2 -> 21.0.2

### DIFF
--- a/pkgs/applications/video/kodi/addons/screensaver-asteroids/default.nix
+++ b/pkgs/applications/video/kodi/addons/screensaver-asteroids/default.nix
@@ -10,13 +10,13 @@
 buildKodiBinaryAddon rec {
   pname = "screensaver-asteroids";
   namespace = "screensaver.asteroids";
-  version = "22.0.2";
+  version = "21.0.2";
 
   src = fetchFromGitHub {
     owner = "xbmc";
     repo = namespace;
     rev = "${version}-${rel}";
-    hash = "sha256-Ri9dgdhJbHybdUkZeRE7X7SQMaV2JZCm7znAyDEa470=";
+    hash = "sha256-cepo7amJn6y1J9hVSt35VgOz/ixT7l/UfjtmHOajBrw=";
   };
 
   extraNativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
The tag contains the kodi release name and the combination of 22.0.2-Omega doesn't exist. The right version to use is 21.0.2-Omega, thus downgrading.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
