### PR TITLE
jetbrains-plugins: fix copilot plugin

### DIFF
--- a/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
@@ -55,30 +55,36 @@
         }
         .${stdenv.hostPlatform.uname.processor} or ""
       }/copilot-language-server'
-      orig_size=$(stat --printf=%s $agent)
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $agent
-      patchelf --set-rpath ${
-        lib.makeLibraryPath [
-          glibc
-          gcc-unwrapped
-        ]
-      } $agent
-      chmod +x $agent
-      new_size=$(stat --printf=%s $agent)
-      var_skip=20
-      var_select=22
-      shift_by=$(($new_size-$orig_size))
-      function fix_offset {
-        # $1 = name of variable to adjust
-        location=$(grep -obUam1 "$1" $agent | cut -d: -f1)
-        location=$(expr $location + $var_skip)
-        value=$(dd if=$agent iflag=count_bytes,skip_bytes skip=$location \
-        bs=1 count=$var_select status=none)
-        value=$(expr $shift_by + $value)
-        echo -n $value | dd of=$agent bs=1 seek=$location conv=notrunc
-      }
-      fix_offset PAYLOAD_POSITION
-      fix_offset PRELUDE_POSITION
+
+              # Helper: find the offset of the payload by matching gzip magic bytes
+        find_payload_offset() {
+          grep -aobUam1 -f <(printf '\x1f\x8b\x08\x00') "$agent" | cut -d: -f1
+        }
+
+        # Helper: find the offset of the prelude by searching for function string start
+        find_prelude_offset() {
+          local prelude_string='(function(process, require, console, EXECPATH_FD, PAYLOAD_POSITION, PAYLOAD_SIZE) {'
+          grep -obUa -- "$prelude_string" "$agent" | cut -d: -f1
+        }
+
+        before_payload_position="$(find_payload_offset)"
+        before_prelude_position="$(find_prelude_offset)"
+
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $agent
+        patchelf --set-rpath ${
+          lib.makeLibraryPath [
+            glibc
+            gcc-unwrapped
+          ]
+        } $agent
+        chmod +x $agent
+
+        after_payload_position="$(find_payload_offset)"
+        after_prelude_position="$(find_prelude_offset)"
+
+        # There are hardcoded positions in the binary, then it replaces the placeholders by himself
+        sed -i -e "s/$before_payload_position/$after_payload_position/g" "$agent"
+        sed -i -e "s/$before_prelude_position/$after_prelude_position/g" "$agent"
     '';
   };
   "22407" = {

--- a/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/specialPlugins.nix
@@ -55,36 +55,55 @@
         }
         .${stdenv.hostPlatform.uname.processor} or ""
       }/copilot-language-server'
+      orig_size=$(stat --printf=%s $agent)
 
-              # Helper: find the offset of the payload by matching gzip magic bytes
-        find_payload_offset() {
-          grep -aobUam1 -f <(printf '\x1f\x8b\x08\x00') "$agent" | cut -d: -f1
-        }
+      find_payload_offset() {
+        grep -aobUam1 -f <(printf '\x1f\x8b\x08\x00') "$agent" | cut -d: -f1
+      }
 
-        # Helper: find the offset of the prelude by searching for function string start
-        find_prelude_offset() {
-          local prelude_string='(function(process, require, console, EXECPATH_FD, PAYLOAD_POSITION, PAYLOAD_SIZE) {'
-          grep -obUa -- "$prelude_string" "$agent" | cut -d: -f1
-        }
+      # Helper: find the offset of the prelude by searching for function string start
+      find_prelude_offset() {
+        local prelude_string='(function(process, require, console, EXECPATH_FD, PAYLOAD_POSITION, PAYLOAD_SIZE) {'
+        grep -obUa -- "$prelude_string" "$agent" | cut -d: -f1
+      }
 
-        before_payload_position="$(find_payload_offset)"
-        before_prelude_position="$(find_prelude_offset)"
+      before_payload_position="$(find_payload_offset)"
+      before_prelude_position="$(find_prelude_offset)"
 
-        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $agent
-        patchelf --set-rpath ${
-          lib.makeLibraryPath [
-            glibc
-            gcc-unwrapped
-          ]
-        } $agent
-        chmod +x $agent
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $agent
+      patchelf --set-rpath ${
+        lib.makeLibraryPath [
+          glibc
+          gcc-unwrapped
+        ]
+      } $agent
+      chmod +x $agent
+      new_size=$(stat --printf=%s $agent)
+      var_skip=20
+      var_select=22
+      shift_by=$(($new_size-$orig_size))
+      function fix_offset {
+        # $1 = name of variable to adjust
+        location=$(grep -obUam1 "$1" $agent | cut -d: -f1)
+        location=$(expr $location + $var_skip)
+        value=$(dd if=$agent iflag=count_bytes,skip_bytes skip=$location \
+        bs=1 count=$var_select status=none)
+        value=$(expr $shift_by + $value)
+        echo -n $value | dd of=$agent bs=1 seek=$location conv=notrunc
+      }
 
-        after_payload_position="$(find_payload_offset)"
-        after_prelude_position="$(find_prelude_offset)"
+      after_payload_position="$(find_payload_offset)"
+      after_prelude_position="$(find_prelude_offset)"
 
+      if [ "${stdenv.hostPlatform.system}" == "aarch64-linux" ]
+      then
+        fix_offset PAYLOAD_POSITION
+        fix_offset PRELUDE_POSITION
+      else
         # There are hardcoded positions in the binary, then it replaces the placeholders by himself
         sed -i -e "s/$before_payload_position/$after_payload_position/g" "$agent"
         sed -i -e "s/$before_prelude_position/$after_prelude_position/g" "$agent"
+      fi
     '';
   };
   "22407" = {

--- a/pkgs/applications/editors/jetbrains/plugins/tests.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/tests.nix
@@ -11,7 +11,6 @@ let
 
   # Known broken plugins, PLEASE remove entries here whenever possible.
   broken-plugins = [
-    "github-copilot" # GitHub Copilot: https://github.com/NixOS/nixpkgs/issues/400317
   ];
 
   ides =


### PR DESCRIPTION
Previous derivation started failing with:
> expr: syntax error: unexpected argument '41911289'

I'm not really sure I understand the fix but someone shared their overlay on the issue that many cited as having worked.

fixes #400317

I would appreciate any advice on how to run it from nixpkgs a bit easier.
I had to do:

```console
> nix eval --impure --expr "let pkgs = import ./. {}; in (pkgs.jetbrains.plugins.addPlugins pkgs.jetbrains.idea-ultimate [\"github-copilot\"])"

«derivation /nix/store/12s79lyvv7dig1fk92kclsqfxy54bwhl-idea-ultimate-with-plugins-2025.1.2.drv»

> nix-store --realize /nix/store/12s79lyvv7dig1fk92kclsqfxy54bwhl-idea-ultimate-with-plugins-2025.1.2.drv

> /nix/store/26ym98znvvbv0q6h4ghwh71nn8svh6rw-idea-ultimate-with-plugins-2025.1.2/bin/idea-ultimate
```


I validated it launches and shows up:
<img width="1545" height="877" alt="image" src="https://github.com/user-attachments/assets/2000dcda-17bc-4294-b9a2-ac993bfc7e98" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

Co-authored-by: Patrizio Bekerle <patrizio@bekerle.com>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
