### PR TITLE
tg-timer: init at 0.7.0

### DIFF
--- a/pkgs/by-name/tg/tg-timer/audio.patch
+++ b/pkgs/by-name/tg/tg-timer/audio.patch
@@ -1,0 +1,18 @@
+diff --git a/src/audio.c b/src/audio.c
+index d1b9762..cb544dd 100644
+
+This package assumes that there will always be an audio device while testing.
+If there is not an audio device, it segfaults. So in the Nix sandbox, it
+unconditionally segfaults without this patch. This patch allows the tests
+to flow through the normal error handling logic.
+
+--- a/src/audio.c
++++ b/src/audio.c
+@@ -637,7 +637,6 @@ int start_portaudio(int device, int *nominal_sample_rate, double *real_sample_ra
+ 	if(testing) {
+ 		*nominal_sample_rate = PA_SAMPLE_RATE;
+ 		*real_sample_rate = PA_SAMPLE_RATE;
+-		goto end;
+ 	}
+ #endif
+ 

--- a/pkgs/by-name/tg/tg-timer/package.nix
+++ b/pkgs/by-name/tg/tg-timer/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  # Configure
+  autoreconfHook,
+  # Build binaries
+  pkg-config,
+  # Build libraries
+  gtk3,
+  portaudio,
+  fftwFloat,
+  libjack2,
+  python3,
+  # Check Binaries
+  xvfb-run,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tg-timer";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "xyzzy42";
+    repo = "tg";
+    tag = "v${finalAttrs.version}-tpiepho";
+    hash = "sha256-9QeTjr/J0Y10YfPKEfYnciu5z2+hmmWFKLdw6CCS3hU=";
+  };
+
+  patches = [
+    ./audio.patch
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    portaudio
+    fftwFloat
+    libjack2
+    (python3.withPackages (p: [
+      p.numpy
+      p.matplotlib
+      p.libtfr
+      p.scipy
+    ]))
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+  nativeCheckInputs = [
+    xvfb-run
+  ];
+  checkPhase = ''
+    runHook preCheck
+
+    xvfb-run -s '-screen 0 800x600x24' \
+    make -j "$NIX_BUILD_CORES" test
+
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "for timing mechanical watches";
+    homepage = "https://github.com/xyzzy42/tg";
+    changelog = "https://github.com/xyzzy42/tg/releases/tag/v${finalAttrs.version}-tpiepho";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "tg";
+    maintainers = with lib.maintainers; [ RossSmyth ];
+  };
+})

--- a/pkgs/development/python-modules/libtfr/default.nix
+++ b/pkgs/development/python-modules/libtfr/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  fetchPypi,
+  buildPythonPackage,
+
+  # build-system
+  setuptools,
+  pkg-config,
+  cython,
+  pkgconfig,
+
+  # Dependencies
+  numpy,
+  fftw,
+  lapack,
+
+  # Check
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "libtfr";
+  version = "2.1.9";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-GxRjkQ6ng2wNONRit8ZsCwWsVlXy//7taeU6np/5aU0=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cython
+  ];
+
+  buildInputs = [
+    fftw
+    lapack
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+    pkgconfig
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "libtfr" ];
+
+  meta = {
+    description = "fast multitaper conventional and reassignment spectrograms";
+    homepage = "https://melizalab.github.io/libtfr/";
+    downloadPage = "https://github.com/melizalab/libtfr";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      RossSmyth
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8190,6 +8190,8 @@ self: super: with self; {
 
   libsupermesh = callPackage ../development/python-modules/libsupermesh { };
 
+  libtfr = callPackage ../development/python-modules/libtfr { };
+
   libthumbor = callPackage ../development/python-modules/libthumbor { };
 
   libtmux = callPackage ../development/python-modules/libtmux { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* Added Python package libtfr
* Added package tg-timer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
