### PR TITLE
workflows/labels: label rebuilds immediately

### DIFF
--- a/ci/labels/labels.cjs
+++ b/ci/labels/labels.cjs
@@ -235,7 +235,7 @@ module.exports = async function ({ github, context, core, dry }) {
 
       const itemLabels = {}
 
-      if (item.pull_request) {
+      if (item.pull_request || context.payload.pull_request) {
         stats.prs++
         Object.assign(itemLabels, await handlePullRequest(item))
       } else {


### PR DESCRIPTION
This fixes labeling in the context of the `pull_request` trigger. Of course, this was supposed to immediately label rebuilds after eval finishes, but we somehow lost this along the way. Rebuilds are still labeled fairly soon, because the scheduled trigger will pick up the same PR within 10 minutes again and then apply the rebuild labels. But of course, immediate is better.

The reason this happened is, that we're looking at `item.pull_request` only. This is the correct distinction between "issue items" and "pull request items", which we both get back from the /issues endpoint. But the payload for the `pull_request*` event doesn't contain this, so labeling in this case was treated like an issue and skipped the whole pull request part.

This can be observed in practice by carefully looking at the history at the moment Eval finishes. At this time only the `actions/labeler` parts will add some labels for topics - and then a few minutes later, the rebuild labels appear.

## Things done

Did not test, because this can't be tested locally in a sensible way. But the new condition matches the condition in the outer function that calls `handle(context.payload.pull_request)`, so I am very confident that this works.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
