### PR TITLE
dupeguru: fix build

### DIFF
--- a/pkgs/applications/misc/dupeguru/default.nix
+++ b/pkgs/applications/misc/dupeguru/default.nix
@@ -20,6 +20,10 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-/jkZiCapmCLMp7WfgUmpsR8aNCfb3gBELlMYaC4e7zI=";
   };
 
+  patches = [
+    ./remove-setuptools-sandbox.patch
+  ];
+
   nativeBuildInputs = [
     gettext
     python3Packages.pyqt5

--- a/pkgs/applications/misc/dupeguru/remove-setuptools-sandbox.patch
+++ b/pkgs/applications/misc/dupeguru/remove-setuptools-sandbox.patch
@@ -1,0 +1,27 @@
+diff --git a/build.py b/build.py
+index 06905a11..56d54a17 100644
+--- a/build.py
++++ b/build.py
+@@ -10,7 +10,7 @@ from optparse import OptionParser
+ import shutil
+ from multiprocessing import Pool
+ 
+-from setuptools import sandbox
++import subprocess
+ from hscommon import sphinxgen
+ from hscommon.build import (
+     add_to_pythonpath,
+@@ -118,7 +118,12 @@ def build_normpo():
+ def build_pe_modules():
+     print("Building PE Modules")
+     # Leverage setup.py to build modules
+-    sandbox.run_setup("setup.py", ["build_ext", "--inplace"])
++    result = subprocess.run(
++        [sys.executable, "setup.py", "build_ext", "--inplace"],
++        check=True,
++    )
++    if result.returncode != 0:
++        sys.exit("Error building PE modules. Please check the output above.")
+ 
+ 
+ def build_normal():


### PR DESCRIPTION
Closes #424849

The project doesn't seem maintained anymore and seems too complex for me to write a pyproject.toml file, so I have created a quick patch that replaces `setuptools.sandbox` with a simple `subprocess.run`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
