### PR TITLE
python3Packages.pydantic: 2.11.4 -> 2.11.7

### DIFF
--- a/pkgs/development/python-modules/pydantic-extra-types/default.nix
+++ b/pkgs/development/python-modules/pydantic-extra-types/default.nix
@@ -5,10 +5,12 @@
   fetchFromGitHub,
   hatchling,
   pydantic,
+  typing-extensions,
   semver,
   pendulum,
   phonenumbers,
   pycountry,
+  pymongo,
   python-ulid,
   pytz,
   pytestCheckHook,
@@ -16,21 +18,21 @@
 
 buildPythonPackage rec {
   pname = "pydantic-extra-types";
-  version = "2.10.2";
+  version = "2.10.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "pydantic-extra-types";
     tag = "v${version}";
-    hash = "sha256-hjwComN2CQWPnF7frWobxbzN9/ZhHGVSsRHnmAkL6wk=";
+    hash = "sha256-05yGIAgN/sW+Nj7F720ZAHeMz/AyvwHMfzp4OdLREe4=";
   };
 
   build-system = [ hatchling ];
 
   dependencies = [
     pydantic
-    semver
+    typing-extensions
   ];
 
   optional-dependencies = {
@@ -38,19 +40,21 @@ buildPythonPackage rec {
       pendulum
       phonenumbers
       pycountry
+      pymongo
       python-ulid
       pytz
+      semver
     ];
+    phonenumbers = [ phonenumbers ];
+    pycountry = [ pycountry ];
+    semver = [ semver ];
+    python_ulid = [ python-ulid ];
+    pendulum = [ pendulum ];
   };
 
   pythonImportsCheck = [ "pydantic_extra_types" ];
 
   nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.all;
-
-  disabledTests = [
-    # outdated jsonschema fixture
-    "test_json_schema"
-  ];
 
   # PermissionError accessing '/etc/localtime'
   disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test_pendulum_dt.py" ];

--- a/pkgs/development/python-modules/pydantic-settings/default.nix
+++ b/pkgs/development/python-modules/pydantic-settings/default.nix
@@ -14,7 +14,7 @@
 let
   self = buildPythonPackage rec {
     pname = "pydantic-settings";
-    version = "2.9.1";
+    version = "2.10.1";
     pyproject = true;
 
     disabled = pythonOlder "3.8";
@@ -22,8 +22,8 @@ let
     src = fetchFromGitHub {
       owner = "pydantic";
       repo = "pydantic-settings";
-      tag = "v${version}";
-      hash = "sha256-KcpDOdp8qDAgTI/+r6rb21UrjkeOFfCFnON1kMSKKSE=";
+      tag = version;
+      hash = "sha256-Bi5MIXB9fVE5hoyk8QxxaGa9+puAlW+YGdi/WMNf/RQ=";
     };
 
     build-system = [ hatchling ];

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -29,7 +29,7 @@
 
 buildPythonPackage rec {
   pname = "pydantic";
-  version = "2.11.4";
+  version = "2.11.7";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     owner = "pydantic";
     repo = "pydantic";
     tag = "v${version}";
-    hash = "sha256-/LMemrO01KnhDrqKbH1qBVyO/uAiqTh5+FHnrxE8BUo=";
+    hash = "sha256-5EQwbAqRExApJvVUJ1C6fsEC1/rEI6/bQEQkStqgf/Q=";
   };
 
   postPatch = ''


### PR DESCRIPTION
    https://github.com/pydantic/pydantic-extra-types/releases/tag/v2.10.3
    https://github.com/pydantic/pydantic-extra-types/releases/tag/v2.10.4
    https://github.com/pydantic/pydantic-extra-types/releases/tag/v2.10.5
    https://github.com/pydantic/pydantic-settings/releases/tag/2.10.0
    https://github.com/pydantic/pydantic-settings/releases/tag/2.10.1
    https://github.com/pydantic/pydantic/blob/v2.11.7/HISTORY.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
https://github.com/pydantic/pydantic/blob/v2.11.7/HISTORY.md