### PR TITLE
python312Packages.mistral-common: 1.5.6 → 1.7.0

### DIFF
--- a/pkgs/development/python-modules/mistral-common/default.nix
+++ b/pkgs/development/python-modules/mistral-common/default.nix
@@ -2,11 +2,12 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  poetry-core,
+  setuptools,
   numpy,
   pydantic,
   jsonschema,
   opencv-python-headless,
+  huggingface-hub,
   sentencepiece,
   typing-extensions,
   tiktoken,
@@ -16,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "mistral-common";
-  version = "1.5.6";
+  version = "1.7.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "mistral_common";
     inherit version;
-    hash = "sha256-TauSQwaEMhFKFfLEb/SRagViCnIrDfjetJ3POD+34r8=";
+    hash = "sha256-Qv/lOBUruLLrAOsfiSeBbfHPSEBamfiEQ25BdsXY/iY=";
   };
 
   pythonRelaxDeps = [
@@ -30,13 +31,14 @@ buildPythonPackage rec {
     "tiktoken"
   ];
 
-  build-system = [ poetry-core ];
+  build-system = [ setuptools ];
 
   dependencies = [
     numpy
     pydantic
     jsonschema
     opencv-python-headless
+    huggingface-hub
     sentencepiece
     typing-extensions
     tiktoken


### PR DESCRIPTION
https://github.com/mistralai/mistral-common/releases/tag/v1.7.0
https://github.com/mistralai/mistral-common/releases/tag/v1.6.3
https://github.com/mistralai/mistral-common/releases/tag/v1.6.2
https://github.com/mistralai/mistral-common/releases/tag/v1.6.0

- mistral-common also switched their build system from poetry to setuptools/uv, hence changed that, too.
- New optional dep: huggingface-hub, included it since opencv was included already as well

Superficially tested via vllm and Mistral Small 3.2:

```console
vllm serve mistralai/Mistral-Small-3.2-24B-Instruct-2506 \
  --tokenizer-mode=mistral \
  --load-format=mistral \
  --config-format=mistral
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] ~~Tested basic functionality of all binary files (usually in `./result/bin/`)~~ (no binary provided)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~ (too minor)
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
