### PR TITLE
eddie: 2.24.4 -> 2.24.6

### DIFF
--- a/pkgs/by-name/ed/eddie/package.nix
+++ b/pkgs/by-name/ed/eddie/package.nix
@@ -28,15 +28,13 @@
 
 buildDotnetModule rec {
   pname = "eddie";
-  version = "2.24.4";
+  version = "2.24.6";
 
   src = fetchFromGitHub {
     owner = "AirVPN";
     repo = "Eddie";
-    # Upstream uses the summaries of commits for
-    # specifying the versions of experimental builds
-    rev = "aeaa7e594d71610dd2c231a8dc5c5aaddc89a7c1";
-    hash = "sha256-AlnWqrKoZb4s4MfPClxlEqzKIOwWL/frA+dx2kCNwW4=";
+    tag = version;
+    hash = "sha256-XSLxjF2k9cw+cx6KzFIQHtjDWqLT2V49KRw+oIyxM5M=";
   };
 
   patches = [

--- a/pkgs/by-name/ed/eddie/package.nix
+++ b/pkgs/by-name/ed/eddie/package.nix
@@ -136,7 +136,9 @@ buildDotnetModule (finalAttrs: {
     homepage = "https://eddie.website";
     license = lib.licenses.gpl3Plus;
     mainProgram = "eddie-ui";
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [
+      ryand56
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ed/eddie/package.nix
+++ b/pkgs/by-name/ed/eddie/package.nix
@@ -26,14 +26,14 @@
   testers,
 }:
 
-buildDotnetModule rec {
+buildDotnetModule (finalAttrs: {
   pname = "eddie";
   version = "2.24.6";
 
   src = fetchFromGitHub {
     owner = "AirVPN";
     repo = "Eddie";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-XSLxjF2k9cw+cx6KzFIQHtjDWqLT2V49KRw+oIyxM5M=";
   };
 
@@ -75,7 +75,7 @@ buildDotnetModule rec {
 
   makeWrapperArgs = [
     "--add-flags \"--path.resources=${placeholder "out"}/share/eddie-ui\""
-    "--prefix PATH : ${nativeRuntimeInputs}"
+    "--prefix PATH : ${finalAttrs.nativeRuntimeInputs}"
   ];
 
   executables = [ "eddie-cli" ];
@@ -120,7 +120,7 @@ buildDotnetModule rec {
 
     makeWrapper "${mono}/bin/mono" $out/bin/eddie-ui \
       --add-flags $out/lib/eddie-ui/App.Forms.Linux.exe \
-      --prefix LD_LIBRARY_PATH : ${runtimeInputs} \
+      --prefix LD_LIBRARY_PATH : ${finalAttrs.runtimeInputs} \
       ''${makeWrapperArgs[@]}
   '';
 
@@ -139,4 +139,4 @@ buildDotnetModule rec {
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
https://github.com/AirVPN/Eddie/releases/tag/2.24.6

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  ~~x86_64-darwin~~
  ~~aarch64-darwin~~
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
