### PR TITLE
kega-fusion: migrate to by-name, enable multilib support

### DIFF
--- a/pkgs/by-name/ke/kega-fusion/package.nix
+++ b/pkgs/by-name/ke/kega-fusion/package.nix
@@ -3,34 +3,24 @@
   lib,
   writeText,
   fetchurl,
-  upx,
-  libGL,
-  libGLU,
-  glib,
-  gtk2,
-  alsa-lib,
-  libsm,
-  libx11,
-  gdk-pixbuf,
-  pango,
-  libxinerama,
+  pkgsi686Linux,
   mpg123,
   runtimeShell,
 }:
 
 let
   libPath = lib.makeLibraryPath [
-    stdenv.cc.cc
-    libGL
-    libGLU
-    glib
-    gtk2
-    alsa-lib
-    libsm
-    libx11
-    gdk-pixbuf
-    pango
-    libxinerama
+    pkgsi686Linux.stdenv.cc.cc
+    pkgsi686Linux.libGL
+    pkgsi686Linux.libGLU
+    pkgsi686Linux.glib
+    pkgsi686Linux.gtk2
+    pkgsi686Linux.alsa-lib
+    pkgsi686Linux.libsm
+    pkgsi686Linux.libx11
+    pkgsi686Linux.gdk-pixbuf
+    pkgsi686Linux.pango
+    pkgsi686Linux.libxinerama
   ];
 
 in
@@ -53,6 +43,10 @@ stdenv.mkDerivation {
 
     kega_libdir="@out@/lib/kega-fusion"
     kega_localdir="$HOME/.Kega Fusion"
+
+    # Force 32-bit gdk-pixbuf loaders
+    export GDK_PIXBUF_MODULEDIR="${pkgsi686Linux.gdk-pixbuf}/lib/gdk-pixbuf-2.0/2.10.0/loaders"
+    export GDK_PIXBUF_MODULE_FILE="${pkgsi686Linux.gdk-pixbuf}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
 
     # create local plugins directory if not present
     mkdir -p "$kega_localdir/Plugins"
@@ -83,12 +77,28 @@ stdenv.mkDerivation {
   dontStrip = true;
   dontPatchELF = true;
 
-  nativeBuildInputs = [ upx ];
+  nativeBuildInputs = [
+    pkgsi686Linux.upx
+  ];
+
+  buildInputs = [
+    pkgsi686Linux.stdenv.cc.cc
+    pkgsi686Linux.libGL
+    pkgsi686Linux.libGLU
+    pkgsi686Linux.glib
+    pkgsi686Linux.gtk2
+    pkgsi686Linux.alsa-lib
+    pkgsi686Linux.libsm
+    pkgsi686Linux.libx11
+    pkgsi686Linux.gdk-pixbuf
+    pkgsi686Linux.pango
+    pkgsi686Linux.libxinerama
+  ];
 
   installPhase = ''
     upx -d Fusion
     install -Dm755 Fusion "$out/lib/kega-fusion/Fusion"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath "${libPath}" "$out/lib/kega-fusion/Fusion"
+    patchelf --set-interpreter "${pkgsi686Linux.stdenv.cc.bintools.dynamicLinker}" --set-rpath "${libPath}" "$out/lib/kega-fusion/Fusion"
 
     tar -xaf $plugins
     mkdir -p "$out/lib/kega-fusion/plugins"
@@ -105,7 +115,10 @@ stdenv.mkDerivation {
     maintainers = [ ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfreeRedistributable;
-    platforms = [ "i686-linux" ];
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
     mainProgram = "kega-fusion";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1211,8 +1211,6 @@ with pkgs;
 
   image-analyzer = callPackage ../applications/emulators/cdemu/analyzer.nix { };
 
-  kega-fusion = pkgsi686Linux.callPackage ../applications/emulators/kega-fusion { };
-
   libmirage = callPackage ../applications/emulators/cdemu/libmirage.nix { };
 
   mame-tools = lib.addMetaAttrs {


### PR DESCRIPTION
Migrate Kega fusion to by-name


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
