### PR TITLE
[Backport staging-25.05] sdl3: 3.2.14 -> 3.2.16; cleanup dependencies; fix cross compilation

### DIFF
--- a/pkgs/by-name/ib/ibusMinimal/package.nix
+++ b/pkgs/by-name/ib/ibusMinimal/package.nix
@@ -1,0 +1,1 @@
+{ ibus }: ibus.override { libOnly = true; }

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -8,7 +8,7 @@
   darwinMinVersionHook,
   dbus,
   fetchFromGitHub,
-  ibus,
+  ibusMinimal,
   installShellFiles,
   libGL,
   libayatana-appindicator,
@@ -104,7 +104,11 @@ stdenv.mkDerivation (finalAttrs: {
       apple-sdk_11
     ]
     ++ lib.optionals ibusSupport [
-      ibus
+      # sdl3 only uses some constants of the ibus headers
+      # it never actually loads the library
+      # thus, it also does not have to care about gtk integration,
+      # so using ibusMinimal avoids an unnecessarily large closure here.
+      ibusMinimal
     ]
     ++ lib.optional waylandSupport zenity;
 

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -50,7 +50,6 @@
     config.pulseaudio or stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   libudevSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   sndioSupport ? false,
-  testSupport ? true,
   traySupport ? true,
   waylandSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   x11Support ? !stdenv.hostPlatform.isAndroid && !stdenv.hostPlatform.isWindows,
@@ -65,15 +64,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";
   version = "3.2.16";
 
-  outputs =
-    [
-      "lib"
-      "dev"
-      "out"
-    ]
-    ++ lib.optionals testSupport [
-      "installedTests"
-    ];
+  outputs = [
+    "lib"
+    "dev"
+    "out"
+    "installedTests"
+  ];
 
   src = fetchFromGitHub {
     owner = "libsdl-org";
@@ -85,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch =
     # Tests timeout on Darwin
     # `testtray` loads assets from a relative path, which we are patching to be absolute
-    lib.optionalString testSupport ''
+    lib.optionalString (finalAttrs.finalPackage.doCheck) ''
       substituteInPlace test/CMakeLists.txt \
         --replace-fail 'set(noninteractive_timeout 10)' 'set(noninteractive_timeout 30)'
 
@@ -175,17 +171,17 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SDL_PIPEWIRE" pipewireSupport)
     (lib.cmakeBool "SDL_PULSEAUDIO" pulseaudioSupport)
     (lib.cmakeBool "SDL_SNDIO" sndioSupport)
-    (lib.cmakeBool "SDL_TEST_LIBRARY" testSupport)
+    (lib.cmakeBool "SDL_TEST_LIBRARY" true)
     (lib.cmakeBool "SDL_TRAY_DUMMY" (!traySupport))
     (lib.cmakeBool "SDL_WAYLAND" waylandSupport)
     (lib.cmakeBool "SDL_WAYLAND_LIBDECOR" libdecorSupport)
     (lib.cmakeBool "SDL_X11" x11Support)
 
-    (lib.cmakeBool "SDL_TESTS" finalAttrs.finalPackage.doCheck)
-    (lib.cmakeBool "SDL_INSTALL_TESTS" testSupport)
+    (lib.cmakeBool "SDL_TESTS" true)
+    (lib.cmakeBool "SDL_INSTALL_TESTS" true)
   ];
 
-  doCheck = testSupport && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  doCheck = true;
 
   # See comment below. We actually *do* need these RPATH entries
   dontPatchELF = true;
@@ -198,10 +194,9 @@ stdenv.mkDerivation (finalAttrs: {
     ) "-rpath ${lib.makeLibraryPath (finalAttrs.dlopenBuildInputs)}";
   };
 
-  postInstall = lib.optionalString testSupport ''
+  postInstall = ''
     moveToOutput "share/installed-tests" "$installedTests"
     moveToOutput "libexec/installed-tests" "$installedTests"
-    install -Dm 444 -t $installedTests/share/assets test/*.bmp
   '';
 
   passthru = {

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -33,6 +33,11 @@
   wayland-scanner,
   xorg,
   zenity,
+  # for passthru.tests
+  SDL_compat,
+  sdl2-compat,
+  sdl3-image,
+  sdl3-ttf,
   alsaSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   dbusSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   drmSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
@@ -204,7 +209,15 @@ stdenv.mkDerivation (finalAttrs: {
     });
 
     tests =
-      {
+      SDL_compat.tests
+      // sdl2-compat.tests
+      // {
+        inherit
+          SDL_compat
+          sdl2-compat
+          sdl3-image
+          sdl3-ttf
+          ;
         pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
         inherit (finalAttrs.passthru) debug-text-example;
       }

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -61,7 +61,7 @@ assert lib.assertMsg (
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";
-  version = "3.2.14";
+  version = "3.2.16";
 
   outputs = [
     "lib"
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libsdl-org";
     repo = "SDL";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-+CcbvF1nxxsVwuO5g50sBVGth0sr5WTFojSfT6B6bok=";
+    hash = "sha256-xFWE/i4l3sU1KritwbqvN67kJ3/WUfNP3iScMfQUbwA=";
   };
 
   postPatch =

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -59,6 +59,7 @@
 assert lib.assertMsg (
   waylandSupport -> openglSupport
 ) "SDL3 requires OpenGL support to enable Wayland";
+assert lib.assertMsg (ibusSupport -> dbusSupport) "SDL3 requires dbus support to enable ibus";
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -95,6 +95,8 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString waylandSupport ''
       substituteInPlace src/video/wayland/SDL_waylandmessagebox.c \
         --replace-fail '"zenity"' '"${lib.getExe zenity}"'
+      substituteInPlace src/dialog/unix/SDL_zenitydialog.c \
+        --replace-fail '"zenity"' '"${lib.getExe zenity}"'
     '';
 
   strictDeps = true;

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -63,11 +63,15 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "sdl3";
   version = "3.2.16";
 
-  outputs = [
-    "lib"
-    "dev"
-    "out"
-  ];
+  outputs =
+    [
+      "lib"
+      "dev"
+      "out"
+    ]
+    ++ lib.optionals testSupport [
+      "installedTests"
+    ];
 
   src = fetchFromGitHub {
     owner = "libsdl-org";
@@ -78,9 +82,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch =
     # Tests timeout on Darwin
+    # `testtray` loads assets from a relative path, which we are patching to be absolute
     lib.optionalString testSupport ''
       substituteInPlace test/CMakeLists.txt \
         --replace-fail 'set(noninteractive_timeout 10)' 'set(noninteractive_timeout 30)'
+
+      substituteInPlace test/testtray.c \
+        --replace-warn '../test/' '${placeholder "installedTests"}/share/assets/'
     ''
     + lib.optionalString waylandSupport ''
       substituteInPlace src/video/wayland/SDL_waylandmessagebox.c \
@@ -169,6 +177,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SDL_X11" x11Support)
 
     (lib.cmakeBool "SDL_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "SDL_INSTALL_TESTS" testSupport)
   ];
 
   doCheck = testSupport && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
@@ -183,6 +192,12 @@ stdenv.mkDerivation (finalAttrs: {
       stdenv.hostPlatform.hasSharedLibraries && stdenv.hostPlatform.extensions.sharedLibrary == ".so"
     ) "-rpath ${lib.makeLibraryPath (finalAttrs.dlopenBuildInputs)}";
   };
+
+  postInstall = lib.optionalString testSupport ''
+    moveToOutput "share/installed-tests" "$installedTests"
+    moveToOutput "libexec/installed-tests" "$installedTests"
+    install -Dm 444 -t $installedTests/share/assets test/*.bmp
+  '';
 
   passthru = {
     # Building this in its own derivation to make sure the rpath hack above propagate to users

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -51,6 +51,7 @@
   libudevSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   sndioSupport ? false,
   testSupport ? true,
+  traySupport ? true,
   waylandSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   x11Support ? !stdenv.hostPlatform.isAndroid && !stdenv.hostPlatform.isWindows,
 }:
@@ -125,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
       libusb1
     ]
     ++ lib.optional (
-      stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isDarwin
+      stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isDarwin && traySupport
     ) libayatana-appindicator
     ++ lib.optional alsaSupport alsa-lib
     ++ lib.optional dbusSupport dbus
@@ -172,6 +173,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SDL_PULSEAUDIO" pulseaudioSupport)
     (lib.cmakeBool "SDL_SNDIO" sndioSupport)
     (lib.cmakeBool "SDL_TEST_LIBRARY" testSupport)
+    (lib.cmakeBool "SDL_TRAY_DUMMY" (!traySupport))
     (lib.cmakeBool "SDL_WAYLAND" waylandSupport)
     (lib.cmakeBool "SDL_WAYLAND_LIBDECOR" libdecorSupport)
     (lib.cmakeBool "SDL_X11" x11Support)

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -182,6 +182,7 @@ stdenv.mkDerivation (finalAttrs: {
       isocodes
       json-glib
       libX11
+      vala # for share/vala/Makefile.vapigen (PKG_CONFIG_VAPIGEN_VAPIGEN)
     ]
     ++ lib.optionals (!libOnly) [
       gtk3
@@ -189,7 +190,6 @@ stdenv.mkDerivation (finalAttrs: {
       gdk-pixbuf
       libdbusmenu-gtk3
       libnotify
-      vala # for share/vala/Makefile.vapigen (PKG_CONFIG_VAPIGEN_VAPIGEN)
     ]
     ++ lib.optionals withWayland [
       libxkbcommon

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -34,6 +34,8 @@
   buildPackages,
   runtimeShell,
   nixosTests,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 let
@@ -59,15 +61,15 @@ let
       '';
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ibus";
   version = "1.5.31";
 
   src = fetchFromGitHub {
     owner = "ibus";
     repo = "ibus";
-    rev = version;
-    sha256 = "sha256-YMCtLIK/9iUdS37Oiow7WMhFFPKhomNXvzWbLzlUkdQ=";
+    tag = finalAttrs.version;
+    hash = "sha256-YMCtLIK/9iUdS37Oiow7WMhFFPKhomNXvzWbLzlUkdQ=";
   };
 
   patches = [
@@ -174,12 +176,14 @@ stdenv.mkDerivation rec {
     ];
 
   enableParallelBuilding = true;
+  strictDeps = true;
 
   doCheck = false; # requires X11 daemon
+
   doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/ibus version
-  '';
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  versionCheckProgram = "${placeholder "out"}/bin/ibus";
 
   postInstall = ''
     # It has some hardcoded FHS paths and also we do not use it
@@ -198,13 +202,15 @@ stdenv.mkDerivation rec {
     tests = {
       installed-tests = nixosTests.installed-tests.ibus;
     };
+    updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://github.com/ibus/ibus/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/ibus/ibus";
     description = "Intelligent Input Bus, input method framework";
-    license = licenses.lgpl21Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ ttuegel ];
+    license = lib.licenses.lgpl21Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ttuegel ];
   };
-}
+})


### PR DESCRIPTION
This brings an update and some nice cross-related improvements from the following PRs:

https://github.com/NixOS/nixpkgs/pull/408880
https://github.com/NixOS/nixpkgs/pull/413222
https://github.com/NixOS/nixpkgs/pull/414169
https://github.com/NixOS/nixpkgs/pull/414472 (partial)
https://github.com/NixOS/nixpkgs/pull/418644
https://github.com/NixOS/nixpkgs/pull/418646


<details>
<summary>Built <code>sdl3.passthru.tests</code> against release-25.05</summary>

```
$ nix-build -A sdl3.passthru.tests
/nix/store/m1563yphzjvg9gmgxbap7sbk9cz0qgxl-SDL2_gfx-1.0.4
/nix/store/d6dv4244l5cyd8wk7dsnc4sxq8n43iwg-SDL2_image-2.8.8
/nix/store/rz7zhdc41zpgfnzxq2rzpbs228in6fpf-SDL2_mixer-2.8.1
/nix/store/jllli5ywagab2q57mk2f7zaswm51009k-SDL2_net-2.2.0
/nix/store/10s02nnnbaprkrssidspv9f6wmsnpdvh-SDL2_sound-2.0.1
/nix/store/33425j1k1s8z9pdknvvw5vxnjkgyj7f5-SDL2_ttf-2.24.0
/nix/store/rqf0rp1zzzvp141ihs5kv4549sy1rg19-SDL_compat-1.2.68
/nix/store/j3x7kkv9w2sl9qdprsm9s97g7f5xq1ab-SDL_image-1.2.12-unstable-2025-04-27
/nix/store/x6qy5rdcs0hbzhcf8cky7y0pzpxm3y5f-SDL_mixer-1.2.12
/nix/store/95yfznchla91mfd05iy2pbfagr6a6rlh-SDL_sound-1.0.3
/nix/store/965dnbn0rdxfj00bfl2glm1j8a9a5jx4-SDL_ttf-2.0.11-unstable-2024-04-23
/nix/store/hqjrwyj61pi6mjlx53b04w687p4a73qz-sdl3-debug-text-example-3.2.16
/nix/store/f6az3m5dy4nfhr4xf3bdhcv3ss34cny3-dosbox-0.74-3
/nix/store/jqlw0wbpynm0q6a1zb67vad361n44si0-monado-25.0.0
/nix/store/0xqhn8k2a6blnijjxhppdadciyib3pzj-vm-test-run-sdl3
/nix/store/6bvrfq2nxk3313v5sb2k1w3715m426r9-check-pkg-config-sdl3
/nix/store/8105jl7nw916xdmihzqsz7z4pmgvmy67-sdl2-compat-2.32.56
/nix/store/vjpjll15blfn11qz60pryap78h0g5mca-sdl3-image-3.2.4-lib
/nix/store/4cl3vxjcdwlk47hzhmv8aqypfaia4fsp-sdl3-ttf-3.2.2
```
</details>

Thanks to @LordGrimmauld for most of these patches. CC @NixOS/sdl

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
