### PR TITLE
kubernetes: enable hairpinning in flannel config

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/flannel.nix
+++ b/nixos/modules/services/cluster/kubernetes/flannel.nix
@@ -41,6 +41,7 @@ in
           cniVersion = "0.3.1";
           delegate = {
             isDefaultGateway = true;
+            hairpinMode = true;
             bridge = "mynet";
           };
         }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

In order for a pod to connect via a service back to itself, we need to enable "hairpinning" in both kubelet (search for "--hairpin-mode" on [this page](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)) and the flannel CNI config ([CNI docs](https://www.cni.dev/plugins/current/main/bridge/) and [Flannel CNI example](https://github.com/flannel-io/flannel/blob/677f40694a1cf0d677dd63a3a5015dc997115d1e/chart/kube-flannel/values.yaml#L70)).  See also [this page in the Kubernetes docs about debugging this edge case](https://kubernetes.io/docs/tasks/debug/debug-application/debug-service/#a-pod-fails-to-reach-itself-via-the-service-ip).

The `services.kubernetes` module already configures the right setting [here](https://github.com/NixOS/nixpkgs/blob/9c492c323374a22963102ceb570dff269c01c2ae/nixos/modules/services/cluster/kubernetes/kubelet.nix#L67), but we also need to enable it in the flannel CNI config per the example above.  This PR adds the missing configuration.

## Testing

I ran the kubernetes passthru tests with `nix-build -A kubernetes.passthru.tests`.

I also tested this in practice by overriding the CNI config and deploying to my kubernetes cluster:
```
          services.kubernetes.kubelet.cni.config = [
            {
              name = "mynet";
              type = "flannel";
              cniVersion = "0.3.1";
              delegate = {
                isDefaultGateway = true;
                hairpinMode = true;   #  NEW LINE
                bridge = "mynet";
              };
            }
          ];
```

After this, I can see that a bunch of the `veth*` network devices have hairpinning enabled whereas none had it before:
```
# cat /sys/devices/virtual/net/mynet/brif/*/hairpin_mode
0
1
0
1
1
0
0
1
...
```

Some of them don't have it enabled, but this seems fine in practice, at least for the problem I was experiencing.  I ran into this when upgrading [Longhorn](https://longhorn.io/) to 1.7.3.  The `longhorn-manager` pod now tries to connect to itself (via a service) to check for the liveness of some webhook controller, but that didn't work because the connection was being refused.  This was annoying to debug because connecting to the service worked fine from the host and from the sibling `longhorn-manager` pods on different hosts; it was only the one actually running the service where the connection wouldn't work.  With the hairpining change to flannel CNI, the pod can connect to itself just fine via the service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
