### PR TITLE
intel-oneapi.{base,hpc}kit: init at 2025.2.0.592, 2025.2.0.575

### DIFF
--- a/pkgs/by-name/gd/gdbm/1.13.nix
+++ b/pkgs/by-name/gd/gdbm/1.13.nix
@@ -1,0 +1,80 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+}:
+let
+  pname = "gdbm";
+  version = "1.13";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "mirror://gnu/gdbm/${pname}-${version}.tar.gz";
+    sha256 = "0lx201q20dvc70f8a3c9s7s18z15inlxvbffph97ngvrgnyjq9cx";
+  };
+
+  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+
+  # Linking static stubs on cygwin requires correct ordering.
+  # Consider upstreaming this.
+
+  # Disable dbmfetch03.at test because it depends on unlink()
+  # failing on a link in a chmod -w directory, which cygwin
+  # apparently allows.
+  postPatch =
+    lib.optionalString stdenv.buildPlatform.isCygwin ''
+      substituteInPlace tests/Makefile.in --replace-fail \
+        '_LDADD = ../src/libgdbm.la ../compat/libgdbm_compat.la' \
+        '_LDADD = ../compat/libgdbm_compat.la ../src/libgdbm.la'
+      substituteInPlace tests/testsuite.at --replace-fail \
+        'm4_include([dbmfetch03.at])' ""
+    ''
+    + ''
+      # GCC>10 fix, see here: https://bugs.gentoo.org/705898
+      substituteInPlace src/parseopt.c \
+        --replace-fail "char *parseopt_program_doc;" "extern char *parseopt_program_doc;" \
+        --replace-fail "char *parseopt_program_args;" "extern char *parseopt_program_args;"
+    '';
+  configureFlags = [ "--enable-libgdbm-compat" ];
+
+  postInstall = ''
+    # create symlinks for compatibility
+    install -dm755 $out/include/gdbm
+    (
+      cd $out/include/gdbm
+      ln -s ../gdbm.h gdbm.h
+      ln -s ../ndbm.h ndbm.h
+      ln -s ../dbm.h  dbm.h
+    )
+  '';
+
+  meta = {
+    description = "GNU dbm key/value database library";
+
+    longDescription = ''
+      GNU dbm (or GDBM, for short) is a library of database functions that
+              use extensible hashing and work similar to the standard UNIX dbm.
+              These routines are provided to a programmer needing to create and
+              manipulate a hashed database.
+
+              The basic use of GDBM is to store key/data pairs in a data file.
+              Each key must be unique and each key is paired with only one data
+              item.
+
+              The library provides primitives for storing key/data pairs,
+              searching and retrieving the data by its key and deleting a key
+              along with its data.  It also support sequential iteration over all
+              key/data pairs in a database.
+
+              For compatibility with programs using old UNIX dbm function, the
+              package also provides traditional dbm and ndbm interfaces.
+    '';
+
+    homepage = "http://www.gnu.org/software/gdbm/";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.blenderfreaky ];
+  };
+}

--- a/pkgs/by-name/in/intel-oneapi-basekit/group-dependencies.sh
+++ b/pkgs/by-name/in/intel-oneapi-basekit/group-dependencies.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p ripgrep gawk coreutils
+
+# Pipe the toolkit build log through this script to see
+# which components are missing which dependencies.
+#
+# For example:
+# $ nix log /nix/store/k5p88p8qih7aw7fs2yvxgz37sc8dr4mx-intel-oneapi-hpckit-2025.2.0.575.drv | ./group-dependencies.sh
+# advisor:
+#   - libgdbm_compat.so.4
+#   - libgdbm.so.4
+#   - libXxf86vm.so.1
+#
+# vtune:
+#   - libgdbm_compat.so.4
+#   - libgdbm.so.4
+#   - libopencl-clang.so.14
+
+rg "error: auto-patchelf could not satisfy dependency (.+?) wanted by (.+)" -r '$2: $1' | \
+  awk '
+    BEGIN { FS = ": "; OFS = ": " }
+
+    # Nearly everything requires libz.so.1, so we filter it out for brevity
+    $2 == "libz.so.1" { next }
+
+    # Group dependencies by the OneAPI component they are a part of
+    # (like mpi, advisor, compiler, ...)
+    {
+      if (match($1, /\/opt\/intel\/oneapi\/([^\/]+)/, a)) {
+        print a[1], $2
+      } else {
+        print "other", $2
+      }
+    }
+  ' | \
+  sort -u | \
+  awk '
+    BEGIN { FS = ": " }
+    $1 != last_group {
+      if (NR > 1) { print "" } # Add space between groups
+      print $1 ":"
+      last_group = $1
+    }
+    { print "  - " $2 }
+  '

