### PR TITLE
python3Packages.tree-sitter-markdown: disable automatic updates

### DIFF
--- a/pkgs/development/python-modules/tree-sitter-markdown/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-markdown/default.nix
@@ -5,6 +5,7 @@
   setuptools,
   tree-sitter,
   pytestCheckHook,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -36,6 +37,15 @@ buildPythonPackage rec {
     pytestCheckHook
     tree-sitter
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      # later versions have incompatible changes, pin it to the latest on PyPI
+      # reverse-dependencies also pull packages from PyPI, see:
+      # https://github.com/Textualize/textual/issues/5868
+      "--version=0.3.2"
+    ];
+  };
 
   meta = {
     description = "Markdown grammar for tree-sitter";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Avoid creating PRs like https://github.com/NixOS/nixpkgs/pull/425137

A better solution would be to use `fetchPypi` to download it from [here](https://pypi.org/project/tree-sitter-markdown/), but this didn't work for me:
```nix
  src = fetchPypi {
    pname = "tree-sitter-markdown";
    version = "0.3.2";
    hash = "";
  };
```

```console
tree-sitter-markdown-0.3.2.tar.gz> Warning: Problem (retrying all errors). Will retry in 4 seconds. 1 retry left.
tree-sitter-markdown-0.3.2.tar.gz> 100   122  100   122    0     0   5620      0 --:--:-- --:--:-- --:--:--  5809
tree-sitter-markdown-0.3.2.tar.gz> 100   300  100   300    0     0   7796      0 --:--:-- --:--:-- --:--:--  7796
tree-sitter-markdown-0.3.2.tar.gz>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
tree-sitter-markdown-0.3.2.tar.gz> curl: (22) The requested URL returned error: 404
tree-sitter-markdown-0.3.2.tar.gz> error: cannot download tree-sitter-markdown-0.3.2.tar.gz from any mirror
```

And I have no idea how the `mirror://` protocol works:
```console
$ nix eval -f . python313Packages.tree-sitter-markdown.src.url
"mirror://pypi/t/tree-sitter-markdown/tree-sitter-markdown-0.3.2.tar.gz"
```

cc @GaetanLepage 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
