### PR TITLE
swaynotificationcenter: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/by-name/sw/swaynotificationcenter/package.nix
+++ b/pkgs/by-name/sw/swaynotificationcenter/package.nix
@@ -11,16 +11,17 @@
   gdk-pixbuf,
   glib,
   gobject-introspection,
-  gtk-layer-shell,
-  gtk3,
+  gtk4-layer-shell,
+  gtk4,
   gvfs,
   json-glib,
+  libadwaita,
   libgee,
-  libhandy,
   libnotify,
   libpulseaudio,
   librsvg,
   meson,
+  blueprint-compiler,
   ninja,
   pkg-config,
   python3,
@@ -34,13 +35,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "SwayNotificationCenter";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "ErikReider";
     repo = "SwayNotificationCenter";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-kRawYbBLVx0ie4t7tChkA8QJShS83fUcGrJSKkxBy8Q=";
+    hash = "sha256-F7fccUaQUSHHqXO0lvnW1H3Af2YTQwQ17rNFhprgFz4=";
   };
 
   # build pkg-config is required to locate the native `scdoc` input
@@ -53,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     gobject-introspection
     meson
+    blueprint-compiler
     ninja
     pkg-config
     python3
@@ -67,16 +69,16 @@ stdenv.mkDerivation (finalAttrs: {
     dbus-glib
     gdk-pixbuf
     glib
-    gtk-layer-shell
-    gtk3
+    gtk4-layer-shell
+    gtk4
     gvfs
     json-glib
+    libadwaita
     libgee
-    libhandy
     libnotify
     libpulseaudio
     librsvg
-    pantheon.granite
+    pantheon.granite7
     # systemd # ends with broken permission
     wayland-scanner
   ];


### PR DESCRIPTION
## Things done

Updated swaynotificationcenter package to version 0.12.0 which was ported to GTK4 so the build deps also needed to be adjusted.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
