### PR TITLE
nixos/mastodon: introduce settings and secrets

### DIFF
--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -10,54 +10,62 @@ let
   cfg = config.services.mastodon;
   opt = options.services.mastodon;
 
+  # This should probably live in pkgs.formats, but pkgs.formats.keyValue doesn't suit our usecase yet.
+  settingToEnvVar =
+    v:
+    if lib.isList v then
+      lib.concatMapStringsSep "," (lib.generators.mkValueStringDefault { }) v
+    else
+      lib.generators.mkValueStringDefault { } v;
+
   # We only want to create a Redis and PostgreSQL databases if we're actually going to connect to it local.
   redisActuallyCreateLocally =
     cfg.redis.createLocally && (cfg.redis.host == "127.0.0.1" || cfg.redis.enableUnixSocket);
   databaseActuallyCreateLocally =
     cfg.database.createLocally && cfg.database.host == "/run/postgresql";
 
-  env = {
-    RAILS_ENV = "production";
-    NODE_ENV = "production";
+  env =
+    builtins.mapAttrs (_: settingToEnvVar) (lib.filterAttrs (_: v: !isNull v) cfg.settings)
+    // {
+      RAILS_ENV = "production";
+      NODE_ENV = "production";
 
-    BOOTSNAP_CACHE_DIR = "/var/cache/mastodon/precompile";
-    LD_PRELOAD = "${pkgs.jemalloc}/lib/libjemalloc.so";
+      BOOTSNAP_CACHE_DIR = "/var/cache/mastodon/precompile";
+      LD_PRELOAD = "${pkgs.jemalloc}/lib/libjemalloc.so";
 
-    # Concurrency mastodon-web
-    WEB_CONCURRENCY = toString cfg.webProcesses;
-    MAX_THREADS = toString cfg.webThreads;
+      # Concurrency mastodon-web
+      WEB_CONCURRENCY = toString cfg.webProcesses;
+      MAX_THREADS = toString cfg.webThreads;
 
-    DB_USER = cfg.database.user;
+      DB_USER = cfg.database.user;
 
-    DB_HOST = cfg.database.host;
-    DB_NAME = cfg.database.name;
-    LOCAL_DOMAIN = cfg.localDomain;
-    SMTP_SERVER = cfg.smtp.host;
-    SMTP_PORT = toString cfg.smtp.port;
-    SMTP_FROM_ADDRESS = cfg.smtp.fromAddress;
-    PAPERCLIP_ROOT_PATH = "/var/lib/mastodon/public-system";
-    PAPERCLIP_ROOT_URL = "/system";
-    ES_ENABLED = if (cfg.elasticsearch.host != null) then "true" else "false";
+      DB_HOST = cfg.database.host;
+      DB_NAME = cfg.database.name;
+      SMTP_SERVER = cfg.smtp.host;
+      SMTP_PORT = toString cfg.smtp.port;
+      SMTP_FROM_ADDRESS = cfg.smtp.fromAddress;
+      PAPERCLIP_ROOT_PATH = "/var/lib/mastodon/public-system";
+      PAPERCLIP_ROOT_URL = "/system";
+      ES_ENABLED = if (cfg.elasticsearch.host != null) then "true" else "false";
 
-    TRUSTED_PROXY_IP = cfg.trustedProxy;
-  }
-  // lib.optionalAttrs (cfg.redis.host != null) { REDIS_HOST = cfg.redis.host; }
-  // lib.optionalAttrs (cfg.redis.port != null) { REDIS_PORT = toString cfg.redis.port; }
-  // lib.optionalAttrs (cfg.redis.createLocally && cfg.redis.enableUnixSocket) {
-    REDIS_URL = "unix://${config.services.redis.servers.mastodon.unixSocket}";
-  }
-  // lib.optionalAttrs (cfg.database.host != "/run/postgresql" && cfg.database.port != null) {
-    DB_PORT = toString cfg.database.port;
-  }
-  // lib.optionalAttrs cfg.smtp.authenticate { SMTP_LOGIN = cfg.smtp.user; }
-  // lib.optionalAttrs (cfg.elasticsearch.host != null) { ES_HOST = cfg.elasticsearch.host; }
-  // lib.optionalAttrs (cfg.elasticsearch.host != null) { ES_PORT = toString cfg.elasticsearch.port; }
-  // lib.optionalAttrs (cfg.elasticsearch.host != null && cfg.elasticsearch.prefix != null) {
-    ES_PREFIX = cfg.elasticsearch.prefix;
-  }
-  // lib.optionalAttrs (cfg.elasticsearch.host != null) { ES_PRESET = cfg.elasticsearch.preset; }
-  // lib.optionalAttrs (cfg.elasticsearch.user != null) { ES_USER = cfg.elasticsearch.user; }
-  // cfg.extraConfig;
+      TRUSTED_PROXY_IP = cfg.trustedProxy;
+    }
+    // lib.optionalAttrs (cfg.redis.host != null) { REDIS_HOST = cfg.redis.host; }
+    // lib.optionalAttrs (cfg.redis.port != null) { REDIS_PORT = toString cfg.redis.port; }
+    // lib.optionalAttrs (cfg.redis.createLocally && cfg.redis.enableUnixSocket) {
+      REDIS_URL = "unix://${config.services.redis.servers.mastodon.unixSocket}";
+    }
+    // lib.optionalAttrs (cfg.database.host != "/run/postgresql" && cfg.database.port != null) {
+      DB_PORT = toString cfg.database.port;
+    }
+    // lib.optionalAttrs cfg.smtp.authenticate { SMTP_LOGIN = cfg.smtp.user; }
+    // lib.optionalAttrs (cfg.elasticsearch.host != null) { ES_HOST = cfg.elasticsearch.host; }
+    // lib.optionalAttrs (cfg.elasticsearch.host != null) { ES_PORT = toString cfg.elasticsearch.port; }
+    // lib.optionalAttrs (cfg.elasticsearch.host != null && cfg.elasticsearch.prefix != null) {
+      ES_PREFIX = cfg.elasticsearch.prefix;
+    }
+    // lib.optionalAttrs (cfg.elasticsearch.host != null) { ES_PRESET = cfg.elasticsearch.preset; }
+    // lib.optionalAttrs (cfg.elasticsearch.user != null) { ES_USER = cfg.elasticsearch.user; };
 
   systemCallsList = [
     "@cpu-emulation"
@@ -265,6 +273,58 @@ in
       "mastodon"
       "otpSecretFile"
     ] "The OTP_SECRET option was removed from Mastodon in version 4.4.0")
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "mastodon"
+        "extraConfig"
+      ]
+      [
+        "services"
+        "mastodon"
+        "settings"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "mastodon"
+        "localDomain"
+      ]
+      [
+        "services"
+        "mastodon"
+        "settings"
+        "LOCAL_DOMAIN"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "mastodon"
+        "secretKeyBaseFile"
+      ]
+      [
+        "services"
+        "mastodon"
+        "secrets"
+        "SECRET_KEY_BASE"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [
+        "services"
+        "mastodon"
+        "database"
+        "passwordFile"
+      ]
+      [
+        "services"
+        "mastodon"
+        "secrets"
+        "DB_PASS"
+      ]
+    )
   ];
 
   options = {
@@ -435,12 +495,6 @@ in
         type = lib.types.str;
       };
 
