### PR TITLE
nixos/meilisearch: generic settings; handle secrets better. + fix racy test

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -882,9 +882,7 @@
     "index.html#module-services-meilisearch-quickstart-search"
   ],
   "module-services-meilisearch-defaults": [
-    "index.html#module-services-meilisearch-defaults"
-  ],
-  "module-services-meilisearch-missing": [
+    "index.html#module-services-meilisearch-defaults",
     "index.html#module-services-meilisearch-missing"
   ],
   "module-services-networking-yggdrasil": [

--- a/nixos/modules/services/search/meilisearch.md
+++ b/nixos/modules/services/search/meilisearch.md
@@ -32,10 +32,12 @@ you first need to add documents to an index before you can search for documents.
 
 - The default nixos package doesn't come with the [dashboard](https://docs.meilisearch.com/learn/getting_started/quick_start.html#search), since the dashboard features makes some assets downloads at compile time.
 
-- Anonymized Analytics sent to meilisearch are disabled by default.
+- `no_analytics` is set to true by default.
 
-- Default deployment is development mode. It doesn't require a secret master key. All routes are not protected and accessible.
+- `http_addr` is derived from {option}`services.meilisearch.listenAddress` and {option}`services.meilisearch.listenPort`. The two sub-fields are separate because this makes it easier to consume in certain other modules.
 
-## Missing {#module-services-meilisearch-missing}
+- `db_path` is set to `/var/lib/meilisearch` by default. Upstream, the default value is equivalent to `/var/lib/meilisearch/data.ms`.
 
-- the snapshot feature is not yet configurable from the module, it's just a matter of adding the relevant environment variables.
+- `dump_dir` and `snapshot_dir` are set to `/var/lib/meilisearch/dumps` and `/var/lib/meilisearch/snapshots`, respectively. This is equivalent to the upstream defaults.
+
+- All other options inherit their upstream defaults. In particular, the default configuration uses `env = "development"`, which doesn't require a master key, in which case all routes are unprotected.

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -7,19 +7,91 @@
 let
   cfg = config.services.meilisearch;
 
+  settingsFormat = pkgs.formats.toml { };
+
+  # These secrets are used in the config file and can be set to paths.
+  secrets-with-path =
+    builtins.map
+      (
+        { environment, name }:
+        {
+          inherit name environment;
+          setting = cfg.settings.${name};
+        }
+      )
+      [
+        {
+          environment = "MEILI_SSL_CERT_PATH";
+          name = "ssl_cert_path";
+        }
+        {
+          environment = "MEILI_SSL_KEY_PATH";
+          name = "ssl_key_path";
+        }
+        {
+          environment = "MEILI_SSL_AUTH_PATH";
+          name = "ssl_auth_path";
+        }
+        {
+          environment = "MEILI_SSL_OCSP_PATH";
+          name = "ssl_ocsp_path";
+        }
+      ];
+
+  # We also handle `master_key` separately.
+  # It cannot be set to a path, so we template it.
+  master-key-placeholder = "@MASTER_KEY@";
+
+  configFile = settingsFormat.generate "config.toml" (
+    builtins.removeAttrs (
+      if cfg.masterKeyFile != null then
+        cfg.settings // { master_key = master-key-placeholder; }
+      else
+        builtins.removeAttrs cfg.settings [ "master_key" ]
+    ) (map (secret: secret.name) secrets-with-path)
+  );
+
 in
 {
-
   meta.maintainers = with lib.maintainers; [
     Br1ght0ne
     happysalada
   ];
   meta.doc = ./meilisearch.md;
 
-  ###### interface
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "meilisearch" "environment" ]
+      [ "services" "meilisearch" "settings" "env" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "meilisearch" "logLevel" ]
+      [ "services" "meilisearch" "settings" "log_level" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "meilisearch" "noAnalytics" ]
+      [ "services" "meilisearch" "settings" "no_analytics" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "meilisearch" "maxIndexSize" ]
+      [ "services" "meilisearch" "settings" "max_index_size" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "meilisearch" "payloadSizeLimit" ]
+      [ "services" "meilisearch" "settings" "http_payload_size_limit" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "meilisearch" "dumplessUpgrade" ]
+      [ "services" "meilisearch" "settings" "experimental_dumpless_upgrade" ]
+    )
+    (lib.mkRemovedOptionModule [ "services" "meilisearch" "masterKeyEnvironmentFile" ] ''
+      Use `services.meilisearch.masterKeyFile` instead. It does not require you to prefix the file with "MEILI_MASTER_KEY=".
+      If you were abusing this option to set other options, you can now configure them with `services.meilisearch.settings`.
+    '')
+  ];
 
   options.services.meilisearch = {
-    enable = lib.mkEnableOption "MeiliSearch - a RESTful search API";
+    enable = lib.mkEnableOption "Meilisearch - a RESTful search API";
 
     package = lib.mkPackageOption pkgs "meilisearch" {
       extraDescription = ''
@@ -28,106 +100,87 @@ in
     };
 
     listenAddress = lib.mkOption {
-      description = "MeiliSearch listen address.";
-      default = "127.0.0.1";
+      default = "localhost";
       type = lib.types.str;
+      description = ''
+        The IP address that Meilisearch will listen on.
+
+        It can also be a hostname like "localhost". If it resolves to an IPv4 and IPv6 address, Meilisearch will listen on both.
+      '';
     };
 
     listenPort = lib.mkOption {
-      description = "MeiliSearch port to listen on.";
       default = 7700;
       type = lib.types.port;
+      description = ''
+        The port that Meilisearch will listen on.
+      '';
     };
 
-    environment = lib.mkOption {
-      description = "Defines the running environment of MeiliSearch.";
-      default = "development";
-      type = lib.types.enum [
-        "development"
-        "production"
-      ];
-    };
-
-    # TODO change this to LoadCredentials once possible
-    masterKeyEnvironmentFile = lib.mkOption {
+    masterKeyFile = lib.mkOption {
       description = ''
         Path to file which contains the master key.
         By doing so, all routes will be protected and will require a key to be accessed.
         If no master key is provided, all routes can be accessed without requiring any key.
-        The format is the following:
-        MEILI_MASTER_KEY=my_secret_key
       '';
       default = null;
-      type = with lib.types; nullOr path;
+      type = lib.types.nullOr lib.types.path;
     };
 
-    noAnalytics = lib.mkOption {
+    settings = lib.mkOption {
       description = ''
-        Deactivates analytics.
-        Analytics allow MeiliSearch to know how many users are using MeiliSearch,
-        which versions and which platforms are used.
-        This process is entirely anonymous.
+        Configuration settings for Meilisearch.
+        Look at the documentation for available options:
+        https://github.com/meilisearch/meilisearch/blob/main/config.toml
+        https://www.meilisearch.com/docs/learn/self_hosted/configure_meilisearch_at_launch#all-instance-options
       '';
-      default = true;
-      type = lib.types.bool;
+
+      default = { };
+
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        imports = builtins.map (secret: {
+          # give them proper types, just so they're easier to consume from this file
+          options.${secret.name} = lib.mkOption {
+            # but they should not show up in documentation as special in any way.
+            visible = false;
+
+            type = lib.types.nullOr lib.types.path;
+            default = null;
+          };
+        }) secrets-with-path;
+      };
     };
-
-    logLevel = lib.mkOption {
-      description = ''
-        Defines how much detail should be present in MeiliSearch's logs.
-        MeiliSearch currently supports four log levels, listed in order of increasing verbosity:
-        - 'ERROR': only log unexpected events indicating MeiliSearch is not functioning as expected
-        - 'WARN:' log all unexpected events, regardless of their severity
-        - 'INFO:' log all events. This is the default value
-        - 'DEBUG': log all events and including detailed information on MeiliSearch's internal processes.
-          Useful when diagnosing issues and debugging
-      '';
-      default = "INFO";
-      type = lib.types.str;
-    };
-
-    maxIndexSize = lib.mkOption {
-      description = ''
-        Sets the maximum size of the index.
-        Value must be given in bytes or explicitly stating a base unit.
-        For example, the default value can be written as 107374182400, '107.7Gb', or '107374 Mb'.
-        Default is 100 GiB
-      '';
-      default = "107374182400";
-      type = lib.types.str;
-    };
-
-    payloadSizeLimit = lib.mkOption {
-      description = ''
-        Sets the maximum size of accepted JSON payloads.
-        Value must be given in bytes or explicitly stating a base unit.
-        For example, the default value can be written as 107374182400, '107.7Gb', or '107374 Mb'.
-        Default is ~ 100 MB
-      '';
-      default = "104857600";
-      type = lib.types.str;
-    };
-
-    # TODO: turn on by default when it stops being experimental
-    dumplessUpgrade = lib.mkOption {
-      default = false;
-      example = true;
-      description = ''
-        Whether to enable (experimental) dumpless upgrade.
-
-        Allows upgrading from Meilisearch >=v1.12 to Meilisearch >=v1.13 without manually
-        dumping and importing the database.
-
-        More information at https://www.meilisearch.com/docs/learn/update_and_migration/updating#dumpless-upgrade
-      '';
-      type = lib.types.bool;
-    };
-
   };
 
-  ###### implementation
-
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !cfg.settings ? master_key;
+        message = ''
+          Do not set `services.meilisearch.settings.master_key` in your configuration.
+          Use `services.meilisearch.masterKeyFile` instead.
+        '';
+      }
+    ];
+
+    services.meilisearch.settings = {
+      # we use `listenAddress` and `listenPort` to derive the `http_addr` setting.
+      # this is the only setting we treat like this.
+      # we do this because some dependent services like Misskey/Sharkey need separate host,port for no good reason.
+      http_addr = "${cfg.listenAddress}:${toString cfg.listenPort}";
+
+      # upstream's default for `db_path` is `/var/lib/meilisearch/data.ms/`, but ours is different for no reason.
+      db_path = lib.mkDefault "/var/lib/meilisearch";
+      # these are equivalent to the upstream defaults, because we set a working directory.
+      # they are only set here for consistency with `db_path`.
+      dump_dir = lib.mkDefault "/var/lib/meilisearch/dumps";
+      snapshot_dir = lib.mkDefault "/var/lib/meilisearch/snapshots";
+
+      # this is intentionally different from upstream's default.
+      no_analytics = lib.mkDefault true;
+    };
 
     warnings = lib.optional (lib.versionOlder cfg.package.version "1.12") ''
       Meilisearch 1.11 will be removed in NixOS 25.11. As it was the last
