### PR TITLE
maintainers: drop d-xo

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5471,12 +5471,6 @@
     name = "Dima";
     keys = [ { fingerprint = "1C4E F4FE 7F8E D8B7 1E88 CCDF BAB1 D15F B7B4 D4CE"; } ];
   };
-  d-xo = {
-    email = "hi@d-xo.org";
-    github = "d-xo";
-    githubId = 6689924;
-    name = "David Terry";
-  };
   d3vil0p3r = {
     name = "Antonio Voza";
     email = "vozaanthony@gmail.com";

--- a/nixos/tests/bazarr.nix
+++ b/nixos/tests/bazarr.nix
@@ -5,7 +5,6 @@ let
 in
 {
   name = "bazarr";
-  meta.maintainers = with lib.maintainers; [ d-xo ];
 
   nodes.machine =
     { pkgs, ... }:

--- a/nixos/tests/wireguard/wg-quick.nix
+++ b/nixos/tests/wireguard/wg-quick.nix
@@ -18,9 +18,6 @@ import ../make-test-python.nix (
   in
   {
     name = "wg-quick";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ d-xo ];
-    };
 
     nodes = {
       peer0 = peer {

--- a/pkgs/by-name/ba/bazarr/package.nix
+++ b/pkgs/by-name/ba/bazarr/package.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.bazarr.media/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ d-xo ];
     mainProgram = "bazarr";
     platforms = platforms.all;
   };

--- a/pkgs/by-name/bt/btc-rpc-explorer/package.nix
+++ b/pkgs/by-name/bt/btc-rpc-explorer/package.nix
@@ -43,7 +43,6 @@ buildNpmPackage rec {
     homepage = "https://github.com/janoside/btc-rpc-explorer";
     license = lib.licenses.mit;
     mainProgram = "btc-rpc-explorer";
-    maintainers = with lib.maintainers; [ d-xo ];
     broken = true;
     # At 2024-06-29
     # https://hydra.nixos.org/build/264232177/nixlog/1

--- a/pkgs/by-name/er/erigon/package.nix
+++ b/pkgs/by-name/er/erigon/package.nix
@@ -67,7 +67,6 @@ buildGoModule {
       gpl3Plus
     ];
     maintainers = with maintainers; [
-      d-xo
       happysalada
     ];
   };

--- a/pkgs/by-name/hs/hsd/package.nix
+++ b/pkgs/by-name/hs/hsd/package.nix
@@ -40,6 +40,5 @@ buildNpmPackage rec {
     description = "Implementation of the Handshake protocol";
     homepage = "https://github.com/handshake-org/hsd";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ d-xo ];
   };
 }

--- a/pkgs/by-name/ln/lndconnect/package.nix
+++ b/pkgs/by-name/ln/lndconnect/package.nix
@@ -25,7 +25,6 @@ buildGoModule rec {
     description = "Generate QRCode to connect apps to lnd Resources";
     license = licenses.mit;
     homepage = "https://github.com/LN-Zap/lndconnect";
-    maintainers = [ maintainers.d-xo ];
     platforms = platforms.linux;
     mainProgram = "lndconnect";
   };

--- a/pkgs/by-name/wi/wireguard-tools/package.nix
+++ b/pkgs/by-name/wi/wireguard-tools/package.nix
@@ -92,7 +92,6 @@ stdenv.mkDerivation rec {
       zx2c4
       globin
       ma27
-      d-xo
     ];
     mainProgram = "wg";
     platforms = platforms.unix;

--- a/pkgs/development/python-modules/ledgerwallet/default.nix
+++ b/pkgs/development/python-modules/ledgerwallet/default.nix
@@ -66,7 +66,6 @@ buildPythonPackage rec {
     mainProgram = "ledgerctl";
     license = licenses.mit;
     maintainers = with maintainers; [
-      d-xo
       erdnaxe
     ];
   };


### PR DESCRIPTION
No activity for at least this year (2025), possibly up to a year (mid 2024).

Dropping according to maintainer guidelines: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#how-to-lose-maintainer-status

@d-xo if you'd like to keep maintaining, please respond within a week.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
