### PR TITLE
workflows/backport: fix concurrent jobs cancelling each other

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,10 +9,6 @@ on:
   pull_request_target:
     types: [closed, labeled]
 
-concurrency:
-  group: backport-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION
When a PR is merged and labeled afterwards - with a non-backport label - the following will happen:
- The first backport job is triggered on the merge.
- The second backport job is triggered on the label event.
- The second job will cancel the first one due to the concurrency group.
- The second job will cancel itself because the label event didn't contain a backport label.

Both jobs end up cancelled and no backport happens.

We made the backport action idempotent upstream a while ago, so we don't need to cancel those actions. Instead, we'll run all of them - subsequent actions running through will just stay silent anyway.

This happened for @emilazy in https://github.com/NixOS/nixpkgs/pull/424593#issuecomment-3065492398.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