--- a/pkgs/by-name/in/intel-oneapi-basekit/installer.nix
+++ b/pkgs/by-name/in/intel-oneapi-basekit/installer.nix
@@ -265,15 +265,14 @@ let
                   --components "$COMPONENTS" \
                   --log-dir ./log \
                   --ignore-errors \
-                  --install-dir $OUT \
+                  --install-dir $out \
               '';
             in
             ''
               runHook preInstall
 
-              export OUT=$out/opt/intel/oneapi
               export COMPONENTS=${components_string}
-              mkdir -p $OUT
+              mkdir -p $out
               ${fhs}/bin/oneapi-installer-fhs-env -- ${install}
 
               runHook postInstall

--- a/pkgs/by-name/in/intel-oneapi-basekit/installer.nix
+++ b/pkgs/by-name/in/intel-oneapi-basekit/installer.nix
@@ -1,0 +1,325 @@
+{
+  buildFHSEnv,
+  stdenv,
+  lib,
+  writeShellScript,
+  fetchurl,
+  autoPatchelfHook,
+
+  config,
+  cudaSupport ? config.cudaSupport,
+  cudaPackages,
+  autoAddDriverRunpath,
+
+  # Core dependencies
+  level-zero,
+  zlib,
+  gcc,
+
+  # MPI dependencies
+  rdma-core,
+  numactl,
+  libpsm2,
+  ucx,
+  libuuid,
+
+  # UI dependencies
+  alsa-lib,
+  at-spi2-atk,
+  bzip2,
+  cairo,
+  libxcrypt-legacy,
+  cups, # .lib
+  dbus, # .lib
+  libdrm,
+  expat,
+  libffi_3_2_1,
+  libgbm,
+  gdbm_1_13,
+  glib,
+  ncurses5,
+  nspr,
+  nss,
+  pango,
+  sqlite,
+  systemd, # For libudev
+  # libuuid,
+  xorg, # .libX11, .libxcb, .libXcomposite, .libXdamage, .libXext, .libXfixes, .libXrandr
+  libxkbcommon,
+
+  # Advisor-only dependencies
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  gtk2,
+  # xorg.libXxf86vm
+
+  # VTune-only dependencies
+  elfutils,
+  gtk3,
+  libnotify,
+  opencl-clang_14,
+  xdg-utils,
+}:
+let
+  makeKit =
+    {
+      # "base" or "hpc"
+      kit,
+      version,
+      uuid,
+      sha256,
+    }:
+    let
+      withComponents =
+        # The components to install
+        # Note that because the offline installer is used, all components will still
+        # be downloaded, however only the selected components will be installed.
+        # Options:
+        # "all", "default", or ["foo", "bar", ...], ["default", "foo", ...] where foo, bar
+        # are components of the Intel OneAPI HPC Toolkit like:
+        #  intel.oneapi.lin.dpcpp-cpp-compiler
+        #  intel.oneapi.lin.dpl
+        #  intel.oneapi.lin.vtune
+        #  ...
+        # or "list", which is a utility that makes the installer list the available components
+        # and exit with a non-zero status code, so that you can see the available components
+        # without running the installer yourself
+        components:
+        let
+          components_all = components == "all";
+          components_default =
+            components == "default" || (lib.isList components && lib.elem "default" components);
+          components_string =
+            if lib.isString components then
+              if components_all || components_default || components == "list" then
+                components
+              else
+                throw "Invalid string for Intel oneAPI components specification. Expected 'all', 'default' or 'list', but got \"${components}\"."
+            else if lib.isList components then
+              if lib.all lib.isString components then
+                if lib.elem "default" components then
+                  let
+                    # "default" is a special-case, and the final string should start with it
+                    otherComponents = lib.filter (c: c != "default") components;
+                    orderedComponents = [ "default" ] ++ otherComponents;
+                  in
+                  lib.concatStringsSep ":" orderedComponents
+                else
+                  lib.concatStringsSep ":" components
+              else
+                throw "Invalid list for oneAPI components specification. The list must only contain strings representing component names."
+            else
+              throw "Invalid type for oneAPI components specification. Expected a string ('all', 'default' or 'list') or a list of component names, but got a ${lib.typeOf components}.";
+          components_used =
+            let
+              all_or_default = components_all || components_default;
+              has_component = c: lib.isList components && lib.elem c components;
+            in
+            {
+              # Even though it's not listed on the download page, both the Base and HPC kit include MPI.
+              mpi = all_or_default || has_component "intel.oneapi.lin.mpi.devel";
+              vtune = all_or_default || has_component "intel.oneapi.lin.vtune";
+              advisor = all_or_default || has_component "intel.oneapi.lin.advisor";
+              ui = components_used.vtune || components_used.advisor;
+            };
+        in
+        stdenv.mkDerivation (finalAttrs: {
+          pname = "intel-oneapi-${kit}kit";
+          inherit version;
+
+          src = fetchurl {
+            url = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/${uuid}/intel-oneapi-${kit}-toolkit-${version}_offline.sh";
+            inherit sha256;
+          };
+
+          unpackPhase = ''
+            runHook preUnpack
+
+            sh $src \
+              --extract-only --extract-folder . \
+              --remove-extracted-files no --log ./extract.log
+
+            runHook postUnpack
+          '';
+
+          nativeBuildInputs =
+            [ autoPatchelfHook ]
+            ++ lib.optionals cudaSupport [
+              autoAddDriverRunpath
+              cudaPackages.cuda_nvcc
+              (lib.getDev cudaPackages.cuda_cudart)
+            ];
+
+          buildInputs =
+            [
+              level-zero
+              zlib
+              gcc
+            ]
+            ++ lib.optionals components_used.mpi [
+              rdma-core
+              numactl
+              libpsm2
+              ucx
+              libuuid
+            ]
+            ++ lib.optionals components_used.ui [
+              alsa-lib
+              at-spi2-atk
+              bzip2
+              cairo
+              libxcrypt-legacy
+              cups.lib
+              dbus.lib
+              libdrm
+              expat
+              libffi_3_2_1
+              libgbm
+              gdbm_1_13
+              glib
+              ncurses5
+              nspr
+              nss
+              pango
+              sqlite
+              systemd # For libudev
+              libuuid
+              xorg.libX11
+              xorg.libxcb
+              xorg.libXcomposite
+              xorg.libXdamage
+              xorg.libXext
+              xorg.libXfixes
+              xorg.libXrandr
+              libxkbcommon
+            ]
+            ++ lib.optionals components_used.vtune [
+              elfutils
+              gtk3
+              libnotify
+              opencl-clang_14
+              xdg-utils
+            ]
+            ++ lib.optionals components_used.advisor [
+              fontconfig
+              freetype
+              gdk-pixbuf
+              gtk2
+              xorg.libXxf86vm
+            ];
+
+          installPhase =
+            let
+              # The installer will try to act as root if we don't wrap it like this.
+              # I could not get it to run using just fakeroot.
+              fhs = buildFHSEnv {
+                name = "oneapi-installer-fhs-env";
+
+                targetPkgs =
+                  pkgs:
+                  (with pkgs; [
+                    patchelf
+                    stdenv.cc.cc.lib
+                  ]);
+
+                nativeBuildInputs = [
+                  autoPatchelfHook
+                ];
+
+                # The installer also links to qt6 and other libraries,
+                # but these are only used for the GUI.
+                # Notably, these are vendored in $src/lib.
+                # The installer runs fine with just the C++ standard library however.
+                buildInputs = [
+                  stdenv.cc.cc.lib
+                ];
+
+                # This allows the installer to actually write to the $out directory.
+                # Otherwise you'd get permission denied errors.
+                extraBwrapArgs = [
+                  "--bind"
+                  "$out"
+                  "$out"
+                ];
+              };
+
+              install = writeShellScript "intel-oneapi-installer" ''
+                cd intel-oneapi-${kit}-toolkit-${version}_offline
+
+                patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+                  ./bootstrapper
+
+                if [ "$COMPONENTS" = "list" ]; then
+                  echo "Available components:"
+                  ./install.sh --list-components
+                  exit 1
+                fi
+
+                echo "Installing the following components: $COMPONENTS"
+
+                mkdir log
+                exec sh ./install.sh \
+                  --silent \
+                  --eula accept \
+                  --components "$COMPONENTS" \
+                  --log-dir ./log \
+                  --ignore-errors \
+                  --install-dir $OUT \
+              '';
+            in
+            ''
+              runHook preInstall
+
+              export OUT=$out/opt/intel/oneapi
+              export COMPONENTS=${components_string}
+              mkdir -p $OUT
+              ${fhs}/bin/oneapi-installer-fhs-env -- ${install}
+
+              runHook postInstall
+            '';
+
+          passthru = {
+            updateScript = writeShellScript "update-intel-oneapi-${kit}kit" ''${./update.sh} ${kit}'';
+            inherit makeKit withComponents;
+          };
+
+          autoPatchelfIgnoreMissingDeps = [
+            "libcuda.so.1"
+          ];
+
+          # When not installing all components there will be broken symlinks for each skipped component like this:
+          #   $out/opt/intel/oneapi/.toolkit_linking_tool/.envs/2025.2/oneapi-${kit}-toolkit/<uninstalled-component>
+          dontCheckForBrokenSymlinks = true;
+
+          meta =
+            {
+              license = lib.licenses.unfree;
+              platforms = lib.platforms.linux;
+              maintainers = [ lib.maintainers.blenderfreaky ];
+            }
+            // (
+              let
+                year = lib.versions.major version;
+              in
+              if kit == "base" then
+                {
+                  description = "Intel OneAPI Base Toolkit";
+                  homepage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html";
+                  changelog = "https://www.intel.com/content/www/us/en/developer/articles/release-notes/oneapi-base-toolkit/${year}.html";
+                }
+              else if kit == "hpc" then
+                {
+                  description = "Intel oneAPI HPC Toolkit";
+                  homepage = "https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html";
+                  changelog = "https://www.intel.com/content/www/us/en/developer/articles/release-notes/oneapi-hpc-toolkit/${year}.html";
+                }
+              else
+                throw "kit must be either 'base' or 'hpc'"
+            );
+        });
+    in
+    # By default we install all components
+    withComponents "all";
+in
+makeKit

