### PR TITLE
python3Packages.watchdog: remove ineffective test deselection and use `disabledTestPaths` for remaining test deselection

### DIFF
--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -37,53 +37,47 @@ buildPythonPackage rec {
     ++ optional-dependencies.watchmedo
     ++ lib.optionals (pythonOlder "3.13") [ eventlet ];
 
-  pytestFlagsArray =
-    [
-      "--deselect=tests/test_emitter.py::test_create_wrong_encoding"
-      "--deselect=tests/test_emitter.py::test_close"
-      # assert cap.out.splitlines(keepends=False).count('+++++ 0') == 2 != 3
-      "--deselect=tests/test_0_watchmedo.py::test_auto_restart_on_file_change_debounce"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
-      # fails to stop process in teardown
-      "--deselect=tests/test_0_watchmedo.py::test_auto_restart_subprocess_termination"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-      # FileCreationEvent != FileDeletionEvent
-      "--deselect=tests/test_emitter.py::test_separate_consecutive_moves"
-      "--deselect=tests/test_observers_polling.py::test___init__"
-      # segfaults
-      "--deselect=tests/test_delayed_queue.py::test_delayed_get"
-      "--deselect=tests/test_emitter.py::test_delete"
-      # AttributeError: '_thread.RLock' object has no attribute 'key'"
-      "--deselect=tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-      # segfaults
-      "--deselect=tests/test_delayed_queue.py::test_delayed_get"
-      "--deselect=tests/test_0_watchmedo.py::test_tricks_from_file"
-      "--deselect=tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_1"
-      "--deselect=tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_2"
-      "--deselect=tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
-      "--deselect=tests/test_fsevents.py::test_recursive_check_accepts_relative_paths"
-      # fsevents:fsevents.py:318 Unhandled exception in FSEventsEmitter
-      "--deselect=tests/test_fsevents.py::test_watchdog_recursive"
-      # SystemError: Cannot start fsevents stream. Use a kqueue or polling observer...
-      "--deselect=tests/test_fsevents.py::test_add_watch_twice"
-      # gets stuck
-      "--deselect=tests/test_fsevents.py::test_converting_cfstring_to_pyunicode"
-    ];
-
   disabledTestPaths =
     [
+      "tests/test_emitter.py::test_create_wrong_encoding"
+      "tests/test_emitter.py::test_close"
       # tests timeout easily
       "tests/test_inotify_buffer.py"
+      # assert cap.out.splitlines(keepends=False).count('+++++ 0') == 2 != 3
+      "tests/test_0_watchmedo.py::test_auto_restart_on_file_change_debounce"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
       # segfaults the testsuite
       "tests/test_emitter.py"
       # unsupported on x86_64-darwin
       "tests/test_fsevents.py"
+      # fails to stop process in teardown
+      "tests/test_0_watchmedo.py::test_auto_restart_subprocess_termination"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+      # FileCreationEvent != FileDeletionEvent
+      "tests/test_emitter.py::test_separate_consecutive_moves"
+      "tests/test_observers_polling.py::test___init__"
+      # segfaults
+      "tests/test_delayed_queue.py::test_delayed_get"
+      "tests/test_emitter.py::test_delete"
+      # AttributeError: '_thread.RLock' object has no attribute 'key'"
+      "tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+      # segfaults
+      "tests/test_delayed_queue.py::test_delayed_get"
+      "tests/test_0_watchmedo.py::test_tricks_from_file"
+      "tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_1"
+      "tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_2"
+      "tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
+      "tests/test_fsevents.py::test_recursive_check_accepts_relative_paths"
+      # fsevents:fsevents.py:318 Unhandled exception in FSEventsEmitter
+      "tests/test_fsevents.py::test_watchdog_recursive"
+      # SystemError: Cannot start fsevents stream. Use a kqueue or polling observer...
+      "tests/test_fsevents.py::test_add_watch_twice"
+      # gets stuck
+      "tests/test_fsevents.py::test_converting_cfstring_to_pyunicode"
     ];
 
   pythonImportsCheck = [ "watchdog" ];

--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -70,8 +70,6 @@ buildPythonPackage rec {
       "--deselect=tests/test_fsevents.py::test_watchdog_recursive"
       # SystemError: Cannot start fsevents stream. Use a kqueue or polling observer...
       "--deselect=tests/test_fsevents.py::test_add_watch_twice"
-      # fsevents:fsevents.py:318 Unhandled exception in FSEventsEmitter
-      "--deselect=ests/test_fsevents.py::test_recursive_check_accepts_relative_paths"
       # gets stuck
       "--deselect=tests/test_fsevents.py::test_converting_cfstring_to_pyunicode"
     ];


### PR DESCRIPTION
Remove a test item deselection, since it is already ineffective due to the typo in the beginning of its path (`ests/` instead of `tests/`).

Put the rest of the test deselection under `disabledTestPaths` to make the attributes more structural.

Please review commit-by-commit for cleaner diff.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
