### PR TITLE
hare: 0.24.2 -> 0.25.2

### DIFF
--- a/pkgs/by-name/ha/hare/001-tzdata.patch
+++ b/pkgs/by-name/ha/hare/001-tzdata.patch
@@ -1,45 +1,60 @@
 diff --git a/time/chrono/+freebsd.ha b/time/chrono/+freebsd.ha
-index af49080e..3dde7963 100644
+index 967ae0a8..1779f6d9 100644
 --- a/time/chrono/+freebsd.ha
 +++ b/time/chrono/+freebsd.ha
-@@ -2,8 +2,8 @@
- // (c) Hare authors <https://harelang.org>
-
- def LOCALTIME_PATH: str = "/etc/localtime";
--def TZDB_PATH: str = "/usr/share/zoneinfo/";
-+def TZDB_PATH: str = "@tzdata@/share/zoneinfo/";
-
+@@ -3,4 +3,4 @@
+ 
  // The filepath of the system's "leap-seconds.list" file, which contains UTC/TAI
  // leap second data.
 -export def UTC_LEAPSECS_PATH: str = "/var/db/ntpd.leap-seconds.list";
 +export def UTC_LEAPSECS_PATH: str = "@tzdata@/share/zoneinfo/leap-seconds.list";
 diff --git a/time/chrono/+linux.ha b/time/chrono/+linux.ha
-index 2756fd6f..1ea22385 100644
+index 3394a7b4..1779f6d9 100644
 --- a/time/chrono/+linux.ha
 +++ b/time/chrono/+linux.ha
-@@ -2,8 +2,8 @@
- // (c) Hare authors <https://harelang.org>
-
- def LOCALTIME_PATH: str = "/etc/localtime";
--def TZDB_PATH: str = "/usr/share/zoneinfo/";
-+def TZDB_PATH: str = "@tzdata@/share/zoneinfo/";
-
+@@ -3,4 +3,4 @@
+ 
  // The filepath of the system's "leap-seconds.list" file, which contains UTC/TAI
  // leap second data.
 -export def UTC_LEAPSECS_PATH: str = "/usr/share/zoneinfo/leap-seconds.list";
 +export def UTC_LEAPSECS_PATH: str = "@tzdata@/share/zoneinfo/leap-seconds.list";
 diff --git a/time/chrono/+openbsd.ha b/time/chrono/+openbsd.ha
-index 2756fd6f..1ea22385 100644
+index 3394a7b4..1779f6d9 100644
 --- a/time/chrono/+openbsd.ha
 +++ b/time/chrono/+openbsd.ha
-@@ -2,8 +2,8 @@
- // (c) Hare authors <https://harelang.org>
-
- def LOCALTIME_PATH: str = "/etc/localtime";
--def TZDB_PATH: str = "/usr/share/zoneinfo/";
-+def TZDB_PATH: str = "@tzdata@/share/zoneinfo/";
-
+@@ -3,4 +3,4 @@
+ 
  // The filepath of the system's "leap-seconds.list" file, which contains UTC/TAI
  // leap second data.
 -export def UTC_LEAPSECS_PATH: str = "/usr/share/zoneinfo/leap-seconds.list";
 +export def UTC_LEAPSECS_PATH: str = "@tzdata@/share/zoneinfo/leap-seconds.list";
