### PR TITLE
jsign: init at 7.2

### DIFF
--- a/pkgs/by-name/js/jsign/package.nix
+++ b/pkgs/by-name/js/jsign/package.nix
@@ -1,0 +1,67 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  fetchpatch2,
+  makeBinaryWrapper,
+  jre_headless,
+  maven,
+  pcsclite,
+  yubico-piv-tool,
+  opensc,
+}:
+
+let
+  jre = jre_headless;
+in
+maven.buildMavenPackage rec {
+  pname = "jsign";
+  # For build from non-release, increment version by one and add -SNAPSHOT
+  # e.g. 7.3-SNAPSHOT
+  version = "7.2";
+
+  src = fetchFromGitHub {
+    owner = "ebourg";
+    repo = "jsign";
+    tag = version;
+    hash = "sha256-ngAwtd4C3KeLq9sM15B8tWS34AH81azYEjXg3+Gy5NA=";
+  };
+
+  mvnHash = "sha256-N91gwM3vsDZQM/BptF5RgRQ/A8g56NOJ6bc2SkxLnBs=";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  # The tests try to access the network
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share
+    install -Dm644 jsign/target/jsign-${version}.jar $out/share/jsign.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/jsign \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          yubico-piv-tool
+          opensc
+        ]
+      } \
+      --add-flags "-Dsun.security.smartcardio.library=${lib.getLib pcsclite}/lib/libpcsclite.so.1 -jar $out/share/jsign.jar"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Authenticode signing for Windows executables, installers & scripts";
+    homepage = "https://ebourg.github.io/jsign";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      johnazoidberg
+    ];
+    mainProgram = "jsign";
+    # Build doesn't work, upstream says running the .jar is supported on darwin though
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+}


### PR DESCRIPTION
jsign is a nice tool to sign PE (Windows, UEFI) binaries on Linux. I use it with codesigning certificate on a yubikey.
For yubikey `services.pcscd.enable` needs to be enabled.

It works with one of two commands:

```
jsign --storetype YUBIKEY --storepass 123456 --tsaurl http://ts.ssl.com --tsmode RFC3161 foo.exe                                                                                                                    
jsign --storetype PIV --storepass 123456 --tsaurl http://ts.ssl.com --tsmode RFC3161 foo.exe                                                                                                                        
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
