### PR TITLE
fehlstart: unstable-2016-05-23 -> 0.5-unstable-2025-01-12

### DIFF
--- a/pkgs/by-name/fe/fehlstart/package.nix
+++ b/pkgs/by-name/fe/fehlstart/package.nix
@@ -2,39 +2,45 @@
   lib,
   stdenv,
   pkg-config,
-  gtk2,
-  keybinder,
-  fetchFromGitLab,
+  gtk3,
+  glib,
+  keybinder3,
+  fetchFromGitea,
 }:
 
 stdenv.mkDerivation {
   pname = "fehlstart";
-  version = "unstable-2016-05-23";
+  version = "0.5-unstable-2025-01-12";
 
-  src = fetchFromGitLab {
-    owner = "fehlstart";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "chuvok";
     repo = "fehlstart";
-    rev = "9f4342d75ec5e2a46c13c99c34894bc275798441";
-    sha256 = "1rfzh7w6n2s9waprv7m1bhvqrk36a77ada7w655pqiwkhdj5q95i";
+    rev = "cf08d6c3964da9abc8d1af0725894fef62352064";
+    hash = "sha256-qq0IhLzSvYnooPb4w+lno8P/tbedrDKTk27HGtQlp2I=";
   };
 
   patches = [ ./use-nix-profiles.patch ];
+
+  strictDeps = true;
+
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
-    gtk2
-    keybinder
+    gtk3
+    keybinder3
   ];
 
-  preConfigure = ''
-    export PREFIX=$out
-  '';
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev glib}/include/gio-unix-2.0";
 
-  meta = with lib; {
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
     description = "Small desktop application launcher with reasonable memory footprint";
-    homepage = "https://gitlab.com/fehlstart/fehlstart";
-    license = licenses.gpl3;
-    maintainers = [ maintainers.mounium ];
-    platforms = platforms.all;
+    homepage = "https://codeberg.org/Chuvok/fehlstart";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.mounium ];
+    platforms = lib.platforms.linux;
     mainProgram = "fehlstart";
   };
 }

--- a/pkgs/by-name/fe/fehlstart/use-nix-profiles.patch
+++ b/pkgs/by-name/fe/fehlstart/use-nix-profiles.patch
@@ -1,21 +1,21 @@
---- fehlstart-9f4342d75ec5e2a46c13c99c34894bc275798441-src/fehlstart.c	1970-01-01 01:00:01.000000000 +0100
-+++ fehlstart.c	2016-08-10 12:21:11.231638418 +0200
-@@ -779,8 +779,15 @@
-     read_settings(setting_file, &settings);
-     update_commands();
-     g_hash_table_foreach(action_map, update_launcher, NULL);
--    add_launchers(STR_S(APPLICATIONS_DIR_0));
--    add_launchers(STR_S(APPLICATIONS_DIR_1));
--    add_launchers(STR_S(USER_APPLICATIONS_DIR));
+diff --git a/fehlstart.c b/fehlstart.c
+index b33c8ff..ce467b5 100644
+--- a/fehlstart.c
++++ b/fehlstart.c
+@@ -802,6 +802,16 @@ static void* update_all(void* user_data)
+     add_launchers(APPLICATIONS_DIR_0);
+     add_launchers(APPLICATIONS_DIR_1);
+     add_launchers(USER_APPLICATIONS_DIR);
 +    const char* nixprofiles = getenv("NIX_PROFILES");
 +    if(nixprofiles != NULL) {
 +      const char* pch = strtok(nixprofiles, " ");
 +      while (pch != NULL)
 +      {
-+          String nix_dir = str_concat((String) { pch, strlen(pch), false },STR_S("/share/applications"));
++          char* nix_dir = g_strconcat(pch, "/share/applications", NULL);
 +          add_launchers(nix_dir);
 +          pch = strtok(NULL, " ");
 +      }
 +    }
      return NULL;
  }
+ 


### PR DESCRIPTION
GTK2 removal tracking issue: https://github.com/NixOS/nixpkgs/issues/410814

Development has moved to codeberg. See original repo: https://gitlab.com/fehlstart/fehlstart

Also, since the patch didn't apply, I had to update it. In the original patch, all of the non-nix-profile directories were skipped. In the new patch, I didn't disable them, so that things installed via Steam and such into `~/.local/share` could still be found.

Maybe there is a way to respect the spec-defined env vars, but I'm sure as hell not going to implement that as a patch.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
