### PR TITLE
python3Packages.wandb: Disable tests that fail in Darwin's strict sandbox

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -279,19 +279,24 @@ buildPythonPackage rec {
     "--timeout=1024"
   ];
 
-  disabledTestPaths = [
-    # Require docker access
-    "tests/system_tests"
+  disabledTestPaths =
+    [
+      # Require docker access
+      "tests/system_tests"
 
-    # broke somewhere between sentry-sdk 2.15.0 and 2.22.0
-    "tests/unit_tests/test_analytics/test_sentry.py"
+      # broke somewhere between sentry-sdk 2.15.0 and 2.22.0
+      "tests/unit_tests/test_analytics/test_sentry.py"
 
-    # Server connection times out under load
-    "tests/unit_tests/test_wandb_login.py"
+      # Server connection times out under load
+      "tests/unit_tests/test_wandb_login.py"
 
-    # PermissionError: unable to write to .cache/wandb/artifacts
-    "tests/unit_tests/test_artifacts/test_wandb_artifacts.py"
-  ];
+      # PermissionError: unable to write to .cache/wandb/artifacts
+      "tests/unit_tests/test_artifacts/test_wandb_artifacts.py"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Breaks in sandbox: "Timed out waiting for wandb service to start"
+      "tests/unit_tests/test_job_builder.py"
+    ];
 
   disabledTests =
     [
@@ -391,6 +396,15 @@ buildPythonPackage rec {
 
       # RuntimeError: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]
       "test_wandb_image_with_matplotlib_figure"
+
+      # AssertionError: assert 'did you mean https://api.wandb.ai' in '1'
+      "test_login_bad_host"
+
+      # Asserttion error: 1 != 0 (testing system exit code)
+      "test_login_host_trailing_slash_fix_invalid"
+
+      # Breaks in sandbox: "Timed out waiting for wandb service to start"
+      "test_setup_offline"
     ];
 
   pythonImportsCheck = [ "wandb" ];


### PR DESCRIPTION
One last batch of fixes.

I normally run with a relaxed sandbox, but tested this time with a standard sandbox and found a few more non-working tests.

@samuela apologies for three of these in a row!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
