### PR TITLE
polypane: init at 25.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13256,6 +13256,12 @@
     githubId = 464625;
     name = "Enric Morales";
   };
+  kilian = {
+    email = "kilian@kilianvalkhof.com";
+    github = "kilian";
+    githubId = 41970;
+    name = "Kilian Valkhof";
+  };
   kilianar = {
     email = "mail@kilianar.de";
     github = "kilianar";
@@ -17087,6 +17093,12 @@
     github = "mrtnvgr";
     githubId = 48406064;
     keys = [ { fingerprint = "6FAD DB43 D5A5 FE52 6835  0943 5B33 79E9 81EF 48B1"; } ];
+  };
+  mrtrimble = {
+    name = "Ryan Trimble";
+    email = "mrtrimble2@gmail.com";
+    github = "mrtrimble";
+    githubId = 5217768;
   };
   mrVanDalo = {
     email = "contact@ingolf-wagner.de";

--- a/pkgs/by-name/po/polypane/package.nix
+++ b/pkgs/by-name/po/polypane/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+}:
+
+let
+  pname = "polypane";
+  version = "25.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/firstversionist/${pname}/releases/download/v${version}/${pname}-${version}.AppImage";
+    name = "${pname}-${version}.AppImage";
+    sha256 = "0l22z8xh882gprzj4700q2dcf6vh0vbsnjr3zf8w45lacawb1pmw";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname src version;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname src version;
+
+  extraPkgs = pkgs: [ pkgs.bash ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
+    install -m 444 -D ${appimageContents}/${pname}.png \
+      $out/share/icons/hicolor/512x512/apps/${pname}.png
+  '';
+
+  meta = with lib; {
+    description = "The browser for devs who care about their craft and users";
+    longDescription = ''
+      A desktop browser for web devs. Preview viewports side-by-side, audit accessibility, SEO and performance. Built to boost productivity and streamline building and testing.
+    '';
+    homepage = "https://polypane.app/";
+    maintainers = with maintainers; [ kilian, mrtrimble ];
+    platforms = [ "x86_64-linux" ];
+    changelog = "https://polypane.app/docs/changelog/";
+    license = licenses.unfree;
+    mainProgram = "polypane";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/po/polypane/package.nix
+++ b/pkgs/by-name/po/polypane/package.nix
@@ -35,7 +35,10 @@ appimageTools.wrapType2 {
       A desktop browser for web devs. Preview viewports side-by-side, audit accessibility, SEO and performance. Built to boost productivity and streamline building and testing.
     '';
     homepage = "https://polypane.app/";
-    maintainers = with maintainers; [ kilian mrtrimble ];
+    maintainers = with maintainers; [
+      kilian
+      mrtrimble
+    ];
     platforms = [ "x86_64-linux" ];
     changelog = "https://polypane.app/docs/changelog/";
     license = licenses.unfree;

--- a/pkgs/by-name/po/polypane/package.nix
+++ b/pkgs/by-name/po/polypane/package.nix
@@ -35,7 +35,7 @@ appimageTools.wrapType2 {
       A desktop browser for web devs. Preview viewports side-by-side, audit accessibility, SEO and performance. Built to boost productivity and streamline building and testing.
     '';
     homepage = "https://polypane.app/";
-    maintainers = with maintainers; [ kilian, mrtrimble ];
+    maintainers = with maintainers; [ kilian mrtrimble ];
     platforms = [ "x86_64-linux" ];
     changelog = "https://polypane.app/docs/changelog/";
     license = licenses.unfree;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1577,7 +1577,6 @@ mapAliases {
 
     Note that Qt 5 versions of most KDE software will be removed in NixOS 25.11.
   ''; # Added 2025-03-07
-  polypane = throw "'polypane' has been removed due to lack of maintenance in nixpkgs"; # Added 2025-06-25
   poretools = throw "poretools has been removed from nixpkgs, as it was broken and unmaintained"; # Added 2024-06-03
   posix_man_pages = throw "'posix_man_pages' has been renamed to/replaced by 'man-pages-posix'"; # Converted to throw 2024-10-17
   powerdns = pdns; # Added 2022-03-28


### PR DESCRIPTION
Re-adds polypane browser after it was removed due to lack of maintenance. Now packaged using pkgs/by-name.

https://polypane.app/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
