### PR TITLE
deviceTree.applyOverlays: Copy through other files

### DIFF
--- a/pkgs/os-specific/linux/device-tree/apply_overlays.py
+++ b/pkgs/os-specific/linux/device-tree/apply_overlays.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from functools import cached_property
 import json
 from pathlib import Path
+import shutil
 
 from libfdt import Fdt, FdtException, FDT_ERR_NOSPACE, FDT_ERR_NOTFOUND, fdt_overlay_apply
 
@@ -56,6 +57,33 @@ def apply_overlay(dt: Fdt, dto: Fdt) -> Fdt:
 
         raise FdtException(err)
 
+def process_dtb(rel_path: Path, source: Path, destination: Path, overlays_data: list[Overlay]):
+    source_dt = source / rel_path
+    print(f"Processing source device tree {rel_path}...")
+    with source_dt.open("rb") as fd:
+        dt = Fdt(fd.read())
+
+    for overlay in overlays_data:
+        if overlay.filter and overlay.filter not in str(rel_path):
+            print(f"  Skipping overlay {overlay.name}: filter does not match")
+            continue
+
+        dt_compatible = get_compatible(dt)
+        if len(dt_compatible) == 0:
+            print(f"  Device tree {rel_path} has no compatible string set. Assuming it's compatible with overlay")
+        elif not overlay.compatible.intersection(dt_compatible):
+            print(f"  Skipping overlay {overlay.name}: {overlay.compatible} is incompatible with {dt_compatible}")
+            continue
+
+        print(f"  Applying overlay {overlay.name}")
+        dt = apply_overlay(dt, overlay.fdt)
+
+    print(f"Saving final device tree {rel_path}...")
+    dest_path = destination / rel_path
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    with dest_path.open("wb") as fd:
+        fd.write(dt.as_bytearray())
+
 def main():
     parser = ArgumentParser(description='Apply a list of overlays to a directory of device trees')
     parser.add_argument("--source", type=Path, help="Source directory")
@@ -77,33 +105,16 @@ def main():
             for item in json.load(fd)
         ]
 
-    for source_dt in source.glob("**/*.dtb"):
-        rel_path = source_dt.relative_to(source)
-
-        print(f"Processing source device tree {rel_path}...")
-        with source_dt.open("rb") as fd:
-            dt = Fdt(fd.read())
-
-        for overlay in overlays_data:
-            if overlay.filter and overlay.filter not in str(rel_path):
-                print(f"  Skipping overlay {overlay.name}: filter does not match")
-                continue
-
-            dt_compatible = get_compatible(dt)
-            if len(dt_compatible) == 0:
-                print(f"  Device tree {rel_path} has no compatible string set. Assuming it's compatible with overlay")
-            elif not overlay.compatible.intersection(dt_compatible):
-                print(f"  Skipping overlay {overlay.name}: {overlay.compatible} is incompatible with {dt_compatible}")
-                continue
-
-            print(f"  Applying overlay {overlay.name}")
-            dt = apply_overlay(dt, overlay.fdt)
-
-        print(f"Saving final device tree {rel_path}...")
-        dest_path = destination / rel_path
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-        with dest_path.open("wb") as fd:
-            fd.write(dt.as_bytearray())
+    for dirpath, dirnames, filenames in source.walk():
+        for filename in filenames:
+            rel_path = (dirpath / filename).relative_to(source)
+            if filename.endswith(".dtb"):
+                process_dtb(rel_path, source, destination, overlays_data)
+            else:
+                # Copy other files through
+                dest_path = destination / rel_path
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(source / rel_path, dest_path)
 
 
 if __name__ == '__main__':

--- a/pkgs/os-specific/linux/device-tree/apply_overlays.py
+++ b/pkgs/os-specific/linux/device-tree/apply_overlays.py
@@ -15,16 +15,16 @@ class Overlay:
     dtbo_file: Path
 
     @cached_property
-    def fdt(self):
+    def fdt(self) -> Fdt:
         with self.dtbo_file.open("rb") as fd:
             return Fdt(fd.read())
 
     @cached_property
-    def compatible(self):
+    def compatible(self) -> set[str]:
         return get_compatible(self.fdt)
 
 
-def get_compatible(fdt):
+def get_compatible(fdt) -> set[str]:
     root_offset = fdt.path_offset("/")
 
     try:


### PR DESCRIPTION
The source devicetree package can have overlays (dtbo) files. This is particularly relevant when working with a vendored BSP, which might apply DTBOs at runtime based on hardware identifiers. When applying overlays specified with `hardware.deviceTree.overlays`, the dtbos from the source are dropped. Make applyOverlays copy through all non-DTB files. This matches the behavior when there are no hardware.deviceTree.overlays described for the system.

I've also added the remaining type annotations to a few functions in apply_overlays.py.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
