### PR TITLE
home-assistant: 2025.7.1 -> 2025.7.2

### DIFF
--- a/pkgs/development/python-modules/aioamazondevices/default.nix
+++ b/pkgs/development/python-modules/aioamazondevices/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "aioamazondevices";
-  version = "3.2.3";
+  version = "3.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "chemelli74";
     repo = "aioamazondevices";
     tag = "v${version}";
-    hash = "sha256-TpsRYL608hAcFhqBwqsstFUdq0BLlNjD9YdGeio8BNs=";
+    hash = "sha256-MXVQ/VtsT/ppeQsSnf+LiddlZFKylQxL48vPRKj932w=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/aioautomower/default.nix
+++ b/pkgs/development/python-modules/aioautomower/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "aioautomower";
-  version = "1.2.2";
+  version = "2025.6.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Thomas55555";
     repo = "aioautomower";
-    tag = "v${version}";
+    tag = version;
     hash = "sha256-6V3utjqCLQmO2iuWdn6kE8oz9XcJ/sCfeSMWmxL/2NE=";
   };
 

--- a/pkgs/development/python-modules/aioshelly/default.nix
+++ b/pkgs/development/python-modules/aioshelly/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "aioshelly";
-  version = "13.7.1";
+  version = "13.7.2";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "aioshelly";
     tag = version;
-    hash = "sha256-EQyq+l/WhM4mAQrq9D4F3hglk2EkvCrSD6tYbUr0aWw=";
+    hash = "sha256-8OOg6+oKaeLk2kUJ44ynxuNx1ZGtAydLhgAhM2N9Hn0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/async-upnp-client/default.nix
+++ b/pkgs/development/python-modules/async-upnp-client/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
 
   # build-system
   setuptools,
@@ -23,16 +22,14 @@
 
 buildPythonPackage rec {
   pname = "async-upnp-client";
-  version = "0.44.0";
+  version = "0.45.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "StevenLooman";
     repo = "async_upnp_client";
     tag = version;
-    hash = "sha256-xtouCq8nkvXxgZ0jX4VuTU41xxrAkXqWEpZg/vms4Zo=";
+    hash = "sha256-bRUEnedPDFBgpJeDPRG6e6fQUJ/R2RaasVKHZX7COp8=";
   };
 
   pythonRelaxDeps = [
@@ -57,6 +54,8 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    "test_decode_ssdp_packet"
+    "test_microsoft_butchers_ssdp"
     # socket.gaierror: [Errno -2] Name or service not known
     "test_async_get_local_ip"
     "test_get_local_ip"
@@ -69,12 +68,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "async_upnp_client" ];
 
-  meta = with lib; {
+  meta = {
     description = "Asyncio UPnP Client library for Python";
     homepage = "https://github.com/StevenLooman/async_upnp_client";
-    changelog = "https://github.com/StevenLooman/async_upnp_client/blob/${version}/CHANGES.rst";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ hexa ];
+    changelog = "https://github.com/StevenLooman/async_upnp_client/blob/${src.tag}/CHANGES.rst";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hexa ];
     mainProgram = "upnp-client";
   };
 }

--- a/pkgs/development/python-modules/gios/default.nix
+++ b/pkgs/development/python-modules/gios/default.nix
@@ -15,16 +15,16 @@
 
 buildPythonPackage rec {
   pname = "gios";
-  version = "6.0.0";
+  version = "6.1.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.11";
+  disabled = pythonOlder "3.12";
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = "gios";
     tag = version;
-    hash = "sha256-SCVyEHxTV+6+3mLh8HEutRXHV2Xt0JzOrNnIKtIcFXw=";
+    hash = "sha256-BjyeWg75JQd+VAIQmtFIwEdByMPdGG+nIOgKCavjF0c=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.105.0";
+  version = "0.106.0";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "nabucasa";
     repo = "hass-nabucasa";
     tag = version;
-    hash = "sha256-KH6wUh5BRsYox0BPo7BNCS+8KaRtpoWvaQHbcuN89hE=";
+    hash = "sha256-GrdtZGAaDZWVsKatiWxp9uSNSLjnzM0Cw+26IHm1KN0=";
   };
 
   build-system = [ setuptools ];
@@ -61,6 +61,11 @@ buildPythonPackage rec {
     pytestCheckHook
     syrupy
     xmltodict
+  ];
+
+  disabledTests = [
+    # mock time 10800s (3h) vs 43200s (12h)
+    "test_subscription_reconnection_handler_renews_and_starts"
   ];
 
   pythonImportsCheck = [ "hass_nabucasa" ];

--- a/pkgs/development/python-modules/nyt-games/default.nix
+++ b/pkgs/development/python-modules/nyt-games/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "nyt-games";
-  version = "0.4.4";
+  version = "0.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joostlek";
     repo = "python-nyt-games";
     tag = "v${version}";
