### PR TITLE
python3Packages.rclone-python: hardcode path to rclone executable and run tests

### DIFF
--- a/pkgs/development/python-modules/rclone-python/default.nix
+++ b/pkgs/development/python-modules/rclone-python/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  replaceVars,
   setuptools,
   rich,
   rclone,
@@ -19,10 +20,15 @@ buildPythonPackage rec {
     hash = "sha256-vvsiXS3uI0TcL+X8+75BQmycrF+EGIgQE1dmGef35rI=";
   };
 
+  patches = [
+    (replaceVars ./hardcode-rclone-path.patch {
+      rclone = lib.getExe rclone;
+    })
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [
-    rclone
     rich
   ];
 

--- a/pkgs/development/python-modules/rclone-python/default.nix
+++ b/pkgs/development/python-modules/rclone-python/default.nix
@@ -2,10 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pytestCheckHook,
   replaceVars,
   setuptools,
   rich,
   rclone,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -32,8 +34,28 @@ buildPythonPackage rec {
     rich
   ];
 
-  # tests require working internet connection
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    # Unlike upstream we don't actually run an S3 server for testing.
+    # See https://github.com/Johannes11833/rclone_python/blob/master/launch_test_server.sh
+    mkdir -p "$HOME/.config/rclone"
+    cat > "$HOME/.config/rclone/rclone.conf" <<EOF
+    [test_server_s3]
+    type = combine
+    upstreams = "testdir=$(mktemp -d)"
+    EOF
+  '';
+
+  disabledTestPaths = [
+    # test requires a remote that supports public links
+    "tests/test_link.py"
+    # test looks up latest version on rclone.org
+    "tests/test_version.py"
+  ];
 
   pythonImportsCheck = [ "rclone_python" ];
 

--- a/pkgs/development/python-modules/rclone-python/hardcode-rclone-path.patch
+++ b/pkgs/development/python-modules/rclone-python/hardcode-rclone-path.patch
@@ -1,0 +1,99 @@
+diff --git a/rclone_python/rclone.py b/rclone_python/rclone.py
+index da399b4..e05365a 100644
+--- a/rclone_python/rclone.py
++++ b/rclone_python/rclone.py
+@@ -43,7 +43,7 @@ def is_installed() -> bool:
+     """
+     :return: True if rclone is correctly installed on the system.
+     """
+-    return which("rclone") is not None
++    return True
+ 
+ 
+ @__check_installed
+@@ -199,7 +199,7 @@ def copy(
+         in_path,
+         out_path,
+         ignore_existing=ignore_existing,
+-        command="rclone copy",
++        command="@rclone@ copy",
+         command_descr="Copying",
+         show_progress=show_progress,
+         listener=listener,
+@@ -234,7 +234,7 @@ def copyto(
+         in_path,
+         out_path,
+         ignore_existing=ignore_existing,
+-        command="rclone copyto",
++        command="@rclone@ copyto",
+         command_descr="Copying",
+         show_progress=show_progress,
+         listener=listener,
+@@ -269,7 +269,7 @@ def move(
+         in_path,
+         out_path,
+         ignore_existing=ignore_existing,
+-        command="rclone move",
++        command="@rclone@ move",
+         command_descr="Moving",
+         show_progress=show_progress,
+         listener=listener,
+@@ -304,7 +304,7 @@ def moveto(
+         in_path,
+         out_path,
+         ignore_existing=ignore_existing,
+-        command="rclone moveto",
++        command="@rclone@ moveto",
+         command_descr="Moving",
+         show_progress=show_progress,
+         listener=listener,
+@@ -336,7 +336,7 @@ def sync(
+     _rclone_transfer_operation(
+         src_path,
+         dest_path,
+-        command="rclone sync",
++        command="@rclone@ sync",
+         command_descr="Syncing",
+         show_progress=show_progress,
+         listener=listener,
+diff --git a/rclone_python/scripts/get_version.py b/rclone_python/scripts/get_version.py
+index b1d30fd..bc00cad 100644
+--- a/rclone_python/scripts/get_version.py
++++ b/rclone_python/scripts/get_version.py
+@@ -2,6 +2,6 @@ from subprocess import check_output
+ 
+ 
+ def get_version():
+-    stdout = check_output("rclone version", shell=True, encoding="utf8")
++    stdout = check_output("@rclone@ version", shell=True, encoding="utf8")
+ 
+     return stdout.split("\n")[0].replace("rclone ", "")
+diff --git a/rclone_python/scripts/update_hash_types.py b/rclone_python/scripts/update_hash_types.py
+index 92fbd0a..ef963cf 100644
+--- a/rclone_python/scripts/update_hash_types.py
++++ b/rclone_python/scripts/update_hash_types.py
+@@ -14,7 +14,7 @@ def update_hashes(output_path: str):
+     """
+ 
+     # get all supported backends
+-    rclone_output = sp.check_output("rclone hashsum", shell=True, encoding="utf8")
++    rclone_output = sp.check_output("@rclone@ hashsum", shell=True, encoding="utf8")
+     lines = rclone_output.splitlines()
+ 
+     hashes = []
+diff --git a/rclone_python/utils.py b/rclone_python/utils.py
+index d4a8413..1b29bd8 100644
+--- a/rclone_python/utils.py
++++ b/rclone_python/utils.py
+@@ -66,9 +66,9 @@ def run_rclone_cmd(
+     # otherwise the default rclone config path is used:
+     config = Config()
+     if config.config_path is not None:
+-        base_command = f"rclone --config={config.config_path}"
++        base_command = f"@rclone@ --config={config.config_path}"
+     else:
+-        base_command = "rclone"
++        base_command = "@rclone@"
+ 
+     # add optional arguments and flags to the command
+     args_str = args2string(args)

--- a/pkgs/development/python-modules/rclone-python/hardcode-rclone-path.patch
+++ b/pkgs/development/python-modules/rclone-python/hardcode-rclone-path.patch
@@ -97,3 +97,33 @@ index d4a8413..1b29bd8 100644
  
      # add optional arguments and flags to the command
      args_str = args2string(args)
+diff --git a/tests/test_copy.py b/tests/test_copy.py
+index 4ded5fa..1cae53b 100644
+--- a/tests/test_copy.py
++++ b/tests/test_copy.py
+@@ -45,11 +45,11 @@ def create_local_file(
+ @pytest.mark.parametrize(
+     "wrapper_command,rclone_command",
+     [
+-        (rclone.copy, "rclone copy"),
+-        (rclone.copyto, "rclone copyto"),
+-        (rclone.sync, "rclone sync"),
+-        (rclone.move, "rclone move"),
+-        (rclone.moveto, "rclone moveto"),
++        (rclone.copy, "@rclone@ copy"),
++        (rclone.copyto, "@rclone@ copyto"),
++        (rclone.sync, "@rclone@ sync"),
++        (rclone.move, "@rclone@ move"),
++        (rclone.moveto, "@rclone@ moveto"),
+     ],
+ )
+ def test_rclone_command_called(wrapper_command: Callable, rclone_command: str):
+@@ -62,7 +62,7 @@ def test_rclone_command_called(wrapper_command: Callable, rclone_command: str):
+         rclone.utils.subprocess,
+         "Popen",
+         return_value=subprocess.Popen(
+-            "rclone help", stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
++            "@rclone@ help", stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+         ),
+     ) as mock:
+         wrapper_command("nothing/not_a.file", "fake_remote:unicorn/folder")


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/288952#pullrequestreview-3017737285
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