@@ -149,24 +202,41 @@ in
     environment.systemPackages = [ cfg.package ];
 
     systemd.services.meilisearch = {
-      description = "MeiliSearch daemon";
+      description = "Meilisearch daemon";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      environment = {
-        MEILI_DB_PATH = "/var/lib/meilisearch";
-        MEILI_HTTP_ADDR = "${cfg.listenAddress}:${toString cfg.listenPort}";
-        MEILI_NO_ANALYTICS = lib.boolToString cfg.noAnalytics;
-        MEILI_ENV = cfg.environment;
-        MEILI_DUMP_DIR = "/var/lib/meilisearch/dumps";
-        MEILI_LOG_LEVEL = cfg.logLevel;
-        MEILI_MAX_INDEX_SIZE = cfg.maxIndexSize;
-        MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE = lib.boolToString cfg.dumplessUpgrade;
-      };
+
+      preStart = lib.mkMerge [
+        ''
+          install -m 700 '${configFile}' "$RUNTIME_DIRECTORY/config.toml"
+        ''
+        (lib.mkIf (cfg.masterKeyFile != null) ''
+          ${lib.getExe pkgs.replace-secret} '${master-key-placeholder}' "$CREDENTIALS_DIRECTORY/master_key" "$RUNTIME_DIRECTORY/config.toml"
+        '')
+      ];
+
+      environment = builtins.listToAttrs (
+        builtins.map (secret: {
+          name = secret.environment;
+          value = lib.mkIf (secret.setting != null) "%d/${secret.name}";
+        }) secrets-with-path
+      );
+
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/meilisearch";
+        LoadCredential = lib.mkMerge (
+          [
+            (lib.mkIf (cfg.masterKeyFile != null) [ "master_key:${cfg.masterKeyFile}" ])
+          ]
+          ++ builtins.map (
+            secret: lib.mkIf (secret.setting != null) [ "${secret.name}:${secret.setting}" ]
+          ) secrets-with-path
+        );
+        ExecStart = "${lib.getExe cfg.package} --config-file-path \${RUNTIME_DIRECTORY}/config.toml";
         DynamicUser = true;
         StateDirectory = "meilisearch";
-        EnvironmentFile = lib.mkIf (cfg.masterKeyEnvironmentFile != null) cfg.masterKeyEnvironmentFile;
+        WorkingDirectory = "%S/meilisearch";
+        RuntimeDirectory = "meilisearch";
+        RuntimeDirectoryMode = "0700";
       };
     };
   };

