### PR TITLE
opencode: use `models-dev` package instead of fetching from online api

### DIFF
--- a/pkgs/by-name/op/opencode/fix-models-macro.patch
+++ b/pkgs/by-name/op/opencode/fix-models-macro.patch
@@ -1,8 +1,0 @@
---- a/packages/opencode/src/provider/models-macro.ts
-+++ b/packages/opencode/src/provider/models-macro.ts
-@@ -1,4 +1,3 @@
- export async function data() {
--  const json = await fetch("https://models.dev/api.json").then((x) => x.text())
--  return json
-+  return process.env.MODELS_JSON || '{}';
- }

--- a/pkgs/by-name/op/opencode/local-models-dev.patch
+++ b/pkgs/by-name/op/opencode/local-models-dev.patch
@@ -1,0 +1,20 @@
+diff --git i/packages/opencode/src/provider/models-macro.ts w/packages/opencode/src/provider/models-macro.ts
+index 91a0348..4f60069 100644
+--- i/packages/opencode/src/provider/models-macro.ts
++++ w/packages/opencode/src/provider/models-macro.ts
+@@ -1,4 +1,15 @@
+ export async function data() {
++  const localApiJsonPath = process.env.MODELS_DEV_API_JSON
++  
++  // Try to read from local file if path is provided
++  if (localApiJsonPath) {
++    const localFile = Bun.file(localApiJsonPath)
++    if (await localFile.exists()) {
++      return await localFile.text()
++    }
++  }
++  
++  // Fallback to fetching from remote URL
+   const json = await fetch("https://models.dev/api.json").then((x) => x.text())
+   return json
+ }


### PR DESCRIPTION
- Added `models-dev` to `nativeBuildInputs`.
- Removed the old patch that fetched data from a remote URL and introduced a new patch to read from a local file if a path is provided via the `MODELS_DEV_API_JSON` environment variable.

Depends on #424373

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
