### PR TITLE
python313Packages.consul: 1.1.0 -> 1.6.0, use fork from criteo

### DIFF
--- a/pkgs/development/python-modules/consul/default.nix
+++ b/pkgs/development/python-modules/consul/default.nix
@@ -1,34 +1,122 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  fetchpatch,
+  setuptools,
   requests,
-  six,
-  pytest,
+  pythonOlder,
+  pytestCheckHook,
+  aiohttp,
+  pytest-asyncio,
+  pytest-cov-stub,
+  python,
+  docker,
 }:
 
 buildPythonPackage rec {
-  pname = "python-consul";
-  version = "1.1.0";
-  format = "setuptools";
+  pname = "py-consul";
+  version = "1.6.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "168f1fa53948047effe4f14d53fc1dab50192e2a2cf7855703f126f469ea11f4";
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "criteo";
+    repo = "py-consul";
+    tag = "v${version}";
+    hash = "sha256-kNIFpY8rXdfGmaW2GAq7SvjK+4ahgaFnyXEqcUrXoEs=";
   };
 
-  buildInputs = [
-    requests
-    six
-    pytest
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/python-team/packages/python-consul/-/raw/master/debian/patches/avoir-usr-requirements.txt.patch";
+      hash = "sha256-lB9Irzuc2IpbQOIP/C3JQ4iYqugf1U6CVlAEXrrFUfI=";
+    })
   ];
 
-  # No tests distributed. https://github.com/cablehead/python-consul/issues/133
-  doCheck = false;
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    requests
+    aiohttp
+  ];
+
+  # Exclude sphinx config from installation
+  postInstall = ''
+    rm -r $out/${python.sitePackages}/docs
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-cov-stub
+    docker
+  ];
+
+  # Most tests want to run a consul docker container ("hashicorp/consul:{version}" in conftest.py)
+  # See also https://salsa.debian.org/python-team/packages/python-consul/-/blob/936c1d9ce3acaac3fa2b6e9384102e843adbbe0b/debian/rules
+  disabledTests = [
+    "test_acl_token_permission_denied"
+    "test_acl_token_list"
+    "test_acl_token_read"
+    "test_acl_token_create"
+    "test_acl_token_clone"
+    "test_acl_token_update"
+    "test_acl_policy_list"
+    "test_acl_policy_read"
+    "test_agent_checks"
+    "test_service_multi_check"
+    "test_service_dereg_issue_156"
+    "test_agent_checks_service_id"
+    "test_agent_register_check_no_service_id"
+    "test_agent_register_enable_tag_override"
+    "test_agent_service_maintenance"
+    "test_agent_node_maintenance"
+    "test_agent_members"
+    "test_agent_self"
+    "test_agent_services"
+    "test_coordinate"
+    "test_event"
+    "test_event_targeted"
+    "test_health_service"
+    "test_health_state"
+    "test_health_service"
+    "test_health_state"
+    "test_health_node"
+    "test_health_checks"
+    "test_kv"
+    "test_kv_wait"
+    "test_kv_encoding"
+    "test_kv_put_cas"
+    "test_kv_put_flags"
+    "test_kv_recurse"
+    "test_kv_delete"
+    "test_kv_delete_cas"
+    "test_kv_acquire_release"
+    "test_kv_keys_only"
+    "test_kv_acquire_release"
+    "test_kv_keys_only"
+    "test_operator"
+    "test_session"
+    "test_session_delete_ttl_renew"
+    "test_status_leader"
+    "test_status_peers"
+    "test_transaction"
+    "test_consul_ctor"
+    "test_acl_token_delete"
+  ];
+
+  pythonImportsCheck = [ "consul" ];
 
   meta = with lib; {
     description = "Python client for Consul (https://www.consul.io/)";
-    homepage = "https://github.com/cablehead/python-consul";
+    homepage = "https://github.com/criteo/py-consul";
     license = licenses.mit;
+    maintainers = with maintainers; [
+      panicgh
+    ];
   };
 }


### PR DESCRIPTION
The original python-consul project from cablehead has not seen releases since 2018 and is archived since 2024: https://github.com/python-consul/python-consul/tags

[It suggests](https://github.com/python-consul/python-consul/blob/a91daae20c72625e764c10b5a98010df6b442238/README.md) to use the better maintained fork of criteo/py-consul.

Some distros use https://github.com/poppyred/python-consul2, but it is also archived since 2024.

~I removed the previous maintainer, because it seems to me that they did not contribute to nixpkgs since 2016 (`git log --author=desiderius -n1`). I hope this is ok.~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `6651e496836e60390a26ca19d8fa456b84f7e417`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>patroni</li>
    <li>patroni.dist</li>
    <li>python312Packages.consul</li>
    <li>python312Packages.consul.dist</li>
    <li>python313Packages.consul</li>
    <li>python313Packages.consul.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