--- a/pkgs/by-name/in/intel-oneapi-basekit/package.nix
+++ b/pkgs/by-name/in/intel-oneapi-basekit/package.nix
@@ -1,0 +1,7 @@
+{ callPackage }:
+callPackage ./installer.nix { } {
+  kit = "base";
+  version = "2025.2.0.592";
+  uuid = "bd1d0273-a931-4f7e-ab76-6a2a67d646c7";
+  sha256 = "sha256-XPYLFTjtt02/ihxvDziGmCY52rcJu3V2PxelrO+6xTA=";
+}

--- a/pkgs/by-name/in/intel-oneapi-basekit/update.sh
+++ b/pkgs/by-name/in/intel-oneapi-basekit/update.sh
@@ -66,6 +66,19 @@ FINAL_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/$UUID/int
 echo "  -> Version: $VERSION"
 echo "  -> UUID:    $UUID"
 echo "  -> Final URL: $FINAL_URL"
+#
+# --- Check if version already matches ---
+if [[ -f "$TARGET_FILE" ]]; then
+  CURRENT_VERSION=$(rg '^\s*version\s*=\s*"([^"]+)"' -o -r '$1' "$TARGET_FILE" || true)
+  if [[ "$CURRENT_VERSION" == "$VERSION" ]]; then
+    echo "Version $VERSION is already up-to-date in $TARGET_FILE. Skipping update."
+    exit 0
+  fi
+  echo "  -> Current version: $CURRENT_VERSION (will update to $VERSION)"
+else
+  echo "Error: Target file '$TARGET_FILE' not found." >&2
+  exit 1
+fi
 
 echo "Prefetching URL to calculate SRI hash..."
 SHA=$(nix-prefetch-url --type sha256 "$FINAL_URL")

