### PR TITLE
scx.full: 1.0.13 -> 1.0.14

### DIFF
--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -118,10 +118,9 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   # We copy the compiled header files to the dev output
   # These are needed for the rust schedulers
-  preInstall = ''
-    mkdir -p ${placeholder "dev"}/libbpf ${placeholder "dev"}/bpftool
-    cp -r libbpf/* ${placeholder "dev"}/libbpf/
-    cp -r bpftool/* ${placeholder "dev"}/bpftool/
+  postFixup = ''
+    mkdir -p ${placeholder "dev"}
+    cp -r libbpf ${placeholder "dev"}
   '';
 
   outputs = [

--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -67,6 +67,10 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     cp ${finalAttrs.fetchLibbpf} meson-scripts/fetch_libbpf
     substituteInPlace meson.build \
       --replace-fail '[build_bpftool' "['${misbehaviorBash}', build_bpftool"
+
+    # TODO: Remove in next release.
+    substituteInPlace lib/scxtest/overrides.h \
+      --replace-fail '#define __builtin_preserve_enum_value(x,y,z) 1' '#define __builtin_preserve_enum_value(x,y) 1'
   '';
 
   nativeBuildInputs =

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -20,8 +20,7 @@ rustPlatform.buildRustPackage {
 
   # Copy compiled headers and libs from scx.cscheds
   postPatch = ''
-    mkdir bpftool libbpf
-    cp -r ${scx.cscheds.dev}/bpftool/* bpftool/
+    mkdir libbpf
     cp -r ${scx.cscheds.dev}/libbpf/* libbpf/
   '';
 

--- a/pkgs/os-specific/linux/scx/version.json
+++ b/pkgs/os-specific/linux/scx/version.json
@@ -1,8 +1,8 @@
 {
   "scx": {
-    "version": "1.0.13",
-    "hash": "sha256-uSYkAsDZEWJ7sB6jd7PZrwYepeLlTdiTi4kAgSDeVsU=",
-    "cargoHash": "sha256-+JDe7l4wX2balOUD11M9z60JSaRyMaIO7Pw1NrjnE30="
+    "version": "1.0.14",
+    "hash": "sha256-Wh+8vaQO93Erj+z8S2C633UDmUrFjQc3Bg+Nm7EML0E=",
+    "cargoHash": "sha256-6uiDx2/5ZcYkz8x8vuOTEUclIttzxVMvh1Q6QHg9N6E="
   },
   "bpftool": {
     "rev": "183e7010387d1fc9f08051426e9a9fbd5f8d409e",


### PR DESCRIPTION
Changelog: https://github.com/sched-ext/scx/releases/tag/v1.0.14
Diff: https://github.com/sched-ext/scx/compare/v1.0.13...v1.0.14

Tests ran successfully and I manually ran all schedulers.
`scx_central` is still non-functional, same as in `1.0.13` (in nixpkgs).

The `substituteInPlace` is needed to compile. It should be removed in the next release, since it already has been changed in master (see: https://github.com/sched-ext/scx/blob/main/lib/scxtest/overrides.h#L16)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
