### PR TITLE
nixos/plymouth-tpm2-totp: init

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1,4 +1,19 @@
 {
+  "module-boot-plymouth-tpm2-totp": [
+    "index.html#module-boot-plymouth-tpm2-totp"
+  ],
+  "module-boot-plymouth-tpm2-totp-quick-start": [
+    "index.html#module-boot-plymouth-tpm2-totp-quick-start"
+  ],
+  "module-boot-plymouth-tpm2-totp-quick-start-check": [
+    "index.html#module-boot-plymouth-tpm2-totp-quick-start-check"
+  ],
+  "module-boot-plymouth-tpm2-totp-quick-start-configure": [
+    "index.html#module-boot-plymouth-tpm2-totp-quick-start-configure"
+  ],
+  "module-boot-plymouth-tpm2-totp-quick-start-enable": [
+    "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
+  ],
   "sec-override-nixos-test": [
     "index.html#sec-override-nixos-test"
   ],

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -88,6 +88,8 @@
 
 - The [Neat IP Address Planner](https://spritelink.github.io/NIPAP/) (NIPAP) can now be enabled through [services.nipap.enable](#opt-services.nipap.enable).
 
+- [tpm2-totp](https://github.com/tpm2-software/tpm2-totp) can now be used to show a TOTP during boot using Plymouth. Available as [boot.plymouth.tpm2-totp](#opt-boot.plymouth.tpm2-totp.enable).
+
 - [nix-store-veritysetup](https://github.com/nikstur/nix-store-veritysetup-generator), a systemd generator to unlock the Nix Store as a dm-verity protected block device. Available as [boot.initrd.nix-store-veritysetup](options.html#opt-boot.initrd.nix-store-veritysetup.enable).
 
 - [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1829,6 +1829,7 @@
   ./system/boot/modprobe.nix
   ./system/boot/networkd.nix
   ./system/boot/nix-store-veritysetup.nix
+  ./system/boot/plymouth-tpm2-totp.nix
   ./system/boot/plymouth.nix
   ./system/boot/resolved.nix
   ./system/boot/shutdown.nix

--- a/nixos/modules/system/boot/plymouth-tpm2-totp.md
+++ b/nixos/modules/system/boot/plymouth-tpm2-totp.md
@@ -1,0 +1,29 @@
+# tpm2-totp with Plymouth {#module-boot-plymouth-tpm2-totp}
+
+[tpm2-totp](https://github.com/tpm2-software/tpm2-totp) attests the trustworthiness of a device against a human using time-based one-time passwords. This module uses a `tpm2-totp` configuration to display a TOTP at boot using Plymouth.
+
+## Quick start {#module-boot-plymouth-tpm2-totp-quick-start}
+
+### 1. Enable modules {#module-boot-plymouth-tpm2-totp-quick-start-enable}
+
+```nix
+{
+  boot.plymouth.tpm2-totp.enable = true;
+
+  # Plymouth and systemd initrd/stage-1 are required:
+  boot.plymouth.enable = true;
+  boot.initrd.systemd.enable = true;
+}
+```
+
+Switch to the new configuration before proceeding to the next step.
+
+### 2. Configure `tpm2-totp` {#module-boot-plymouth-tpm2-totp-quick-start-configure}
+
+Generate a new TOTP secret and save the secret in your chosen authenticator app. See `man tpm2-totp` for commands and configuration examples.
+
+More information, including security considerations, can be found in the `README.md` in the [tpm2-totp](https://github.com/tpm2-software/tpm2-totp) repository. Be sure to select the tag for the version of `tpm2-totp` you have installed.
+
+### 3. Check configuration {#module-boot-plymouth-tpm2-totp-quick-start-check}
+
+Reboot and you should see the TOTP appear on the Plymouth boot screen. The TOTP should match the code displayed in your authenticator app (or the code immediately before/after).

--- a/nixos/modules/system/boot/plymouth-tpm2-totp.nix
+++ b/nixos/modules/system/boot/plymouth-tpm2-totp.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.boot.plymouth.tpm2-totp;
+in
+{
+  options.boot.plymouth.tpm2-totp = {
+    enable = lib.mkEnableOption "tpm2-totp using Plymouth" // {
+      description = "Whether to display a TOTP during boot using tpm2-totp and Plymouth.";
+    };
+
+    package = lib.mkPackageOption pkgs "tpm2-totp" { default = "tpm2-totp-with-plymouth"; };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ majiir ];
+    doc = ./plymouth-tpm2-totp.md;
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.boot.initrd.systemd.enable;
+        message = "boot.plymouth.tpm2-totp is only supported with boot.initrd.systemd.";
+      }
+    ];
+
+    environment.systemPackages = [
+      cfg.package
+    ];
+
+    boot.initrd.systemd.storePaths = [
+      "${cfg.package}/libexec/tpm2-totp/plymouth-tpm2-totp"
+      "${cfg.package}/lib/libtpm2-totp.so.0"
+      "${cfg.package}/lib/libtpm2-totp.so.0.0.0"
+    ];
+
+    # Based on https://github.com/tpm2-software/tpm2-totp/blob/9bcfdcbfdd42e0b2e1d7769852009608f889631c/dist/plymouth-tpm2-totp.service.in
+    boot.initrd.systemd.services.plymouth-tpm2-totp = {
+      description = "Display a TOTP during boot using Plymouth";
+      requires = [ "plymouth-start.service" ];
+      after = [
+        "plymouth-start.service"
+        "tpm2.target"
+      ];
+      wantedBy = [ "sysinit.target" ];
+      unitConfig.DefaultDependencies = false;
+      serviceConfig = {
+        Type = "exec";
+        ExecStart = "${cfg.package}/libexec/tpm2-totp/plymouth-tpm2-totp";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/tp/tpm2-totp/package.nix
+++ b/pkgs/by-name/tp/tpm2-totp/package.nix
@@ -7,6 +7,8 @@
   autoconf-archive,
   pandoc,
   pkg-config,
+  withPlymouth ? false,
+  plymouth,
   qrencode,
 }:
 
@@ -35,7 +37,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     tpm2-tss
     qrencode
-  ];
+  ]
+  ++ lib.optional withPlymouth plymouth;
 
   meta = with lib; {
     description = "Attest the trustworthiness of a device against a human using time-based one-time passwords";

--- a/pkgs/by-name/tp/tpm2-totp/package.nix
+++ b/pkgs/by-name/tp/tpm2-totp/package.nix
@@ -5,6 +5,7 @@
   tpm2-tss,
   autoreconfHook,
   autoconf-archive,
+  pandoc,
   pkg-config,
   qrencode,
 }:
@@ -27,6 +28,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     autoconf-archive
+    pandoc
     pkg-config
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4275,6 +4275,10 @@ with pkgs;
     }
   );
 
+  tpm2-totp-with-plymouth = tpm2-totp.override {
+    withPlymouth = true;
+  };
+
   trackma-curses = trackma.override { withCurses = true; };
 
   trackma-gtk = trackma.override { withGTK = true; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Summary

- Fixes man page generation for `tpm2-totp`.
- Adds a `boot.plymouth.tpm2-totp` module for showing a TOTP during boot using `tpm2-totp` and Plymouth.

## Pings

@RaitoBezarius (`tpm2-totp` maintainer)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