--- a/pkgs/by-name/in/intel-oneapi-basekit/update.sh
+++ b/pkgs/by-name/in/intel-oneapi-basekit/update.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p ripgrep sd curl nix
+set -euo pipefail
+
+# The URLs will look like this:
+#   https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bd1d0273-a931-4f7e-ab76-6a2a67d646c7/intel-oneapi-base-toolkit-2025.2.0.592_offline.sh
+#                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                           ^^^^^^^^^^^^ ^^^^^^
+#                                                               UUID                                                           Version      See below
+#
+# The code changes with new releases.
+#
+# Usage:
+#   ./update.sh base
+#   ./update.sh hpc
+
+# --- Argument Parsing ---
+if [[ $# -ne 1 ]]; then
+  echo "Error: Missing argument. Please specify 'base' or 'hpc'." >&2
+  echo "Usage: $0 <base|hpc>" >&2
+  exit 1
+fi
+
+nixpkgs="$(git rev-parse --show-toplevel || (printf 'Could not find root of nixpkgs repo\nAre we running from within the nixpkgs git repo?\n' >&2; exit 1))"
+
+KIT_NAME=$1
+DOWNLOAD_PAGE_URL=""
+
+# --- Set Kit-Specific Variables ---
+case "$KIT_NAME" in
+  base)
+    DOWNLOAD_PAGE_URL='https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?packages=oneapi-toolkit&oneapi-toolkit-os=linux&oneapi-lin=offline'
+    TARGET_FILE="$nixpkgs/pkgs/by-name/in/intel-oneapi-basekit/package.nix"
+    ;;
+  hpc)
+    DOWNLOAD_PAGE_URL='https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit-download.html?packages=hpc-toolkit&hpc-toolkit-os=linux&hpc-toolkit-lin=offline'
+    TARGET_FILE="$nixpkgs/pkgs/by-name/in/intel-oneapi-hpckit/package.nix"
+    ;;
+  *)
+    echo "Error: Invalid argument '$KIT_NAME'. Please use 'base' or 'hpc'." >&2
+    echo "Usage: $0 <base|hpc>" >&2
+    exit 1
+    ;;
+esac
+
+echo "Updating Intel OneAPI $KIT_NAME Toolkit..."
+
+KIT_PATTERN="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/([0-9a-z-]+)/intel-oneapi-${KIT_NAME}-toolkit-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)(_offline)?\.sh"
+
+echo "Fetching data from Intel's download page..."
+FOUND_URL=$(curl -s "$DOWNLOAD_PAGE_URL" | rg -o "$KIT_PATTERN" || true)
+
+if [[ -z "$FOUND_URL" ]]; then
+  echo "Error: Could not find a matching download URL on the page." >&2
+  exit 1
+fi
+
+echo "Successfully found a URL: $FOUND_URL"
+
+UUID=$(echo "$FOUND_URL" | rg -N "$KIT_PATTERN" --replace '$1')
+VERSION=$(echo "$FOUND_URL" | rg -N "$KIT_PATTERN" --replace '$2')
+
+# Reconstruct the URL to ensure it points to the offline installer, as sometimes
+# the page only links to the online one (which has the same UUID and version).
+FINAL_URL="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/$UUID/intel-oneapi-${KIT_NAME}-toolkit-${VERSION}_offline.sh"
+
+echo "  -> Version: $VERSION"
+echo "  -> UUID:    $UUID"
+echo "  -> Final URL: $FINAL_URL"
+
+echo "Prefetching URL to calculate SRI hash..."
+SHA=$(nix-prefetch-url --type sha256 "$FINAL_URL")
+SRI_SHA=$(nix hash convert --hash-algo sha256 "$SHA")
+echo "  -> SRI Hash: $SRI_SHA"
+
+if [[ ! -f "$TARGET_FILE" ]]; then
+    echo "Error: Target file '$TARGET_FILE' not found." >&2
+    exit 1
+fi
+
+echo "Applying updates to $TARGET_FILE..."
+
+sd '(^\s*version\s*=\s*)".*?"' "\$1\"$VERSION\"" "$TARGET_FILE"
+sd '(^\s*uuid\s*=\s*)".*?"' "\$1\"$UUID\"" "$TARGET_FILE"
+sd '(^\s*sha256\s*=\s*)".*?"' "\$1\"$SRI_SHA\"" "$TARGET_FILE"
+
+echo "Successfully updated $TARGET_FILE."

