### PR TITLE
treewide: adjust pnpm.fetchDeps parameter order

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -443,8 +443,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "...";
     fetcherVersion = 2;
+    hash = "...";
   };
 })
 ```
@@ -568,8 +568,8 @@ This is the version of the output of `pnpm.fetchDeps`, if you haven't set it alr
   # ...
   pnpmDeps = pnpm.fetchDeps {
     # ...
-    hash = "..."; # you can use your already set hash here
     fetcherVersion = 1;
+    hash = "..."; # you can use your already set hash here
   };
 }
 ```
@@ -581,8 +581,8 @@ After upgrading to a newer `fetcherVersion`, you need to regenerate the hash:
   # ...
   pnpmDeps = pnpm.fetchDeps {
     # ...
-    hash = "..."; # clear this hash and generate a new one
     fetcherVersion = 2;
+    hash = "..."; # clear this hash and generate a new one
   };
 }
 ```

--- a/pkgs/applications/audio/youtube-music/default.nix
+++ b/pkgs/applications/audio/youtube-music/default.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-xIQyTetHU37gTxCcQp4VCqzGdIfVQGy/aORCVba6YQ0=";
     fetcherVersion = 1;
+    hash = "sha256-xIQyTetHU37gTxCcQp4VCqzGdIfVQGy/aORCVba6YQ0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ao/aonsoku/package.nix
+++ b/pkgs/by-name/ao/aonsoku/package.nix
@@ -27,8 +27,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # lockfileVersion: '6.0' need old pnpm
   pnpmDeps = pnpm_8.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-h1rcM+H2c0lk7bpGeQT5ue9bQIggrCFHkj4o7KxnH08=";
     fetcherVersion = 1;
+    hash = "sha256-h1rcM+H2c0lk7bpGeQT5ue9bQIggrCFHkj4o7KxnH08=";
   };
 
   cargoRoot = "src-tauri";

--- a/pkgs/by-name/ap/apache-answer/package.nix
+++ b/pkgs/by-name/ap/apache-answer/package.nix
@@ -28,8 +28,8 @@ buildGoModule rec {
     pnpmDeps = pnpm_9.fetchDeps {
       inherit src version pname;
       sourceRoot = "${src.name}/ui";
-      hash = "sha256-/se6IWeHdazqS7PzOpgtT4IxCJ1WptqBzZ/BdmGb4BA=";
       fetcherVersion = 1;
+      hash = "sha256-/se6IWeHdazqS7PzOpgtT4IxCJ1WptqBzZ/BdmGb4BA=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -33,8 +33,8 @@ let
 
     pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname version src;
-      hash = "sha256-QIfadS2gNPtH006O86EndY/Hx2ml2FoKfUXJF5qoluw=";
       fetcherVersion = 1;
+      hash = "sha256-QIfadS2gNPtH006O86EndY/Hx2ml2FoKfUXJF5qoluw=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       prePnpmInstall
       ;
-    hash = "sha256-tlpk+wbLjJqt37lu67p2A2RZAR1ZfnZFiYoqIQwvWPQ=";
     fetcherVersion = 1;
+    hash = "sha256-tlpk+wbLjJqt37lu67p2A2RZAR1ZfnZFiYoqIQwvWPQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/au/autobrr/package.nix
+++ b/pkgs/by-name/au/autobrr/package.nix
@@ -40,8 +40,8 @@ let
         src
         sourceRoot
         ;
-      hash = "sha256-TbdRJqLdNI7wchUsx2Kw1LlDyv50XlCiKyn6rhZyN1U=";
       fetcherVersion = 1;
+      hash = "sha256-TbdRJqLdNI7wchUsx2Kw1LlDyv50XlCiKyn6rhZyN1U=";
     };
 
     postBuild = ''

--- a/pkgs/by-name/au/autoprefixer/package.nix
+++ b/pkgs/by-name/au/autoprefixer/package.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-zb/BwL//i0oly5HEXN20E3RzZXdaOn+G2yIWRas3PB4=";
     fetcherVersion = 1;
+    hash = "sha256-zb/BwL//i0oly5HEXN20E3RzZXdaOn+G2yIWRas3PB4=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -33,8 +33,8 @@ let
 
     pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname version src;
-      hash = "sha256-q7VMQb/FRT953yT2cyGMxUPp8p8XkA9mvqGI7S7Eifg=";
       fetcherVersion = 1;
+      hash = "sha256-q7VMQb/FRT953yT2cyGMxUPp8p8XkA9mvqGI7S7Eifg=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/ba/bash-language-server/package.nix
+++ b/pkgs/by-name/ba/bash-language-server/package.nix
@@ -28,8 +28,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       src
       pnpmWorkspaces
       ;
-    hash = "sha256-NvyqPv5OKgZi3hW98Da8LhsYatmrzrPX8kLOfLr+BrI=";
     fetcherVersion = 1;
+    hash = "sha256-NvyqPv5OKgZi3hW98Da8LhsYatmrzrPX8kLOfLr+BrI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/bu/bumpp/package.nix
+++ b/pkgs/by-name/bu/bumpp/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-duxpym1DlJM4q5j0wmrubYiAHQ3cDEFfeD9Gyic6mbI=";
     fetcherVersion = 1;
+    hash = "sha256-duxpym1DlJM4q5j0wmrubYiAHQ3cDEFfeD9Gyic6mbI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ca/cargo-tauri/test-app.nix
+++ b/pkgs/by-name/ca/cargo-tauri/test-app.nix
@@ -34,8 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       ;
 
-    hash = "sha256-plANa/+9YEQ4ipgdQ7QzPyxgz6eDCBhO7qFlxK6Ab58=";
     fetcherVersion = 1;
+    hash = "sha256-plANa/+9YEQ4ipgdQ7QzPyxgz6eDCBhO7qFlxK6Ab58=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cd/cdxgen/package.nix
+++ b/pkgs/by-name/cd/cdxgen/package.nix
@@ -37,8 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-7NrDYd4H0cPQs8w4lWlB0BhqcYZVo6/9zf0ujPjBzsE=";
     fetcherVersion = 1;
+    hash = "sha256-7NrDYd4H0cPQs8w4lWlB0BhqcYZVo6/9zf0ujPjBzsE=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -37,8 +37,8 @@ rustPlatform.buildRustPackage {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = pnpm-hash;
     fetcherVersion = 1;
+    hash = pnpm-hash;
   };
 
   env = {

--- a/pkgs/by-name/co/concurrently/package.nix
+++ b/pkgs/by-name/co/concurrently/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       patches
       ;
-    hash = "sha256-F1teWIABkK0mqZcK3RdGNKmexI/C59QWSrrD1jYbHt0=";
     fetcherVersion = 1;
+    hash = "sha256-F1teWIABkK0mqZcK3RdGNKmexI/C59QWSrrD1jYbHt0=";
   };
 
   patches = [

--- a/pkgs/by-name/da/daed/package.nix
+++ b/pkgs/by-name/da/daed/package.nix
@@ -27,8 +27,8 @@ let
 
     pnpmDeps = pnpm_9.fetchDeps {
       inherit pname version src;
-      hash = "sha256-+yLpSbDzr1OV/bmUUg6drOvK1ok3cBd+RRV7Qrrlp+Q=";
       fetcherVersion = 1;
+      hash = "sha256-+yLpSbDzr1OV/bmUUg6drOvK1ok3cBd+RRV7Qrrlp+Q=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/de/deltachat-desktop/package.nix
+++ b/pkgs/by-name/de/deltachat-desktop/package.nix
@@ -48,8 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-PBCmyNmlH88y5s7+8WHcei8SP3Q0lIAAnAQn9uaFxLc=";
     fetcherVersion = 1;
+    hash = "sha256-PBCmyNmlH88y5s7+8WHcei8SP3Q0lIAAnAQn9uaFxLc=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/do/dorion/package.nix
+++ b/pkgs/by-name/do/dorion/package.nix
@@ -59,8 +59,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-xBonUzA4+1zbViEsKap6CaG6ZRldW1LjNYIB+FmVRFs=";
     fetcherVersion = 1;
+    hash = "sha256-xBonUzA4+1zbViEsKap6CaG6ZRldW1LjNYIB+FmVRFs=";
   };
 
   # CMake (webkit extension)

--- a/pkgs/by-name/em/emmet-language-server/package.nix
+++ b/pkgs/by-name/em/emmet-language-server/package.nix
@@ -20,8 +20,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-hh5PEtmSHPs6QBgwWHS0laGU21e82JckIP3mB/P9/vE=";
     fetcherVersion = 1;
+    hash = "sha256-hh5PEtmSHPs6QBgwWHS0laGU21e82JckIP3mB/P9/vE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/en/en-croissant/package.nix
+++ b/pkgs/by-name/en/en-croissant/package.nix
@@ -30,8 +30,8 @@ rustPlatform.buildRustPackage rec {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-hvWXSegUWJvwCU5NLb2vqnl+FIWpCLxw96s9NUIgJTI=";
     fetcherVersion = 1;
+    hash = "sha256-hvWXSegUWJvwCU5NLb2vqnl+FIWpCLxw96s9NUIgJTI=";
   };
 
   cargoRoot = "src-tauri";

--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -39,8 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       patches
       ;
-    hash = "sha256-laTyxRh54x3iopGVgoFtcgaV7R6IKux1O/+tzGEy0Fg=";
     fetcherVersion = 1;
+    hash = "sha256-laTyxRh54x3iopGVgoFtcgaV7R6IKux1O/+tzGEy0Fg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-fjfzBy1Z7AUKA53yjjCQ6yasHc5QMaOBtXtXA5fNK5s=";
     fetcherVersion = 1;
+    hash = "sha256-fjfzBy1Z7AUKA53yjjCQ6yasHc5QMaOBtXtXA5fNK5s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-n7LolizpKng7zzccytYoCwJ7uGQbMagsgYPDuq0mdxU=";
     fetcherVersion = 1;
+    hash = "sha256-n7LolizpKng7zzccytYoCwJ7uGQbMagsgYPDuq0mdxU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fe/fedistar/package.nix
+++ b/pkgs/by-name/fe/fedistar/package.nix
@@ -38,8 +38,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-xXVsjAXmrsOp+mXrYAxSKz4vX5JApLZ+Rh6hrYlnJDI=";
     fetcherVersion = 1;
+    hash = "sha256-xXVsjAXmrsOp+mXrYAxSKz4vX5JApLZ+Rh6hrYlnJDI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -37,8 +37,8 @@ let
     pnpmDeps = pnpm.fetchDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${src.name}/frontend";
-      hash = "sha256-vLOtVeGFeHXgQglvKsih4lj1uIs6wipwfo374viIq4I=";
       fetcherVersion = 1;
+      hash = "sha256-vLOtVeGFeHXgQglvKsih4lj1uIs6wipwfo374viIq4I=";
     };
 
     installPhase = ''

--- a/pkgs/by-name/fi/firezone-gui-client/package.nix
+++ b/pkgs/by-name/fi/firezone-gui-client/package.nix
@@ -40,8 +40,8 @@ let
     pnpmDeps = pnpm_9.fetchDeps {
       inherit pname version;
       src = "${src}/rust/gui-client";
-      hash = "sha256-ttbTYBuUv0vyiYzrFATF4x/zngsRXjuLPfL3qW2HEe4=";
       fetcherVersion = 1;
+      hash = "sha256-ttbTYBuUv0vyiYzrFATF4x/zngsRXjuLPfL3qW2HEe4=";
     };
     pnpmRoot = "rust/gui-client";
 

--- a/pkgs/by-name/fi/firezone-server/package.nix
+++ b/pkgs/by-name/fi/firezone-server/package.nix
@@ -34,8 +34,8 @@ beamPackages.mixRelease rec {
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version;
     src = "${src}/apps/web/assets";
-    hash = "sha256-ejyBppFtKeyVhAWmssglbpLleOnbw9d4B+iM5Vtx47A=";
     fetcherVersion = 1;
+    hash = "sha256-ejyBppFtKeyVhAWmssglbpLleOnbw9d4B+iM5Vtx47A=";
   };
   pnpmRoot = "apps/web/assets";
 

--- a/pkgs/by-name/fl/flood/package.nix
+++ b/pkgs/by-name/fl/flood/package.nix
@@ -22,8 +22,8 @@ buildNpmPackage rec {
   npmDeps = pnpmDeps;
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-E2VxRcOMLvvCQb9gCAGcBTsly571zh/HWM6Q1Zd2eVw=";
     fetcherVersion = 1;
+    hash = "sha256-E2VxRcOMLvvCQb9gCAGcBTsly571zh/HWM6Q1Zd2eVw=";
   };
 
   passthru = {

--- a/pkgs/by-name/fo/follow/package.nix
+++ b/pkgs/by-name/fo/follow/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-xNGLYzEz1G5sZSqmji+ItJ9D1vvZcwkkygnDeuypcIM=";
     fetcherVersion = 1;
+    hash = "sha256-xNGLYzEz1G5sZSqmji+ItJ9D1vvZcwkkygnDeuypcIM=";
   };
 
   env = {

--- a/pkgs/by-name/fr/froide/package.nix
+++ b/pkgs/by-name/fr/froide/package.nix
@@ -118,8 +118,8 @@ python.pkgs.buildPythonApplication rec {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit pname version src;
-    hash = "sha256-g7YX2fVXGmb3Qq9NNCb294bk4/0khcIZVSskYbE8Mdw=";
     fetcherVersion = 1;
+    hash = "sha256-g7YX2fVXGmb3Qq9NNCb294bk4/0khcIZVSskYbE8Mdw=";
   };
 
   postBuild = ''

--- a/pkgs/by-name/gi/gitbutler/package.nix
+++ b/pkgs/by-name/gi/gitbutler/package.nix
@@ -64,8 +64,8 @@ rustPlatform.buildRustPackage rec {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-5NtfstUuIYyntt09Mu9GAFAOImfO6VMmJ7g15kvGaLE=";
     fetcherVersion = 1;
+    hash = "sha256-5NtfstUuIYyntt09Mu9GAFAOImfO6VMmJ7g15kvGaLE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gi/gitify/package.nix
+++ b/pkgs/by-name/gi/gitify/package.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-eIvqZ9a+foYH+jXuqGz1m/4C+0Xq8mTvm7ZajKeOw58=";
     fetcherVersion = 1;
+    hash = "sha256-eIvqZ9a+foYH+jXuqGz1m/4C+0Xq8mTvm7ZajKeOw58=";
   };
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -42,8 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm'.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-8dSyU9arSvISc2kDWbg/CP6L4sZjZi/Zv7TZN4ONOjQ=";
     fetcherVersion = 1;
+    hash = "sha256-8dSyU9arSvISc2kDWbg/CP6L4sZjZi/Zv7TZN4ONOjQ=";
   };
 
   env = {

--- a/pkgs/by-name/gu/gui-for-clash/package.nix
+++ b/pkgs/by-name/gu/gui-for-clash/package.nix
@@ -43,8 +43,8 @@ let
     pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/frontend";
-      hash = "sha256-5tz1FItH9AvZhJjka8i5Kz22yf/tEmRPkDhz6iswZzc=";
       fetcherVersion = 1;
+      hash = "sha256-5tz1FItH9AvZhJjka8i5Kz22yf/tEmRPkDhz6iswZzc=";
     };
 
     sourceRoot = "${finalAttrs.src.name}/frontend";

--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -45,8 +45,8 @@ let
     pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/frontend";
-      hash = "sha256-5tz1FItH9AvZhJjka8i5Kz22yf/tEmRPkDhz6iswZzc=";
       fetcherVersion = 1;
+      hash = "sha256-5tz1FItH9AvZhJjka8i5Kz22yf/tEmRPkDhz6iswZzc=";
     };
 
     sourceRoot = "${finalAttrs.src.name}/frontend";

--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-9WCIdQ91IU8pfq6kpbmmn6APBTNwpCi9ovgRuWYUad8=";
     fetcherVersion = 1;
+    hash = "sha256-9WCIdQ91IU8pfq6kpbmmn6APBTNwpCi9ovgRuWYUad8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -38,8 +38,8 @@ buildGo123Module {
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version;
     src = "${src}/frontend";
-    hash = "sha256-6Q+tIY5dl5jCQyv1F8btLdJg0oEUGs0Wyu/joVdVhf8=";
     fetcherVersion = 1;
+    hash = "sha256-6Q+tIY5dl5jCQyv1F8btLdJg0oEUGs0Wyu/joVdVhf8=";
   };
   pnpmRoot = "../frontend";
 

--- a/pkgs/by-name/ho/homepage-dashboard/package.nix
+++ b/pkgs/by-name/ho/homepage-dashboard/package.nix
@@ -50,8 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       patches
       ;
-    hash = "sha256-aPkXHKG3vDsfYqYx9q9+2wZhuFqmPcXdoBqOfAvW9oA=";
     fetcherVersion = 1;
+    hash = "sha256-aPkXHKG3vDsfYqYx9q9+2wZhuFqmPcXdoBqOfAvW9oA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ho/homer/package.nix
+++ b/pkgs/by-name/ho/homer/package.nix
@@ -25,8 +25,8 @@ stdenvNoCC.mkDerivation rec {
       src
       patches
       ;
-    hash = "sha256-y1R+rlaOtFOHHAgEHPBl40536U10Ft0iUSfGcfXS08Y=";
     fetcherVersion = 1;
+    hash = "sha256-y1R+rlaOtFOHHAgEHPBl40536U10Ft0iUSfGcfXS08Y=";
   };
 
   # Enables specifying a custom Sass compiler binary path via `SASS_EMBEDDED_BIN_PATH` environment variable.

--- a/pkgs/by-name/it/it-tools/package.nix
+++ b/pkgs/by-name/it/it-tools/package.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
 
   pnpmDeps = pnpm_8.fetchDeps {
     inherit pname version src;
-    hash = "sha256-m1eXBE5rakcq8NGnPC9clAAvNJQrN5RuSQ94zfgGZxw=";
     fetcherVersion = 1;
+    hash = "sha256-m1eXBE5rakcq8NGnPC9clAAvNJQrN5RuSQ94zfgGZxw=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/je/jellyseerr/package.nix
+++ b/pkgs/by-name/je/jellyseerr/package.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Ym16jPHMHKmojMQOuMamDsW/u+oP1UhbCP5dooTUzFQ=";
     fetcherVersion = 1;
+    hash = "sha256-Ym16jPHMHKmojMQOuMamDsW/u+oP1UhbCP5dooTUzFQ=";
   };
 
   buildInputs = [ sqlite ];

--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -53,8 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
       '';
     };
 
-    hash = "sha256-yf8A0oZ0Y4A5k7gfinIU02Lbqp/ygyvIBlldS0pv5+0=";
     fetcherVersion = 1;
+    hash = "sha256-yf8A0oZ0Y4A5k7gfinIU02Lbqp/ygyvIBlldS0pv5+0=";
   };
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -44,8 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-nobOORfhwlGEvNt+MfDKd3rXor6tJHDulz5oD1BGY4I=";
     fetcherVersion = 1;
+    hash = "sha256-nobOORfhwlGEvNt+MfDKd3rXor6tJHDulz5oD1BGY4I=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/me/memos/package.nix
+++ b/pkgs/by-name/me/memos/package.nix
@@ -61,8 +61,8 @@ let
     pnpmDeps = pnpm.fetchDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/web";
-      hash = "sha256-AyQYY1vtBB6DTcieC7nw5aOOVuwESJSDs8qU6PGyaTw=";
       fetcherVersion = 1;
+      hash = "sha256-AyQYY1vtBB6DTcieC7nw5aOOVuwESJSDs8qU6PGyaTw=";
     };
     pnpmRoot = "web";
     nativeBuildInputs = [

--- a/pkgs/by-name/me/metacubexd/package.nix
+++ b/pkgs/by-name/me/metacubexd/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Ct/YLnpZb0YBXVaghd5W1bmDcjVRladwQNRoLagHgJo=";
     fetcherVersion = 1;
+    hash = "sha256-Ct/YLnpZb0YBXVaghd5W1bmDcjVRladwQNRoLagHgJo=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -37,8 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
   # https://nixos.org/manual/nixpkgs/unstable/#javascript-pnpm
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-T8LwpEjeWNmkIo3Dn1BCFHBsTzA/Dt6/pk/NMtvT0N4=";
     fetcherVersion = 1;
+    hash = "sha256-T8LwpEjeWNmkIo3Dn1BCFHBsTzA/Dt6/pk/NMtvT0N4=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
+++ b/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
@@ -36,8 +36,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Q6e942R+3+511qFe4oehxdquw1TgaWMyOGOmP3me54o=";
     fetcherVersion = 1;
+    hash = "sha256-Q6e942R+3+511qFe4oehxdquw1TgaWMyOGOmP3me54o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mo/moonfire-nvr/package.nix
+++ b/pkgs/by-name/mo/moonfire-nvr/package.nix
@@ -32,8 +32,8 @@ let
     pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/ui";
-      hash = "sha256-7fMhUFlV5lz+A9VG8IdWoc49C2CTdLYQlEgBSBqJvtw=";
       fetcherVersion = 1;
+      hash = "sha256-7fMhUFlV5lz+A9VG8IdWoc49C2CTdLYQlEgBSBqJvtw=";
     };
     installPhase = ''
       runHook preInstall

--- a/pkgs/by-name/mo/moonlight/package.nix
+++ b/pkgs/by-name/mo/moonlight/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     buildInputs = [ nodejs_22 ];
 
-    hash = "sha256-vrSfrAnLc30kba+8VOPawdp8KaQVUhsD6mUq+YdAJTY=";
     fetcherVersion = 1;
+    hash = "sha256-vrSfrAnLc30kba+8VOPawdp8KaQVUhsD6mUq+YdAJTY=";
   };
 
   env = {

--- a/pkgs/by-name/n8/n8n/package.nix
+++ b/pkgs/by-name/n8/n8n/package.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-HzJej2Mt110n+1KX0wzuAn6j69zQOzI42EGxQB6PYbc=";
     fetcherVersion = 1;
+    hash = "sha256-HzJej2Mt110n+1KX0wzuAn6j69zQOzI42EGxQB6PYbc=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/ni/ni/package.nix
+++ b/pkgs/by-name/ni/ni/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-gDBjAwut217mdbWyk/dSU4JOkoRbOk4Czlb/lXhWqRU=";
     fetcherVersion = 1;
+    hash = "sha256-gDBjAwut217mdbWyk/dSU4JOkoRbOk4Czlb/lXhWqRU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/oc/ocis/package.nix
+++ b/pkgs/by-name/oc/ocis/package.nix
@@ -50,8 +50,8 @@ buildGoModule rec {
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     sourceRoot = "${src.name}/services/idp";
-    hash = "sha256-gNlN+u/bobnTsXrsOmkDcWs67D/trH3inT5AVQs3Brs=";
     fetcherVersion = 1;
+    hash = "sha256-gNlN+u/bobnTsXrsOmkDcWs67D/trH3inT5AVQs3Brs=";
   };
   pnpmRoot = "services/idp";
 

--- a/pkgs/by-name/oc/ocis/web.nix
+++ b/pkgs/by-name/oc/ocis/web.nix
@@ -36,8 +36,8 @@ stdenvNoCC.mkDerivation rec {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-3Erva6srdkX1YQ727trx34Ufx524nz19MUyaDQToz6M=";
     fetcherVersion = 1;
+    hash = "sha256-3Erva6srdkX1YQ727trx34Ufx524nz19MUyaDQToz6M=";
   };
 
   meta = {

--- a/pkgs/by-name/op/opencloud/idp-web.nix
+++ b/pkgs/by-name/op/opencloud/idp-web.nix
@@ -16,8 +16,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.pnpmRoot}";
-    hash = "sha256-NW7HK2B9h5JprK3JcIGi/OHcyoa5VTs/P0s3BZr+4FU=";
     fetcherVersion = 1;
+    hash = "sha256-NW7HK2B9h5JprK3JcIGi/OHcyoa5VTs/P0s3BZr+4FU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/opencloud/web.nix
+++ b/pkgs/by-name/op/opencloud/web.nix
@@ -20,8 +20,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-vxZxwbJByTk45GDD2FNphMMdeLlF8uxyrlc9x42crNA=";
     fetcherVersion = 1;
+    hash = "sha256-vxZxwbJByTk45GDD2FNphMMdeLlF8uxyrlc9x42crNA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openlist/frontend.nix
+++ b/pkgs/by-name/op/openlist/frontend.nix
@@ -32,8 +32,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-PTZ+Vhg3hNnORnulkzuVg6TF/jY0PvUWYja9z7S4GdM=";
     fetcherVersion = 1;
+    hash = "sha256-PTZ+Vhg3hNnORnulkzuVg6TF/jY0PvUWYja9z7S4GdM=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/ov/overlayed/package.nix
+++ b/pkgs/by-name/ov/overlayed/package.nix
@@ -35,8 +35,8 @@ rustPlatform.buildRustPackage rec {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-+yyxoodcDfqJ2pkosd6sMk77/71RDsGthedo1Oigwto=";
     fetcherVersion = 1;
+    hash = "sha256-+yyxoodcDfqJ2pkosd6sMk77/71RDsGthedo1Oigwto=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -69,8 +69,8 @@ let
 
       pnpmDeps = pnpm.fetchDeps {
         inherit pname version src;
-        hash = "sha256-VtYYwpMXPAC3g1OESnw3dzLTwiGqJBQcicFZskEucok=";
         fetcherVersion = 1;
+        hash = "sha256-VtYYwpMXPAC3g1OESnw3dzLTwiGqJBQcicFZskEucok=";
       };
 
       nativeBuildInputs =

--- a/pkgs/by-name/pa/parca/package.nix
+++ b/pkgs/by-name/pa/parca/package.nix
@@ -24,8 +24,8 @@ let
 
     pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname src version;
-      hash = "sha256-gczEkCU9xESn9T1eVOmGAufh+24mOsYCMO6f5tcbdmQ=";
       fetcherVersion = 1;
+      hash = "sha256-gczEkCU9xESn9T1eVOmGAufh+24mOsYCMO6f5tcbdmQ=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pd/pds/package.nix
+++ b/pkgs/by-name/pd/pds/package.nix
@@ -50,8 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = "sha256-KyHa7pZaCgyqzivI0Y7E6Y4yBRllYdYLnk1s0o0dyHY=";
     fetcherVersion = 1;
+    hash = "sha256-KyHa7pZaCgyqzivI0Y7E6Y4yBRllYdYLnk1s0o0dyHY=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/pg/pgrok/package.nix
+++ b/pkgs/by-name/pg/pgrok/package.nix
@@ -33,8 +33,8 @@ buildGoModule {
 
   env.pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-o6wxO8EGRmhcYggJnfxDkH+nbt+isc8bfHji8Hu9YKg=";
     fetcherVersion = 1;
+    hash = "sha256-o6wxO8EGRmhcYggJnfxDkH+nbt+isc8bfHji8Hu9YKg=";
   };
 
   vendorHash = "sha256-nIxsG1O5RG+PDSWBcUWpk+4aFq2cYaxpkgOoDqLjY90=";

--- a/pkgs/by-name/pi/piped/package.nix
+++ b/pkgs/by-name/pi/piped/package.nix
@@ -28,8 +28,8 @@ buildNpmPackage rec {
   npmDeps = pnpmDeps;
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-WtZfRZFRV9I1iBlAoV69GGFjdiQhTSBG/iiEadPVcys=";
     fetcherVersion = 1;
+    hash = "sha256-WtZfRZFRV9I1iBlAoV69GGFjdiQhTSBG/iiEadPVcys=";
   };
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -60,8 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-8lNmCLfuAkXK1Du4iYYasRTozZf0HoAttf8Dfc6Jglw=";
     fetcherVersion = 1;
+    hash = "sha256-8lNmCLfuAkXK1Du4iYYasRTozZf0HoAttf8Dfc6Jglw=";
   };
 
   patches = [

--- a/pkgs/by-name/po/porn-vault/package.nix
+++ b/pkgs/by-name/po/porn-vault/package.nix
@@ -51,8 +51,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Xr9tRiP1hW+aFs9FnPvPkeJ0/LtJI57cjWY5bZQaRTQ=";
     fetcherVersion = 1;
+    hash = "sha256-Xr9tRiP1hW+aFs9FnPvPkeJ0/LtJI57cjWY5bZQaRTQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/po/pot/package.nix
+++ b/pkgs/by-name/po/pot/package.nix
@@ -41,8 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-iYQNGRWqXYBU+WIH/Xm8qndgOQ6RKYCtAyi93kb7xrQ=";
     fetcherVersion = 1;
+    hash = "sha256-iYQNGRWqXYBU+WIH/Xm8qndgOQ6RKYCtAyi93kb7xrQ=";
   };
 
   cargoRoot = "src-tauri";

--- a/pkgs/by-name/pr/prisma/package.nix
+++ b/pkgs/by-name/pr/prisma/package.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-dhEpn0oaqZqeiRMfcSiaqhud/RsKd6Wm5RR5iyQp1I8=";
     fetcherVersion = 1;
+    hash = "sha256-dhEpn0oaqZqeiRMfcSiaqhud/RsKd6Wm5RR5iyQp1I8=";
   };
 
   patchPhase = ''

--- a/pkgs/by-name/qu/quantframe/package.nix
+++ b/pkgs/by-name/qu/quantframe/package.nix
@@ -41,8 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-3IHwwbl1aH3Pzh9xq2Jfev9hj6/LXZaVaIJOPbgsquE=";
     fetcherVersion = 1;
+    hash = "sha256-3IHwwbl1aH3Pzh9xq2Jfev9hj6/LXZaVaIJOPbgsquE=";
   };
 
   useFetchCargoVendor = true;

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -39,8 +39,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-lez75n3dIM4efpP+qPuDteCfMnC6wPD+L2173iJbTZM=";
     fetcherVersion = 1;
+    hash = "sha256-lez75n3dIM4efpP+qPuDteCfMnC6wPD+L2173iJbTZM=";
   };
 
   pnpmRoot = "../..";

--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -39,8 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-XOlFJFFyzbx8Bg92HXhVFFCI51j2GUK7+LJKfqVOQyU=";
     fetcherVersion = 1;
+    hash = "sha256-XOlFJFFyzbx8Bg92HXhVFFCI51j2GUK7+LJKfqVOQyU=";
   };
 
   env.COREPACK_ENABLE_STRICT = 0;

--- a/pkgs/by-name/rm/rmfakecloud/package.nix
+++ b/pkgs/by-name/rm/rmfakecloud/package.nix
@@ -28,8 +28,8 @@ buildGoModule rec {
     inherit pname version src;
     sourceRoot = "${src.name}/ui";
     pnpmLock = "${src}/ui/pnpm-lock.yaml";
-    hash = "sha256-VNmCT4um2W2ii8jAm+KjQSjixYEKoZkw7CeRwErff/o=";
     fetcherVersion = 1;
+    hash = "sha256-VNmCT4um2W2ii8jAm+KjQSjixYEKoZkw7CeRwErff/o=";
   };
   preBuild = lib.optionals enableWebui ''
     # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart

--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -64,8 +64,8 @@ rustPlatform.buildRustPackage rec {
       patches
       ;
     postPatch = "cd ${pnpmRoot}";
-    hash = app-type-either "sha256-V46V/VPwCKEe3sAp8zK0UUU5YigqgYh1GIOorqIAiNE=" "sha256-8QRigYNtxirXidFFnTzA6rP0+L64M/iakPqe2lZKegs=";
     fetcherVersion = 1;
+    hash = app-type-either "sha256-V46V/VPwCKEe3sAp8zK0UUU5YigqgYh1GIOorqIAiNE=" "sha256-8QRigYNtxirXidFFnTzA6rP0+L64M/iakPqe2lZKegs=";
   };
 
   useFetchCargoVendor = true;

--- a/pkgs/by-name/rs/rsshub/package.nix
+++ b/pkgs/by-name/rs/rsshub/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-7qh6YZbIH/kHVssDZxHY7X8bytrnMcUq0MiJzWZYItc=";
     fetcherVersion = 1;
+    hash = "sha256-7qh6YZbIH/kHVssDZxHY7X8bytrnMcUq0MiJzWZYItc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sa/satisfactorymodmanager/package.nix
+++ b/pkgs/by-name/sa/satisfactorymodmanager/package.nix
@@ -55,8 +55,8 @@ buildGoModule rec {
     pnpmDeps = pnpm_8.fetchDeps {
       inherit pname version src;
       sourceRoot = "${src.name}/frontend";
-      hash = "sha256-OP+3zsNlvqLFwvm2cnBd2bj2Kc3EghQZE3hpotoqqrQ=";
       fetcherVersion = 1;
+      hash = "sha256-OP+3zsNlvqLFwvm2cnBd2bj2Kc3EghQZE3hpotoqqrQ=";
     };
 
     pnpmRoot = "frontend";

--- a/pkgs/by-name/sh/shadcn/package.nix
+++ b/pkgs/by-name/sh/shadcn/package.nix
@@ -28,8 +28,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       src
       pnpmWorkspaces
       ;
-    hash = "sha256-/80LJm65ZRqyfhsNqGl83bsI2wjgVkvrA6Ij4v8rtoQ=";
     fetcherVersion = 1;
+    hash = "sha256-/80LJm65ZRqyfhsNqGl83bsI2wjgVkvrA6Ij4v8rtoQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sh/sharkey/package.nix
+++ b/pkgs/by-name/sh/sharkey/package.nix
@@ -34,8 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-S8LxawbtguFOEZyYbS1FQWw/TcRm4Z6mG7dUhfXbf1c=";
     fetcherVersion = 1;
+    hash = "sha256-S8LxawbtguFOEZyYbS1FQWw/TcRm4Z6mG7dUhfXbf1c=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -68,8 +68,8 @@ let
 
     pnpmDeps = pnpm.fetchDeps {
       inherit (finalAttrs) pname src version;
-      hash = "sha256-cT7Ixl/V/mesPHvJUsG63Y/wXwKjbjkjdjP3S7uEOa0=";
       fetcherVersion = 1;
+      hash = "sha256-cT7Ixl/V/mesPHvJUsG63Y/wXwKjbjkjdjP3S7uEOa0=";
     };
 
     strictDeps = true;
@@ -119,12 +119,12 @@ stdenv.mkDerivation (finalAttrs: {
       src
       patches
       ;
+    fetcherVersion = 1;
     hash =
       if withAppleEmojis then
         "sha256-ry7s9fbKx4e1LR8DlI2LIJY9GQrxmU7JQt+3apJGw/M="
       else
         "sha256-AkrfugpNvk4KgesRLQbso8p5b96Dg174R9/xuP4JtJg=";
-    fetcherVersion = 1;
   };
 
   env = {

--- a/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-regaYG+SDvIgdnHQVR1GG1A1FSBXpzFfLuyTEdMt1kQ=";
     fetcherVersion = 1;
+    hash = "sha256-regaYG+SDvIgdnHQVR1GG1A1FSBXpzFfLuyTEdMt1kQ=";
   };
 
   cargoRoot = "deps/extension";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -96,8 +96,8 @@ stdenv.mkDerivation (finalAttrs: {
       sourceRoot
       postPatch
       ;
-    hash = "sha256-eSf4mpKBm1G4K9+V6VXEiPrIVQMyru7o9BGVIUycQaQ=";
     fetcherVersion = 1;
+    hash = "sha256-eSf4mpKBm1G4K9+V6VXEiPrIVQMyru7o9BGVIUycQaQ=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";

--- a/pkgs/by-name/sk/sketchybar-app-font/package.nix
+++ b/pkgs/by-name/sk/sketchybar-app-font/package.nix
@@ -20,8 +20,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-NGAgueJ+cuK/csjdf94KNklu+Xf91BHoWKVgEctX6eA=";
     fetcherVersion = 1;
+    hash = "sha256-NGAgueJ+cuK/csjdf94KNklu+Xf91BHoWKVgEctX6eA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -39,8 +39,8 @@ rustPlatform.buildRustPackage rec {
   pnpmDeps = pnpm_9.fetchDeps {
     pname = "${pname}-pnpm-deps";
     inherit version src;
-    hash = "sha256-lh5IKdBXuH9GZFUTrzaQFDWCEYj0UJhKwCdPmsiwfCs=";
     fetcherVersion = 1;
+    hash = "sha256-lh5IKdBXuH9GZFUTrzaQFDWCEYj0UJhKwCdPmsiwfCs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sp/splayer/package.nix
+++ b/pkgs/by-name/sp/splayer/package.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation (final: {
 
   pnpmDeps = final.pnpm.fetchDeps {
     inherit (final) pname version src;
-    hash = "sha256-mC1iJtkZpTd2Vte5DLI3ntZ7vSO5Gka2qOk7ihQd3Gs=";
     fetcherVersion = 1;
+    hash = "sha256-mC1iJtkZpTd2Vte5DLI3ntZ7vSO5Gka2qOk7ihQd3Gs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -28,8 +28,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-PVA6sXbiuxqvi9u3sPoeVIJSSpSbFQHQQnTFO3w31WE=";
     fetcherVersion = 1;
+    hash = "sha256-PVA6sXbiuxqvi9u3sPoeVIJSSpSbFQHQQnTFO3w31WE=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -66,8 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-oreeV9g16/F7JGLApi0Uq+vTqNhIg7Lg1Z4k00RUOYI=";
     fetcherVersion = 1;
+    hash = "sha256-oreeV9g16/F7JGLApi0Uq+vTqNhIg7Lg1Z4k00RUOYI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sy/synchrony/package.nix
+++ b/pkgs/by-name/sy/synchrony/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-+hS4UK7sncCxv6o5Yl72AeY+LSGLnUTnKosAYB6QsP0=";
     fetcherVersion = 1;
+    hash = "sha256-+hS4UK7sncCxv6o5Yl72AeY+LSGLnUTnKosAYB6QsP0=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/sy/syncyomi/package.nix
+++ b/pkgs/by-name/sy/syncyomi/package.nix
@@ -33,8 +33,8 @@ buildGoModule rec {
         src
         sourceRoot
         ;
-      hash = "sha256-edcZIqshnvM3jJpZWIR/UncI0VCMLq26h/n3VvV/384=";
       fetcherVersion = 1;
+      hash = "sha256-edcZIqshnvM3jJpZWIR/UncI0VCMLq26h/n3VvV/384=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/ta/tabby-agent/package.nix
+++ b/pkgs/by-name/ta/tabby-agent/package.nix
@@ -48,8 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-SiJJxRzmKQxqw3UESN7q+3qkU1nK+7z6K5RpIMRRces=";
     fetcherVersion = 1;
+    hash = "sha256-SiJJxRzmKQxqw3UESN7q+3qkU1nK+7z6K5RpIMRRces=";
   };
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/ta/tailwindcss-language-server/package.nix
+++ b/pkgs/by-name/ta/tailwindcss-language-server/package.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       pnpmWorkspaces
       ;
-    hash = "sha256-SUEq20gZCiTDkFuNgMc5McHBPgW++8P9Q1MJb7a7pY8=";
     fetcherVersion = 1;
+    hash = "sha256-SUEq20gZCiTDkFuNgMc5McHBPgW++8P9Q1MJb7a7pY8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -56,8 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-pLe5smsXdzSBgz/OYNO5FVEI2L6y/p+jMxEkzqUaX34=";
     fetcherVersion = 1;
+    hash = "sha256-pLe5smsXdzSBgz/OYNO5FVEI2L6y/p+jMxEkzqUaX34=";
   };
 
   buildInputs = [ nodejs_20 ];

--- a/pkgs/by-name/ta/taze/package.nix
+++ b/pkgs/by-name/ta/taze/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-aUMV2REINp5LDcj1s8bgQAj/4508UEewu+ebD+JT0+M=";
     fetcherVersion = 1;
+    hash = "sha256-aUMV2REINp5LDcj1s8bgQAj/4508UEewu+ebD+JT0+M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/te/teleport/package.nix
+++ b/pkgs/by-name/te/teleport/package.nix
@@ -73,8 +73,8 @@ let
 
     pnpmDeps = pnpm_10.fetchDeps {
       inherit src pname version;
-      hash = pnpmHash;
       fetcherVersion = 1;
+      hash = pnpmHash;
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/ts/tsx/package.nix
+++ b/pkgs/by-name/ts/tsx/package.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-57KDZ9cHb7uqnypC0auIltmYMmIhs4PWyf0HTRWEFiU=";
     fetcherVersion = 1;
+    hash = "sha256-57KDZ9cHb7uqnypC0auIltmYMmIhs4PWyf0HTRWEFiU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ty/typespec/package.nix
+++ b/pkgs/by-name/ty/typespec/package.nix
@@ -38,8 +38,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       postPatch
       ;
-    hash = "sha256-9RQZ2ycu78W3Ie6MLpo6x7Sa/iYsUdq5bYed56mOPxs=";
     fetcherVersion = 1;
+    hash = "sha256-9RQZ2ycu78W3Ie6MLpo6x7Sa/iYsUdq5bYed56mOPxs=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ve/vencord/package.nix
+++ b/pkgs/by-name/ve/vencord/package.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname src;
-    hash = "sha256-hO6QKRr4jTfesRDAEGcpFeJmGTGLGMw6EgIvD23DNzw=";
     fetcherVersion = 1;
+    hash = "sha256-hO6QKRr4jTfesRDAEGcpFeJmGTGLGMw6EgIvD23DNzw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -36,8 +36,8 @@ let
         src
         sourceRoot
         ;
-      hash = "sha256-94ZlywOZYmW/NsvE0dtEA81MeBWGUrJsBXTUauuOmZM=";
       fetcherVersion = 1;
+      hash = "sha256-94ZlywOZYmW/NsvE0dtEA81MeBWGUrJsBXTUauuOmZM=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -64,8 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
       moreutils
     ];
 
-    hash = "sha256-RKgqFmHQnjHS7yeUIbH9awpNozDOCCHplc/bmfxmMyg=";
     fetcherVersion = 1;
+    hash = "sha256-RKgqFmHQnjHS7yeUIbH9awpNozDOCCHplc/bmfxmMyg=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -40,8 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       version
       ;
-    hash = "sha256-SdqeTYRH60CyU522+nBo0uCDnzxDP48eWBAtGTL/pqg=";
     fetcherVersion = 1;
+    hash = "sha256-SdqeTYRH60CyU522+nBo0uCDnzxDP48eWBAtGTL/pqg=";
   };
 
   # Patches to get submodule sha from file instead of 'git submodule status'

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) src pname version;
-    hash = "sha256-KupqObdNrnWbbt9C4NNmgmQCfJ2O4FjJBwGy6XQhhHg=";
     fetcherVersion = 1;
+    hash = "sha256-KupqObdNrnWbbt9C4NNmgmQCfJ2O4FjJBwGy6XQhhHg=";
   };
 
   cargoRoot = "src-tauri";

--- a/pkgs/by-name/wo/wox/package.nix
+++ b/pkgs/by-name/wo/wox/package.nix
@@ -74,8 +74,8 @@ let
         src
         sourceRoot
         ;
-      hash = "sha256-4Xj6doUHFoZSwel+cPnr2m3rfvlxNmQCppm5gXGIEtU=";
       fetcherVersion = 1;
+      hash = "sha256-4Xj6doUHFoZSwel+cPnr2m3rfvlxNmQCppm5gXGIEtU=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       postPatch
       ;
-    hash = "sha256-r3QswmqP6CNufnsFM0KeKojm/HjHogrfYO/TdL3SrmA=";
     fetcherVersion = 1;
+    hash = "sha256-r3QswmqP6CNufnsFM0KeKojm/HjHogrfYO/TdL3SrmA=";
   };
   # pnpm packageManager version in workers-sdk root package.json may not match nixpkgs
   postPatch = ''

--- a/pkgs/by-name/za/zammad/package.nix
+++ b/pkgs/by-name/za/zammad/package.nix
@@ -81,8 +81,8 @@ stdenvNoCC.mkDerivation {
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname src;
 
-    hash = "sha256-mfdzb/LXQYL8kaQpWi9wD3OOroOOonDlJrhy9Dwl1no";
     fetcherVersion = 1;
+    hash = "sha256-mfdzb/LXQYL8kaQpWi9wD3OOroOOonDlJrhy9Dwl1no";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/za/zashboard/package.nix
+++ b/pkgs/by-name/za/zashboard/package.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-aiSZS6FEs7kqGXxC9Tx6Rngv3qrPMi5gOuh5Z3/oZyc=";
     fetcherVersion = 1;
+    hash = "sha256-aiSZS6FEs7kqGXxC9Tx6Rngv3qrPMi5gOuh5Z3/oZyc=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/ze/zenn-cli/package.nix
+++ b/pkgs/by-name/ze/zenn-cli/package.nix
@@ -56,8 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-AjdXclrNl1AHJ4LXq9I5Rk6KGyDaWXW187o2uLwRy/o=";
     fetcherVersion = 1;
+    hash = "sha256-AjdXclrNl1AHJ4LXq9I5Rk6KGyDaWXW187o2uLwRy/o=";
   };
 
   preBuild =

--- a/pkgs/by-name/zi/zigbee2mqtt_2/package.nix
+++ b/pkgs/by-name/zi/zigbee2mqtt_2/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-OPfs9WiUehKPaAqqgMOiIELoCPVBFYpNKeesfmA8Db0=";
     fetcherVersion = 1;
+    hash = "sha256-OPfs9WiUehKPaAqqgMOiIELoCPVBFYpNKeesfmA8Db0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/zi/zipline/package.nix
+++ b/pkgs/by-name/zi/zipline/package.nix
@@ -43,8 +43,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-kIneqtLPZ29PzluKUGO4XbQYHbNddu0kTfoP4C22k7U=";
     fetcherVersion = 1;
+    hash = "sha256-kIneqtLPZ29PzluKUGO4XbQYHbNddu0kTfoP4C22k7U=";
   };
 
   buildInputs = [

--- a/pkgs/development/python-modules/django-filingcabinet/default.nix
+++ b/pkgs/development/python-modules/django-filingcabinet/default.nix
@@ -94,8 +94,8 @@ buildPythonPackage rec {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit pname version src;
-    hash = "sha256-kvLV/pCX/wQHG0ttrjSro7/CoQ5K1T0aFChafQOwvNw=";
     fetcherVersion = 1;
+    hash = "sha256-kvLV/pCX/wQHG0ttrjSro7/CoQ5K1T0aFChafQOwvNw=";
   };
 
   postBuild = ''

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -85,8 +85,8 @@ buildPythonPackage rec {
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
-    hash = "sha256-h3ulPik0Uf8X687Se3J7h3+8jYzwXtbO6obsO27zyfA=";
     fetcherVersion = 1;
+    hash = "sha256-h3ulPik0Uf8X687Se3J7h3+8jYzwXtbO6obsO27zyfA=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -139,6 +139,7 @@ in
           '';
 
           passthru = {
+            inherit fetcherVersion;
             serve = callPackage ./serve.nix {
               pnpm = args.pnpm or pnpm';
               pnpmDeps = finalAttrs.finalPackage;

--- a/pkgs/servers/authelia/web.nix
+++ b/pkgs/servers/authelia/web.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = pnpmDepsHash;
     fetcherVersion = 1;
+    hash = pnpmDepsHash;
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/custom-sidebar/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/custom-sidebar/package.nix
@@ -19,8 +19,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-ZWh2R6wr7FH2RfoFAE81Kl+wHnUeNjUbFG3KIk8ZN3g=";
     fetcherVersion = 1;
+    hash = "sha256-ZWh2R6wr7FH2RfoFAE81Kl+wHnUeNjUbFG3KIk8ZN3g=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -233,8 +233,8 @@ let
     pnpmDeps = pnpm_9.fetchDeps {
       pname = "discourse-assets";
       inherit version src;
-      hash = "sha256-WyRBnuKCl5NJLtqy3HK/sJcrpMkh0PjbasGPNDV6+7Y=";
       fetcherVersion = 1;
+      hash = "sha256-WyRBnuKCl5NJLtqy3HK/sJcrpMkh0PjbasGPNDV6+7Y=";
     };
 
     nativeBuildInputs = runtimeDeps ++ [

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -42,8 +42,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   extraBuildInputs = [ libsass ];
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = pinData.uiPNPMDepsHash;
     fetcherVersion = 1;
+    hash = pinData.uiPNPMDepsHash;
   };
 
   buildPhase = ''


### PR DESCRIPTION
It is more common to specify hash as the last attribute of fetcher function args. Let's move fetcherVersion right above hash for all occurrences.

CC @SuperSandro2000 @gepbird
See https://github.com/NixOS/nixpkgs/pull/422975#discussion_r2204693393


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
