### PR TITLE
bootc: 1.1.2 -> 1.4.0; follow upstream redirect

### DIFF
--- a/pkgs/by-name/bo/bootc/package.nix
+++ b/pkgs/by-name/bo/bootc/package.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "bootc";
-  version = "1.1.2";
+  version = "1.4.0";
   useFetchCargoVendor = true;
-  cargoHash = "sha256-/Sb2XtVguj5zpj/OTl90xFHFSaBeLgb8xIlNm4UrnRI=";
+  cargoHash = "sha256-7Fn68bcm8ZyR5eALCMIdcXcZ595EnWFHKdnqI5vMso4=";
   doInstallCheck = true;
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "bootc";
     rev = "v${version}";
-    hash = "sha256-p1+j62MllmPcvWnijieSZmlgwYy76X17fv12Haetz78=";
+    hash = "sha256-FuU3rQtKpK+ScQ10GivisSJseY2GOFJ/y2HRKIiU0G8=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -33,6 +33,19 @@ rustPlatform.buildRustPackage rec {
     openssl
     glib
     ostree-full
+  ];
+
+  checkFlags = [
+    # These all require a writable /var/tmp
+    "--skip=test_cli_fns"
+    "--skip=test_diff"
+    "--skip=test_tar_export_reproducible"
+    "--skip=test_tar_export_structure"
+    "--skip=test_tar_import_empty"
+    "--skip=test_tar_import_export"
+    "--skip=test_tar_import_signed"
+    "--skip=test_tar_write"
+    "--skip=test_tar_write_tar_layer"
   ];
 
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/bo/bootc/package.nix
+++ b/pkgs/by-name/bo/bootc/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
   doInstallCheck = true;
 
   src = fetchFromGitHub {
-    owner = "containers";
+    owner = "bootc-dev";
     repo = "bootc";
     rev = "v${version}";
     hash = "sha256-FuU3rQtKpK+ScQ10GivisSJseY2GOFJ/y2HRKIiU0G8=";
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     description = "Boot and upgrade via container images";
-    homepage = "https://containers.github.io/bootc";
+    homepage = "https://bootc-dev.github.io/bootc";
     license = lib.licenses.mit;
     mainProgram = "bootc";
     maintainers = with lib.maintainers; [ thesola10 ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
