### PR TITLE
nixos/postgresql: implement auto-restart & rework dependencies of postgresql.target

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -769,7 +769,7 @@ in
     systemd.targets.postgresql = {
       description = "PostgreSQL";
       wantedBy = [ "multi-user.target" ];
-      bindsTo = [
+      requires = [
         "postgresql.service"
         "postgresql-setup.service"
       ];
@@ -780,8 +780,13 @@ in
 
       after = [ "network.target" ];
 
-      # To trigger the .target also on "systemctl start postgresql".
-      bindsTo = [ "postgresql.target" ];
+      # To trigger the .target also on "systemctl start postgresql" as well as on
+      # restarts & stops.
+      # Please note that postgresql.service & postgresql.target binding to
+      # each other makes the Restart=always rule racy and results
+      # in sometimes the service not being restarted.
+      wants = [ "postgresql.target" ];
+      partOf = [ "postgresql.target" ];
 
       environment.PGDATA = cfg.dataDir;
 

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -101,6 +101,12 @@ let
           machine.fail(check_count("SELECT * FROM sth;", 4))
           machine.succeed(check_count("SELECT xpath('/test/text()', doc) FROM xmltest;", 1))
 
+          with subtest("killing postgres process should trigger an automatic restart"):
+              machine.succeed("systemctl kill -s KILL postgresql")
+
+              machine.wait_until_succeeds("systemctl is-active postgresql.service")
+              machine.wait_until_succeeds("systemctl is-active postgresql.target")
+
           with subtest("Backup service works"):
               machine.succeed(
                   "systemctl start ${backupService}.service",


### PR DESCRIPTION
__Note:__ I'd like to settle on an approach before updating the manual accordingly. Hence, a draft.

At my employer's NixOS-based platform, PostgreSQL is configured with `Restart=always` which got never upstreamed, unfortunately.

This however revealed an interesting problem when using bi-directional BindsTo: when killing `postgresql.service`, sometimes both the service & target starts back up and sometimes they don't. According to an upstream bugreport[1] this is a known problem because you have two conflicting operations scheduled in a single transaction, namely

* When (auto-)restarting, a restart job for all units bound to the restarting unit are immediately scheduled[2].

* Due to the `BindsTo` relationship, a stop-job for `postgresql.target` is scheduled immediately by the manager loop[3]. This is caused by the `UNIT_ATOM_CANNOT_BE_ACTIVE_WITHOUT` "atom" which is ONLY set for a BindsTo relationship[4].

  When this is processed first, the restart is inhibited:

      Jul 12 13:25:51 nixos systemd[1]: postgresql.service: Main process exited, code=killed, status=9/KILL
      Jul 12 13:25:51 nixos systemd[1]: postgresql.service: Changed running -> stop-sigterm
      Jul 12 13:25:51 nixos systemd[1]: postgresql.target: Trying to enqueue job postgresql.target/stop/replace
      Jul 12 13:25:51 nixos systemd[1]: postgresql.service: Installed new job postgresql.service/stop as 80053
      Jul 12 13:25:51 nixos systemd[1]: postgresql.target: Installed new job postgresql.target/stop as 80052
      Jul 12 13:25:51 nixos systemd[1]: postgresql.target: Enqueued job postgresql.target/stop as 80052
      [...]
      Jul 12 13:25:51 nixos systemd[1]: postgresql.service: Service restart not allowed.

It's subtle and non-obvious from the man-page, but the way how units are stopped is different when using `PartOf=` or `Requires=` which don't have the `UNIT_ATOM_CANNOT_BE_ACTIVE_WITHOUT` property, but instead schedules the stop/start of the target AFTER the stop-job of postgresql.service which is turned into a start-job because of Restart=always:

    Jul 12 13:33:00 nixos systemd[1]: postgresql.service: Main process exited, code=killed, status=9/KILL
    [...]
    Jul 12 13:33:00 nixos systemd[1]: postgresql.service: Failed with result 'signal'.
    Jul 12 13:33:00 nixos systemd[1]: postgresql.service: Service will restart (restart setting)
    [...]
    Jul 12 13:33:00 nixos systemd[1]: postgresql.target: Installed new job postgresql.target/restart as 80996
    Jul 12 13:33:00 nixos systemd[1]: postgresql.service: Installed new job postgresql.service/restart as 80907
    [...]
    Jul 12 13:33:00 nixos systemd[1]: postgresql.service: Scheduled restart job, restart counter is at 1.
    [...]
    Jul 12 13:33:00 nixos systemd[1]: Stopped target postgresql.target.
    Jul 12 13:33:00 nixos systemd[1]: postgresql.target: Converting job postgresql.target/restart -> postgresql.target/start
    Jul 12 13:33:00 nixos systemd[1]: Stopping postgresql.target...
    [...]
    Jul 12 13:33:00 nixos systemd[1]: Stopped postgresql.service.
    Jul 12 13:33:00 nixos systemd[1]: postgresql.service: Converting job postgresql.service/restart -> postgresql.service/start
    [...]
    Jul 12 13:33:00 nixos systemd[1]: postgresql.service: Changed dead -> running
    Jul 12 13:33:00 nixos systemd[1]: postgresql.service: Job 80907 postgresql.service/start finished, result=done
    Jul 12 13:33:00 nixos systemd[1]: Started postgresql.service.
    Jul 12 13:33:00 nixos systemd[1]: postgresql.target: Changed dead -> active
    [...]
    Jul 12 13:33:00 nixos systemd[1]: Reached target postgresql.target.

Do note that the stop job (including the restart) of postgresql.service is fully processed here before dealing with PartOf/ConsistsOf relationships.

I tested this against the following cases:

    | Unit               | Action       | Propagates to      |
    | ------------------ | ------------ | ------------------ |
    | postgresql.target  | restart      | postgresql.service |
    | postgresql.target  | start        | postgresql.service |
    | postgresql.target  | stop         | psotgresql.service |
    | postgresql.service | start        | postgresql.target  |
    | postgresql.service | restart      | postgresql.target  |
    | postgresql.service | stop         | postgresql.target  |
    | postgresql.service | auto-restart | postgresql.target  |
    | postgresql.service | failure      | postgresql.target  |

Additionally, I took the Restart=always setting including a slightly more careful config around restarts:

* We have intervals of 5 seconds between restarts instead of 100ms.

* If we exceed 5 start attempts in 5*120s (with 120s being the timeout), start job gets rate-limited and thus aborted. Do note that there are at most 5 start attempts allowed in ~625s by default. If the startup fails very quickly, either wait until the rate-limit is over or reset the counter using `systemctl reset-failed postgresql.service`.

* The interval of 625s (plus 5s of buffer) are automatically derived from RestartSec & TimeoutSec. Changing either will also affect StartLimitIntervalSec unless overridden with `mkForce`.

[1] e.g. systemd issue 8374
[2] https://github.com/systemd/systemd/blob/v256-stable/src/core/service.c#L2535-L2542
[3] https://github.com/systemd/systemd/blob/v256-stable/src/core/manager.c#L1611-L1626
[4] https://github.com/systemd/systemd/blob/v256-stable/src/core/unit-dependency-atom.c#L30-L35


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
