### PR TITLE
lib.getExe, writeTextFile, makeScriptWriter: allow `lib.getExe` to return the store path of bare scripts

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -479,9 +479,12 @@ rec {
     x: y:
     assert assertMsg (isDerivation x)
       "lib.meta.getExe': The first argument is of type ${typeOf x}, but it should be a derivation instead.";
-    assert assertMsg (isString y)
-      "lib.meta.getExe': The second argument is of type ${typeOf y}, but it should be a string instead.";
-    assert assertMsg (match ".*/.*" y == null)
-      "lib.meta.getExe': The second argument \"${y}\" is a nested path with a \"/\" character, but it should just be the name of the executable instead.";
-    "${getBin x}/bin/${y}";
+    if isNull y then
+      "${getBin x}"
+    else
+      assert assertMsg (isString y)
+        "lib.meta.getExe': The second argument is of type ${typeOf y}, but it should be a string instead.";
+      assert assertMsg (match ".*/.*" y == null)
+        "lib.meta.getExe': The second argument \"${y}\" is a nested path with a \"/\" character, but it should just be the name of the executable instead.";
+      "${getBin x}/bin/${y}";
 }

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -134,7 +134,10 @@ rec {
             ;
           passAsFile = [ "text" ] ++ derivationArgs.passAsFile or [ ];
           meta =
-            lib.optionalAttrs (executable && matches != null) {
+            lib.optionalAttrs (executable && destination == "") {
+              mainProgram = null;
+            }
+            // lib.optionalAttrs (executable && matches != null) {
               mainProgram = lib.head matches;
             }
             // meta

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -175,7 +175,7 @@ rec {
     # This breaks the override pattern.
     # In case this turns out to be a problem, we can still add more magic
     else
-      pkgs.runCommandLocal name { } ''
+      pkgs.runCommandLocal name { meta.mainProgram = null; } ''
         ln -s ${inner}/bin/${name} $out
       '';
 

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -347,6 +347,7 @@ let
         any
         listOf
         bool
+        nullOr
         ;
       platforms = listOf (union [
         str
@@ -356,7 +357,7 @@ let
     {
       # These keys are documented
       description = str;
-      mainProgram = str;
+      mainProgram = nullOr str;
       longDescription = str;
       branch = str;
       homepage = union [

--- a/pkgs/stdenv/generic/meta-types.nix
+++ b/pkgs/stdenv/generic/meta-types.nix
@@ -58,6 +58,17 @@ lib.fix (self: {
     verify = isList;
   };
 
+  nullOr =
+    t:
+    assert isTypeDef t;
+    let
+      inherit (t) verify;
+    in
+    {
+      name = "nullOr<${t.name}>";
+      verify = v: isNull v || verify v;
+    };
+
   attrsOf =
     t:
     assert isTypeDef t;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR:
- Allows a derivation to signal to `lib.getExe` that the store path itself is the derivation's main program by setting `meta.mainProgram = null;`.
- Causes bare executable variants of `pkgs.writeTextFile`, such as `pkgs.writeShellScript`, to automatically set this.
- Causes bare executable variants of `pkgs.makeScriptWriter`, such as `pkgs.writers.writePython3`, to automatically set this.

This generally increases the applicability of `lib.getExe`, but the specific motivation for this change was creating flake `apps` through flake-parts, as it (sensibly enough) [uses `lib.getExe`](https://github.com/hercules-ci/flake-parts/blob/main/modules/apps.nix#L16) to normalize the option value when it isn't already a string.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