--- a/nixos/modules/services/web-apps/sharkey.nix
+++ b/nixos/modules/services/web-apps/sharkey.nix
@@ -54,7 +54,7 @@ in
         description = ''
           Whether to automatically set up a local Meilisearch instance and configure Sharkey to use it.
 
-          You need to ensure `services.meilisearch.masterKeyEnvironmentFile` is correctly configured for a working
+          You need to ensure `services.meilisearch.masterKeyFile` is correctly configured for a working
           Meilisearch setup. You also need to configure Sharkey to use an API key obtained from Meilisearch with the
           `MK_CONFIG_MEILISEARCH_APIKEY` environment variable, and set `services.sharkey.settings.meilisearch.index` to
           the created index. See https://docs.joinsharkey.org/docs/customisation/search/meilisearch/ for how to create
@@ -240,7 +240,7 @@ in
       (mkIf cfg.setupMeilisearch {
         services.meilisearch = {
           enable = mkDefault true;
-          environment = mkDefault "production";
+          settings.env = mkDefault "production";
         };
 
         services.sharkey.settings = {

--- a/nixos/tests/web-apps/sharkey.nix
+++ b/nixos/tests/web-apps/sharkey.nix
@@ -19,9 +19,7 @@ in
         };
       };
 
-      services.meilisearch.masterKeyEnvironmentFile = pkgs.writeText "meilisearch-key" ''
-        MEILI_MASTER_KEY=${meilisearchKey}
-      '';
+      services.meilisearch.masterKeyFile = pkgs.writeText "meilisearch-key" meilisearchKey;
     };
 
   testScript =