-      localDomain = lib.mkOption {
-        description = "The domain serving your Mastodon instance.";
-        example = "social.example.org";
-        type = lib.types.str;
-      };
-
       activeRecordEncryptionDeterministicKeyFile = lib.mkOption {
         description = ''
           This key must be set to enable the Active Record Encryption feature within
@@ -483,19 +537,6 @@ in
           keys.
         '';
         default = "/var/lib/mastodon/secrets/active-record-encryption-primary-key";
-        type = lib.types.str;
-      };
-
-      secretKeyBaseFile = lib.mkOption {
-        description = ''
-          Path to file containing the secret key base.
-          A new secret key base can be generated by running:
-
-          `nix build -f '<nixpkgs>' mastodon; cd result; bin/bundle exec rails secret`
-
-          If this file does not exist, it will be created with a new secret key base.
-        '';
-        default = "/var/lib/mastodon/secrets/secret-key-base";
         type = lib.types.str;
       };
 
@@ -593,16 +634,6 @@ in
           type = lib.types.str;
           default = "mastodon";
           description = "Database user.";
-        };
-
-        passwordFile = lib.mkOption {
-          type = lib.types.nullOr lib.types.path;
-          default = null;
-          example = "/var/lib/mastodon/secrets/db-password";
-          description = ''
-            A file containing the password corresponding to
-            {option}`database.user`.
-          '';
         };
       };
 
