### PR TITLE
deezer-enhanced: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16580,6 +16580,12 @@
     githubId = 92937;
     name = "Breland Miley";
   };
+  minegameYTB = {
+    name = "Minegame YTB";
+    github = "minegameYTB";
+    githubId = 53137994;
+    matrix = "@minegame2018:matrix.org";
+  };
   minersebas = {
     email = "scherthan_sebastian@web.de";
     github = "MinerSebas";

--- a/pkgs/by-name/de/deezer-enhanced/package.nix
+++ b/pkgs/by-name/de/deezer-enhanced/package.nix
@@ -1,0 +1,129 @@
+{
+  ### Tools
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  autoPatchelfHook,
+  dpkg,
+  gnutar,
+
+  ### Libs
+  xorg,
+  libxkbcommon,
+  glib,
+  nss,
+  dbus,
+  at-spi2-atk,
+  cups,
+  gtk3,
+  pango,
+  cairo,
+  expat,
+  systemdLibs,
+  alsa-lib,
+  nwjs,
+  libGL,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "deezer-enhanced";
+  version = "1.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/duzda/deezer-enhanced/releases/download/v${version}/deezer-enhanced_${version}_amd64.deb";
+    hash = "sha256-zHgrLzPByAPww0aSEDETsddX71O/GU80AZH729YjQQ0=";
+  };
+
+  nativeBuildInputs = [
+    ### To unpack deezer-enhanced
+    dpkg
+    gnutar
+
+    makeWrapper
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+
+    ### Xorg libs
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libxcb
+
+    ### Systemd libs
+    systemdLibs
+    dbus
+
+    ### Other libs
+    libxkbcommon
+    nss
+    glib
+    at-spi2-atk
+    cups
+    gtk3
+    libGL
+    nwjs # For libffmpeg.so
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg-deb --fsys-tarfile $src | tar --no-same-owner --no-same-permissions -xvf -
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ### Create directory and copy files
+    mkdir -p $out
+    mv usr/* $out
+
+    ### Wrap deezer-enhanced to include all libraries in the environment
+    wrapProgram $out/bin/${pname} \
+      --set LD_LIBRARY_PATH ${
+        lib.makeLibraryPath [
+          ### Xorg libs
+          xorg.libX11
+          xorg.libXcomposite
+          xorg.libXdamage
+          xorg.libXext
+          xorg.libXfixes
+          xorg.libXrandr
+          xorg.libxcb
+
+          ### Systemd libs
+          systemdLibs
+          dbus
+
+          ### Other libs
+          libxkbcommon
+          nss
+          glib
+          at-spi2-atk
+          cups
+          gtk3
+          nwjs
+          libGL
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/duzda/deezer-enhanced";
+    changelog = "https://github.com/duzda/deezer-enhanced/releases/tag/v${version}";
+    description = "Unofficial application for Deezer with enhanced features";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "deezer-enhanced";
+    maintainers = with lib.maintainers; [ minegameYTB ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
