### PR TITLE
klipper: 0.13.0-unstable-2025-05-22 -> 0.13.0-unstable-2025-06-18; new flash script

### DIFF
--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "klipper";
-  version = "0.13.0-unstable-2025-05-22";
+  version = "0.13.0-unstable-2025-07-12";
 
   src = fetchFromGitHub {
     owner = "KevinOConnor";
     repo = "klipper";
-    rev = "b1011e3fb14df7470d9b74e59042383012b199c6";
-    sha256 = "sha256-gDOGGTS0UPe0ni+zcRUz9CRhkL6hq1PXCzYC9RpqNU8=";
+    rev = "9323a5dfe28619a53c7f350c2e894d299c342bca";
+    sha256 = "sha256-m6A8a3lR8aeMudA/kz1wCynm+6jZY3w6v2Pag54lQd8=";
   };
 
   sourceRoot = "${src.name}/klippy";

--- a/pkgs/servers/klipper/klipper-firmware.nix
+++ b/pkgs/servers/klipper/klipper-firmware.nix
@@ -33,7 +33,14 @@ stdenv.mkDerivation rec {
     wxGTK32 # Required for bossac
   ];
 
-  preBuild = "cp ${firmwareConfig} ./.config";
+  configurePhase = ''
+    cp ${firmwareConfig} ./.config
+    chmod +w ./.config
+    echo qy | { make menuconfig >/dev/null || true; }
+    if ! diff ${firmwareConfig} ./.config; then
+      echo " !!! Menuconfig has changed. Please update your configuration."
+    fi
+  '';
 
   postPatch = ''
     patchShebangs .
@@ -41,7 +48,6 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "V=1"
-    "KCONFIG_CONFIG=${firmwareConfig}"
     "WXVERSION=3.2"
   ];
 
@@ -58,7 +64,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     inherit (klipper.meta) homepage license;
     description = "Firmware part of Klipper";
