### PR TITLE
python3Packages.docutils: Fix upstream URL (repo.or.cz -> sourceforge)

### DIFF
--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromRepoOrCz,
+  fetchurl,
   buildPythonPackage,
   flit-core,
   pillow,
@@ -19,10 +19,9 @@ let
 
     disabled = pythonOlder "3.7";
 
-    src = fetchFromRepoOrCz {
-      repo = "docutils";
-      rev = "docutils-${version}";
-      hash = "sha256-Q+9yW+BYUEvPYV504368JsAoKKoaTZTeKh4tVeiNv5Y=";
+    src = fetchurl {
+      url = "mirror://sourceforge/docutils/docutils-${version}.tar.gz";
+      hash = "sha256-OmsYcy7fGC2qPNEndbuzOM9WkUaPke7rEJ3v9uv6mG8=";
     };
 
     build-system = [ flit-core ];
@@ -53,7 +52,7 @@ let
         psfl
         gpl3Plus
       ];
-      maintainers = with maintainers; [ ];
+      maintainers = with maintainers; [ jherland ];
     };
   };
 in

--- a/pkgs/development/python-modules/docutils/default.nix
+++ b/pkgs/development/python-modules/docutils/default.nix
@@ -17,8 +17,6 @@ let
     version = "0.21.2";
     pyproject = true;
 
-    disabled = pythonOlder "3.7";
-
     src = fetchurl {
       url = "mirror://sourceforge/docutils/docutils-${version}.tar.gz";
       hash = "sha256-OmsYcy7fGC2qPNEndbuzOM9WkUaPke7rEJ3v9uv6mG8=";
@@ -33,7 +31,9 @@ let
     nativeCheckInputs = [ pillow ];
 
     checkPhase = ''
+      runHook preCheck
       ${python.interpreter} test/alltests.py
+      runHook postCheck
     '';
 
     # Create symlinks lacking a ".py" suffix, many programs depend on these names
@@ -43,16 +43,20 @@ let
       done
     '';
 
-    meta = with lib; {
+    pythonImportsCheck = [ "docutils" ];
+
+    meta = {
       description = "Python Documentation Utilities";
       homepage = "http://docutils.sourceforge.net/";
-      license = with licenses; [
+      changelog = "https://sourceforge.net/projects/docutils/files/docutils/${version}";
+      license = with lib.licenses; [
         publicDomain
         bsd2
         psfl
         gpl3Plus
       ];
-      maintainers = with maintainers; [ jherland ];
+      maintainers = with lib.maintainers; [ jherland ];
+      mainProgram = "docutils";
     };
   };
 in


### PR DESCRIPTION
Commits:
- `python3Packages.docutils`: Fix upstream URL (repo.or.cz -> sourceforge)
- `python3Packages.docutils`: Various minor updates/modernization


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
