### PR TITLE
lixPackageSets.git: 2.94.0-pre-20250704_362bfd827f52 -> 2.94.0-pre-20250711_ae00b1298353

### DIFF
--- a/pkgs/by-name/ca/capnproto/package.nix
+++ b/pkgs/by-name/ca/capnproto/package.nix
@@ -45,7 +45,7 @@ clangStdenv.mkDerivation rec {
     openssl
     zlib
   ]
-  ++ lib.optional (clangStdenv.cc.isClang && clangStdenv.targetPlatform.isStatic) empty-libgcc_eh;
+  ++ lib.optional (clangStdenv.cc.isClang && clangStdenv.hostPlatform.isStatic) empty-libgcc_eh;
 
   # FIXME: separate the binaries from the stuff that user systems actually use
   # This runs into a terrible UX issue in Lix and I just don't want to debug it

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -57,7 +57,7 @@ assert lib.assertMsg (
   rustc,
   toml11,
   pegtl,
-  python3,
+  buildPackages,
   pkg-config,
   rapidcheck,
   sqlite,
@@ -137,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     # python3.withPackages does not splice properly, see https://github.com/NixOS/nixpkgs/issues/305858
-    (python3.pythonOnBuildForHost.withPackages (
+    (buildPackages.python3.withPackages (
       p:
       [
         p.python-frontmatter
@@ -154,7 +154,6 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     cmake
-    python3
     # Required for libstd++ assertions that leaks inside of the final binary.
     removeReferencesTo
 

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -229,7 +229,7 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure =
     # Copy libboost_context so we don't get all of Boost in our closure.
     # https://github.com/NixOS/nixpkgs/issues/45462
-    lib.optionalString (!enableStatic) ''
+    lib.optionalString (lib.versionOlder version "2.91" && !enableStatic) ''
       mkdir -p $out/lib
       cp -pd ${boost}/lib/{libboost_context*,libboost_thread*,libboost_system*} $out/lib
       rm -f $out/lib/*.a
@@ -299,7 +299,7 @@ stdenv.mkDerivation (finalAttrs: {
       mkdir -p $out/nix-support
       echo "file binary-dist $out/bin/nix" >> $out/nix-support/hydra-build-products
     ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    + lib.optionalString (lib.versionOlder version "2.91" && stdenv.hostPlatform.isDarwin) ''
       for lib in liblixutil.dylib liblixexpr.dylib; do
         install_name_tool \
           -change "${lib.getLib boost}/lib/libboost_context.dylib" \

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -137,12 +137,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     # python3.withPackages does not splice properly, see https://github.com/NixOS/nixpkgs/issues/305858
-    (python3.pythonOnBuildForHost.withPackages (p: [
-      p.pytest
-      p.pytest-xdist
-      p.python-frontmatter
-      p.toml
-    ]))
+    (python3.pythonOnBuildForHost.withPackages (
+      p:
+      [
+        p.python-frontmatter
+        p.toml
+      ]
+      ++ lib.optionals finalAttrs.doInstallCheck [
+        p.pytest
+        p.pytest-xdist
+      ]
+    ))
     pkg-config
     flex
     jq

--- a/pkgs/tools/package-management/lix/common-nix-eval-jobs.nix
+++ b/pkgs/tools/package-management/lix/common-nix-eval-jobs.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3;
     teams = [ lib.teams.lix ];
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isStatic;
+    broken = lib.versionOlder version "2.94" && stdenv.hostPlatform.isStatic;
   };
 }

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -271,20 +271,20 @@ lib.makeExtensible (self: {
     attrName = "git";
 
     lix-args = rec {
-      version = "2.94.0-pre-20250704_${builtins.substring 0 12 src.rev}";
+      version = "2.94.0-pre-20250807_${builtins.substring 0 12 src.rev}";
 
       src = fetchFromGitea {
         domain = "git.lix.systems";
         owner = "lix-project";
         repo = "lix";
-        rev = "362bfd827f522b57062e4ebcb465bb51941632a4";
-        hash = "sha256-4CVRbeYExqIDpFH+QMZb5IeUGkP6kA/zHSuExYoZygk=";
+        rev = "8bbd5e1d0df9c31b4d86ba07bc85beb952e42ccb";
+        hash = "sha256-P+WiN95OjCqHhfygglS/VOFTSj7qNdL5XQDo2wxhQqg=";
       };
 
       cargoDeps = rustPlatform.fetchCargoVendor {
         name = "lix-${version}";
         inherit src;
-        hash = "sha256-YMyNOXdlx0I30SkcmdW/6DU0BYc3ZOa2FMJSKMkr7I8=";
+        hash = "sha256-APm8m6SVEAO17BBCka13u85/87Bj+LePP7Y3zHA3Mpg=";
       };
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