--- a/pkgs/by-name/in/intel-oneapi-hpckit/package.nix
+++ b/pkgs/by-name/in/intel-oneapi-hpckit/package.nix
@@ -1,0 +1,7 @@
+{ intel-oneapi-basekit }:
+intel-oneapi-basekit.makeKit {
+  kit = "hpc";
+  version = "2025.2.0.575";
+  uuid = "e974de81-57b7-4ac1-b039-0512f8df974e";
+  sha256 = "sha256-xu00FBbRgyVE7kWOI29Kt2l58ZTs7E90vYMTV9d7LX4=";
+}

--- a/pkgs/by-name/op/opencl-clang/14.nix
+++ b/pkgs/by-name/op/opencl-clang/14.nix
@@ -1,0 +1,125 @@
+{
+  lib,
+  stdenv,
+  applyPatches,
+  fetchFromGitHub,
+  cmake,
+  git,
+  llvmPackages_14,
+  spirv-llvm-translator,
+  buildWithPatches ? true,
+}:
+let
+  addPatches =
+    component: pkg:
+    pkg.overrideAttrs (oldAttrs: {
+      postPatch =
+        oldAttrs.postPatch or ""
+        + ''
+          for p in ${passthru.patchesOut}/${component}/*; do
+            patch -p1 -i "$p"
+          done
+        '';
+    });
+
+  llvmPkgs = llvmPackages_14;
+  inherit (llvmPkgs) llvm;
+  spirv-llvm-translator' = spirv-llvm-translator.override { inherit llvm; };
+  libclang = if buildWithPatches then passthru.libclang else llvmPkgs.libclang;
+
+  passthru = rec {
+    spirv-llvm-translator = spirv-llvm-translator';
+    llvm = addPatches "llvm" llvmPkgs.llvm;
+    libclang = addPatches "clang" llvmPkgs.libclang;
+
+    clang-unwrapped = libclang.out;
+    clang = llvmPkgs.clang.override {
+      cc = clang-unwrapped;
+    };
+
+    patchesOut = stdenv.mkDerivation {
+      pname = "opencl-clang-patches";
+      inherit version src;
+      # Clang patches assume the root is the llvm root dir
+      # but clang root in nixpkgs is the clang sub-directory
+      postPatch = ''
+        for filename in patches/clang/*.patch; do
+          substituteInPlace "$filename" \
+            --replace-fail "a/clang/" "a/" \
+            --replace-fail "b/clang/" "b/"
+        done
+      '';
+
+      installPhase = ''
+        [ -d patches ] && cp -r patches/ $out || mkdir $out
+        mkdir -p $out/clang $out/llvm
+      '';
+    };
+  };
+
+  version = "14.0.0-unstable-2024-07-09";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "intel";
+      repo = "opencl-clang";
+      # https://github.com/intel/opencl-clang/compare/ocl-open-140
+      rev = "470cf0018e1ef6fc92eda1356f5f31f7da452abc";
+      hash = "sha256-Ja+vJ317HI3Nh45kcAMhyLVTIqyy6pE5KAsKs4ou9J8=";
+    };
+
+    patches = [
+      # Build script tries to find Clang OpenCL headers under ${llvm}
+      # Work around it by specifying that directory manually.
+      ./opencl-headers-dir.patch
+    ];
+
+    postPatch =
+      ''
+        # fix not be able to find clang from PATH
+        substituteInPlace cl_headers/CMakeLists.txt \
+          --replace-fail " NO_DEFAULT_PATH" ""
+      ''
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        # Uses linker flags that are not supported on Darwin.
+        sed -i -e '/SET_LINUX_EXPORTS_FILE/d' CMakeLists.txt
+        substituteInPlace CMakeLists.txt \
+          --replace-fail '-Wl,--no-undefined' ""
+      '';
+  };
+in
+stdenv.mkDerivation {
+  pname = "opencl-clang";
+  inherit version src;
+
+  nativeBuildInputs = [
+    cmake
+    git
+    llvm.dev
+  ];
+
+  buildInputs = [
+    libclang
+    llvm
+    spirv-llvm-translator'
+  ];
+
+  cmakeFlags = [
+    "-DPREFERRED_LLVM_VERSION=${lib.getVersion llvm}"
+    "-DOPENCL_HEADERS_DIR=${lib.getLib libclang}/lib/clang/${lib.getVersion libclang}/include/"
+
+    "-DLLVMSPIRV_INCLUDED_IN_LLVM=OFF"
+    "-DSPIRV_TRANSLATOR_DIR=${spirv-llvm-translator'}"
+  ];
+
+  inherit passthru;
+
+  meta = {
+    homepage = "https://github.com/intel/opencl-clang/";
+    description = "Clang wrapper library with an OpenCL-oriented API and the ability to compile OpenCL C kernels to SPIR-V modules";
+    license = lib.licenses.ncsa;
+    maintainers = [ lib.maintainers.blenderfreaky ];
+    platforms = lib.platforms.all;
+    # error: invalid value 'CL3.0' in '-cl-std=CL3.0'
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+}

--- a/pkgs/development/libraries/libffi/3.2.1-cygwin.patch
+++ b/pkgs/development/libraries/libffi/3.2.1-cygwin.patch
@@ -1,0 +1,10 @@
+--- libffi-3.2.1/src/closures.c	2014-11-08 13:47:24.000000000 +0100
++++ libffi-3.2.1/src/closures.c	2015-05-19 10:15:50.059325900 +0200
+@@ -212,6 +212,7 @@
+ #include <sys/mman.h>
+
+ /* Cygwin is Linux-like, but not quite that Linux-like.  */
++#define is_emutramp_enabled() 0
+ #define is_selinux_enabled() 0
+
+ #endif /* !defined(X86_WIN32) && !defined(X86_WIN64) */

--- a/pkgs/development/libraries/libffi/3.2.1.nix
+++ b/pkgs/development/libraries/libffi/3.2.1.nix
@@ -1,0 +1,109 @@
+{
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  lib,
+  autoreconfHook,
+  # libffi is used in darwin stdenv
+  # we cannot run checks within it
+  doCheck ? !stdenv.isDarwin,
+  dejagnu,
+}:
+let
+  pname = "libffi";
+  version = "3.2.1";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl {
+    url = "https://sourceware.org/pub/libffi/${pname}-${version}.tar.gz";
+    sha256 = "0dya49bnhianl0r65m65xndz6ls2jn1xngyn72gd28ls3n7bnvnh";
+  };
+
+  patches =
+    lib.optional stdenv.isCygwin ./3.2.1-cygwin.patch
+    ++ lib.optional stdenv.isAarch64 (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/libffi/raw/ccffc1700abfadb0969495a6e51b964117fc03f6/f/libffi-aarch64-rhbz1174037.patch";
+      sha256 = "1vpirrgny43hp0885rswgv3xski8hg7791vskpbg3wdjdpb20wbc";
+    })
+    ++ lib.optional stdenv.hostPlatform.isMusl (fetchpatch {
+      name = "gnu-linux-define.patch";
+      url = "https://git.alpinelinux.org/cgit/aports/plain/main/libffi/gnu-linux-define.patch?id=bb024fd8ec6f27a76d88396c9f7c5c4b5800d580";
+      sha256 = "11pvy3xkhyvnjfyy293v51f1xjy3x0azrahv1nw9y9mw8bifa2j2";
+    })
+    ++ lib.optional stdenv.hostPlatform.isRiscV (fetchpatch {
+      name = "riscv-support.patch";
+      url = "https://github.com/sorear/libffi-riscv/commit/e46492e8bb1695a19bc1053ed869e6c2bab02ff2.patch";
+      sha256 = "1vl1vbvdkigs617kckxvj8j4m2cwg62kxm1clav1w5rnw9afxg0y";
+    })
+    ++ lib.optionals stdenv.isMips [
+      (fetchpatch {
+        name = "0001-mips-Use-compiler-internal-define-for-linux.patch";
+        url = "https://cgit.openembedded.org/openembedded-core/plain/meta/recipes-support/libffi/libffi/0001-mips-Use-compiler-internal-define-for-linux.patch?id=318e33a708378652edcf61ce7d9d7f3a07743000";
+        sha256 = "1gc53lw90p6hc0cmhj3csrwincfz7va5ss995ksw5gm0yrr9mrvb";
+      })
+      (fetchpatch {
+        name = "0001-mips-fix-MIPS-softfloat-build-issue.patch";
+        url = "https://cgit.openembedded.org/openembedded-core/plain/meta/recipes-support/libffi/libffi/0001-mips-fix-MIPS-softfloat-build-issue.patch?id=318e33a708378652edcf61ce7d9d7f3a07743000";
+        sha256 = "0l8xgdciqalg4z9rcwyk87h8fdxpfv4hfqxwsy2agpnpszl5jjdq";
+      })
+    ];
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+    "info"
+  ];
+
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isRiscV autoreconfHook;
+
+  configureFlags = [
+    "--with-gcc-arch=generic" # no detection of -march= or -mtune=
+    "--enable-pax_emutramp"
+  ];
+
+  preCheck = ''
+    # The tests use -O0 which is not compatible with -D_FORTIFY_SOURCE.
+    NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}
+    NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify3/}
+  '';
+
+  checkInputs = [ dejagnu ];
+
+  inherit doCheck;
+
+  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
+
+  # Install headers and libs in the right places.
+  postFixup = ''
+    mkdir -p "$dev/"
+    mv "$out/lib/${pname}-${version}/include" "$dev/include"
+    rmdir "$out/lib/${pname}-${version}"
+    substituteInPlace "$dev/lib/pkgconfig/libffi.pc" \
+      --replace-fail 'includedir=''${libdir}/libffi-3.2.1' "includedir=$dev"
+  '';
+
+  meta = {
+    description = "A foreign function call interface library";
+    longDescription = ''
+      The libffi library provides a portable, high level programming
+      interface to various calling conventions.  This allows a
+      programmer to call any function specified by a call interface
+      description at run-time.
+
+      FFI stands for Foreign Function Interface.  A foreign function
+      interface is the popular name for the interface that allows code
+      written in one language to call code written in another
+      language.  The libffi library really only provides the lowest,
+      machine dependent layer of a fully featured foreign function
+      interface.  A layer must exist above libffi that handles type
+      conversions for values passed between the two languages.
+    '';
+    homepage = "https://sourceware.org/libffi/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.blenderfreaky ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7054,6 +7054,8 @@ with pkgs;
   #
   # `libffiReal` is provided in case the upstream libffi package is needed on Darwin instead of the fork.
   libffi = if stdenv.hostPlatform.isDarwin then darwin.libffi else libffiReal;
+  libffi_3_3 = callPackage ../development/libraries/libffi/3.3.nix { };
+  libffi_3_2_1 = callPackage ../development/libraries/libffi/3.2.1.nix { };
 
   # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=README;h=fd6e1a83f55696c1f7a08f6dfca08b2d6b7617ec;hb=70058cd9f944d620764e57c838209afae8a58c78#l118
   libgpg-error-gen-posix-lock-obj = libgpg-error.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2622,6 +2622,8 @@ with pkgs;
 
   gparted-full = gparted.override { withAllTools = true; };
 
+  gdbm_1_13 = callPackage ../by-name/gd/gdbm/1.13.nix { };
+
   gdown = with python3Packages; toPythonApplication gdown;
 
   gpt4all-cuda = gpt4all.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3257,6 +3257,8 @@ with pkgs;
 
   open-interpreter = with python3Packages; toPythonApplication open-interpreter;
 
+  opencl-clang_14 = callPackage ../by-name/op/opencl-clang/14.nix { };
+
   openhantek6022 = libsForQt5.callPackage ../applications/science/electronics/openhantek6022 { };
 
   openmvs = callPackage ../applications/science/misc/openmvs {


### PR DESCRIPTION
This PR introduces the Intel oneAPI base and HPC toolkits.

Due to the toolkits' dependencies on older packages, three legacy package versions have been reintroduced. Each is based on historical nixpkgs versions (see individual commit messages for exact versions). These packages required minimal modernization (primarily `name` → `pname` & `version` and `stdenv.lib` → `lib`) but otherwise remain faithful to their originals.

The way the oneAPI installer is currently packaged is by running the installer itself in a FHSEnv. This is to deal with permission errors - the installer would try to install to `/` no matter what (I had no success with tools like `fakeroot`).
The resulting binaries do not need an FHSEnv to run though.

There's some open questions:

- [ ] Is the way the legacy dependencies were reintroduced here the right way?
- [ ] I've made a flag for allowing the user to select which components to install - I think I may have over-complicated this a bit. Should this stay as-is or be reduced to just a plain string, handed down to the installer 1:1?
- [ ] Should `.withComponents` be documented somewhere outside the source-file itself? If so where?
- [ ] I've made an attempt at supporting CUDA, but as I am on an AMD GPU at the moment I can't test that. Can someone with an Nvidia GPU check this?
- [ ] Should the compiler(s) be wrapped, e.g. with `wrapCC`? If so, how?
- [ ] Install to `$out/` or `$out/opt/intel/oneapi/` for potential compat stuff?

See also: #367722 #74148 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
