### PR TITLE
gpac: add ffmpeg support & refactor

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25956,6 +25956,11 @@
     githubId = 91203390;
     name = "Felix Kimmel";
   };
+  thesn = {
+    github = "thesn10";
+    githubId = 38666407;
+    name = "TheSN";
+  };
   thesola10 = {
     email = "me@thesola.io";
     github = "Thesola10";

--- a/pkgs/by-name/gp/gpac/package.nix
+++ b/pkgs/by-name/gp/gpac/package.nix
@@ -36,15 +36,15 @@
 
 stdenv.mkDerivation rec {
   pname = "gpac";
-  version = if releaseChannel == "nightly" then "2.4-unstable-2025-07-11" else "2.4.0";
+  version = if releaseChannel == "nightly" then "2.4-unstable-2025-10-26" else "2.4.0";
 
   src =
     if releaseChannel == "nightly" then
       fetchFromGitHub {
         owner = "gpac";
         repo = "gpac";
-        rev = "fe88c3545aadd597b250ccf23271d5d3de50ccc8";
-        hash = "sha256-c6B9Y19ZZ3PLz82GCcjkWzcUQSEK7ufVNEzqHQqOvrI=";
+        rev = "e1a54e81b3befba2b0bffd1d4c1cf50da516c5f3";
+        hash = "sha256-jSMBPuWPmTDCebImdmAcCZl0hEQpJK4QMNGcEXgs3A4=";
       }
     else
       fetchFromGitHub {

--- a/pkgs/by-name/gp/gpac/package.nix
+++ b/pkgs/by-name/gp/gpac/package.nix
@@ -5,35 +5,98 @@
   cctools,
   pkg-config,
   zlib,
+  ffmpeg,
+  freetype,
+  libjpeg,
+  libpng,
+  libmad,
+  faad2,
+  libogg,
+  libvorbis,
+  libtheora,
+  a52dec,
+  nghttp2,
+  openjpeg,
+  libcaca,
+  libXv,
+  mesa,
+  mesa_glu,
+  xvidcore,
+  openssl,
+  jack2,
+  alsa-lib,
+  pulseaudio,
+  SDL2,
+  curl,
+
+  withFullDeps ? false,
+  withFfmpeg ? withFullDeps,
+  releaseChannel ? "stable",
 }:
 
 stdenv.mkDerivation rec {
   pname = "gpac";
-  version = "2.4.0";
+  version = if releaseChannel == "nightly" then "2.4-unstable-2025-07-11" else "2.4.0";
 
-  src = fetchFromGitHub {
-    owner = "gpac";
-    repo = "gpac";
-    rev = "v${version}";
-    hash = "sha256-RADDqc5RxNV2EfRTzJP/yz66p0riyn81zvwU3r9xncM=";
-  };
+  src =
+    if releaseChannel == "nightly" then
+      fetchFromGitHub {
+        owner = "gpac";
+        repo = "gpac";
+        rev = "fe88c3545aadd597b250ccf23271d5d3de50ccc8";
+        hash = "sha256-c6B9Y19ZZ3PLz82GCcjkWzcUQSEK7ufVNEzqHQqOvrI=";
+      }
+    else
+      fetchFromGitHub {
+        owner = "gpac";
+        repo = "gpac";
+        rev = "v${version}";
+        hash = "sha256-RADDqc5RxNV2EfRTzJP/yz66p0riyn81zvwU3r9xncM=";
+      };
 
-  # this is the bare minimum configuration, as I'm only interested in MP4Box
-  # For most other functionality, this should probably be extended
-  nativeBuildInputs = [
-    pkg-config
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    cctools
-  ];
+  nativeBuildInputs =
+    [
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      cctools
+    ]
+    ++ lib.optionals withFfmpeg [
+      ffmpeg
+    ];
 
+  # ref: https://wiki.gpac.io/Build/build/GPAC-Build-Guide-for-Linux/#gpac-easy-build-recommended-for-most-users
   buildInputs = [
     zlib
+  ]
+  ++ lib.optionals withFullDeps [
+    freetype
+    libjpeg
+    libpng
+    libmad
+    faad2
+    libogg
+    libvorbis
+    libtheora
+    a52dec
+    nghttp2
+    openjpeg
+    libcaca
+    libXv
+    mesa
+    mesa_glu
+    xvidcore
+    openssl
+    jack2
+    alsa-lib
+    pulseaudio
+    SDL2
+    curl
   ];
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "Open Source multimedia framework for research and academic purposes";
     longDescription = ''
       GPAC is an Open Source multimedia framework for research and academic purposes.
@@ -48,10 +111,11 @@ stdenv.mkDerivation rec {
       And some server tools included in MP4Box and MP42TS applications.
     '';
     homepage = "https://gpac.wp.imt.fr";
-    license = licenses.lgpl21;
-    maintainers = with maintainers; [
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [
       mgdelacroix
+      thesn
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14540,16 +14540,7 @@ with pkgs;
     php = php83; # https://github.com/tchapi/davis/issues/195
   };
 
-  gpac = callPackage ../by-name/gp/gpac/package.nix {
-    ffmpeg = ffmpeg.override {
-      version = "7.0.2";
-      hash = "sha256-6bcTxMt0rH/Nso3X7zhrFNkkmWYtxsbUqVQKh25R1Fs=";
-      ffmpegVariant = "headless";
-    };
-  };
-
-  gpac_nightly = callPackage ../by-name/gp/gpac/package.nix {
-    ffmpeg = ffmpeg-headless;
-    releaseChannel = "nightly";
+  gpac-unstable = callPackage ../by-name/gp/gpac/package.nix {
+    releaseChannel = "unstable";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14539,4 +14539,17 @@ with pkgs;
   davis = callPackage ../by-name/da/davis/package.nix {
     php = php83; # https://github.com/tchapi/davis/issues/195
   };
+
+  gpac = callPackage ../by-name/gp/gpac/package.nix {
+    ffmpeg = ffmpeg.override {
+      version = "7.0.2";
+      hash = "sha256-6bcTxMt0rH/Nso3X7zhrFNkkmWYtxsbUqVQKh25R1Fs=";
+      ffmpegVariant = "headless";
+    };
+  };
+
+  gpac_nightly = callPackage ../by-name/gp/gpac/package.nix {
+    ffmpeg = ffmpeg-headless;
+    releaseChannel = "nightly";
+  };
 }


### PR DESCRIPTION
This is my first contribution so i am happy to take advice ^^

- Adds FFmpeg support to gpac
- Adds `gpac_nightly` package that tracks HEAD
  - This is needed, because the gpac team [recommends using nightly](https://gpac.io/downloads/gpac-nightly-builds) over stable
- Adds myself as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
