### PR TITLE
ghidra-extensions.ghidra-delinker-extension: 0.5.1 -> 0.7.0

### DIFF
--- a/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/binary-file-toolkit.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/binary-file-toolkit.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  maven,
+}:
+maven.buildMavenPackage rec {
+  pname = "binary-file-toolkit";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "boricj";
+    repo = "binary-file-toolkit";
+    tag = "v${version}";
+    hash = "sha256-ABDJDdx0OxXVOgYAw4kZAP3Psr+w7YevP1xk1RszXw8=";
+  };
+
+  mvnHash = "sha256-Ek2qulMSHd1ZJfEloo6fIe+QMqub/Ftna/TzTt01ky8=";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/
+    cp dist/* $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Set of Java libraries for manipulating toolchain file formats";
+    homepage = "https://github.com/boricj/binary-file-toolkit";
+    changelog = "https://github.com/boricj/binary-file-toolkit/releases";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ timschumi ];
+  };
+}

--- a/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/default.nix
@@ -1,23 +1,35 @@
 {
+  callPackage,
   lib,
   ghidra,
   gradle,
   fetchFromGitHub,
+
+  binary-file-toolkit ? callPackage ./binary-file-toolkit.nix { },
 }:
 ghidra.buildGhidraExtension (finalAttrs: {
   pname = "ghidra-delinker-extension";
-  version = "0.5.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "boricj";
     repo = "ghidra-delinker-extension";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-h6F50Z7S6tPOl9mIhChLKoFxHuAkq/n36ysUEFwWGxI=";
+    hash = "sha256-Hgpf1eqP/DRYczRDvAhXTWoycHe8N/xhMorlYDjytZg=";
   };
+
+  patches = [
+    # The GitHub Maven repository is not available unauthenticated,
+    # so patch in the dependency this way and replace the fake path
+    # with the locally built derivation later.
+    # This is tracked at boricj/binary-file-toolkit#1.
+    ./local-binary-file-toolkit.patch
+  ];
 
   postPatch = ''
     substituteInPlace build.gradle \
-      --replace-fail '"''${getGitHash()}"' '"v${finalAttrs.version}"'
+      --replace-fail '"''${getGitHash()}"' '"v${finalAttrs.version}"' \
+      --replace-fail '"@binary-file-toolkit@"' '"${binary-file-toolkit}"'
   '';
 
   gradleBuildTask = "buildExtension";

--- a/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/local-binary-file-toolkit.patch
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/local-binary-file-toolkit.patch
@@ -1,0 +1,23 @@
+diff --git a/build.gradle b/build.gradle
+index 6f3bc6f..16fc51b 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -55,16 +55,8 @@ else {
+ repositories {
+ 	mavenLocal()
+ 	mavenCentral()
+-	maven {
+-		name = "boricj's binary-file-toolkit"
+-		url = uri("https://maven.pkg.github.com/boricj/binary-file-toolkit")
+-		credentials(HttpHeaderCredentials) {
+-            name = "Authorization"
+-            value = "Bearer " + project.findProperty("githubToken") as String ?: System.getenv("GITHUB_TOKEN")
+-		}
+-        authentication {
+-            header(HttpHeaderAuthentication)
+-        }
++	flatDir {
++		dirs "@binary-file-toolkit@"
+ 	}
+ }
+ 


### PR DESCRIPTION
Changelog can be found [here](https://github.com/boricj/ghidra-delinker-extension/releases), both 0.6.0 and 0.7.0 applies.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~Currently marked a draft since~~ ghidra-delinker-extension 0.6.0 and newer depend on binary-file-toolkit, which is only published to the GitHub Maven repository and requires authentication to download. This is tracked at boricj/binary-file-toolkit#1. We solve this here by building binary-file-toolkit as its own derivation and patching the ghidra-delinker-extension source to load the JAR files from that path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
