### PR TITLE
xfce.xfce4-screensaver: 4.18.4 -> 4.20.0

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-screensaver/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screensaver/default.nix
@@ -1,6 +1,15 @@
 {
-  mkXfceDerivation,
-  gobject-introspection,
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  docbook_xml_dtd_412,
+  docbook-xsl-ns,
+  gettext,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
+  xmlto,
   dbus-glib,
   garcon,
   glib,
@@ -17,22 +26,37 @@
   systemd,
   xfconf,
   xfdesktop,
-  lib,
+  gitUpdater,
 }:
 
 let
   # For xfce4-screensaver-configure
   pythonEnv = python3.withPackages (pp: [ pp.pygobject3 ]);
 in
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-screensaver";
-  version = "4.18.4";
+  version = "4.20.0";
 
-  sha256 = "sha256-vkxkryi7JQg1L/JdWnO9qmW6Zx6xP5Urq4kXMe7Iiyc=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "xfce4-screensaver";
+    tag = "xfce4-screensaver-${finalAttrs.version}";
+    hash = "sha256-Pt7Rl+WlR2D4KC6GTXjQhs3yirrUgUG5XkKXnyaJZbo=";
+  };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
-    gobject-introspection
+    docbook_xml_dtd_412
+    docbook-xsl-ns
+    gettext
+    glib # glib-compile-resources
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
+    xmlto
   ];
 
   buildInputs = [
@@ -53,18 +77,20 @@ mkXfceDerivation {
     xfconf
   ];
 
-  configureFlags = [ "--without-console-kit" ];
-
-  makeFlags = [ "DBUS_SESSION_SERVICE_DIR=$(out)/etc" ];
-
   preFixup = ''
     # For default wallpaper.
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${xfdesktop}/share")
   '';
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "xfce4-screensaver-"; };
+
+  meta = {
+    homepage = "https://gitlab.xfce.org/apps/xfce4-screensaver";
     description = "Screensaver for Xfce";
-    maintainers = with maintainers; [ symphorien ];
-    teams = [ teams.xfce ];
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "xfce4-screensaver";
+    maintainers = with lib.maintainers; [ symphorien ];
+    teams = [ lib.teams.xfce ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
https://gitlab.xfce.org/apps/xfce4-screensaver/-/compare/xfce4-screensaver-4.18.4...xfce4-screensaver-4.20.0

I [authored](https://github.com/xfce-mirror/xfce4-screensaver/compare/62fb84e31419dddf4b79ba4314d7f898b8f35bed...xfce4-screensaver-4.20.0) the upstream meson port, I took the chance to do the following changes:

- Install dbus files in package's own prefix.
- Make wayland support disabled by default (because it requires unreleased `libwlembed`).
- Disallow having both consolekit and systemd enabled at the same time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

