### PR TITLE
thunar: expose unwrapped derivation

### DIFF
--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -19,6 +19,8 @@
 
       services.xserver.desktopManager.xfce.enable = true;
       environment.systemPackages = [ pkgs.xfce.xfce4-whiskermenu-plugin ];
+
+      programs.thunar.plugins = [ pkgs.xfce.thunar-archive-plugin ];
     };
 
   enableOCR = true;

--- a/pkgs/desktops/xfce/core/thunar/default.nix
+++ b/pkgs/desktops/xfce/core/thunar/default.nix
@@ -16,82 +16,63 @@
   pcre2,
   xfce4-panel,
   xfconf,
-  makeWrapper,
-  symlinkJoin,
-  thunarPlugins ? [ ],
   withIntrospection ? false,
-  buildPackages,
   gobject-introspection,
 }:
 
-let
-  unwrapped = mkXfceDerivation {
-    category = "xfce";
-    pname = "thunar";
-    version = "4.20.3";
+mkXfceDerivation {
+  category = "xfce";
+  pname = "thunar";
+  version = "4.20.3";
 
-    sha256 = "sha256-YOh7tuCja9F2VvzX+QqsKHJfebXWbhLqvcraq6PBOGo=";
+  sha256 = "sha256-YOh7tuCja9F2VvzX+QqsKHJfebXWbhLqvcraq6PBOGo=";
 
-    nativeBuildInputs =
-      [
-        docbook_xsl
-        libxslt
-      ]
-      ++ lib.optionals withIntrospection [
-        gobject-introspection
-      ];
-
-    buildInputs = [
-      exo
-      gdk-pixbuf
-      gtk3
-      libX11
-      libexif # image properties page
-      libgudev
-      libnotify
-      libxfce4ui
-      libxfce4util
-      pcre2 # search & replace renamer
-      xfce4-panel # trash panel applet plugin
-      xfconf
+  nativeBuildInputs =
+    [
+      docbook_xsl
+      libxslt
+    ]
+    ++ lib.optionals withIntrospection [
+      gobject-introspection
     ];
 
-    configureFlags = [ "--with-custom-thunarx-dirs-enabled" ];
+  buildInputs = [
+    exo
+    gdk-pixbuf
+    gtk3
+    libX11
+    libexif # image properties page
+    libgudev
+    libnotify
+    libxfce4ui
+    libxfce4util
+    pcre2 # search & replace renamer
+    xfce4-panel # trash panel applet plugin
+    xfconf
+  ];
 
-    # the desktop file … is in an insecure location»
-    # which pops up when invoking desktop files that are
-    # symlinks to the /nix/store
-    #
-    # this error was added by this commit:
-    # https://github.com/xfce-mirror/thunar/commit/1ec8ff89ec5a3314fcd6a57f1475654ddecc9875
-    postPatch = ''
-      sed -i -e 's|thunar_dialogs_show_insecure_program (parent, _(".*"), file, exec)|1|' thunar/thunar-file.c
-    '';
+  configureFlags = [ "--with-custom-thunarx-dirs-enabled" ];
 
-    preFixup = ''
-      gappsWrapperArgs+=(
-        # https://github.com/NixOS/nixpkgs/issues/329688
-        --prefix PATH : ${lib.makeBinPath [ exo ]}
-      )
-    '';
+  # the desktop file … is in an insecure location»
+  # which pops up when invoking desktop files that are
+  # symlinks to the /nix/store
+  #
+  # this error was added by this commit:
+  # https://github.com/xfce-mirror/thunar/commit/1ec8ff89ec5a3314fcd6a57f1475654ddecc9875
+  postPatch = ''
+    sed -i -e 's|thunar_dialogs_show_insecure_program (parent, _(".*"), file, exec)|1|' thunar/thunar-file.c
+  '';
 
-    meta = with lib; {
-      description = "Xfce file manager";
-      mainProgram = "thunar";
-      teams = [ teams.xfce ];
-    };
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # https://github.com/NixOS/nixpkgs/issues/329688
+      --prefix PATH : ${lib.makeBinPath [ exo ]}
+    )
+  '';
+
+  meta = with lib; {
+    description = "Xfce file manager";
+    mainProgram = "thunar";
+    teams = [ teams.xfce ];
   };
-
-in
-if thunarPlugins == [ ] then
-  unwrapped
-else
-  import ./wrapper.nix {
-    inherit
-      makeWrapper
-      symlinkJoin
-      thunarPlugins
-      lib
-      ;
-    thunar = unwrapped;
-  }
+}

--- a/pkgs/desktops/xfce/core/thunar/wrapper.nix
+++ b/pkgs/desktops/xfce/core/thunar/wrapper.nix
@@ -2,53 +2,61 @@
   lib,
   makeWrapper,
   symlinkJoin,
-  thunar,
-  thunarPlugins,
+  thunar-unwrapped,
+  thunarPlugins ? [ ],
 }:
 