-    maintainers = with maintainers; [ vtuan10 ];
+    maintainers = with maintainers; [ vtuan10 cab404 ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/klipper/klipper-firmware.nix
+++ b/pkgs/servers/klipper/klipper-firmware.nix
@@ -1,4 +1,5 @@
-{
+args@{
+  klipper-firmware,
   stdenv,
   lib,
   pkg-config,
@@ -12,9 +13,19 @@
   klipper,
   avrdude,
   stm32flash,
+  klipper-flash,
   mcu ? "mcu",
   firmwareConfig ? ./simulator.cfg,
 }:
+# are used by flash scripts
+# find those with `rg '\[\"lib'` inside of klipper repo
+let
+  flashBinaries = [
+    "lib/bossac/bin/bossac"
+    "lib/hidflash/hid-flash"
+    "lib/rp2040_flash/rp2040_flash"
+  ];
+in
 stdenv.mkDerivation rec {
   name = "klipper-firmware-${mcu}-${version}";
   version = klipper.version;
@@ -38,12 +49,17 @@ stdenv.mkDerivation rec {
     chmod +w ./.config
     echo qy | { make menuconfig >/dev/null || true; }
     if ! diff ${firmwareConfig} ./.config; then
-      echo " !!! Menuconfig has changed. Please update your configuration."
+      echo " !!! Klipper KConfig has changed. Please run klipper-genconf to update your configuration."
     fi
   '';
 
   postPatch = ''
     patchShebangs .
+  '';
+
+  postBuild = ''
+    # build flash binaries
+    ${with builtins; concatStringsSep "\n" (map (path: "make ${path} $out/bin/ || true") flashBinaries)}
   '';
 
   makeFlags = [
@@ -57,14 +73,47 @@ stdenv.mkDerivation rec {
     cp out/klipper.bin $out/ || true
     cp out/klipper.elf $out/ || true
     cp out/klipper.uf2 $out/ || true
+
+    mkdir -p $out/lib/
+
+    ${
+      with builtins;
+      concatStringsSep "\n" (
+        map (path: ''
+          if [ -e ${path} ]; then
+            mkdir -p $out/$(dirname ${path})
+            cp -r ${path} $out/$(dirname ${path})
+          fi
+        '') flashBinaries
+      )
+    }
+    rmdir $out/lib 2>/dev/null || echo "Flash binaries exist, not cleaning up lib/"
+
   '';
 
   dontFixup = true;
 
+  passthru = {
+    makeFlasher =
+      { flashDevice }:
+      klipper-flash.override {
+        klipper-firmware = klipper-firmware.override args;
+        inherit
+          klipper
+          firmwareConfig
+          mcu
+          flashDevice
+          ;
+      };
+  };
+
   meta = with lib; {
     inherit (klipper.meta) homepage license;
     description = "Firmware part of Klipper";
-    maintainers = with maintainers; [ vtuan10 cab404 ];
+    maintainers = with maintainers; [
+      vtuan10
+      cab404
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/klipper/klipper-flash.nix
+++ b/pkgs/servers/klipper/klipper-flash.nix
@@ -1,47 +1,53 @@
 {
   lib,
   writeShellApplication,
-  gnumake,
-  pkgsCross,
   klipper,
   klipper-firmware,
-  python3,
   avrdude,
+  dfu-util,
   stm32flash,
   mcu ? "mcu",
   flashDevice ? "/dev/null",
   firmwareConfig ? ./simulator.cfg,
 }:
 let
-  supportedArches = [
-    "avr"
-    "stm32"
-    "lpc176x"
-  ];
-  matchBoard =
+  getConfigField =
+    field:
     with builtins;
-    match ''^.*CONFIG_BOARD_DIRECTORY="([a-zA-Z0-9_]+)".*$'' (readFile firmwareConfig);
-  boardArch = if matchBoard == null then null else builtins.head matchBoard;
+    let
+      matches = match ''^.*${field}="([a-zA-Z0-9_]+)".*$'' (readFile firmwareConfig);
+    in
+    if matches != null then head matches else null;
+  matchPlatform = getConfigField "CONFIG_BOARD_DIRECTORY";
+  matchBoard = getConfigField "CONFIG_MCU";
 in
 writeShellApplication {
   name = "klipper-flash-${mcu}";
-  runtimeInputs = [
-    python3
-    pkgsCross.avr.stdenv.cc
-    gnumake
-  ]
-  ++ lib.optionals (boardArch == "avr") [ avrdude ]
-  ++ lib.optionals (boardArch == "stm32") [ stm32flash ];
-  text = ''
-    if ${lib.boolToString (!builtins.elem boardArch supportedArches)}; then
-      printf "Flashing Klipper firmware to your board is not supported yet.\n"
-      printf "Please use the compiled firmware at ${klipper-firmware} and flash it using the tools provided for your microcontroller."
-      exit 1
-    fi
-    if ${lib.boolToString (boardArch == "stm32")}; then
-      make -C ${klipper.src} FLASH_DEVICE="${toString flashDevice}" OUT="${klipper-firmware}/" KCONFIG_CONFIG="${klipper-firmware}/config" serialflash
+  runtimeInputs =
+    [ ]
+    ++ lib.optionals (matchPlatform == "avr") [ avrdude ]
+    ++ lib.optionals (matchPlatform == "stm32") [
+      stm32flash
+      dfu-util
+    ]
+    ++ lib.optionals (matchPlatform == "lpc176x") [ dfu-util ]
+  # bossac, hid-flash and RP2040 flash binaries are built by klipper-firmware
+  ;
+  text =
+    # generic USB script for most things with serial and bootloader (see MCU_TYPES in scripts/flash_usb.py)
+    if matchBoard != null && matchPlatform != null then
+      ''
+        pushd ${klipper-firmware}
+        ${klipper}/lib/scripts/flash_usb.py -t ${matchBoard} -d ${flashDevice} ${klipper-firmware}/klipper.bin $@
+        popd
+      ''
     else
-      make -C ${klipper.src} FLASH_DEVICE="${toString flashDevice}" OUT="${klipper-firmware}/" KCONFIG_CONFIG="${klipper-firmware}/config" flash
-    fi
-  '';
+      ''
+        cat <<EOF
+        Board pair ${toString matchBoard}/${toString matchPlatform} (config ${firmwareConfig}) is not supported in NixOS auto flashing script.
+        Please manually flash the firmware using the appropriate tool for your board.
+        Built firmware is located here:
+        ${klipper-firmware}
+        EOF
+      '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Klipper bumped, and kconfig updater integrated.
- Klipper flash rewritten to work at least for some boards and not destroy your rpi sdcard on each update

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
