### PR TITLE
cubiomes-viewer: add darwin support

### DIFF
--- a/pkgs/by-name/cu/cubiomes-viewer/package.nix
+++ b/pkgs/by-name/cu/cubiomes-viewer/package.nix
@@ -41,17 +41,27 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/bin
-    cp cubiomes-viewer $out/bin
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          mkdir -p "$out/Applications/"
+          cp -R cubiomes-viewer.app "$out/Applications/cubiomes-viewer.app"
+          ln -s "$out/Applications/cubiomes-viewer.app/Contents/MacOS/cubiomes-viewer" "$out/bin/cubiomes-viewer"
+        ''
+      else
+        ''
+          cp cubiomes-viewer $out/bin
 
-    mkdir -p $out/share/{pixmaps,applications}
-    cp rc/icons/map.png $out/share/pixmaps/com.github.cubitect.cubiomes-viewer.png
-    cp etc/com.github.cubitect.cubiomes-viewer.desktop $out/share/applications
+          mkdir -p $out/share/{pixmaps,applications}
+          cp rc/icons/map.png $out/share/pixmaps/com.github.cubitect.cubiomes-viewer.png
+          cp etc/com.github.cubitect.cubiomes-viewer.desktop $out/share/applications
+        ''
+    }
 
     runHook postInstall
   '';
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
     homepage = "https://github.com/Cubitect/cubiomes-viewer";
     description = "Graphical Minecraft seed finder and map viewer";
     mainProgram = "cubiomes-viewer";

--- a/pkgs/by-name/cu/cubiomes-viewer/package.nix
+++ b/pkgs/by-name/cu/cubiomes-viewer/package.nix
@@ -4,15 +4,14 @@
   fetchFromGitHub,
   qt5,
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cubiomes-viewer";
   version = "4.1.2";
 
   src = fetchFromGitHub {
     owner = "Cubitect";
-    repo = pname;
-    rev = version;
+    repo = "cubiomes-viewer";
+    tag = finalAttrs.version;
     hash = "sha256-izDKS08LNT2rV5rIxlWRHevJAKEbAVzekjfZy0Oen1I=";
     fetchSubmodules = true;
   };
@@ -51,7 +50,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     broken = stdenv.hostPlatform.isDarwin;
     homepage = "https://github.com/Cubitect/cubiomes-viewer";
     description = "Graphical Minecraft seed finder and map viewer";
@@ -60,8 +59,8 @@ stdenv.mkDerivation rec {
       Cubiomes Viewer provides a graphical interface for the efficient and flexible seed-finding
       utilities provided by cubiomes and a map viewer for the Minecraft biomes and structure generation.
     '';
-    platforms = platforms.all;
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ hqurve ];
+    platforms = lib.platforms.all;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ hqurve ];
   };
-}
+})

--- a/pkgs/by-name/cu/cubiomes-viewer/package.nix
+++ b/pkgs/by-name/cu/cubiomes-viewer/package.nix
@@ -2,10 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qtbase,
-  qmake,
-  qttools,
-  wrapQtAppsHook,
+  qt5,
 }:
 
 stdenv.mkDerivation rec {
@@ -27,13 +24,13 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    qtbase
+    qt5.qtbase
   ];
 
   nativeBuildInputs = [
-    qmake
-    qttools
-    wrapQtAppsHook
+    qt5.qmake
+    qt5.qttools
+    qt5.wrapQtAppsHook
   ];
 
   preBuild = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7110,8 +7110,6 @@ with pkgs;
 
   ctagsWrapped = callPackage ../development/tools/misc/ctags/wrapped.nix { };
 
-  cubiomes-viewer = libsForQt5.callPackage ../applications/misc/cubiomes-viewer { };
-
   # can't use override - it triggers infinite recursion
   cmakeMinimal = callPackage ../by-name/cm/cmake/package.nix {
     isMinimalBuild = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cubiomes-viewer supports building for macOS, albeit not fully officially (see cubitect/cubiomes-viewer#107)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
