### PR TITLE
envoy: fix setting `wasmRuntime` to v8 or wasmtime

### DIFF
--- a/pkgs/by-name/en/envoy/0005-com_github_wasmtime_from_nix.patch
+++ b/pkgs/by-name/en/envoy/0005-com_github_wasmtime_from_nix.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Colton J. McCurdy" <mccurdyc22@gmail.com>
+Date: Sun, 6 Jul 2025 20:21:53 -0400
+Subject: [PATCH] com_github_wasmtime_from_nix
+
+Signed-off-by: Colton J. McCurdy <mccurdyc22@gmail.com>
+---
+ WORKSPACE | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index e4460bfc547561a9dfe1f2e2f3a39b01c992a3c2..32d880446dc76c635f17e3eed0b5a681cd1cc035 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -1,5 +1,13 @@
+ workspace(name = "envoy")
+ 
++# com_github_wasmtime matches the name in repository_locations to essentially override it.
++new_local_repository(
++    name = "com_github_wasmtime",
++    path = "@com_github_wasmtime_from_nix@",
++
++    build_file = "@proxy_wasm_cpp_host//:bazel/external/wasmtime.BUILD",
++)
++
+ load("//bazel:api_binding.bzl", "envoy_api_binding")
+ 
+ envoy_api_binding()

--- a/pkgs/by-name/en/envoy/0006-proxy_wasm_cpp_host_from_nix.patch
+++ b/pkgs/by-name/en/envoy/0006-proxy_wasm_cpp_host_from_nix.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Colton J. McCurdy" <mccurdyc22@gmail.com>
+Date: Fri, 4 Jul 2025 15:55:54 -0400
+Subject: [PATCH] proxy_wasm_cpp_host_from_nix
+
+Signed-off-by: Colton J. McCurdy <mccurdyc22@gmail.com>
+---
+ WORKSPACE | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/WORKSPACE b/WORKSPACE
+index e4460bfc547561a9dfe1f2e2f3a39b01c992a3c2..8cb19fef07fdcb86ab716f11fe3048bb42fa4f83 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -1,5 +1,11 @@
+ workspace(name = "envoy")
+ 
++# matches the name in bazel/repository_locations.bzl to essentially override it.
++local_repository(
++    name = "proxy_wasm_cpp_host",
++    path = "@proxy_wasm_cpp_host_from_nix@",
++)
++
+ load("//bazel:api_binding.bzl", "envoy_api_binding")
+ 
+ envoy_api_binding()

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -60,9 +60,7 @@ let
     # matches version in upstream envoy
     # https://github.com/mccurdyc/envoy/blob/6371b185dee99cd267e61ada6191e97f2406e334/bazel/repository_locations.bzl#L1407
     rev = "c4d7bb0fda912e24c64daf2aa749ec54cec99412";
-    # sha256 = pkgs.lib.fakeSha256;
     sha256 = "sha256-NSowlubJ3OK4h2W9dqmzhkgpceaXZ7ore2cRkNlBm5Q=";
-    # Do we need to somehow also tell envoy that this is used for extensions or is this only doing the override of fetching the source?
   };
 
   # these need to be updated for any changes to fetchAttrs
@@ -100,6 +98,7 @@ buildBazelPackage rec {
       # bump rules_rust to support newer Rust
       ./0004-nixpkgs-bump-rules_rust-to-0.60.0.patch
 
+      # TODO: These could maybe just be stored directly in the bazel repository cache instead of these patches
       # https://github.com/mccurdyc/envoy/blob/6371b185dee99cd267e61ada6191e97f2406e334/api/bazel/envoy_http_archive.bzl#L4-L9
       # Envoy's Bazel WONT fetch repos that are listed in the existing_rules list
       ./0005-com_github_wasmtime_from_nix.patch
@@ -118,6 +117,7 @@ buildBazelPackage rec {
     sed -i '/"-Werror"/d' bazel/envoy_internal.bzl
 
     # https://nixos.org/manual/nixpkgs/unstable/#fun-substitute
+    # TODO: These could maybe just be stored directly in the bazel repository cache instead of these patches
     substituteInPlace WORKSPACE --subst-var-by com_github_wasmtime_from_nix ${com_github_wasmtime}
     substituteInPlace WORKSPACE --subst-var-by proxy_wasm_cpp_host_from_nix ${proxy_wasm_cpp_host}
 
@@ -161,7 +161,11 @@ buildBazelPackage rec {
 
   buildInputs = [ linuxHeaders ];
 
+  # This is a full derivation on its own
   fetchAttrs = {
+    # Has network access to fetch.
+    # The fetchAttrs phase creates a content-addressed cache of all dependencies
+    # The sha256 here is the hash of the fixed-output derivation
     sha256 = depsHash;
     env.CARGO_BAZEL_REPIN = true;
     dontUseCmakeConfigure = true;


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nixpkgs/issues/425065

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
