### PR TITLE
Fix: Correct podman systemd service name

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -185,11 +185,9 @@ let
             Refer to the
             [Docker engine documentation](https://docs.docker.com/engine/network/#published-ports) for full details.
           '';
-          example = literalExpression ''
-            [
-              "127.0.0.1:8080:9000"
-            ]
-          '';
+          example = [
+            "127.0.0.1:8080:9000"
+          ];
         };
 
         user = mkOption {
@@ -387,7 +385,9 @@ let
   mkService =
     name: container:
     let
-      dependsOn = map (x: "${cfg.backend}-${x}.service") container.dependsOn;
+      dependsOn = lib.attrsets.mapAttrsToList (k: v: "${v.serviceName}.service") (
+        lib.attrsets.getAttrs container.dependsOn cfg.containers
+      );
       escapedName = escapeShellArg name;
       preStartScript = pkgs.writeShellApplication {
         name = "pre-start";
@@ -539,7 +539,7 @@ let
         Restart = "always";
       }
       // optionalAttrs (cfg.backend == "podman") {
-        Environment = "PODMAN_SYSTEMD_UNIT=podman-${name}.service";
+        Environment = "PODMAN_SYSTEMD_UNIT=%n";
         Type = "notify";
         NotifyAccess = "all";
         Delegate = mkIf (container.podman.sdnotify == "healthy") true;

--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -9,6 +9,8 @@ let
 
   inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
 
+  serviceName = "nginxtest"; # different on purpose to verify proper systemd unit generation
+
   mkOCITest =
     backend:
     makeTest {
@@ -23,6 +25,7 @@ let
             virtualisation.oci-containers = {
               inherit backend;
               containers.nginx = {
+                inherit serviceName;
                 image = "nginx-container";
                 imageStream = pkgs.dockerTools.examples.nginxStream;
                 ports = [ "8181:80" ];
@@ -39,7 +42,7 @@ let
 
             # Stop systemd from killing remaining processes if ExecStop script
             # doesn't work, so that proper stopping can be tested.
-            systemd.services."${backend}-nginx".serviceConfig.KillSignal = "SIGCONT";
+            systemd.services.${serviceName}.serviceConfig.KillSignal = "SIGCONT";
           };
       };
 
@@ -47,11 +50,11 @@ let
         import json
 
         start_all()
-        ${backend}.wait_for_unit("${backend}-nginx.service")
+        ${backend}.wait_for_unit("${serviceName}.service")
         ${backend}.wait_for_open_port(8181)
         ${backend}.wait_until_succeeds("curl -f http://localhost:8181 | grep Hello")
         output = json.loads(${backend}.succeed("${backend} inspect nginx --format json").strip())[0]
-        ${backend}.succeed("systemctl stop ${backend}-nginx.service", timeout=10)
+        ${backend}.succeed("systemctl stop ${serviceName}.service", timeout=10)
         assert output['HostConfig']['CapAdd'] == ["CAP_AUDIT_READ"]
         assert output['HostConfig']['CapDrop'] == ${
           if backend == "docker" then "[\"CAP_AUDIT_WRITE\"]" else "[]"
@@ -60,6 +63,9 @@ let
         assert output['HostConfig']['Devices'] == [{'PathOnHost': '/dev/random', 'PathInContainer': '/dev/random', 'CgroupPermissions': '${
           if backend == "docker" then "rwm" else ""
         }'}]
+      ''
+      + lib.strings.optionalString (backend == "podman") ''
+        assert output['Config']['Labels']['PODMAN_SYSTEMD_UNIT'] == '${serviceName}.service'
       '';
     };
 


### PR DESCRIPTION
Resolves: https://github.com/NixOS/nixpkgs/issues/425167


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
