### PR TITLE
Fix path to agent-bootstrapper.jar for gocd agent.

### DIFF
--- a/nixos/modules/services/continuous-integration/gocd-agent/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-agent/default.nix
@@ -216,7 +216,7 @@ in
         ${pkgs.git}/bin/git config --global --add http.sslCAinfo ${config.security.pki.caBundle}
         ${pkgs.jre}/bin/java ${lib.concatStringsSep " " cfg.startupOptions} \
                         ${lib.concatStringsSep " " cfg.extraOptions} \
-                              -jar ${pkgs.gocd-agent}/go-agent/agent-bootstrapper.jar \
+                              -jar ${pkgs.gocd-agent}/go-agent/lib/agent-bootstrapper.jar \
                               -serverUrl ${cfg.goServer}
       '';
 


### PR DESCRIPTION
Add missing lib component in agent-bootstrapper.jar gocd-agent service script path.