### PR TITLE
home-assistant-custom-components.lednetwf_ble: 0.0.14.2 -> 0.0.15

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/lednetwf_ble/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/lednetwf_ble/package.nix
@@ -8,7 +8,7 @@
   nix-update-script,
 }:
 let
-  version = "0.0.14.2";
+  version = "0.0.15";
 in
 buildHomeAssistantComponent {
   owner = "8none1";
@@ -18,8 +18,8 @@ buildHomeAssistantComponent {
   src = fetchFromGitHub {
     owner = "8none1";
     repo = "lednetwf_ble";
-    tag = "v.${version}";
-    hash = "sha256-FgLUBCIYsmvrU8auraFVJ+hnl/p6KHpEeIWMT4KGJBM=";
+    tag = "v${version}";
+    hash = "sha256-Ir3a6mr9OmBiiHRJktrv6HirHcVzKhc730aq6lynTmg=";
   };
 
   dependencies = [
@@ -36,7 +36,7 @@ buildHomeAssistantComponent {
   meta = {
     description = "Home Assistant custom integration for LEDnetWF devices";
     homepage = "https://github.com/8none1/lednetwf_ble";
-    changelog = "https://github.com/8none1/lednetwf_ble/releases/tag/v.${version}";
+    changelog = "https://github.com/8none1/lednetwf_ble/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ blenderfreaky ];
   };


### PR DESCRIPTION
The previous version had an extra dot in it, so the auto-updater failed. The previous tag was `v.0.0.14.2`, now it's `v0.0.15` (no dot after the v).

It seems like all other versions also do not have the extra dot, so auto-updates should work in the future now.

Minor side-note: the extension still shows up as 0.0.14.3 in Home Assistant - seems like they forgot to update the manifest. Extension works fine though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
