### PR TITLE
clang: patch like gcc to mangle store path output by __FILE__

### DIFF
--- a/pkgs/development/compilers/llvm/20/clang/macro_file_mangling.patch
+++ b/pkgs/development/compilers/llvm/20/clang/macro_file_mangling.patch
@@ -1,0 +1,78 @@
+Without the change `__FILE__` used in static inline functions in headers
+embed paths to header files into executable images. For local headers
+it's not a problem, but for headers in `/nix/store` this causes `-dev`
+inputs to be retained in runtime closure.
+
+Typical examples are `nix` -> `nlohmann_json` and `pipewire` ->
+`lttng-ust.dev`.
+
+For this reason we want to remove the occurrences of hashes in the
+expansion of `__FILE__`. `nuke-references` does it by replacing hashes
+by `eeeeee...`. It is handy to be able to invert the transformation to
+go back to the original store path. The chosen solution is to make the
+hash uppercase:
+- it does not trigger runtime references (except for all digit hashes,
+  which are unlikely enough)
+- it visually looks like a bogus store path
+- it is easy to find the original store path if required
+
+Ideally we would like to use `-fmacro-prefix-map=` feature of `gcc` and `clang` as:
+
+  -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/$HASH1-nlohmann-json-ver
+  -fmacro-prefix-map=/nix/...
+
+In practice it quickly exhausts argument length limit due to `gcc`
+deficiency: https://gcc.gnu.org/PR111527
+This patch to `clang` is a copy of the corresponding `gcc` patch so the same
+approach was kept.
+
+This patch hardcode header mangling if $NIX_STORE variable
+is present in the environment.
+
+Tested as:
+
+    $ printf "# 0 \"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-pppppp-vvvvvvv\" \nconst char * f(void) { return __FILE__; }" | NIX_STORE=/nix/store ./gcc/xgcc -Bgcc -x c - -S -o -
+    ...
+    .string "/nix/store/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-pppppp-vvvvvvv"
+    ...
+
+Mangled successfully.
+
+To reverse the effect of the mangle use new `NIX_CLANG_DONT_MANGLE_PREFIX_MAP`
+environment variable. It should not normally be needed.
+
+The ability to go back to the original store path is relied on by
+nixseparatedebuginfod, for example.
+--- clang/lib/Basic/LangOptions.cpp
++++ clang/lib/Basic/LangOptions.cpp
+@@ -12,6 +12,8 @@
+ 
+ #include "clang/Basic/LangOptions.h"
+ #include "llvm/Support/Path.h"
++#include <cctype>
++#include <cstdlib>
+ 
+ using namespace clang;
+ 
+@@ -76,6 +78,21 @@ void LangOptions::remapPathPrefix(SmallVectorImpl<char> &Path) const {
+   for (const auto &Entry : MacroPrefixMap)
+     if (llvm::sys::path::replace_path_prefix(Path, Entry.first, Entry.second))
+       break;
++  if (std::getenv("NIX_CLANG_DONT_MANGLE_PREFIX_MAP") == nullptr) {
++    char* nix_store = getenv("NIX_STORE");
++    if (nix_store == nullptr) {
++      return;
++    }
++    size_t nix_store_len = strlen(nix_store);
++    if (Path.size() <= nix_store_len + 1 + 32) {
++      return;
++    }
++    if (std::equal(Path.begin(), Path.begin() + nix_store_len, nix_store)) {
++      for (auto c = Path.begin() + nix_store_len + 1; c < Path.begin() + nix_store_len + 1 + 32; c++) {
++        *c = std::toupper(*c);
++      }
++    }
++  }
+ }
+ 
+ std::string LangOptions::getOpenCLVersionString() const {

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation (
     patches =
       [
         (getVersionFile "clang/purity.patch")
+        (getVersionFile "clang/macro_file_mangling.patch")
         # Remove extraneous ".a" suffix from baremetal clang_rt.builtins when compiling for baremetal.
         # https://reviews.llvm.org/D51899
         (getVersionFile "clang/gnu-install-dirs.patch")

--- a/pkgs/development/compilers/llvm/common/patches.nix
+++ b/pkgs/development/compilers/llvm/common/patches.nix
@@ -24,6 +24,12 @@
       path = ../12;
     }
   ];
+  "clang/macro_file_mangling.patch" = [
+    {
+      after = "19";
+      path = ../20;
+    }
+  ];
   "clang/aarch64-tblgen.patch" = [
     {
       after = "17";


### PR DESCRIPTION
this prevents unwanted references to -dev outputs. A similar patch exists for gcc.

tested with
```
printf "# 0 \"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-pppppp-vvvvvvv\" \nconst char * f(void) { return __FILE__; }" | NIX_STORE=/nix/store result/bin/clang -x c - -S -o  -
```

the goal is to replace sanitiseHeaderPathsHook because it breaks the filenames of headers in debug symbols and makes gdb useless in template instantiation.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
