### PR TITLE
gnomeExtensions: auto-update

### DIFF
--- a/pkgs/desktops/gnome/extensions/collisions.json
+++ b/pkgs/desktops/gnome/extensions/collisions.json
@@ -38,6 +38,7 @@
   ],
   "system-monitor": [
     "System_Monitor@bghome.gmail.com",
+    "system-monitor@axet.github.com",
     "system-monitor@gnome-shell-extensions.gcampax.github.com"
   ]
 }

--- a/pkgs/desktops/gnome/extensions/extensionRenames.nix
+++ b/pkgs/desktops/gnome/extensions/extensionRenames.nix
@@ -12,6 +12,7 @@
 
   "system-monitor@gnome-shell-extensions.gcampax.github.com" = "system-monitor";
   "System_Monitor@bghome.gmail.com" = "system-monitor-2";
+  "system-monitor@axet.github.com" = "system-monitor-3";
 
   "FuzzyClock@fire-man-x" = "fuzzy-clock-3";
   "FuzzyClock@johngoetz" = "fuzzy-clock";


### PR DESCRIPTION
- ran `./pkgs/desktops/gnome/extensions/update-extensions.py`.
- added 1 new collision (another System Monitor fork).

motivated by the Window Desaturation extension needing an update to unbreak on GNOME 48.