@@ -711,14 +742,6 @@ in
 
       package = lib.mkPackageOption pkgs "mastodon" { };
 
-      extraConfig = lib.mkOption {
-        type = lib.types.attrs;
-        default = { };
-        description = ''
-          Extra environment variables to pass to all mastodon services.
-        '';
-      };
-
       extraEnvFiles = lib.mkOption {
         type = with lib.types; listOf path;
         default = [ ];
@@ -768,6 +791,72 @@ in
           '';
         };
       };
+
+      settings = lib.mkOption {
+        description = ''
+          Environment variable passed to Mastodon.
+          See <https://docs.joinmastodon.org/admin/config/> for documentation.
+        '';
+        default = { };
+        type = lib.types.submodule {
+          freeformType =
+            with lib.types;
+            let
+              atom = oneOf [
+                bool
+                int
+                float
+                str
+              ];
+            in
+            attrsOf (
+              nullOr (oneOf [
+                atom
+                (listOf atom)
+              ])
+            );
+          options = {
+            LOCAL_DOMAIN = lib.mkOption {
+              description = "The domain serving your Mastodon instance.";
+              example = "social.example.org";
+              type = lib.types.str;
+            };
+          };
+        };
+      };
+      secrets = lib.mkOption {
+        description = ''
+          Similar to `services.mastodon.settings` but for secret values that are therefore exposed as file paths with the individual secret value inside.
+        '';
+        default = { };
+        type = lib.types.submodule {
+          freeformType = lib.types.attrsOf (lib.types.nullOr lib.types.path);
+          options = {
+            SECRET_KEY_BASE = lib.mkOption {
+              description = ''
+                Path to file containing the secret key base.
+                A new secret key base can be generated by running:
+
+                `nix build -f '<nixpkgs>' mastodon; cd result; bin/bundle exec rails secret`
+
+                If this file does not exist, it will be created with a new secret key base.
+              '';
+              default = "/var/lib/mastodon/secrets/secret-key-base";
+              type = lib.types.path;
+            };
+            DB_PASS = lib.mkOption {
+              type = lib.types.nullOr lib.types.path;
+              default = null;
+              example = "/var/lib/mastodon/secrets/db-password";
+              description = ''
+                A file containing the password corresponding to
+                {option}`database.user`.
+              '';
+            };
+          };
+        };
+      };
+
     };
   };
 
@@ -846,7 +935,14 @@ in
               -> lib.versionAtLeast config.services.postgresql.finalPackage.version "14";
             message = "Mastodon requires at least PostgreSQL 14.";
           }
-        ];
+        ]
+        ++ (map (secret: {
+          assertion = !cfg.settings ? secret;
+          message = ''
+            ${secret} can't be defined in `services.mastodon.settings` as it is a secret.
+            Store it in a file and provide it via `services.mastodon.secrets.${secret}` instead.
+          '';
+        }) (builtins.attrNames cfg.secrets));
 
         environment.systemPackages = [ mastodonTootctl ];
 
