### PR TITLE
maintainers: drop mkazulak

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16716,12 +16716,6 @@
     githubId = 16974598;
     name = "Mike Playle";
   };
-  mkazulak = {
-    email = "kazulakm@gmail.com";
-    github = "mulderr";
-    githubId = 5698461;
-    name = "Maciej Kazulak";
-  };
   mkez = {
     email = "matias+nix@zwinger.fi";
     github = "mk3z";

--- a/pkgs/by-name/od/odpic/package.nix
+++ b/pkgs/by-name/od/odpic/package.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Oracle ODPI-C library";
     homepage = "https://oracle.github.io/odpi/";
-    maintainers = with maintainers; [ mkazulak ];
     license = licenses.asl20;
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
Inactive since 2022.

Dropping in accordance with the maintainer guidelines: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#how-to-lose-maintainer-status

@mulderr if you'd like to stay maintainer, please respond within a week.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
