### PR TITLE
python3Packages.buildPythonPackage: default enabledTestPaths = [ "." ]

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1285,6 +1285,7 @@ Adding `pytest` is not required, since it is included with `pytestCheckHook`.
 `enabledTestPaths` and `disabledTestPaths`
 
 :   To specify path globs (files or directories) or test items.
+    `enabledTestPaths` defaults to `[ "." ]`.
 
 `enabledTests` and `disabledTests`
 

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -18,6 +18,12 @@
 
 - The minimum version of Nix required to evaluate Nixpkgs has been raised from 2.3 to 2.18.
 
+- `buildPythonPackage` and `buildPythonApplication` now set `enabledTestPaths = [ "." ]` by default if not specified otherwise, and require the specified value to be a non-empty list to simplify overriding.
+
+  When running install-checks with `pytestCheckHook`, such default value resembles `pytest`'s default behaviour of discovering tests in the current working directory.
+
+  To support both version of Nixpkgs before and after this change, set `enabledTestPaths = [ "." ]` manually for packages that don't need custom `enabledTestPaths` specification.
+
 - The `offrss` package was removed due to lack of upstream maintenance since 2012. It's recommended for users to migrate to another RSS reader
 
 - `base16-builder` node package has been removed due to lack of upstream maintenance.

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -431,6 +431,17 @@ let
       # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
       installCheckPhase = attrs.checkPhase;
     }
+    // {
+      # `pytest` defaults to discover tests in the current directory if no paths or test items are specified.
+      # Provide an explicit default value to simplify overriding.
+      enabledTestPaths =
+        if attrs ? enabledTestPaths then
+          lib.throwIf (!lib.isList attrs.enabledTestPaths || attrs.enabledTestPaths == [ ])
+            "${lib.getName finalAttrs}: enabledTestPaths must be a non-empty list (default to [ \".\" ])."
+            attrs.enabledTestPaths
+        else
+          [ "." ];
+    }
     //
       lib.mapAttrs
         (
@@ -442,7 +453,6 @@ let
         (
           getOptionalAttrs [
             "enabledTestMarks"
-            "enabledTestPaths"
             "enabledTests"
           ] attrs
         )


### PR DESCRIPTION
## Description

### Summary

This is a proposal to explicitly provide a default value for the argument `enabledTestPaths` as the current working directory (`enabledTestPaths = [ "." ]`) to simplify overriding (making `enabledTestPaths` always specified as a non-empty list) while preserving `pytest`'s default behaviour of discovering tests in the current working directory.

### Background

`pytestCheckHook`'s current test-selection interface consists of the following attributes:
- `enabledTestPaths` and `disabledTestPaths`
- `enabledTestMarks` and `disabledTestMarks`
- `enabledTests` and `disabledTests`

Where `enabledTests` and the current implementation of `(enabled|disabled)(TestMarks|Tests)` is provided in PR #386513

To avoid semantic confusion, the `enabled`-attributes are not allow to take an empty list (`[ ]`). They can either be unspecified, `null`, or a non-empty list. This results in a rather complex overriding interface -- The overriding function need to handle the edge case where the previous state of the attribute might be unspecified or `null` before starting list operation, and set it to null and optionally `doCheck` to false when the processed list might otherwise be empty.

After the proposed change, `enabledTestPaths` should always be specified as a non-empty list, which greatly simplifies the overriding.

### Drawbacks

- Global (as in `buildPythonPackage`) namespace pollution
    - Reason: specifying an attribute specific to `pytestCheckHook` globally even when the setup hook is not used seems unclean and could be confusing.
    - Refutation: `pytest` is the de facto standard for writing Python tests, which somehow justifies its space in the `buildPythonPackage`-level.
- Inconsistency between other two `enabled(Tests|TestMarks)` attributes
    - Reason: After this change, the way to override `enabledTestPaths` will differ from that of `enabledTestMarks` and `enabledTests`.
    - Refutation: The logic behind `enabledTestPaths` and the other two `enabled`-attributes are quite different, and the former occurs much more often than the latter.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
