### PR TITLE
scuba: init at 2.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24683,6 +24683,14 @@
     githubId = 1552853;
     name = "Vincent Ambo";
   };
+  tbaldwin = {
+    email = "trent.baldwin@proton.me";
+    matrix = "@tbaldwin:matrix.org";
+    github = "tbaldwin-dev";
+    githubId = 220447215;
+    name = "Trent Baldwin";
+    keys = [ { fingerprint = "930C 3A61 F911 1296 7DA5  56D1 665A 9E2A FCDD 68AA"; } ];
+  };
   tbenst = {
     email = "nix@tylerbenster.com";
     github = "tbenst";

--- a/pkgs/by-name/sc/scuba/package.nix
+++ b/pkgs/by-name/sc/scuba/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  pkgsStatic,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+let
+  version = "2.14.0";
+
+  src = fetchFromGitHub {
+    owner = "JonathonReinhart";
+    repo = "scuba";
+    tag = "v${version}";
+    hash = "sha256-AX70js/bvt88zWJlXpuHIeBsBRfAL4qZjuthPFKSnFI=";
+  };
+
+  # This must be built statically because scuba will execute unknown docker environments
+  scubainit = pkgsStatic.rustPlatform.buildRustPackage rec {
+    pname = "scubainit";
+    inherit src version;
+
+    sourceRoot = "${src.name}/scubainit";
+
+    cargoHash = "sha256-YUYo2B5hzzmDeNiWUC+198Qbz+JPgUJfpAqyPWAXTRA=";
+  };
+in
+python3Packages.buildPythonPackage rec {
+  pname = "scuba";
+  inherit src version;
+  pyproject = true;
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    argcomplete
+    pyyaml
+  ];
+
+  postPatch = ''
+    # Version detection fails
+    # Patch in the version instead
+    substituteInPlace scuba/version.py \
+      --replace-fail "__version__ = get_version()" "__version__ = \"${version}\""
+
+    # Disable calling cargo through the make file
+    # scubainit has already been built
+    substituteInPlace setup.py \
+      --replace-fail "check_call([\"make\"])" "pass"
+  '';
+
+  preBuild = ''
+    # Link scubainit into the build tree
+    ln -s ${scubainit}/bin/scubainit scuba/scubainit
+  '';
+
+  meta = {
+    description = "Simple Container-Utilizing Build Apparatus";
+    homepage = "https://github.com/JonathonReinhart/scuba";
+    changelog = "https://github.com/JonathonReinhart/scuba/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tbaldwin ];
+    mainProgram = "scuba";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

### Scuba

From the docs:
> SCUBA is the Simple Container-Utilizing Build Apparatus
>
> Scuba makes it easier to use Docker containers in everyday development. It allows a developer to commit an environment setup where the entire build environment is encapsulated in a Docker container.

This package is used throughout the company I work at. We have adopted it to enable sharing development environments easily through docker. Ideally I would like us to move to nix for this; however, it is still a useful package to automatically bind mount your current directory and enter a user environment for arbitrary docker containers.

### Refs
- https://github.com/JonathonReinhart/scuba
- https://pypi.org/project/scuba/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
