### PR TITLE
tt-rss-plugin-markasread: init at 2022-07-05

### DIFF
--- a/pkgs/by-name/tt/tt-rss-plugin-markasread/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-markasread/package.nix
@@ -5,15 +5,15 @@
   tt-rss,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tt-rss-plugin-markasread";
-  version = "unstable-2022-07-05";
+  version = "0.4";
 
   src = fetchFromGitHub {
     owner = "Elv1zz";
     repo = "ttrss_plugin-markasread";
-    rev = "7aa64334689869320ff9635e05221705b4ad136b";
-    sha256 = "sha256-IDCwlxWIchfIq4KmpCF6plFuM+BNQtDS0s8fkwwNqCQ=";
+    tag = finalAttrs.version;
+    hash = "sha256-IDCwlxWIchfIq4KmpCF6plFuM+BNQtDS0s8fkwwNqCQ=";
   };
 
   installPhase = ''
@@ -22,16 +22,16 @@ stdenv.mkDerivation {
     cp init.php markasread.css markasread.js *.png $out/markasread/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Google Reader like 'Mark as read' checkbox for Tiny Tiny RSS";
     longDescription = ''
       This plugin for Tiny Tiny RSS (tt-rss) adds a checkbox in the article
       footer to mark an article as read and unread just like in discontinued
       Google Reader.
     '';
-    license = licenses.free; # No explicit license found in repository
+    license = lib.licenses.unfree; # No explicit license found in repository
     homepage = "https://github.com/Elv1zz/ttrss_plugin-markasread";
-    maintainers = with maintainers; [ lostmsu ];
+    maintainers = with lib.maintainers; [ lostmsu ];
     inherit (tt-rss.meta) platforms;
   };
-}
+})

--- a/pkgs/by-name/tt/tt-rss-plugin-markasread/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-markasread/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   tt-rss,
 }:
 
@@ -12,9 +13,16 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Elv1zz";
     repo = "ttrss_plugin-markasread";
-    tag = finalAttrs.version;
+    tag = "v${finalAttrs.version}";
     hash = "sha256-IDCwlxWIchfIq4KmpCF6plFuM+BNQtDS0s8fkwwNqCQ=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/Elv1zz/ttrss_plugin-markasread/pull/8.patch";
+      hash = "sha256-nOyjmiSB5jyfTtTK9ZsLJQwaY4Fvet9lFUD0TD1Ptk8=";
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/markasread

--- a/pkgs/by-name/tt/tt-rss-plugin-markasread/package.nix
+++ b/pkgs/by-name/tt/tt-rss-plugin-markasread/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  tt-rss,
+}:
+
+stdenv.mkDerivation {
+  pname = "tt-rss-plugin-markasread";
+  version = "unstable-2022-07-05";
+
+  src = fetchFromGitHub {
+    owner = "Elv1zz";
+    repo = "ttrss_plugin-markasread";
+    rev = "7aa64334689869320ff9635e05221705b4ad136b";
+    sha256 = "sha256-IDCwlxWIchfIq4KmpCF6plFuM+BNQtDS0s8fkwwNqCQ=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/markasread
+
+    cp init.php markasread.css markasread.js *.png $out/markasread/
+  '';
+
+  meta = with lib; {
+    description = "Google Reader like 'Mark as read' checkbox for Tiny Tiny RSS";
+    longDescription = ''
+      This plugin for Tiny Tiny RSS (tt-rss) adds a checkbox in the article
+      footer to mark an article as read and unread just like in discontinued
+      Google Reader.
+    '';
+    license = licenses.free; # No explicit license found in repository
+    homepage = "https://github.com/Elv1zz/ttrss_plugin-markasread";
+    maintainers = with maintainers; [ lostmsu ];
+    inherit (tt-rss.meta) platforms;
+  };
+}


### PR DESCRIPTION
A TT-RSS plugin that adds a Google Reader-style Mark as Read toggle

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

@milogert @gileri @globin @zohl 

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

With help from Claude 4 Sonnet