### PR TITLE
lean-lsp-mcp: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27362,6 +27362,12 @@
     github = "wuyoli";
     githubId = 104238274;
   };
+  wvhulle = {
+    name = "Willem Vanhulle";
+    email = "willemvanhulle@protonmail.com";
+    github = "wvhulle";
+    githubId = 7688680;
+  };
   wykurz = {
     email = "wykurz@gmail.com";
     github = "wykurz";

--- a/pkgs/by-name/le/lean-lsp-mcp/package.nix
+++ b/pkgs/by-name/le/lean-lsp-mcp/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "lean-lsp-mcp";
+  version = "0.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "oOo0oOo";
+    repo = "lean-lsp-mcp";
+    tag = "v${version}";
+    hash = "sha256-dnu53nUOWWVQZ2RokDqwyJnA0zhuEkeqpEc4VueQumI=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    leanclient
+    mcp
+  ];
+
+  pythonImportsCheck = false; # Ran into a build error: module `1` not found.
+  dontCheckRuntimeDeps = true;
+  doCheck = true;
+
+  meta = {
+    description = "Lean Theorem Prover MCP (Model Context Protocol) server";
+    longDescription = ''
+      A Model Context Protocol (MCP) server that provides access to Lean 4 theorem prover
+      functionality. This allows AI assistants and other tools to interact with Lean projects,
+      query definitions, and get theorem proving assistance.
+    '';
+    homepage = "https://github.com/oOo0oOo/lean-lsp-mcp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wvhulle ];
+    mainProgram = "lean-lsp-mcp";
+  };
+}

--- a/pkgs/development/python-modules/leanclient/default.nix
+++ b/pkgs/development/python-modules/leanclient/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  orjson,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "leanclient";
+  version = "0.1.13";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-cSow9A4AnKnv3y0HUkeM28FYRsgCBTRKVpWDpCH1juc=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    orjson
+    tqdm
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Lean client library for Python";
+    homepage = "https://pypi.org/project/leanclient/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wvhulle ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7931,6 +7931,8 @@ self: super: with self; {
 
   leanblueprint = callPackage ../development/python-modules/leanblueprint { };
 
+  leanclient = callPackage ../development/python-modules/leanclient { };
+
   leaone-ble = callPackage ../development/python-modules/leaone-ble { };
 
   leather = callPackage ../development/python-modules/leather { };


### PR DESCRIPTION
Package the following new Python packages / binaries:

- leanclient: v 0.13.0
- lean-lsp-mcp: v0.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