+diff --git a/time/date/+freebsd.ha b/time/date/+freebsd.ha
+index 3b08c385..b036002a 100644
+--- a/time/date/+freebsd.ha
++++ b/time/date/+freebsd.ha
+@@ -7,4 +7,4 @@ export def LOCALTIME_PATH: str = "/etc/localtime";
+ 
+ // The filepath of the system's TZDB (Timezone Database) directory, a filetree
+ // of TZif (Time Zone Information Format) files and other related files.
+-export def TZDB_PATH: str = "/usr/share/zoneinfo";
++export def TZDB_PATH: str = "@tzdata@/share/zoneinfo";
+diff --git a/time/date/+linux.ha b/time/date/+linux.ha
+index 3b08c385..b036002a 100644
+--- a/time/date/+linux.ha
++++ b/time/date/+linux.ha
+@@ -7,4 +7,4 @@ export def LOCALTIME_PATH: str = "/etc/localtime";
+ 
+ // The filepath of the system's TZDB (Timezone Database) directory, a filetree
+ // of TZif (Time Zone Information Format) files and other related files.
+-export def TZDB_PATH: str = "/usr/share/zoneinfo";
++export def TZDB_PATH: str = "@tzdata@/share/zoneinfo";
+diff --git a/time/date/+openbsd.ha b/time/date/+openbsd.ha
+index 3b08c385..b036002a 100644
+--- a/time/date/+openbsd.ha
++++ b/time/date/+openbsd.ha
+@@ -7,4 +7,4 @@ export def LOCALTIME_PATH: str = "/etc/localtime";
+ 
+ // The filepath of the system's TZDB (Timezone Database) directory, a filetree
+ // of TZif (Time Zone Information Format) files and other related files.
+-export def TZDB_PATH: str = "/usr/share/zoneinfo";
++export def TZDB_PATH: str = "@tzdata@/share/zoneinfo";

--- a/pkgs/by-name/ha/hare/002-dont-build-haredoc.patch
+++ b/pkgs/by-name/ha/hare/002-dont-build-haredoc.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 2482be1f..9d58bc81 100644
+index f562138a..d5d68416 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -5,7 +5,7 @@ all:
@@ -11,7 +11,7 @@ index 2482be1f..9d58bc81 100644
  
  HARE_DEFINES = \
  	-D PLATFORM:str='"$(PLATFORM)"' \
-@@ -79,11 +79,10 @@ docs: \
+@@ -83,11 +83,10 @@ docs: \
  	docs/haredoc.1 \
  	docs/hare-run.1 \
  	docs/hare-test.1 \
@@ -25,15 +25,15 @@ index 2482be1f..9d58bc81 100644
  
  bootstrap:
  	@BINOUT=$(BINOUT) ./scripts/genbootstrap
-@@ -104,7 +103,6 @@ install-cmd:
+@@ -108,7 +107,6 @@ install-cmd: all $(BINOUT)/hare-install
  		'$(DESTDIR)$(BINDIR)' '$(DESTDIR)$(MANDIR)/man1' \
  		'$(DESTDIR)$(BINDIR)' '$(DESTDIR)$(MANDIR)/man5'
- 	install -m755 '$(BINOUT)/hare' '$(DESTDIR)$(BINDIR)/hare'
+ 	install -m755 '$(BINOUT)/hare-install' '$(DESTDIR)$(BINDIR)/hare'
 -	install -m755 '$(BINOUT)/haredoc' '$(DESTDIR)$(BINDIR)/haredoc'
  	for i in $(MAN1); do install -m644 docs/$$i.1 '$(DESTDIR)$(MANDIR)'/man1/$$i.1; done
  	for i in $(MAN5); do install -m644 docs/$$i.5 '$(DESTDIR)$(MANDIR)'/man5/$$i.5; done
  
-@@ -115,7 +113,6 @@ install-mods:
+@@ -119,7 +117,6 @@ install-mods:
  
  uninstall:
  	rm -- '$(DESTDIR)$(BINDIR)/hare'

--- a/pkgs/by-name/ha/hare/003-hardcode-qbe-and-harec.patch
+++ b/pkgs/by-name/ha/hare/003-hardcode-qbe-and-harec.patch
@@ -1,16 +1,7 @@
 diff --git a/cmd/hare/build.ha b/cmd/hare/build.ha
-index ce19af9e..8631b325 100644
+index c1f4a9df..21095392 100644
 --- a/cmd/hare/build.ha
 +++ b/cmd/hare/build.ha
