### PR TITLE
[Backport release-25.05] i-pi: 3.1.4 -> 3.1.5.1

### DIFF
--- a/pkgs/development/python-modules/i-pi/default.nix
+++ b/pkgs/development/python-modules/i-pi/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "i-pi";
-  version = "3.1.5";
+  version = "3.1.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "i-pi";
     repo = "i-pi";
     tag = "v${version}";
-    hash = "sha256-jXryhWC8IGdj33rM50KHxX9WONyJlqpUXbzi33VQdPA=";
+    hash = "sha256-az1rQlXwYUyPA4wP5wxBZtmJhQlvHxhRZF2O141i76o=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/i-pi/default.nix
+++ b/pkgs/development/python-modules/i-pi/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "i-pi";
-  version = "3.1.4";
+  version = "3.1.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "i-pi";
     repo = "i-pi";
     tag = "v${version}";
-    hash = "sha256-qM1DQNHTliYGWtVeYo0KEAg88cdt9GPB9w0pep0erj8=";
+    hash = "sha256-jXryhWC8IGdj33rM50KHxX9WONyJlqpUXbzi33VQdPA=";
   };
 
   build-system = [


### PR DESCRIPTION
Manual backport of #412647 #420943 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.