### PR TITLE
fio: enable nbd engine

### DIFF
--- a/pkgs/by-name/fi/fio/package.nix
+++ b/pkgs/by-name/fi/fio/package.nix
@@ -4,10 +4,13 @@
   fetchFromGitHub,
   makeWrapper,
   libaio,
+  pkg-config,
   python3,
   zlib,
   withGnuplot ? false,
-  gnuplot ? null,
+  gnuplot,
+  withLibnbd ? true,
+  libnbd,
 }:
 
 stdenv.mkDerivation rec {
@@ -25,16 +28,20 @@ stdenv.mkDerivation rec {
     python3
     zlib
   ]
-  ++ lib.optional (!stdenv.hostPlatform.isDarwin) libaio;
+  ++ lib.optional (!stdenv.hostPlatform.isDarwin) libaio
+  ++ lib.optional withLibnbd libnbd;
 
   # ./configure does not support autoconf-style --build=/--host=.
   # We use $CC instead.
   configurePlatforms = [ ];
 
+  configureFlags = lib.optional withLibnbd "--enable-libnbd";
+
   dontAddStaticConfigureFlags = true;
 
   nativeBuildInputs = [
     makeWrapper
+    pkg-config
     python3.pkgs.wrapPython
   ];
 


### PR DESCRIPTION
FIO has a mode where it can run against a local or remote [NBD][] server instead of an actual file or block device, using [libnbd][] to actually speak the protocol. This can help when testing unconventional I/O gadgets by running them as userspace NBD servers instead of plugging them into the kernel, Qemu, or the like, when playing block-device mix-and-match games with [nbdkit], etc.

[NBD]: https://github.com/NetworkBlockDevice/nbd
[libnbd]: https://libguestfs.org/libnbd.3.html
[nbdkit]: https://libguestfs.org/nbdkit.1.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
