### PR TITLE
nixos-rebuild-ng: run upgrade_channels with sudo

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -281,7 +281,7 @@ def execute(argv: list[str]) -> None:
     copy_flags = common_flags | vars(args_groups["copy_flags"])
 
     if args.upgrade or args.upgrade_all:
-        nix.upgrade_channels(bool(args.upgrade_all))
+        nix.upgrade_channels(args.upgrade_all, args.sudo)
 
     action = Action(args.action)
     # Only run shell scripts from the Nixpkgs tree if the action is

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -693,7 +693,7 @@ def switch_to_configuration(
     )
 
 
-def upgrade_channels(all_channels: bool = False) -> None:
+def upgrade_channels(all_channels: bool = False, sudo: bool = False) -> None:
     """Upgrade channels for classic Nix.
 
     It will either upgrade just the `nixos` channel (including any channel
@@ -705,4 +705,8 @@ def upgrade_channels(all_channels: bool = False) -> None:
             or channel_path.name == "nixos"
             or (channel_path / ".update-on-nixos-rebuild").exists()
         ):
-            run_wrapper(["nix-channel", "--update", channel_path.name], check=False)
+            run_wrapper(
+                ["nix-channel", "--update", channel_path.name],
+                check=False,
+                sudo=sudo,
+            )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -699,6 +699,12 @@ def upgrade_channels(all_channels: bool = False, sudo: bool = False) -> None:
     It will either upgrade just the `nixos` channel (including any channel
     that has a `.update-on-nixos-rebuild` file) or all.
     """
+    if not sudo and os.geteuid() != 0:
+        raise NixOSRebuildError(
+            "if you pass the '--upgrade' or '--upgrade-all' flag, you must "
+            "also pass '--sudo' or run the command as root (e.g., with sudo)"
+        )
+
     for channel_path in Path("/nix/var/nix/profiles/per-user/root/channels/").glob("*"):
         if channel_path.is_dir() and (
             all_channels

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -838,15 +838,19 @@ def test_switch_to_configuration_with_systemd_run(
 @patch("pathlib.Path.is_dir", autospec=True, return_value=True)
 def test_upgrade_channels(mock_is_dir: Mock, mock_glob: Mock) -> None:
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
-        n.upgrade_channels(False)
-    mock_run.assert_called_once_with(["nix-channel", "--update", "nixos"], check=False)
+        n.upgrade_channels(all_channels=False, sudo=True)
+    mock_run.assert_called_once_with(
+        ["nix-channel", "--update", "nixos"], check=False, sudo=True
+    )
 
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
-        n.upgrade_channels(True)
+        n.upgrade_channels(all_channels=True, sudo=False)
     mock_run.assert_has_calls(
         [
-            call(["nix-channel", "--update", "nixos"], check=False),
-            call(["nix-channel", "--update", "nixos-hardware"], check=False),
-            call(["nix-channel", "--update", "home-manager"], check=False),
+            call(["nix-channel", "--update", "nixos"], check=False, sudo=False),
+            call(
+                ["nix-channel", "--update", "nixos-hardware"], check=False, sudo=False
+            ),
+            call(["nix-channel", "--update", "home-manager"], check=False, sudo=False),
         ]
     )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -836,15 +836,28 @@ def test_switch_to_configuration_with_systemd_run(
     ],
 )
 @patch("pathlib.Path.is_dir", autospec=True, return_value=True)
-def test_upgrade_channels(mock_is_dir: Mock, mock_glob: Mock) -> None:
-    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
-        n.upgrade_channels(all_channels=False, sudo=True)
+@patch("os.geteuid", autospec=True, return_value=1000)
+@patch(get_qualified_name(n.run_wrapper, n), autospec=True)
+def test_upgrade_channels(
+    mock_run: Mock,
+    mock_geteuid: Mock,
+    mock_is_dir: Mock,
+    mock_glob: Mock,
+) -> None:
+    with pytest.raises(m.NixOSRebuildError) as e:
+        n.upgrade_channels(all_channels=False, sudo=False)
+    assert str(e.value) == (
+        "error: if you pass the '--upgrade' or '--upgrade-all' flag, you must "
+        "also pass '--sudo' or run the command as root (e.g., with sudo)"
+    )
+
+    n.upgrade_channels(all_channels=False, sudo=True)
     mock_run.assert_called_once_with(
         ["nix-channel", "--update", "nixos"], check=False, sudo=True
     )
 
-    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
-        n.upgrade_channels(all_channels=True, sudo=False)
+    mock_geteuid.return_value = 0
+    n.upgrade_channels(all_channels=True, sudo=False)
     mock_run.assert_has_calls(
         [
             call(["nix-channel", "--update", "nixos"], check=False, sudo=False),


### PR DESCRIPTION
Fix #424749.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