-    hash = "sha256-eMJ96E4sGmekr6mOR30UIZBclH/0xc8AWv3zL1ItKjo=";
+    hash = "sha256-bpamhrTBDFp1c/RvvbVjRFXEn5HoxY+3jGH7NkfsFxo=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.7.1";
+  version = "2025.7.2";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -522,21 +522,9 @@ python.pkgs.buildPythonApplication rec {
     "--dist loadfile"
     # enable full variable printing on error
     "--showlocals"
-    # AssertionError: assert 1 == 0
-    "--deselect tests/test_config.py::test_merge"
-    # checks whether pip is installed
-    "--deselect=tests/util/test_package.py::test_check_package_fragment"
-    # flaky
-    "--deselect=tests/test_bootstrap.py::test_setup_hass_takes_longer_than_log_slow_startup"
-    "--deselect=tests/test_test_fixtures.py::test_evict_faked_translations"
-    "--deselect=tests/helpers/test_backup.py::test_async_get_manager"
-    # (2025.7.0) Fails to find name of tracked time interval in scheduled jobs
-    "--deselect=tests/helpers/test_event.py::test_track_time_interval_name"
-    # (2025.7.2) Exception string mismatch (non-blocking vs non blocking)
-    "--deselect=tests/test_core.py::test_services_call_return_response_requires_blocking"
-    # tests are located in tests/
-    "tests"
   ];
+
+  enabledTestPaths = [ "tests" ];
 
   disabledTestPaths = [
     # we neither run nor distribute hassfest
@@ -547,6 +535,18 @@ python.pkgs.buildPythonApplication rec {
     "tests/test_circular_imports.py"
     # don't bulk test all components
     "tests/components"
+    # AssertionError: assert 1 == 0
+    "tests/test_config.py::test_merge"
+    # checks whether pip is installed
+    "tests/util/test_package.py::test_check_package_fragment"
+    # flaky
+    "tests/test_bootstrap.py::test_setup_hass_takes_longer_than_log_slow_startup"
+    "tests/test_test_fixtures.py::test_evict_faked_translations"
+    "tests/helpers/test_backup.py::test_async_get_manager"
+    # (2025.7.0) Fails to find name of tracked time interval in scheduled jobs
+    "tests/helpers/test_event.py::test_track_time_interval_name"
+    # (2025.7.2) Exception string mismatch (non-blocking vs non blocking)
+    "tests/test_core.py::test_services_call_return_response_requires_blocking"
   ];
 
   preCheck = ''

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -354,7 +354,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.7.1";
+  hassVersion = "2025.7.2";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -375,13 +375,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-KaepdkW1PLbWf7yl90ZqmZ6OIgZlRcaw2pSf2wTev+Q=";
+    hash = "sha256-aBIG4dxCdj1dQP5wMd5ySXggUvspGlnh7btxmMr/51Y=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-Gmq42r4O6mNNXaVwTlC3UjeAsu8TOm417WCm/2E3I6E=";
+    hash = "sha256-J8KH9y8dNsKW+jc5Wkqnw9VreKoUQH0dEBbne/6xiMw=";
   };
 
   build-system = with python.pkgs; [
@@ -532,6 +532,8 @@ python.pkgs.buildPythonApplication rec {
     "--deselect=tests/helpers/test_backup.py::test_async_get_manager"
     # (2025.7.0) Fails to find name of tracked time interval in scheduled jobs
     "--deselect=tests/helpers/test_event.py::test_track_time_interval_name"
+    # (2025.7.2) Exception string mismatch (non-blocking vs non blocking)
+    "--deselect=tests/test_core.py::test_services_call_return_response_requires_blocking"
     # tests are located in tests/
     "tests"
   ];

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20250702.1";
+  version = "20250702.2";
   format = "wheel";
 
   src = fetchPypi {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-I0aOjDkoyru+okZDJfigJHpLXyu7m/pylYWd810fJgI=";
+    hash = "sha256-3/m2T2yUpjczHEIywdwL+fqr9juiN2Mtd1iT+X+lTxo=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.7.1";
+  version = "2025.7.2";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-ozfVFmq2OAVWoXYt+UqHNYI0MC6gl/beE7wMiWKtpQs=";
+    hash = "sha256-qpNDeJHnGmjxgFOfNDl1jyK+t/BFzC+VtkTu+zL8NaQ=";
   };
 
   build-system = [


### PR DESCRIPTION
    https://github.com/KapJI/homeassistant-stubs/releases/tag/2025.7.2
    https://github.com/home-assistant/core/releases/tag/2025.7.2
    https://github.com/joostlek/python-nyt-games/releases/tag/v0.5.0
    https://github.com/NabuCasa/hass-nabucasa/releases/tag/0.106.0
    https://github.com/bieniu/gios/releases/tag/6.1.1
    https://github.com/home-assistant-libs/aioshelly/releases/tag/13.7.2
    https://github.com/Thomas55555/aioautomower/releases/tag/2025.6.0
    https://github.com/chemelli74/aioamazondevices/blob/v3.3.0/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
