### PR TITLE
[Backport staging-25.05] python3Packages.watchdog: remove ineffective test deselection and use `disabledTestPaths` for remaining test deselection

### DIFF
--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -43,53 +43,47 @@ buildPythonPackage rec {
       --replace "--cov-report=term-missing" ""
   '';
 
-  pytestFlagsArray =
-    [
-      "--deselect=tests/test_emitter.py::test_create_wrong_encoding"
-      "--deselect=tests/test_emitter.py::test_close"
-      # assert cap.out.splitlines(keepends=False).count('+++++ 0') == 2 != 3
-      "--deselect=tests/test_0_watchmedo.py::test_auto_restart_on_file_change_debounce"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
-      # fails to stop process in teardown
-      "--deselect=tests/test_0_watchmedo.py::test_auto_restart_subprocess_termination"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-      # FileCreationEvent != FileDeletionEvent
-      "--deselect=tests/test_emitter.py::test_separate_consecutive_moves"
-      "--deselect=tests/test_observers_polling.py::test___init__"
-      # segfaults
-      "--deselect=tests/test_delayed_queue.py::test_delayed_get"
-      "--deselect=tests/test_emitter.py::test_delete"
-      # AttributeError: '_thread.RLock' object has no attribute 'key'"
-      "--deselect=tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-      # segfaults
-      "--deselect=tests/test_delayed_queue.py::test_delayed_get"
-      "--deselect=tests/test_0_watchmedo.py::test_tricks_from_file"
-      "--deselect=tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_1"
-      "--deselect=tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_2"
-      "--deselect=tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
-      "--deselect=tests/test_fsevents.py::test_recursive_check_accepts_relative_paths"
-      # fsevents:fsevents.py:318 Unhandled exception in FSEventsEmitter
-      "--deselect=tests/test_fsevents.py::test_watchdog_recursive"
-      # SystemError: Cannot start fsevents stream. Use a kqueue or polling observer...
-      "--deselect=tests/test_fsevents.py::test_add_watch_twice"
-      # gets stuck
-      "--deselect=tests/test_fsevents.py::test_converting_cfstring_to_pyunicode"
-    ];
-
   disabledTestPaths =
     [
+      "tests/test_emitter.py::test_create_wrong_encoding"
+      "tests/test_emitter.py::test_close"
       # tests timeout easily
       "tests/test_inotify_buffer.py"
+      # assert cap.out.splitlines(keepends=False).count('+++++ 0') == 2 != 3
+      "tests/test_0_watchmedo.py::test_auto_restart_on_file_change_debounce"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
       # segfaults the testsuite
       "tests/test_emitter.py"
       # unsupported on x86_64-darwin
       "tests/test_fsevents.py"
+      # fails to stop process in teardown
+      "tests/test_0_watchmedo.py::test_auto_restart_subprocess_termination"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+      # FileCreationEvent != FileDeletionEvent
+      "tests/test_emitter.py::test_separate_consecutive_moves"
+      "tests/test_observers_polling.py::test___init__"
+      # segfaults
+      "tests/test_delayed_queue.py::test_delayed_get"
+      "tests/test_emitter.py::test_delete"
+      # AttributeError: '_thread.RLock' object has no attribute 'key'"
+      "tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+      # segfaults
+      "tests/test_delayed_queue.py::test_delayed_get"
+      "tests/test_0_watchmedo.py::test_tricks_from_file"
+      "tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_1"
+      "tests/test_fsevents.py::test_watcher_deletion_while_receiving_events_2"
+      "tests/test_skip_repeats_queue.py::test_eventlet_monkey_patching"
+      "tests/test_fsevents.py::test_recursive_check_accepts_relative_paths"
+      # fsevents:fsevents.py:318 Unhandled exception in FSEventsEmitter
+      "tests/test_fsevents.py::test_watchdog_recursive"
+      # SystemError: Cannot start fsevents stream. Use a kqueue or polling observer...
+      "tests/test_fsevents.py::test_add_watch_twice"
+      # gets stuck
+      "tests/test_fsevents.py::test_converting_cfstring_to_pyunicode"
     ];
 
   pythonImportsCheck = [ "watchdog" ];

--- a/pkgs/development/python-modules/watchdog/default.nix
+++ b/pkgs/development/python-modules/watchdog/default.nix
@@ -76,8 +76,6 @@ buildPythonPackage rec {
       "--deselect=tests/test_fsevents.py::test_watchdog_recursive"
       # SystemError: Cannot start fsevents stream. Use a kqueue or polling observer...
       "--deselect=tests/test_fsevents.py::test_add_watch_twice"
-      # fsevents:fsevents.py:318 Unhandled exception in FSEventsEmitter
-      "--deselect=ests/test_fsevents.py::test_recursive_check_accepts_relative_paths"
       # gets stuck
       "--deselect=tests/test_fsevents.py::test_converting_cfstring_to_pyunicode"
     ];


### PR DESCRIPTION
Manual backport of #424799 to `staging-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.