-symlinkJoin {
-  name = "thunar-with-plugins-${thunar.version}";
+let
+  thunar = thunar-unwrapped;
+in
 
-  paths = [ thunar ] ++ thunarPlugins;
+if thunarPlugins == [ ] then
+  thunar
 
-  nativeBuildInputs = [ makeWrapper ];
+else
+  symlinkJoin {
+    name = "thunar-with-plugins-${thunar.version}";
 
-  postBuild = ''
-    wrapProgram "$out/bin/thunar" \
-      --set "THUNARX_DIRS" "$out/lib/thunarx-3"
+    paths = [ thunar ] ++ thunarPlugins;
 
-    wrapProgram "$out/bin/thunar-settings" \
-      --set "THUNARX_DIRS" "$out/lib/thunarx-3"
+    nativeBuildInputs = [ makeWrapper ];
 
-    # NOTE: we need to remove the folder symlink itself and create
-    # a new folder before trying to substitute any file below.
-    rm -f "$out/lib/systemd/user"
-    mkdir -p "$out/lib/systemd/user"
+    postBuild = ''
+      wrapProgram "$out/bin/thunar" \
+        --set "THUNARX_DIRS" "$out/lib/thunarx-3"
 
-    # point to wrapped binary in all service files
-    for file in "lib/systemd/user/thunar.service" \
-      "share/dbus-1/services/org.xfce.FileManager.service" \
-      "share/dbus-1/services/org.xfce.Thunar.FileManager1.service" \
-      "share/dbus-1/services/org.xfce.Thunar.service"
-    do
-      rm -f "$out/$file"
-      substitute "${thunar}/$file" "$out/$file" \
-        --replace "${thunar}" "$out"
-    done
-  '';
+      wrapProgram "$out/bin/thunar-settings" \
+        --set "THUNARX_DIRS" "$out/lib/thunarx-3"
 
-  meta = with lib; {
-    inherit (thunar.meta)
-      homepage
-      license
-      platforms
-      teams
-      ;
+      # NOTE: we need to remove the folder symlink itself and create
+      # a new folder before trying to substitute any file below.
+      rm -f "$out/lib/systemd/user"
+      mkdir -p "$out/lib/systemd/user"
 
-    description =
-      thunar.meta.description
-      +
-        optionalString (0 != length thunarPlugins)
-          " (with plugins: ${concatStringsSep ", " (map (x: x.name) thunarPlugins)})";
-  };
-}
+      # point to wrapped binary in all service files
+      for file in "lib/systemd/user/thunar.service" \
+        "share/dbus-1/services/org.xfce.FileManager.service" \
+        "share/dbus-1/services/org.xfce.Thunar.FileManager1.service" \
+        "share/dbus-1/services/org.xfce.Thunar.service"
+      do
+        rm -f "$out/$file"
+        substitute "${thunar}/$file" "$out/$file" \
+          --replace "${thunar}" "$out"
+      done
+    '';
+
+    meta = with lib; {
+      inherit (thunar.meta)
+        homepage
+        license
+        platforms
+        teams
+        ;
+
+      description =
+        thunar.meta.description
+        +
+          optionalString (0 != length thunarPlugins)
+            " (with plugins: ${concatStringsSep ", " (map (x: x.name) thunarPlugins)})";
+    };
+  }

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -33,9 +33,9 @@ makeScopeWithSplicing' {
 
       libxfce4windowing = callPackage ./core/libxfce4windowing { };
 
-      thunar = callPackage ./core/thunar {
-        thunarPlugins = [ ];
-      };
+      thunar-unwrapped = callPackage ./core/thunar { };
+
+      thunar = callPackage ./core/thunar/wrapper.nix { };
 
       thunar-volman = callPackage ./core/thunar-volman { };
 
@@ -169,7 +169,7 @@ makeScopeWithSplicing' {
 
       xinitrc = self.xfce4-session.xinitrc; # added 2019-11-04
 
-      thunar-bare = self.thunar.override { thunarPlugins = [ ]; }; # added 2019-11-04
+      thunar-bare = self.thunar-unwrapped; # added 2019-11-04
 
       xfce4-datetime-plugin = throw ''
         xfce4-datetime-plugin has been removed: this plugin has been merged into the xfce4-panel's built-in clock


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/424367 by exposing the unwrapped Thunar derivation as `xfce.thunar-unwrapped`, allowing it to be patched.

For example, one can now use the following:

```nix
xfce.thunar.override {
  thunarPlugins = [ xfce.thunar-archive-plugin ];
  thunar-unwrapped = xfce.thunar-unwrapped.overrideAttrs /* ... */;
}
```

Or, using an overlay:

```nix
final: prev: {
  xfce = prev.xfce.overrideScope (xfinal: xprev: {
    thunar-unwrapped = xprev.thunar-unwrapped.overrideAttrs /* ... */;
  });
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) (`xfce`)
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