### PR DESCRIPTION
This PR creates the option `services.meilisearch.settings` (as per [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)) and moves all Meilisearch configuration to that free-form TOML option, with two exceptions:

- `services.meilisearch.listenAddress` and `services.meilisearch.listenPort` have *not* been merged into `services.meilisearch.settings.http_addr`, because Misskey (+ Sharkey) won't like that. [They need `host` and `port` separately](https://github.com/NixOS/nixpkgs/blob/6017db9d735aaebac206dd593d571fb9adaaf73c/nixos/modules/services/web-apps/misskey.nix#L304-L306) (and also `ssl` as a separate bool! wtf??); this is completely arbitrary [and they really do just merge them into a single URL](https://activitypub.software/TransFem-org/Sharkey/-/blob/05a499ac55f13d654453eb3419ddae2c8eab1a34/packages/backend/src/GlobalModule.ts#L48), so there's *no good reason* why they are separate like this. But i didn't feel like solving that issue today. Besides, having `services.meilisearch.listenPort` can be useful for reverse proxy setups so you don't have to specify the port multiple times or create your own option; you can just use the one that already exists.

- `services.meilisearch.masterKeyEnvironmentFile` has, of course, *not* been merged into `services.meilisearch.settings`. I have, however, changed it into `services.meilisearch.masterKeyFile`, which no longer needs the env prefix. We now load this file using `LoadCredential=` and substitute the config file with it.

Additionally, while i was managing secrets, i noticed that there are some SSL-related secrets in the meilisearch config. These already take paths; their schema is *perfect*, so we don't need an "out-of-band" option to specify them, but they are now transformed such that they go through `LoadCredential=` and Meilisearch only receives paths in the credentials directory.

You couldn't specify those secrets before. But now you can. Yay!

