### PR TITLE
nixosTests.wireguard: handleTest -> runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1553,7 +1553,10 @@ in
   whoogle-search = runTest ./whoogle-search.nix;
   wiki-js = runTest ./wiki-js.nix;
   wine = handleTest ./wine.nix { };
-  wireguard = handleTest ./wireguard { };
+  wireguard = import ./wireguard {
+    inherit pkgs runTest;
+    inherit (pkgs) lib;
+  };
   wg-access-server = runTest ./wg-access-server.nix;
   without-nix = runTest ./without-nix.nix;
   wmderland = runTest ./wmderland.nix;

--- a/nixos/tests/wireguard/amneziawg-quick.nix
+++ b/nixos/tests/wireguard/amneziawg-quick.nix
@@ -1,125 +1,120 @@
-import ../make-test-python.nix (
-  {
-    pkgs,
-    lib,
-    kernelPackages ? null,
-    nftables ? false,
-    ...
-  }:
-  let
-    wg-snakeoil-keys = import ./snakeoil-keys.nix;
-    peer = import ./make-peer.nix { inherit lib; };
-    commonConfig = {
-      boot.kernelPackages = lib.mkIf (kernelPackages != null) kernelPackages;
+{
+  lib,
+  kernelPackages ? null,
+  nftables ? false,
+  ...
+}:
+let
+  wg-snakeoil-keys = import ./snakeoil-keys.nix;
+  peer = import ./make-peer.nix;
+  commonConfig =
+    { pkgs, ... }:
+    {
+      boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
       networking.nftables.enable = nftables;
       # Make sure iptables doesn't work with nftables enabled
       boot.blacklistedKernelModules = lib.mkIf nftables [ "nft_compat" ];
     };
-    extraOptions = {
-      Jc = 5;
-      Jmin = 10;
-      Jmax = 42;
-      S1 = 60;
-      S2 = 90;
-    };
-  in
-  {
-    name = "amneziawg-quick";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [
-        averyanalex
-        azahi
-      ];
-    };
+  extraOptions = {
+    Jc = 5;
+    Jmin = 10;
+    Jmax = 42;
+    S1 = 60;
+    S2 = 90;
+  };
+in
+{
+  name = "amneziawg-quick";
+  meta.maintainers = with lib.maintainers; [
+    averyanalex
+    azahi
+  ];
 
-    nodes = {
-      peer0 = peer {
-        ip4 = "192.168.0.1";
-        ip6 = "fd00::1";
-        extraConfig = lib.mkMerge [
-          commonConfig
-          {
-            networking.firewall.allowedUDPPorts = [ 23542 ];
-            networking.wg-quick.interfaces.wg0 = {
-              type = "amneziawg";
+  nodes = {
+    peer0 = peer {
+      ip4 = "192.168.0.1";
+      ip6 = "fd00::1";
+      extraConfig = {
+        imports = [ commonConfig ];
 
-              address = [
-                "10.23.42.1/32"
-                "fc00::1/128"
-              ];
-              listenPort = 23542;
+        networking.firewall.allowedUDPPorts = [ 23542 ];
+        networking.wg-quick.interfaces.wg0 = {
+          type = "amneziawg";
 
-              inherit (wg-snakeoil-keys.peer0) privateKey;
+          address = [
+            "10.23.42.1/32"
+            "fc00::1/128"
+          ];
+          listenPort = 23542;
 
-              peers = lib.singleton {
-                allowedIPs = [
-                  "10.23.42.2/32"
-                  "fc00::2/128"
-                ];
+          inherit (wg-snakeoil-keys.peer0) privateKey;
 
-                inherit (wg-snakeoil-keys.peer1) publicKey;
-              };
+          peers = lib.singleton {
+            allowedIPs = [
+              "10.23.42.2/32"
+              "fc00::2/128"
+            ];
 
-              dns = [
-                "10.23.42.2"
-                "fc00::2"
-                "wg0"
-              ];
+            inherit (wg-snakeoil-keys.peer1) publicKey;
+          };
 
-              inherit extraOptions;
-            };
-          }
-        ];
-      };
+          dns = [
+            "10.23.42.2"
+            "fc00::2"
+            "wg0"
+          ];
 
-      peer1 = peer {
-        ip4 = "192.168.0.2";
-        ip6 = "fd00::2";
-        extraConfig = lib.mkMerge [
-          commonConfig
-          {
-            networking.useNetworkd = true;
-            networking.wg-quick.interfaces.wg0 = {
-              type = "amneziawg";
-
-              address = [
-                "10.23.42.2/32"
-                "fc00::2/128"
-              ];
-              inherit (wg-snakeoil-keys.peer1) privateKey;
-
-              peers = lib.singleton {
-                allowedIPs = [
-                  "0.0.0.0/0"
-                  "::/0"
-                ];
-                endpoint = "192.168.0.1:23542";
-                persistentKeepalive = 25;
-
-                inherit (wg-snakeoil-keys.peer0) publicKey;
-              };
-
-              dns = [
-                "10.23.42.1"
-                "fc00::1"
-                "wg0"
-              ];
-
-              inherit extraOptions;
-            };
-          }
-        ];
+          inherit extraOptions;
+        };
       };
     };
 
-    testScript = ''
-      start_all()
+    peer1 = peer {
+      ip4 = "192.168.0.2";
+      ip6 = "fd00::2";
+      extraConfig = {
+        imports = [ commonConfig ];
 
-      peer0.wait_for_unit("wg-quick-wg0.service")
-      peer1.wait_for_unit("wg-quick-wg0.service")
+        networking.useNetworkd = true;
+        networking.wg-quick.interfaces.wg0 = {
+          type = "amneziawg";
 
-      peer1.succeed("ping -c5 fc00::1")
-      peer1.succeed("ping -c5 10.23.42.1")
-    '';
-  }
-)
+          address = [
+            "10.23.42.2/32"
+            "fc00::2/128"
+          ];
+          inherit (wg-snakeoil-keys.peer1) privateKey;
+
+          peers = lib.singleton {
+            allowedIPs = [
+              "0.0.0.0/0"
+              "::/0"
+            ];
+            endpoint = "192.168.0.1:23542";
+            persistentKeepalive = 25;
+
+            inherit (wg-snakeoil-keys.peer0) publicKey;
+          };
+
+          dns = [
+            "10.23.42.1"
+            "fc00::1"
+            "wg0"
+          ];
+
+          inherit extraOptions;
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    peer0.wait_for_unit("wg-quick-wg0.service")
+    peer1.wait_for_unit("wg-quick-wg0.service")
+
+    peer1.succeed("ping -c5 fc00::1")
+    peer1.succeed("ping -c5 10.23.42.1")
+  '';
+}

--- a/nixos/tests/wireguard/amneziawg.nix
+++ b/nixos/tests/wireguard/amneziawg.nix
@@ -1,36 +1,34 @@
-import ../make-test-python.nix (
-  {
-    pkgs,
-    lib,
-    kernelPackages ? null,
-    ...
-  }:
-  let
-    wg-snakeoil-keys = import ./snakeoil-keys.nix;
-    peer = (import ./make-peer.nix) { inherit lib; };
-    extraOptions = {
-      Jc = 5;
-      Jmin = 10;
-      Jmax = 42;
-      S1 = 60;
-      S2 = 90;
-    };
-  in
-  {
-    name = "amneziawg";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [
-        averyanalex
-        azahi
-      ];
-    };
+{
+  lib,
+  kernelPackages ? null,
+  ...
+}:
+let
+  wg-snakeoil-keys = import ./snakeoil-keys.nix;
+  peer = import ./make-peer.nix;
+  extraOptions = {
+    Jc = 5;
+    Jmin = 10;
+    Jmax = 42;
+    S1 = 60;
+    S2 = 90;
+  };
+in
+{
+  name = "amneziawg";
+  meta.maintainers = with lib.maintainers; [
+    averyanalex
+    azahi
+  ];
 
-    nodes = {
-      peer0 = peer {
-        ip4 = "192.168.0.1";
-        ip6 = "fd00::1";
-        extraConfig = {
-          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+  nodes = {
+    peer0 = peer {
+      ip4 = "192.168.0.1";
+      ip6 = "fd00::1";
+      extraConfig =
+        { lib, pkgs, ... }:
+        {
+          boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
           networking.firewall.allowedUDPPorts = [ 23542 ];
           networking.wireguard.interfaces.wg0 = {
             type = "amneziawg";
@@ -54,13 +52,15 @@ import ../make-test-python.nix (
             inherit extraOptions;
           };
         };
-      };
+    };
 
-      peer1 = peer {
-        ip4 = "192.168.0.2";
-        ip6 = "fd00::2";
-        extraConfig = {
-          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+    peer1 = peer {
+      ip4 = "192.168.0.2";
+      ip6 = "fd00::2";
+      extraConfig =
+        { lib, pkgs, ... }:
+        {
+          boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
           networking.wireguard.interfaces.wg0 = {
             type = "amneziawg";
             ips = [
@@ -85,27 +85,26 @@ import ../make-test-python.nix (
 
             postSetup =
               let
-                inherit (pkgs) iproute2;
+                ip = lib.getExe' pkgs.iproute2 "ip";
               in
               ''
-                ${iproute2}/bin/ip route replace 10.23.42.1/32 dev wg0
-                ${iproute2}/bin/ip route replace fc00::1/128 dev wg0
+                ${ip} route replace 10.23.42.1/32 dev wg0
+                ${ip} route replace fc00::1/128 dev wg0
               '';
 
             inherit extraOptions;
           };
         };
-      };
     };
+  };
 
-    testScript = ''
-      start_all()
+  testScript = ''
+    start_all()
 
-      peer0.wait_for_unit("wireguard-wg0.service")
-      peer1.wait_for_unit("wireguard-wg0.service")
+    peer0.wait_for_unit("wireguard-wg0.service")
+    peer1.wait_for_unit("wireguard-wg0.service")
 
-      peer1.succeed("ping -c5 fc00::1")
-      peer1.succeed("ping -c5 10.23.42.1")
-    '';
-  }
-)
+    peer1.succeed("ping -c5 fc00::1")
+    peer1.succeed("ping -c5 10.23.42.1")
+  '';
+}

--- a/nixos/tests/wireguard/basic.nix
+++ b/nixos/tests/wireguard/basic.nix
@@ -1,26 +1,24 @@
-import ../make-test-python.nix (
-  {
-    pkgs,
-    lib,
-    kernelPackages ? null,
-    ...
-  }:
-  let
-    wg-snakeoil-keys = import ./snakeoil-keys.nix;
-    peer = (import ./make-peer.nix) { inherit lib; };
-  in
-  {
-    name = "wireguard";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ ma27 ];
-    };
+{
+  lib,
+  kernelPackages ? null,
+  ...
+}:
+let
+  wg-snakeoil-keys = import ./snakeoil-keys.nix;
+  peer = import ./make-peer.nix;
+in
+{
+  name = "wireguard";
+  meta.maintainers = with lib.maintainers; [ ma27 ];
 
-    nodes = {
-      peer0 = peer {
-        ip4 = "192.168.0.1";
-        ip6 = "fd00::1";
-        extraConfig = {
-          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+  nodes = {
+    peer0 = peer {
+      ip4 = "192.168.0.1";
+      ip6 = "fd00::1";
+      extraConfig =
+        { lib, pkgs, ... }:
+        {
+          boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
           networking.firewall.allowedUDPPorts = [ 23542 ];
           networking.wireguard.interfaces.wg0 = {
             ips = [
@@ -41,13 +39,15 @@ import ../make-test-python.nix (
             };
           };
         };
-      };
+    };
 
-      peer1 = peer {
-        ip4 = "192.168.0.2";
-        ip6 = "fd00::2";
-        extraConfig = {
-          boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+    peer1 = peer {
+      ip4 = "192.168.0.2";
+      ip6 = "fd00::2";
+      extraConfig =
+        { lib, pkgs, ... }:
+        {
+          boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
           networking.wireguard.interfaces.wg0 = {
             ips = [
               "10.23.42.2/32"
@@ -71,25 +71,24 @@ import ../make-test-python.nix (
 
             postSetup =
               let
-                inherit (pkgs) iproute2;
+                ip = lib.getExe' pkgs.iproute2 "ip";
               in
               ''
-                ${iproute2}/bin/ip route replace 10.23.42.1/32 dev wg0
-                ${iproute2}/bin/ip route replace fc00::1/128 dev wg0
+                ${ip} route replace 10.23.42.1/32 dev wg0
+                ${ip} route replace fc00::1/128 dev wg0
               '';
           };
         };
-      };
     };
+  };
 
-    testScript = ''
-      start_all()
+  testScript = ''
+    start_all()
 
-      peer0.wait_for_unit("wireguard-wg0.service")
-      peer1.wait_for_unit("wireguard-wg0.service")
+    peer0.wait_for_unit("wireguard-wg0.service")
+    peer1.wait_for_unit("wireguard-wg0.service")
 
-      peer1.succeed("ping -c5 fc00::1")
-      peer1.succeed("ping -c5 10.23.42.1")
-    '';
-  }
-)
+    peer1.succeed("ping -c5 fc00::1")
+    peer1.succeed("ping -c5 10.23.42.1")
+  '';
+}

--- a/nixos/tests/wireguard/default.nix
+++ b/nixos/tests/wireguard/default.nix
@@ -1,46 +1,49 @@
 {
-  system ? builtins.currentSystem,
-  config ? { },
-  pkgs ? import ../../.. { inherit system config; },
+  runTest,
+  lib,
+  pkgs,
   # Test current default (LTS) and latest kernel
   kernelVersionsToTest ? [
-    (pkgs.lib.versions.majorMinor pkgs.linuxPackages.kernel.version)
+    (lib.versions.majorMinor pkgs.linuxPackages.kernel.version)
     "latest"
   ],
 }:
 
-with pkgs.lib;
-
 let
   tests =
     let
-      callTest = p: args: import p ({ inherit system pkgs; } // args);
+      callTest =
+        p: args:
+        runTest {
+          imports = [ p ];
+          _module = { inherit args; };
+        };
     in
     {
       basic = callTest ./basic.nix;
       amneziawg = callTest ./amneziawg.nix;
       namespaces = callTest ./namespaces.nix;
       networkd = callTest ./networkd.nix;
-      wg-quick = callTest ./wg-quick.nix;
+      wg-quick = args: callTest ./wg-quick.nix ({ nftables = false; } // args);
       wg-quick-nftables = args: callTest ./wg-quick.nix ({ nftables = true; } // args);
-      amneziawg-quick = callTest ./amneziawg-quick.nix;
+      amneziawg-quick = args: callTest ./amneziawg-quick.nix ({ nftables = false; } // args);
       generated = callTest ./generated.nix;
-      dynamic-refresh = callTest ./dynamic-refresh.nix;
+      dynamic-refresh = args: callTest ./dynamic-refresh.nix ({ useNetworkd = false; } // args);
       dynamic-refresh-networkd = args: callTest ./dynamic-refresh.nix ({ useNetworkd = true; } // args);
     };
 in
 
-listToAttrs (
-  flip concatMap kernelVersionsToTest (
+lib.listToAttrs (
+  lib.flip lib.concatMap kernelVersionsToTest (
     version:
     let
-      v' = replaceStrings [ "." ] [ "_" ] version;
+      v' = lib.replaceString "." "_" version;
     in
-    flip mapAttrsToList tests (
+    lib.flip lib.mapAttrsToList tests (
       name: test:
-      nameValuePair "wireguard-${name}-linux-${v'}" (test {
+      lib.nameValuePair "wireguard-${name}-linux-${v'}" (test {
         kernelPackages =
-          if v' == "latest" then pkgs.linuxPackages_latest else pkgs.linuxKernel.packages."linux_${v'}";
+          pkgs: if v' == "latest" then pkgs.linuxPackages_latest else pkgs.linuxKernel.packages."linux_${v'}";
       })
     )
   )

--- a/nixos/tests/wireguard/generated.nix
+++ b/nixos/tests/wireguard/generated.nix
@@ -1,22 +1,20 @@
-import ../make-test-python.nix (
-  {
-    pkgs,
-    lib,
-    kernelPackages ? null,
-    ...
-  }:
-  {
-    name = "wireguard-generated";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [
-        ma27
-        grahamc
-      ];
-    };
+{
+  lib,
+  kernelPackages ? null,
+  ...
+}:
+{
+  name = "wireguard-generated";
+  meta.maintainers = with lib.maintainers; [
+    ma27
+    grahamc
+  ];
 
-    nodes = {
-      peer1 = {
-        boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+  nodes = {
+    peer1 =
+      { lib, pkgs, ... }:
+      {
+        boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
         networking.firewall.allowedUDPPorts = [ 12345 ];
         networking.wireguard.interfaces.wg0 = {
           ips = [ "10.10.10.1/24" ];
@@ -27,8 +25,10 @@ import ../make-test-python.nix (
         };
       };
 
-      peer2 = {
-        boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+    peer2 =
+      { lib, pkgs, ... }:
+      {
+        boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
         networking.firewall.allowedUDPPorts = [ 12345 ];
         networking.wireguard.interfaces.wg0 = {
           ips = [ "10.10.10.2/24" ];
@@ -37,38 +37,37 @@ import ../make-test-python.nix (
           generatePrivateKeyFile = true;
         };
       };
-    };
+  };
 
-    testScript = ''
-      start_all()
+  testScript = ''
+    start_all()
 
-      peer1.wait_for_unit("wireguard-wg0.service")
-      peer2.wait_for_unit("wireguard-wg0.service")
+    peer1.wait_for_unit("wireguard-wg0.service")
+    peer2.wait_for_unit("wireguard-wg0.service")
 
-      retcode, peer1pubkey = peer1.execute("wg pubkey < /etc/wireguard/private")
-      if retcode != 0:
-          raise Exception("Could not read public key from peer1")
+    retcode, peer1pubkey = peer1.execute("wg pubkey < /etc/wireguard/private")
+    if retcode != 0:
+        raise Exception("Could not read public key from peer1")
 
-      retcode, peer2pubkey = peer2.execute("wg pubkey < /etc/wireguard/private")
-      if retcode != 0:
-          raise Exception("Could not read public key from peer2")
+    retcode, peer2pubkey = peer2.execute("wg pubkey < /etc/wireguard/private")
+    if retcode != 0:
+        raise Exception("Could not read public key from peer2")
 
-      peer1.succeed(
-          "wg set wg0 peer {} allowed-ips 10.10.10.2/32 endpoint 192.168.1.2:12345 persistent-keepalive 1".format(
-              peer2pubkey.strip()
-          )
-      )
-      peer1.succeed("ip route replace 10.10.10.2/32 dev wg0 table main")
+    peer1.succeed(
+        "wg set wg0 peer {} allowed-ips 10.10.10.2/32 endpoint 192.168.1.2:12345 persistent-keepalive 1".format(
+            peer2pubkey.strip()
+        )
+    )
+    peer1.succeed("ip route replace 10.10.10.2/32 dev wg0 table main")
 
-      peer2.succeed(
-          "wg set wg0 peer {} allowed-ips 10.10.10.1/32 endpoint 192.168.1.1:12345 persistent-keepalive 1".format(
-              peer1pubkey.strip()
-          )
-      )
-      peer2.succeed("ip route replace 10.10.10.1/32 dev wg0 table main")
+    peer2.succeed(
+        "wg set wg0 peer {} allowed-ips 10.10.10.1/32 endpoint 192.168.1.1:12345 persistent-keepalive 1".format(
+            peer1pubkey.strip()
+        )
+    )
+    peer2.succeed("ip route replace 10.10.10.1/32 dev wg0 table main")
 
-      peer1.succeed("ping -c1 10.10.10.2")
-      peer2.succeed("ping -c1 10.10.10.1")
-    '';
-  }
-)
+    peer1.succeed("ping -c1 10.10.10.2")
+    peer2.succeed("ping -c1 10.10.10.1")
+  '';
+}

--- a/nixos/tests/wireguard/make-peer.nix
+++ b/nixos/tests/wireguard/make-peer.nix
@@ -1,32 +1,33 @@
-{ lib, ... }:
 {
   ip4,
   ip6,
   extraConfig,
 }:
-lib.mkMerge [
-  {
-    boot.kernel.sysctl = {
-      "net.ipv6.conf.all.forwarding" = "1";
-      "net.ipv6.conf.default.forwarding" = "1";
-      "net.ipv4.ip_forward" = "1";
-    };
+{
+  imports = [
+    {
+      boot.kernel.sysctl = {
+        "net.ipv6.conf.all.forwarding" = "1";
+        "net.ipv6.conf.default.forwarding" = "1";
+        "net.ipv4.ip_forward" = "1";
+      };
 
-    networking.useDHCP = false;
-    networking.interfaces.eth1 = {
-      ipv4.addresses = [
-        {
-          address = ip4;
-          prefixLength = 24;
-        }
-      ];
-      ipv6.addresses = [
-        {
-          address = ip6;
-          prefixLength = 64;
-        }
-      ];
-    };
-  }
-  extraConfig
-]
+      networking.useDHCP = false;
+      networking.interfaces.eth1 = {
+        ipv4.addresses = [
+          {
+            address = ip4;
+            prefixLength = 24;
+          }
+        ];
+        ipv6.addresses = [
+          {
+            address = ip6;
+            prefixLength = 64;
+          }
+        ];
+      };
+    }
+    extraConfig
+  ];
+}

--- a/nixos/tests/wireguard/namespaces.nix
+++ b/nixos/tests/wireguard/namespaces.nix
@@ -1,3 +1,8 @@
+{
+  lib,
+  kernelPackages ? null,
+  ...
+}:
 let
   listenPort = 12345;
   socketNamespace = "foo";
@@ -10,27 +15,18 @@ let
       generatePrivateKeyFile = true;
     };
   };
-
 in
+{
+  name = "wireguard-with-namespaces";
+  meta.maintainers = with lib.maintainers; [ asymmetric ];
 
-import ../make-test-python.nix (
-  {
-    pkgs,
-    lib,
-    kernelPackages ? null,
-    ...
-  }:
-  {
-    name = "wireguard-with-namespaces";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ asymmetric ];
-    };
-
-    nodes = {
-      # interface should be created in the socketNamespace
-      # and not moved from there
-      peer0 = pkgs.lib.attrsets.recursiveUpdate node {
-        boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+  nodes = {
+    # interface should be created in the socketNamespace
+    # and not moved from there
+    peer0 =
+      { lib, pkgs, ... }:
+      lib.attrsets.recursiveUpdate node {
+        boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
         networking.wireguard.interfaces.wg0 = {
           preSetup = ''
             ip netns add ${socketNamespace}
@@ -38,10 +34,12 @@ import ../make-test-python.nix (
           inherit socketNamespace;
         };
       };
-      # interface should be created in the init namespace
-      # and moved to the interfaceNamespace
-      peer1 = pkgs.lib.attrsets.recursiveUpdate node {
-        boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+    # interface should be created in the init namespace
+    # and moved to the interfaceNamespace
+    peer1 =
+      { lib, pkgs, ... }:
+      lib.attrsets.recursiveUpdate node {
+        boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
         networking.wireguard.interfaces.wg0 = {
           preSetup = ''
             ip netns add ${interfaceNamespace}
@@ -50,10 +48,12 @@ import ../make-test-python.nix (
           inherit interfaceNamespace;
         };
       };
-      # interface should be created in the socketNamespace
-      # and moved to the interfaceNamespace
-      peer2 = pkgs.lib.attrsets.recursiveUpdate node {
-        boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+    # interface should be created in the socketNamespace
+    # and moved to the interfaceNamespace
+    peer2 =
+      { lib, pkgs, ... }:
+      lib.attrsets.recursiveUpdate node {
+        boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
         networking.wireguard.interfaces.wg0 = {
           preSetup = ''
             ip netns add ${socketNamespace}
@@ -62,10 +62,12 @@ import ../make-test-python.nix (
           inherit socketNamespace interfaceNamespace;
         };
       };
-      # interface should be created in the socketNamespace
-      # and moved to the init namespace
-      peer3 = pkgs.lib.attrsets.recursiveUpdate node {
-        boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+    # interface should be created in the socketNamespace
+    # and moved to the init namespace
+    peer3 =
+      { lib, pkgs, ... }:
+      lib.attrsets.recursiveUpdate node {
+        boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
         networking.wireguard.interfaces.wg0 = {
           preSetup = ''
             ip netns add ${socketNamespace}
@@ -74,18 +76,17 @@ import ../make-test-python.nix (
           interfaceNamespace = "init";
         };
       };
-    };
+  };
 
-    testScript = ''
-      start_all()
+  testScript = ''
+    start_all()
 
-      for machine in peer0, peer1, peer2, peer3:
-          machine.wait_for_unit("wireguard-wg0.service")
+    for machine in peer0, peer1, peer2, peer3:
+        machine.wait_for_unit("wireguard-wg0.service")
 
-      peer0.succeed("ip -n ${socketNamespace} link show wg0")
-      peer1.succeed("ip -n ${interfaceNamespace} link show wg0")
-      peer2.succeed("ip -n ${interfaceNamespace} link show wg0")
-      peer3.succeed("ip link show wg0")
-    '';
-  }
-)
+    peer0.succeed("ip -n ${socketNamespace} link show wg0")
+    peer1.succeed("ip -n ${interfaceNamespace} link show wg0")
+    peer2.succeed("ip -n ${interfaceNamespace} link show wg0")
+    peer3.succeed("ip link show wg0")
+  '';
+}

--- a/nixos/tests/wireguard/wg-quick.nix
+++ b/nixos/tests/wireguard/wg-quick.nix
@@ -1,104 +1,101 @@
-import ../make-test-python.nix (
-  {
-    pkgs,
-    lib,
-    kernelPackages ? null,
-    nftables ? false,
-    ...
-  }:
-  let
-    wg-snakeoil-keys = import ./snakeoil-keys.nix;
-    peer = import ./make-peer.nix { inherit lib; };
-    commonConfig = {
-      boot.kernelPackages = lib.mkIf (kernelPackages != null) kernelPackages;
+{
+  lib,
+  kernelPackages ? null,
+  nftables ? false,
+  ...
+}:
+let
+  wg-snakeoil-keys = import ./snakeoil-keys.nix;
+  peer = import ./make-peer.nix;
+  commonConfig =
+    { pkgs, ... }:
+    {
+      boot.kernelPackages = lib.mkIf (kernelPackages != null) (kernelPackages pkgs);
       networking.nftables.enable = nftables;
       # Make sure iptables doesn't work with nftables enabled
       boot.blacklistedKernelModules = lib.mkIf nftables [ "nft_compat" ];
     };
-  in
-  {
-    name = "wg-quick";
+in
+{
+  name = "wg-quick";
 
-    nodes = {
-      peer0 = peer {
-        ip4 = "192.168.0.1";
-        ip6 = "fd00::1";
-        extraConfig = lib.mkMerge [
-          commonConfig
-          {
-            networking.firewall.allowedUDPPorts = [ 23542 ];
-            networking.wg-quick.interfaces.wg0 = {
-              address = [
-                "10.23.42.1/32"
-                "fc00::1/128"
-              ];
-              listenPort = 23542;
+  nodes = {
+    peer0 = peer {
+      ip4 = "192.168.0.1";
+      ip6 = "fd00::1";
+      extraConfig = {
+        imports = [ commonConfig ];
 
-              inherit (wg-snakeoil-keys.peer0) privateKey;
+        networking.firewall.allowedUDPPorts = [ 23542 ];
+        networking.wg-quick.interfaces.wg0 = {
+          address = [
+            "10.23.42.1/32"
+            "fc00::1/128"
+          ];
+          listenPort = 23542;
 
-              peers = lib.singleton {
-                allowedIPs = [
-                  "10.23.42.2/32"
-                  "fc00::2/128"
-                ];
+          inherit (wg-snakeoil-keys.peer0) privateKey;
 
-                inherit (wg-snakeoil-keys.peer1) publicKey;
-              };
+          peers = lib.singleton {
+            allowedIPs = [
+              "10.23.42.2/32"
+              "fc00::2/128"
+            ];
 
-              dns = [
-                "10.23.42.2"
-                "fc00::2"
-                "wg0"
-              ];
-            };
-          }
-        ];
-      };
+            inherit (wg-snakeoil-keys.peer1) publicKey;
+          };
 
-      peer1 = peer {
-        ip4 = "192.168.0.2";
-        ip6 = "fd00::2";
-        extraConfig = lib.mkMerge [
-          commonConfig
-          {
-            networking.useNetworkd = true;
-            networking.wg-quick.interfaces.wg0 = {
-              address = [
-                "10.23.42.2/32"
-                "fc00::2/128"
-              ];
-              inherit (wg-snakeoil-keys.peer1) privateKey;
-
-              peers = lib.singleton {
-                allowedIPs = [
-                  "0.0.0.0/0"
-                  "::/0"
-                ];
-                endpoint = "192.168.0.1:23542";
-                persistentKeepalive = 25;
-
-                inherit (wg-snakeoil-keys.peer0) publicKey;
-              };
-
-              dns = [
-                "10.23.42.1"
-                "fc00::1"
-                "wg0"
-              ];
-            };
-          }
-        ];
+          dns = [
+            "10.23.42.2"
+            "fc00::2"
+            "wg0"
+          ];
+        };
       };
     };
 
-    testScript = ''
-      start_all()
+    peer1 = peer {
+      ip4 = "192.168.0.2";
+      ip6 = "fd00::2";
+      extraConfig = {
+        imports = [ commonConfig ];
 
-      peer0.wait_for_unit("wg-quick-wg0.service")
-      peer1.wait_for_unit("wg-quick-wg0.service")
+        networking.useNetworkd = true;
+        networking.wg-quick.interfaces.wg0 = {
+          address = [
+            "10.23.42.2/32"
+            "fc00::2/128"
+          ];
+          inherit (wg-snakeoil-keys.peer1) privateKey;
 
-      peer1.succeed("ping -c5 fc00::1")
-      peer1.succeed("ping -c5 10.23.42.1")
-    '';
-  }
-)
+          peers = lib.singleton {
+            allowedIPs = [
+              "0.0.0.0/0"
+              "::/0"
+            ];
+            endpoint = "192.168.0.1:23542";
+            persistentKeepalive = 25;
+
+            inherit (wg-snakeoil-keys.peer0) publicKey;
+          };
+
+          dns = [
+            "10.23.42.1"
+            "fc00::1"
+            "wg0"
+          ];
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    peer0.wait_for_unit("wg-quick-wg0.service")
+    peer1.wait_for_unit("wg-quick-wg0.service")
+
+    peer1.succeed("ping -c5 fc00::1")
+    peer1.succeed("ping -c5 10.23.42.1")
+  '';
+}


### PR DESCRIPTION
This PR causes 0 rebuilds.

Run the following commands on 214bf605 (master) and 71d0e1c8 (this PR) and compare outputs, note that the derivations are the same.

```
nix eval --read-only .#nixosTests.wireguard
```

Related to #386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