-@@ -36,7 +36,7 @@ fn build(name: str, cmd: *getopt::command) (void | error) = {
- 		case let ncpu: size =>
- 			yield ncpu;
- 		},
--		version = build::get_version(os::tryenv("HAREC", "harec"))?,
-+		version = build::get_version(os::tryenv("HAREC", "@harec_bin@"))?,
- 		arch = arch,
- 		platform = build::get_platform(os::sysname())?,
- 		...
 @@ -143,8 +143,8 @@ fn build(name: str, cmd: *getopt::command) (void | error) = {
  	set_arch_tags(&ctx.ctx.tags, arch);
  

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -76,7 +76,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare";
-  version = "0.24.2";
+  version = "0.25.2";
 
   outputs = [
     "out"
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "~sircmpwn";
     repo = "hare";
     rev = finalAttrs.version;
-    hash = "sha256-61lckI0F+Ez5LR/8g6ftS0W7Q/+EU/1flTDFleBg6pc=";
+    hash = "sha256-aq1LfBQ/BxBEJggP2x6k8bVeBoSKzYxtS4SbMXtw280=";
   };
 
   patches = [

--- a/pkgs/by-name/ha/harec/package.nix
+++ b/pkgs/by-name/ha/harec/package.nix
@@ -5,6 +5,7 @@
   lib,
   qbe,
   stdenv,
+  fetchpatch,
 }:
 let
   platform = lib.toLower stdenv.hostPlatform.uname.system;
@@ -19,14 +20,22 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "harec";
-  version = "0.24.2";
+  version = "0.25.2";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "harec";
     rev = finalAttrs.version;
-    hash = "sha256-YCUBdPYr/44stW9k54QoUEhNkti6ULJkVBphx7xhmKo=";
+    hash = "sha256-5+aYoO7khH1wfH0iC6ZiIVZ4Y11+TpIC4yaEEEC00GM=";
   };
+
+  patches = [
+    # Fix miscellaneous gcc warnings
+    (fetchpatch {
+      url = "https://git.sr.ht/~sircmpwn/harec/commit/31df27c26e026f3d934759f0e7b3ff105e7bf74c.patch";
+      hash = "sha256-in1MQjiNovlebGaykE8/aMEJkz+bRtlr5EYvCXW4jSA=";
+    })
+  ];
 
   nativeBuildInputs = [ qbe ];
 

--- a/pkgs/development/hare-third-party/hare-toml/default.nix
+++ b/pkgs/development/hare-third-party/hare-toml/default.nix
@@ -1,6 +1,5 @@
 {
   fetchFromGitea,
-  fetchpatch,
   hareHook,
   lib,
   nix-update-script,
@@ -9,23 +8,15 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-toml";
-  version = "0.1.2";
+  version = "0.2.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "lunacb";
     repo = "hare-toml";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-MfflJElDMu15UBuewssqhCEsNtzmN/H421H4HV+JCWc=";
+    hash = "sha256-R0kKiIDumhpKJ/C980ncI8WL7AphEc0cRhBUGBPBm0M=";
   };
-
-  patches = [
-    # Update strconv module functions for 0.24.2
-    (fetchpatch {
-      url = "https://codeberg.org/lunacb/hare-toml/commit/9849908ba1fd3457abd6c708272ecb896954d2bc.patch";
-      hash = "sha256-herJZXJ8uusTO2b7Ddby2chIvDRuAPDFOPEt+wotTA0=";
-    })
-  ];
 
   nativeBuildInputs = [
     scdoc


### PR DESCRIPTION
https://harelang.org/blog/2025-06-21-hare-0.25.2-released/
https://git.sr.ht/~sircmpwn/harec/refs/0.25.2
https://git.sr.ht/~sircmpwn/hare/refs/0.25.2

Major question marks include the new "hare tool" subcommand and how it works, see the blog post for details.
Might be possible to do this update first, and then figure out the tool stuff when we package [hare-update](https://git.sr.ht/~sircmpwn/hare-update)?

cc @onemoresuza 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