I also made sure you can't set `services.meilisearch.settings.master_key` the naive way: all secrets in the config *have* to be specified with a path (and `master_key` gets special out-of-band treatment because it has the wrong schema in the main section)

---

The NixOS manual chapter for meilisearch previously states that "the snapshot feature is not yet configurable from the module". It is now configurable, so i removed that section. I'm not quite sure where the identifier should redirect; i just made it point to the one above it for now.

I have *not* made any release note entry yet, because my intention is that all my changes are backwards-compatible, so i don't consider this a "major" change worthy of a release notes entry. Besides the two exceptions noted earlier that haven't been moved into `services.meilisearch.settings`, every other option that existed *has* been merged seamlessly with renames.

However, the new effective config is not necessarily *identical* to what was there before: `max_index_size` and `http_payload_size_limit` have defaults that aren't exactly the same as what the module previously defines. If you set either of these already, your definition will be respected. Previously, `services.meilisearch.payloadSizeLimit` *did not actually do anything*.  It simply didn't configure meilisearch at all. In this PR, i chose to make it a `mkRenamedOptionModule` that *does* apply its value to `services.meilisearch.settings.http_payload_size_limit`, since if you set it, you surely wanted it to apply. `services.meilisearch.maxIndexSize` *did* previously apply its value, but what's changed is that the *default* value is no longer set in our module (nor is the default value for `http_payload_size_limit`). They are kinda, meh, whatever? They're max size limits. The upstream defaults are fine. If you set them, nothing changes, but if you didn't set them, the new effective defaults are technically different.

---

By default, in upstream code, the `db_path`, `dump_dir`, and `snapshot_dir` options are set to some path relative to the working directory. Because of this default behaviour, i've set `WorkingDirectory=` in the service definition to the state directory; this way, the "default" paths for these features are placed in the state directory. The default paths would previously be relative to the root directory (so, duh, of course snapshots didn't work if it tries to write to `/snapshots`). Now with the working directory, snapshots should work fine out of the box even without any configuration. (because the default path is actually writable)

Previously, we had set `db_path` and `dump_dir` to the absolute paths `/var/lib/meilisearch` and `/var/lib/meilisearch/dumps`. I've preserved these values exactly, and i've *also* set the default value of `snapshot_dir` to `/var/lib/meilisearch/snapshots`. These values for `dump_dir` and `snapshot_dir` are exactly equivalent to the upstream defaults; as long as the working directory is `/var/lib/meilisearch` (which it now is). `dump_dir` and `snapshot_dir` are mostly set for aesthetic consistency with `db_path`; their values don't actually matter and these defaults could be removed and the module would behave identically.

The default value for `db_path` is **wrong** and i have not bothered to fix it. All upstream documentation suggests that the database should be placed in a directory `data.ms` relative to the state directory. The upstream default value for `db_path` is `./data.ms/`. Our default *was* already wrong before i touched it, and fixing it is out of scope for this PR which aims to make no breaking changes. Meilisearch can work fine with this misconfiguration; but it is unfortunate that our `dumps` and `snapshots` directory is placed "inside" of the database.

---

Despite most of these changes being backwards-compatible or non-breaking in every way that matters, they *did* actually cause my system to break for the simple reason that i was running a really outdated Meilisearch. I set up Sharkey like 14 months ago and never bothered doing the database upgrades; so, i just pinned meilisearch to 1.8.3 and never looked back. That version does conditional compilation of the entire analytics feature, so the `no_analytics=true` set by default from this PR caused the service to fail initialization; this is an unknown config key. It went unnoticed before, since it would just ignore unknown environment variables. Other users *may* have similar issues once this is merged? But our module doesn't actively support such old versions of meilisearch; this is fine i reckon.

---

Finally, while i was finishing up this PR, i noticed `nixosTests.meilisearch` was failing. It also fails on the master branch; this isn't caused by my PR, but rather by a race condition that existed there since forever ago. I went ahead and fixed that. It's completely separate to everything else i'm doing; so i've ordered that commit first. The NixOS test *does* indeed now pass with my changes.

`nixosTests.sharkey` also passes (it makes use of meilisearch)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
