### PR TITLE
libmypaint: fix build

### DIFF
--- a/pkgs/by-name/li/libmypaint/0001-configure-use-regular-GETTEXT-unconditionally.patch
+++ b/pkgs/by-name/li/libmypaint/0001-configure-use-regular-GETTEXT-unconditionally.patch
@@ -1,0 +1,37 @@
+From dd663ee7bf6a2ff7dd47fc360ac7cd44c83039d0 Mon Sep 17 00:00:00 2001
+From: Grimmauld <Grimmauld@grimmauld.de>
+Date: Sat, 12 Jul 2025 12:46:58 +0200
+Subject: [PATCH] configure: use regular GETTEXT unconditionally
+
+Modern autoconf breaks when `IT_PROG_INTLTOOL` is conditional [1].
+
+`glib` gettext is obsolete and broken, so switch to regular gettext instead.
+This also needs to be unconditional.
+
+To achieve unconditional directives, indentation needs to be removed
+as indentation is part of the syntax.
+
+[1] https://github.com/mypaint/libmypaint/issues/178
+---
+ configure.ac | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 416d9fe..9479db9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -248,8 +248,9 @@ if test "x$enable_i18n" != "xno"; then
+   AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE",
+                      [The prefix for our gettext translation domains.])
+   AC_SUBST(GETTEXT_PACKAGE)
+-  IT_PROG_INTLTOOL
+-  AM_GLIB_GNU_GETTEXT
++IT_PROG_INTLTOOL
++AM_GNU_GETTEXT([external])
++AM_GNU_GETTEXT_VERSION([0.21])
+ 
+   dnl Debian: stdlib
+   dnl Windows, and OSX: -lintl
+-- 
+2.49.0
+

--- a/pkgs/by-name/li/libmypaint/package.nix
+++ b/pkgs/by-name/li/libmypaint/package.nix
@@ -1,8 +1,6 @@
 {
   lib,
   stdenv,
-  autoconf,
-  automake,
   fetchFromGitHub,
   glib,
   intltool,
@@ -10,6 +8,8 @@
   libtool,
   pkg-config,
   python3,
+  gettext,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -28,12 +28,17 @@ stdenv.mkDerivation rec {
     sha256 = "1ppgpmnhph9h8ayx9776f79a0bxbdszfw9c6bw7c3ffy2yk40178";
   };
 
+  patches = [
+    # glib gettext macros are broken/obsolete,
+    # so we patch libmypaint to use regular gettext instead.
+    ./0001-configure-use-regular-GETTEXT-unconditionally.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [
-    autoconf
-    automake
-    glib # AM_GLIB_GNU_GETTEXT
+    autoreconfHook
+    gettext
     intltool
     libtool
     pkg-config


### PR DESCRIPTION
`dev` output unchanged (verified by `diffoscope`).

`out` output still contains all the translation files, with no obvious encoding issues i spotted. Slight
deviations in the metadata, but should be fine.

This change is cursed. Part of the issue is libmypaint being broken with modern autoreconf [1], so before patching in the gettext build fixes, autoreconf needed fixing.

[1] https://github.com/mypaint/libmypaint/issues/178


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