@@ -867,6 +963,7 @@ in
 
         systemd.services.mastodon-init-dirs = {
           script = ''
+            set -eou pipefail
             umask 077
 
             if ! test -d /var/cache/mastodon/precompile; then
@@ -884,9 +981,9 @@ in
               mkdir -p $(dirname ${cfg.activeRecordEncryptionPrimaryKeyFile})
               bin/rails db:encryption:init | grep --only-matching "ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=[^ ]\+" | sed 's/^ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=//' > ${cfg.activeRecordEncryptionPrimaryKeyFile}
             fi
-            if ! test -f ${cfg.secretKeyBaseFile}; then
-              mkdir -p $(dirname ${cfg.secretKeyBaseFile})
-              bin/bundle exec rails secret > ${cfg.secretKeyBaseFile}
+            if ! test -f ${cfg.secrets.SECRET_KEY_BASE}; then
+              mkdir -p $(dirname ${cfg.secrets.SECRET_KEY_BASE})
+              bin/bundle exec rails secret > ${cfg.secrets.SECRET_KEY_BASE}
             fi
             if ! test -f ${cfg.vapidPrivateKeyFile}; then
               mkdir -p $(dirname ${cfg.vapidPrivateKeyFile}) $(dirname ${cfg.vapidPublicKeyFile})
@@ -899,15 +996,14 @@ in
             ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="$(cat ${cfg.activeRecordEncryptionDeterministicKeyFile})"
             ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="$(cat ${cfg.activeRecordEncryptionKeyDerivationSaltFile})"
             ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY="$(cat ${cfg.activeRecordEncryptionPrimaryKeyFile})"
-            SECRET_KEY_BASE="$(cat ${cfg.secretKeyBaseFile})"
             VAPID_PRIVATE_KEY="$(cat ${cfg.vapidPrivateKeyFile})"
             VAPID_PUBLIC_KEY="$(cat ${cfg.vapidPublicKeyFile})"
           ''
+          + (lib.concatMapAttrsStringSep "" (name: path: ''
+            ${name}="$(cat '${path}')"
+          '') (lib.filterAttrs (_: v: !isNull v) cfg.secrets))
           + lib.optionalString (cfg.redis.passwordFile != null) ''
             REDIS_PASSWORD="$(cat ${cfg.redis.passwordFile})"
-          ''
-          + lib.optionalString (cfg.database.passwordFile != null) ''
-            DB_PASS="$(cat ${cfg.database.passwordFile})"
           ''
           + lib.optionalString cfg.smtp.authenticate ''
             SMTP_PASSWORD="$(cat ${cfg.smtp.passwordFile})"
@@ -939,7 +1035,7 @@ in
           script =
             lib.optionalString (!databaseActuallyCreateLocally) ''
               umask 077
-              export PGPASSWORD="$(cat '${cfg.database.passwordFile}')"
+              export PGPASSWORD="$(cat '${cfg.secrets.DB_PASS}')"
             ''
             + ''
               result="$(psql -t --csv -c \
@@ -1062,7 +1158,7 @@ in
         services.nginx = lib.mkIf cfg.configureNginx {
           enable = true;
           recommendedProxySettings = true; # required for redirections to work
-          virtualHosts."${cfg.localDomain}" = {
+          virtualHosts."${cfg.settings.LOCAL_DOMAIN}" = {
             root = "${cfg.package}/public/";
             # mastodon only supports https, but you can override this if you offload tls elsewhere.
             forceSSL = lib.mkDefault true;
@@ -1104,7 +1200,7 @@ in
 
         services.postfix = lib.mkIf (cfg.smtp.createLocally && cfg.smtp.host == "127.0.0.1") {
           enable = true;
-          settings.main.myhostname = lib.mkDefault "${cfg.localDomain}";
+          settings.main.myhostname = lib.mkDefault "${cfg.settings.LOCAL_DOMAIN}";
         };
 
         services.redis.servers.mastodon = lib.mkIf redisActuallyCreateLocally (

--- a/nixos/tests/web-apps/mastodon/remote-databases.nix
+++ b/nixos/tests/web-apps/mastodon/remote-databases.nix
@@ -126,7 +126,7 @@ import ../../make-test-python.nix (
           environment = {
             etc = {
               "mastodon/password-redis-db".text = redisPassword;
-              "mastodon/password-posgressql-db".text = postgresqlPassword;
+              "mastodon/password-postgresql-db".text = postgresqlPassword;
             };
           };
 
@@ -149,7 +149,6 @@ import ../../make-test-python.nix (
           services.mastodon = {
             enable = true;
             configureNginx = false;
-            localDomain = "mastodon.local";
             enableUnixSocket = false;
             streamingProcesses = 2;
             redis = {
@@ -164,18 +163,19 @@ import ../../make-test-python.nix (
               port = 5432;
               name = "mastodon";
               user = "mastodon";
-              passwordFile = "/etc/mastodon/password-posgressql-db";
             };
             smtp = {
               createLocally = false;
               fromAddress = "mastodon@mastodon.local";
             };
-            extraConfig = {
+            trustedProxy = "192.168.2.103";
+            settings = {
+              LOCAL_DOMAIN = "mastodon.local";
               BIND = "0.0.0.0";
               EMAIL_DOMAIN_ALLOWLIST = "example.com";
               RAILS_SERVE_STATIC_FILES = "true";
-              TRUSTED_PROXY_IP = "192.168.2.103";
             };
+            secrets.DB_PASS = "/etc/mastodon/password-postgresql-db";
           };
         };
 

--- a/nixos/tests/web-apps/mastodon/standard.nix
+++ b/nixos/tests/web-apps/mastodon/standard.nix
@@ -52,14 +52,14 @@ import ../../make-test-python.nix (
           services.mastodon = {
             enable = true;
             configureNginx = true;
-            localDomain = "mastodon.local";
             enableUnixSocket = false;
             streamingProcesses = 2;
             smtp = {
               createLocally = false;
               fromAddress = "mastodon@mastodon.local";
             };
-            extraConfig = {
+            settings = {
+              LOCAL_DOMAIN = "mastodon.local";
               EMAIL_DOMAIN_ALLOWLIST = "example.com";
             };
           };


### PR DESCRIPTION
The Mastodon module provides an extensive abstraction over the [Mastodon configuration interface](https://docs.joinmastodon.org/admin/config/). This makes it harder for people to migrate their Mastodon instance to NixOS, as basically for each setting they have to find the corresponding NixOS option. Also maintaining this abstraction is a burden, and while the module seems to have gotten a lot of more users over the years, the amount of maintainers didn't really increase.

I'd propose to convert as many options to their official names as possible. In the spirit of [RFC0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) I'd build a `settings` and a `secrets` interface to do that. This would allow us to convert around 35 (marked with `x`) of the currently 54 options to a name that is documented by upstream.

```
  services.mastodon.enable
  services.mastodon.enableUnixSocket
  services.mastodon.package
x services.mastodon.activeRecordEncryptionDeterministicKeyFile
x services.mastodon.activeRecordEncryptionKeyDerivationSaltFile
x services.mastodon.activeRecordEncryptionPrimaryKeyFile
  services.mastodon.automaticMigrations
  services.mastodon.configureNginx
  services.mastodon.database.createLocally
x services.mastodon.database.host
x services.mastodon.database.name
x services.mastodon.database.passwordFile
x services.mastodon.database.port
x services.mastodon.database.user
x services.mastodon.elasticsearch.host
x services.mastodon.elasticsearch.passwordFile
x services.mastodon.elasticsearch.port
x services.mastodon.elasticsearch.prefix
x services.mastodon.elasticsearch.preset
x services.mastodon.elasticsearch.user
x services.mastodon.extraConfig
x services.mastodon.extraEnvFiles
  services.mastodon.group
x services.mastodon.localDomain
  services.mastodon.mediaAutoRemove.enable
  services.mastodon.mediaAutoRemove.olderThanDays
  services.mastodon.mediaAutoRemove.startAt
x services.mastodon.otpSecretFile
x services.mastodon.redis.enableUnixSocket (through REDIS_URL)
  services.mastodon.redis.createLocally
x services.mastodon.redis.host
x services.mastodon.redis.passwordFile
x services.mastodon.redis.port
x services.mastodon.secretKeyBaseFile
  services.mastodon.sidekiqPort
  services.mastodon.sidekiqProcesses
  services.mastodon.sidekiqProcesses.<name>.jobClasses
  services.mastodon.sidekiqProcesses.<name>.threads
  services.mastodon.sidekiqThreads
x services.mastodon.smtp.authenticate (through SMTP_PASSWORD)
  services.mastodon.smtp.createLocally
x services.mastodon.smtp.fromAddress
x services.mastodon.smtp.host
x services.mastodon.smtp.passwordFile
x services.mastodon.smtp.port
x services.mastodon.smtp.user
  services.mastodon.streamingProcesses
x services.mastodon.trustedProxy
  services.mastodon.user
x services.mastodon.vapidPrivateKeyFile
x services.mastodon.vapidPublicKeyFile
x services.mastodon.webPort
x services.mastodon.webProcesses
x services.mastodon.webThreads
```

Other benefits I see:
- Pointing out inconsistencies with upstream docs gets easier
- It actually gets harder to add a secret in `extraConfig`/`settings` as it's checked by an assertion now.

What stays the same:
- We can still type-check settings as numbers, bools and lists (comma-separated)

Cons:
- Every existing user has to rewrite their config, but will be guided by good error messages from `mkRenamedOptionModule`
- We loose our bundling of different components, for example Redis config will live in both `services.mastodon.redis` as well as `services.mastodon.settings`
- We loose a little bit of expressiveness for list types. The only example I see is `EMAIL_DOMAIN_ALLOWLIST` which is separated by `|` instead of commas, so we would need to expose that as a string and not as a list

This would be too much to do in a single PR, so I'd do that iteratively. For now I only migrated `LOCAL_DOMAIN` and `SECRET_KEY_BASE`.

What do you think? Pinging the people that contributed to the module in the past: @SuperSandro2000 @Izorkin @Ma27 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
