### PR TITLE
tabby-terminal: init at 1.0.233

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9101,7 +9101,7 @@
   geodic = {
   	name = "geodic";
   	email = "th3geodic@proton.me";
-  	matrix = "@geodic:matrix.org"
+  	matrix = "@geodic:matrix.org";
   	github = "geodic";
   	githubId = 64704703;
   };

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9099,11 +9099,11 @@
     keys = [ { fingerprint = "386E D1BF 848A BB4A 6B4A  3C45 FC83 907C 125B C2BC"; } ];
   };
   geodic = {
-  	name = "geodic";
-  	email = "th3geodic@proton.me";
-  	matrix = "@geodic:matrix.org";
-  	github = "geodic";
-  	githubId = 64704703;
+    name = "geodic";
+    email = "th3geodic@proton.me";
+    matrix = "@geodic:matrix.org";
+    github = "geodic";
+    githubId = 64704703;
   };
   geoffreyfrogeye = {
     name = "Geoffrey Frogeye";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9098,6 +9098,13 @@
     githubId = 6905586;
     keys = [ { fingerprint = "386E D1BF 848A BB4A 6B4A  3C45 FC83 907C 125B C2BC"; } ];
   };
+  geodic = {
+  	name = "geodic";
+  	email = "th3geodic@proton.me";
+  	matrix = "@geodic:matrix.org"
+  	github = "geodic";
+  	githubId = 64704703;
+  };
   geoffreyfrogeye = {
     name = "Geoffrey Frogeye";
     email = "geoffrey@frogeye.fr";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -17,9 +17,12 @@
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - [gtklock](https://github.com/jovanlanik/gtklock), a GTK-based lockscreen for Wayland. Available as [programs.gtklock](#opt-programs.gtklock.enable).
+
 - [Chrysalis](https://github.com/keyboardio/Chrysalis), a graphical configurator for Kaleidoscope-powered keyboards. Available as [programs.chrysalis](#opt-programs.chrysalis.enable).
 
 - [Pi-hole](https://pi-hole.net/), a DNS sinkhole for advertisements based on Dnsmasq. Available as [services.pihole-ftl](#opt-services.pihole-ftl.enable), and [services.pihole-web](#opt-services.pihole-web.enable) for the web GUI and API.
+
+- [Tabby](https://tabby.sh), a terminal for a more modern age.
 
 - [Fediwall](https://fediwall.social), a web application for live displaying toots from mastodon, inspired by mastowall. Available as [services.fediwall](#opt-services.fediwall.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -22,8 +22,6 @@
 
 - [Pi-hole](https://pi-hole.net/), a DNS sinkhole for advertisements based on Dnsmasq. Available as [services.pihole-ftl](#opt-services.pihole-ftl.enable), and [services.pihole-web](#opt-services.pihole-web.enable) for the web GUI and API.
 
-- [Tabby](https://tabby.sh), a terminal for a more modern age.
-
 - [Fediwall](https://fediwall.social), a web application for live displaying toots from mastodon, inspired by mastowall. Available as [services.fediwall](#opt-services.fediwall.enable).
 
 - [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files. Available as [services.filebrowser](#opt-services.filebrowser.enable).

--- a/pkgs/by-name/ta/tabby-terminal/package.nix
+++ b/pkgs/by-name/ta/tabby-terminal/package.nix
@@ -8,7 +8,7 @@
   yarn,
   git,
   patch-package,
-  electron_32,
+  electron_36,
   prefetch-yarn-deps,
   fixup-yarn-lock,
   python3,
@@ -25,13 +25,14 @@
 }:
 
 let
-  version = "1.0.223" ;
+  version = "1.0.233";
+  fullVersion = "1.0.223-unstable-2025-05-24" ;
   
   src = fetchFromGitHub {
     owner = "Eugeny";
     repo = "tabby";
-    rev = "v${version}";
-    hash = "sha256-YWqbVrxG3/tOw1ERkoEosVlz6k2eTkcsQnHAtdKpkpE=";
+    rev = "406e9e1";
+    hash = "sha256-IMrRak6u7LRcvp2Ve2AOreNDPJM0kofMp53sKaobqO4=";
     leaveDotGit = true;
   };
 
@@ -79,7 +80,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "tabby-terminal";
-  version = version;
+  version = fullVersion;
   src = src;
 
   patches = [ ./splice-argv.patch ];
@@ -110,16 +111,16 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  electronPackage = electron_32;
+  electronPackage = electron_36;
 
   electronHeaders = fetchurl {
     url = "https://www.electronjs.org/headers/v${finalAttrs.electronPackage.version}/node-v${finalAttrs.electronPackage.version}-headers.tar.gz";
-    hash = "sha256-D9j1wSDzartWUfDm2UrZDrgum2X+vV+DpDlKPFCtBbA=";
+    hash = "sha256-ppac1cHhnxNZTG1RLfBowMMs5qOnzX2KuNgBTVsE/N8=";
   };
 
   electronHeadersSHA = fetchurl {
     url = "https://www.electronjs.org/headers/v${finalAttrs.electronPackage.version}/SHASUMS256.txt";
-    hash = "sha256-ZnWVCzTwwog4kgeFAZGsM2F2mmebrpXMVMxn/K+LWlU=";
+    hash = "sha256-PdAXN3i/CngtTzdgCLP5749mXTfRNj9dporJvrhvvJU=";
   };
 
   buildInputs = [
@@ -177,7 +178,7 @@ stdenv.mkDerivation (finalAttrs: {
     + ''
       cd $buildDir/node_modules
     ''
-    # Loop thought the "built in" plugins and link them to the node_modules
+    # Loop through the "built in" plugins and link them to the node_modules
     + lib.concatMapStringsSep "\n" (plugin: ''
       ln -fs ../${plugin} ${plugin}
     '') builtinPlugins

--- a/pkgs/by-name/ta/tabby-terminal/package.nix
+++ b/pkgs/by-name/ta/tabby-terminal/package.nix
@@ -26,8 +26,8 @@
 
 let
   version = "1.0.233";
-  fullVersion = "1.0.223-unstable-2025-05-24" ;
-  
+  fullVersion = "1.0.223-unstable-2025-05-24";
+
   src = fetchFromGitHub {
     owner = "Eugeny";
     repo = "tabby";

--- a/pkgs/by-name/ta/tabby-terminal/package.nix
+++ b/pkgs/by-name/ta/tabby-terminal/package.nix
@@ -25,164 +25,14 @@
 }:
 
 let
-  tabby = rec {
-    pname = "tabby-terminal";
-    version = "1.0.223";
-
-    src = fetchFromGitHub {
-      owner = "Eugeny";
-      repo = "tabby";
-      rev = "v${version}";
-      hash = "sha256-YWqbVrxG3/tOw1ERkoEosVlz6k2eTkcsQnHAtdKpkpE=";
-      leaveDotGit = true;
-    };
-
-    patches = [ ./splice-argv.patch ];
-
-    meta = {
-      description = "A terminal for a more modern age";
-      homepage = "https://tabby.sh";
-      license = lib.licenses.mit;
-      mainProgram = "tabby";
-      maintainers = with lib.maintainers; [ geodic ];
-      platforms = lib.platforms.linux;
-    };
-
-    __darwinAllowLocalNetworking = true;
-
-    desktopItems = [
-      (makeDesktopItem {
-        name = "tabby";
-        desktopName = "Tabby";
-        exec = "tabby %u";
-        comment = "A terminal for a more modern age";
-        icon = "tabby";
-        categories = [
-          "Utility"
-          "TerminalEmulator"
-          "System"
-        ];
-      })
-    ];
-
-    electronPackage = electron_32;
-
-    electronHeaders = fetchurl {
-      url = "https://www.electronjs.org/headers/v${electronPackage.version}/node-v${electronPackage.version}-headers.tar.gz";
-      hash = "sha256-D9j1wSDzartWUfDm2UrZDrgum2X+vV+DpDlKPFCtBbA=";
-    };
-
-    electronHeadersSHA = fetchurl {
-      url = "https://www.electronjs.org/headers/v${electronPackage.version}/SHASUMS256.txt";
-      hash = "sha256-ZnWVCzTwwog4kgeFAZGsM2F2mmebrpXMVMxn/K+LWlU=";
-    };
-
-    buildInputs = [
-      nodejs
-      python3
-      fontconfig
-      electronPackage
-    ];
-
-    nativeBuildInputs = [
-      git
-      yarn
-      patch-package
-      prefetch-yarn-deps
-      fixup-yarn-lock
-      (python3.withPackages (python-pkgs: [
-        python-pkgs.distutils
-        python-pkgs.gyp
-      ]))
-      makeWrapper
-      http-server
-      pkg-config
-      libsecret
-      copyDesktopItems
-      jq
-      moreutils
-    ];
-
-    prePatch = ''
-      jq '.version = "${version}"' app/package.json | sponge app/package.json
-    '';
-
-    configurePhase =
-      ''
-        runHook preConfigure
-
-        export buildDir=$PWD
-
-        git tag ${version}
-      ''
-      # Loop through all the yarn caches and install the deps for the respective package
-      + lib.concatMapStringsSep "\n" (cache: ''
-        cd ${cache.pkg}
-        export HOME=$PWD/yarn_home
-        fixup-yarn-lock yarn.lock
-        yarn config --offline set yarn-offline-mirror ${cache.cache}
-        echo "Installing deps for ${cache.pkg}"
-        yarn install --offline --prefer-offline --frozen-lockfile --ignore-scripts --no-progress --non-interactive
-        patch-package
-        patchShebangs node_modules
-        echo "Done!"
-        cd $buildDir
-      '') yarnCaches
-
-      + ''
-        cd $buildDir/node_modules
-      ''
-      # Loop thought the "built in" plugins and link them to the node_modules
-      + lib.concatMapStringsSep "\n" (plugin: ''
-        ln -fs ../${plugin} ${plugin}
-      '') builtinPlugins
-
-      + ''
-        cd $buildDir
-
-        runHook postConfigure
-      '';
-
-    buildPhase =
-      # Start a fake (and completely unnecessary) http-server to let electron-rebuild "download" the headers and hashes
-      ''
-        runHook preBuild
-
-        mkdir -p http-cache/v${electronPackage.version}
-        cp $electronHeaders http-cache/v${electronPackage.version}/node-v${electronPackage.version}-headers.tar.gz
-        cp $electronHeadersSHA http-cache/v${electronPackage.version}/SHASUMS256.txt
-        http-server http-cache &
-      ''
-      # Rebuild all the needed packages using electron-rebuild
-      + lib.concatMapStringsSep "\n" (pkg: ''
-        yarn --offline electron-rebuild -v ${electronPackage.version} -m ${pkg} -f -d "http://localhost:8080"
-      '') rebuildPkgs
-      + ''
-        kill $!
-        yarn build
-
-        runHook postBuild
-      '';
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/share/tabby
-      mkdir -p $out/bin
-      cp -r . $out/share/tabby
-
-      # Tabby needs TABBY_DEV to run manually with electron
-      makeWrapper "${electronPackage}/bin/electron" "$out/bin/tabby" --add-flags "$out/share/tabby/app" --set TABBY_DEV 1
-
-      for iconsize in 16 32 64 128
-      do
-        size=$iconsize"x"$iconsize
-        mkdir -p $out/share/icons/hicolor/$size/apps
-        ln -s $out/share/tabby/build/icons/"$size".png $out/share/icons/hicolor/$size/apps/tabby.png
-      done
-
-      runHook postInstall
-    '';
+  version = "1.0.223" ;
+  
+  src = fetchFromGitHub {
+    owner = "Eugeny";
+    repo = "tabby";
+    rev = "v${version}";
+    hash = "sha256-YWqbVrxG3/tOw1ERkoEosVlz6k2eTkcsQnHAtdKpkpE=";
+    leaveDotGit = true;
   };
 
   builtinPlugins = [
@@ -213,7 +63,7 @@ let
   yarnCaches = map (pkg: {
     inherit pkg;
     cache = fetchYarnDeps {
-      src = lib.removeSuffix "/." (tabby.src + "/" + pkg);
+      src = lib.removeSuffix "/." (src + "/" + pkg);
       hash = pkgHashes.${pkg};
     };
   }) packages;
@@ -227,4 +77,155 @@ let
   ];
 
 in
-stdenv.mkDerivation tabby
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tabby-terminal";
+  version = version;
+  src = src;
+
+  patches = [ ./splice-argv.patch ];
+
+  meta = {
+    description = "A terminal for a more modern age";
+    homepage = "https://tabby.sh";
+    license = lib.licenses.mit;
+    mainProgram = "tabby";
+    maintainers = with lib.maintainers; [ geodic ];
+    platforms = lib.platforms.linux;
+  };
+
+  __darwinAllowLocalNetworking = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "tabby";
+      desktopName = "Tabby";
+      exec = "tabby %u";
+      comment = "A terminal for a more modern age";
+      icon = "tabby";
+      categories = [
+        "Utility"
+        "TerminalEmulator"
+        "System"
+      ];
+    })
+  ];
+
+  electronPackage = electron_32;
+
+  electronHeaders = fetchurl {
+    url = "https://www.electronjs.org/headers/v${finalAttrs.electronPackage.version}/node-v${finalAttrs.electronPackage.version}-headers.tar.gz";
+    hash = "sha256-D9j1wSDzartWUfDm2UrZDrgum2X+vV+DpDlKPFCtBbA=";
+  };
+
+  electronHeadersSHA = fetchurl {
+    url = "https://www.electronjs.org/headers/v${finalAttrs.electronPackage.version}/SHASUMS256.txt";
+    hash = "sha256-ZnWVCzTwwog4kgeFAZGsM2F2mmebrpXMVMxn/K+LWlU=";
+  };
+
+  buildInputs = [
+    nodejs
+    python3
+    fontconfig
+    finalAttrs.electronPackage
+  ];
+
+  nativeBuildInputs = [
+    git
+    yarn
+    patch-package
+    prefetch-yarn-deps
+    fixup-yarn-lock
+    (python3.withPackages (python-pkgs: [
+      python-pkgs.distutils
+      python-pkgs.gyp
+    ]))
+    makeWrapper
+    http-server
+    pkg-config
+    libsecret
+    copyDesktopItems
+    jq
+    moreutils
+  ];
+
+  prePatch = ''
+    jq '.version = "${version}"' app/package.json | sponge app/package.json
+  '';
+
+  configurePhase =
+    ''
+      runHook preConfigure
+
+      export buildDir=$PWD
+
+      git tag ${version}
+    ''
+    # Loop through all the yarn caches and install the deps for the respective package
+    + lib.concatMapStringsSep "\n" (cache: ''
+      cd ${cache.pkg}
+      export HOME=$PWD/yarn_home
+      fixup-yarn-lock yarn.lock
+      yarn config --offline set yarn-offline-mirror ${cache.cache}
+      echo "Installing deps for ${cache.pkg}"
+      yarn install --offline --prefer-offline --frozen-lockfile --ignore-scripts --no-progress --non-interactive
+      patch-package
+      patchShebangs node_modules
+      echo "Done!"
+      cd $buildDir
+    '') yarnCaches
+
+    + ''
+      cd $buildDir/node_modules
+    ''
+    # Loop thought the "built in" plugins and link them to the node_modules
+    + lib.concatMapStringsSep "\n" (plugin: ''
+      ln -fs ../${plugin} ${plugin}
+    '') builtinPlugins
+
+    + ''
+      cd $buildDir
+
+      runHook postConfigure
+    '';
+
+  buildPhase =
+    # Start a fake (and completely unnecessary) http-server to let electron-rebuild "download" the headers and hashes
+    ''
+      runHook preBuild
+
+      mkdir -p http-cache/v${finalAttrs.electronPackage.version}
+      cp $electronHeaders http-cache/v${finalAttrs.electronPackage.version}/node-v${finalAttrs.electronPackage.version}-headers.tar.gz
+      cp $electronHeadersSHA http-cache/v${finalAttrs.electronPackage.version}/SHASUMS256.txt
+      http-server http-cache &
+    ''
+    # Rebuild all the needed packages using electron-rebuild
+    + lib.concatMapStringsSep "\n" (pkg: ''
+      yarn --offline electron-rebuild -v ${finalAttrs.electronPackage.version} -m ${pkg} -f -d "http://localhost:8080"
+    '') rebuildPkgs
+    + ''
+      kill $!
+      yarn build
+
+      runHook postBuild
+    '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/tabby
+    mkdir -p $out/bin
+    cp -r . $out/share/tabby
+
+    # Tabby needs TABBY_DEV to run manually with electron
+    makeWrapper "${finalAttrs.electronPackage}/bin/electron" "$out/bin/tabby" --add-flags "$out/share/tabby/app" --set TABBY_DEV 1
+
+    for iconsize in 16 32 64 128
+    do
+      size=$iconsize"x"$iconsize
+      mkdir -p $out/share/icons/hicolor/$size/apps
+      ln -s $out/share/tabby/build/icons/"$size".png $out/share/icons/hicolor/$size/apps/tabby.png
+    done
+
+    runHook postInstall
+  '';
+})

--- a/pkgs/by-name/ta/tabby-terminal/package.nix
+++ b/pkgs/by-name/ta/tabby-terminal/package.nix
@@ -1,0 +1,230 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  fetchYarnDeps,
+  nodejs,
+  yarn,
+  git,
+  patch-package,
+  electron_32,
+  prefetch-yarn-deps,
+  fixup-yarn-lock,
+  python3,
+  makeWrapper,
+  http-server,
+  fontconfig,
+  pkg-config,
+  libsecret,
+  makeDesktopItem,
+  copyDesktopItems,
+  jq,
+  moreutils,
+  applyPatches,
+}:
+
+let
+  tabby = rec {
+    pname = "tabby-terminal";
+    version = "1.0.223";
+
+    src = fetchFromGitHub {
+      owner = "Eugeny";
+      repo = "tabby";
+      rev = "v${version}";
+      hash = "sha256-YWqbVrxG3/tOw1ERkoEosVlz6k2eTkcsQnHAtdKpkpE=";
+      leaveDotGit = true;
+    };
+
+    patches = [ ./splice-argv.patch ];
+
+    meta = {
+      description = "A terminal for a more modern age";
+      homepage = "https://tabby.sh";
+      license = lib.licenses.mit;
+      mainProgram = "tabby";
+      maintainers = with lib.maintainers; [ geodic ];
+      platforms = lib.platforms.linux;
+    };
+
+    __darwinAllowLocalNetworking = true;
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "tabby";
+        desktopName = "Tabby";
+        exec = "tabby %u";
+        comment = "A terminal for a more modern age";
+        icon = "tabby";
+        categories = [
+          "Utility"
+          "TerminalEmulator"
+          "System"
+        ];
+      })
+    ];
+
+    electronPackage = electron_32;
+
+    electronHeaders = fetchurl {
+      url = "https://www.electronjs.org/headers/v${electronPackage.version}/node-v${electronPackage.version}-headers.tar.gz";
+      hash = "sha256-D9j1wSDzartWUfDm2UrZDrgum2X+vV+DpDlKPFCtBbA=";
+    };
+
+    electronHeadersSHA = fetchurl {
+      url = "https://www.electronjs.org/headers/v${electronPackage.version}/SHASUMS256.txt";
+      hash = "sha256-ZnWVCzTwwog4kgeFAZGsM2F2mmebrpXMVMxn/K+LWlU=";
+    };
+
+    buildInputs = [
+      nodejs
+      python3
+      fontconfig
+      electronPackage
+    ];
+
+    nativeBuildInputs = [
+      git
+      yarn
+      patch-package
+      prefetch-yarn-deps
+      fixup-yarn-lock
+      (python3.withPackages (python-pkgs: [
+        python-pkgs.distutils
+        python-pkgs.gyp
+      ]))
+      makeWrapper
+      http-server
+      pkg-config
+      libsecret
+      copyDesktopItems
+      jq
+      moreutils
+    ];
+
+    prePatch = ''
+      jq '.version = "${version}"' app/package.json | sponge app/package.json
+    '';
+
+    configurePhase =
+      ''
+        runHook preConfigure
+
+        export buildDir=$PWD
+
+        git tag ${version}
+      ''
+      # Loop through all the yarn caches and install the deps for the respective package
+      + lib.concatMapStringsSep "\n" (cache: ''
+        cd ${cache.pkg}
+        export HOME=$PWD/yarn_home
+        fixup-yarn-lock yarn.lock
+        yarn config --offline set yarn-offline-mirror ${cache.cache}
+        echo "Installing deps for ${cache.pkg}"
+        yarn install --offline --prefer-offline --frozen-lockfile --ignore-scripts --no-progress --non-interactive
+        patch-package
+        patchShebangs node_modules
+        echo "Done!"
+        cd $buildDir
+      '') yarnCaches
+
+      + ''
+        cd $buildDir/node_modules
+      ''
+      # Loop thought the "built in" plugins and link them to the node_modules
+      + lib.concatMapStringsSep "\n" (plugin: ''
+        ln -fs ../${plugin} ${plugin}
+      '') builtinPlugins
+
+      + ''
+        cd $buildDir
+
+        runHook postConfigure
+      '';
+
+    buildPhase =
+      # Start a fake (and completely unnecessary) http-server to let electron-rebuild "download" the headers and hashes
+      ''
+        runHook preBuild
+
+        mkdir -p http-cache/v${electronPackage.version}
+        cp $electronHeaders http-cache/v${electronPackage.version}/node-v${electronPackage.version}-headers.tar.gz
+        cp $electronHeadersSHA http-cache/v${electronPackage.version}/SHASUMS256.txt
+        http-server http-cache &
+      ''
+      # Rebuild all the needed packages using electron-rebuild
+      + lib.concatMapStringsSep "\n" (pkg: ''
+        yarn --offline electron-rebuild -v ${electronPackage.version} -m ${pkg} -f -d "http://localhost:8080"
+      '') rebuildPkgs
+      + ''
+        kill $!
+        yarn build
+
+        runHook postBuild
+      '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/tabby
+      mkdir -p $out/bin
+      cp -r . $out/share/tabby
+
+      # Tabby needs TABBY_DEV to run manually with electron
+      makeWrapper "${electronPackage}/bin/electron" "$out/bin/tabby" --add-flags "$out/share/tabby/app" --set TABBY_DEV 1
+
+      for iconsize in 16 32 64 128
+      do
+        size=$iconsize"x"$iconsize
+        mkdir -p $out/share/icons/hicolor/$size/apps
+        ln -s $out/share/tabby/build/icons/"$size".png $out/share/icons/hicolor/$size/apps/tabby.png
+      done
+
+      runHook postInstall
+    '';
+  };
+
+  builtinPlugins = [
+    "tabby-core"
+    "tabby-settings"
+    "tabby-terminal"
+    "tabby-web"
+    "tabby-community-color-schemes"
+    "tabby-ssh"
+    "tabby-serial"
+    "tabby-telnet"
+    "tabby-local"
+    "tabby-electron"
+    "tabby-plugin-manager"
+    "tabby-linkifier"
+  ];
+
+  packages = builtinPlugins ++ [
+    "."
+    "app"
+    "web"
+    "tabby-web-demo"
+  ];
+
+  pkgHashes = lib.importJSON ./pkg-hashes.json;
+
+  # Loop through all the packages and create a yarn cache for them
+  yarnCaches = map (pkg: {
+    inherit pkg;
+    cache = fetchYarnDeps {
+      src = lib.removeSuffix "/." (tabby.src + "/" + pkg);
+      hash = pkgHashes.${pkg};
+    };
+  }) packages;
+
+  rebuildPkgs = [
+    "app"
+    "tabby-core"
+    "tabby-local"
+    "tabby-ssh"
+    "tabby-terminal"
+  ];
+
+in
+stdenv.mkDerivation tabby

--- a/pkgs/by-name/ta/tabby-terminal/pkg-hashes.json
+++ b/pkgs/by-name/ta/tabby-terminal/pkg-hashes.json
@@ -1,6 +1,6 @@
 {
-  ".": "sha256-w0vdE7PSvN8EhkuB0zc9v03clLbo13XFcJ+T9Nl1GHs=",
-  "app": "sha256-34OVqPdlG+sk1Rt8T9pEAgBXTP9LtwghrqeP/zMqRls=",
+  ".": "sha256-yddGJtt82EwdFZU3dXWHB+NJk7aIgaUouNM1ctqwUXs=",
+  "app": "sha256-/4JoOaSFjfHG2BBFKrLjCKDUDa74VSsIEfxCkC36m+E=",
   "web": "sha256-kdER/yB8O7gfWnLZ/rNl4ha1eNnypcVmS1L7RrFCn0Q=",
   "tabby-core": "sha256-Z42TZeE0z96ZRtIFIgGbQyv8gtGY/Llya/Dhs8JtuWo=",
   "tabby-local": "sha256-GmVoeKxF8Sj55fDPN4GhwGVXoktdiwF3EFYTJHGO/NQ=",

--- a/pkgs/by-name/ta/tabby-terminal/pkg-hashes.json
+++ b/pkgs/by-name/ta/tabby-terminal/pkg-hashes.json
@@ -1,0 +1,18 @@
+{
+  ".": "sha256-w0vdE7PSvN8EhkuB0zc9v03clLbo13XFcJ+T9Nl1GHs=",
+  "app": "sha256-34OVqPdlG+sk1Rt8T9pEAgBXTP9LtwghrqeP/zMqRls=",
+  "web": "sha256-kdER/yB8O7gfWnLZ/rNl4ha1eNnypcVmS1L7RrFCn0Q=",
+  "tabby-core": "sha256-Z42TZeE0z96ZRtIFIgGbQyv8gtGY/Llya/Dhs8JtuWo=",
+  "tabby-local": "sha256-GmVoeKxF8Sj55fDPN4GhwGVXoktdiwF3EFYTJHGO/NQ=",
+  "tabby-settings": "sha256-7t9mXsMqU892fLHyHmivgDxECSVn8KgRNAz9E2nKC/I=",
+  "tabby-electron": "sha256-h5HIu1FCbPsQIijhto3LdpLD2FnRmalqPq4/sjU9EOM=",
+  "tabby-web-demo": "sha256-i8UoUMb5m+rf/73eKPm2S0v6cs8qSqy6lRjnZ6GoO/k=",
+  "tabby-linkifier": "sha256-78wgw6BbN/GtRMYeJF9svn9hn82bTZj4+8TXf/rAC64=",
+  "tabby-web": "sha256-ErhWM0jiVK4PBosBz4IHi1xiemAzRuk/EE8ntyhO2PE=",
+  "tabby-telnet": "sha256-J8nBBUxwTdigcdohEF6dw8+EHRBUm8O1SLM9oDB3VaA=",
+  "tabby-ssh": "sha256-GJP0KyDCLQ9MszCJcm4851g07fnZCN0svpPgnVjXjgY=",
+  "tabby-community-color-schemes": "sha256-oZgyP0hTU9bxszOVg3Bmiu6yos2d2Inc1Do8To4z8GQ=",
+  "tabby-plugin-manager": "sha256-CrgsIGg834A+WQh7o07Quv+SSFqYxPMugZsSOHCrdPU=",
+  "tabby-serial": "sha256-sg/CJnlkUcohFgmY6xGE79WG5mmx9jh196mb8iVCk6g=",
+  "tabby-terminal": "sha256-LS30V7iqLI0sEm3xlnMFtMnIxhALOMjQ148+zR0NyqU="
+}

--- a/pkgs/by-name/ta/tabby-terminal/splice-argv.patch
+++ b/pkgs/by-name/ta/tabby-terminal/splice-argv.patch
@@ -1,0 +1,17 @@
+diff --git a/app/lib/cli.ts b/app/lib/cli.ts
+index 03213dd8..2ff31389 100644
+--- a/app/lib/cli.ts
++++ b/app/lib/cli.ts
+@@ -1,9 +1,9 @@
+ import { app } from 'electron'
+ 
+ export function parseArgs (argv: string[], cwd: string): any {
+-    if (argv[0].includes('node')) {
+-        argv = argv.slice(1)
+-    }
++
++    // This is because we are running with electron
++    argv = argv.slice(1)
+ 
+     return require('yargs/yargs')(argv.slice(1))
+         .usage('tabby [command] [arguments]')


### PR DESCRIPTION
Added Tabby, an electron-based terminal emulator that proclaims itself "A terminal for a more modern age".

Homepage: https://tabby.sh

Fixes #233509, previous PR #368048, but branch somehow got force overwritten

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
