### PR TITLE
gccNGPackages_15: init grust, dedupe flags, better pname in gcc

### DIFF
--- a/pkgs/development/compilers/gcc/ng/common/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/default.nix
@@ -127,10 +127,7 @@ makeScopeWithSplicing' {
         extraPackages = [
           targetGccPackages.libgcc
         ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-          "-B${targetGccPackages.libssp}/lib"
-          "-B${targetGccPackages.libatomic}/lib"
+        nixSupport.cc-cflags = gccPackages.gfortranNoLibgfortran.nixSupport.cc-cflags ++ [
           "-B${targetGccPackages.libgfortran}/lib/"
         ];
       };
@@ -142,11 +139,7 @@ makeScopeWithSplicing' {
         extraPackages = [
           targetGccPackages.libgcc
         ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-          "-B${targetGccPackages.libssp}/lib"
-          "-B${targetGccPackages.libatomic}/lib"
-        ];
+        inherit (gccPackages.gcc) nixSupport;
       };
 
       gcc = wrapCCWith rec {
@@ -156,9 +149,7 @@ makeScopeWithSplicing' {
         extraPackages = [
           targetGccPackages.libgcc
         ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-          "-B${targetGccPackages.libssp}/lib"
+        nixSupport.cc-cflags = gccPackages.gccWithLibatomic.nixSupport.cc-cflags ++ [
           "-B${targetGccPackages.libatomic}/lib"
         ];
       };
@@ -200,8 +191,7 @@ makeScopeWithSplicing' {
         extraPackages = [
           targetGccPackages.libgcc
         ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
+        nixSupport.cc-cflags = gccPackages.gccWithLibc.nixSupport.cc-cflags ++ [
           "-B${targetGccPackages.libssp}/lib"
         ];
       };
@@ -217,9 +207,7 @@ makeScopeWithSplicing' {
         extraPackages = [
           targetGccPackages.libgcc
         ];
-        nixSupport.cc-cflags = [
-          "-B${targetGccPackages.libgcc}/lib"
-          "-B${targetGccPackages.libssp}/lib"
+        nixSupport.cc-cflags = gccPackages.gccWithLibssp.nixSupport.cc-cflags ++ [
           "-B${targetGccPackages.libatomic}/lib"
         ];
       };

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -15,6 +15,7 @@
   langObjC ? stdenv.targetPlatform.isDarwin,
   langObjCpp ? stdenv.targetPlatform.isDarwin,
   langJit ? false,
+  langRust ? false,
   enablePlugin ? lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform,
   runCommand,
   buildPackages,
@@ -31,6 +32,7 @@
   getVersionFile,
   buildGccPackages,
   targetPackages,
+  cargo,
   libc,
   bintools,
 }:
@@ -48,7 +50,8 @@ let
     ++ lib.optional langGo "go"
     ++ lib.optional langObjC "objc"
     ++ lib.optional langObjCpp "obj-c++"
-    ++ lib.optional langJit "jit";
+    ++ lib.optional langJit "jit"
+    ++ lib.optional langRust "rust";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "${targetPrefix}${
@@ -86,11 +89,14 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [
-    texinfo
-    which
-    gettext
-  ] ++ lib.optional (perl != null) perl;
+  nativeBuildInputs =
+    [
+      texinfo
+      which
+      gettext
+    ]
+    ++ lib.optional (perl != null) perl
+    ++ lib.optional langRust cargo;
 
   buildInputs =
     [

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -37,9 +37,28 @@
 let
   inherit (stdenv) targetPlatform hostPlatform;
   targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
+
+  langs =
+    lib.optional langC "c"
+    ++ lib.optional langCC "c++"
+    ++ lib.optional langD "d"
+    ++ lib.optional langFortran "fortran"
+    ++ lib.optional langJava "java"
+    ++ lib.optional langAda "ada"
+    ++ lib.optional langGo "go"
+    ++ lib.optional langObjC "objc"
+    ++ lib.optional langObjCpp "obj-c++"
+    ++ lib.optional langJit "jit";
 in
 stdenv.mkDerivation (finalAttrs: {
-  pname = "${targetPrefix}${if langFortran then "gfortran" else "gcc"}";
+  pname = "${targetPrefix}${
+    if (lib.length langs == 2 && langC && langCC) || (lib.length langs == 1 && (langC || langCC)) then
+      "gcc"
+    else if lib.length langs == 1 then
+      "g${lib.elemAt langs 0}"
+    else
+      "gcc-${lib.concatStrings (lib.intersperse "-" langs)}"
+  }";
   inherit version;
 
   src = monorepoSrc;
@@ -175,22 +194,7 @@ stdenv.mkDerivation (finalAttrs: {
       "--disable-multilib"
       "--disable-nls"
       "--disable-shared"
-      "--enable-languages=${
-        lib.concatStrings (
-          lib.intersperse "," (
-            lib.optional langC "c"
-            ++ lib.optional langCC "c++"
-            ++ lib.optional langD "d"
-            ++ lib.optional langFortran "fortran"
-            ++ lib.optional langJava "java"
-            ++ lib.optional langAda "ada"
-            ++ lib.optional langGo "go"
-            ++ lib.optional langObjC "objc"
-            ++ lib.optional langObjCpp "obj-c++"
-            ++ lib.optional langJit "jit"
-          )
-        )
-      }"
+      "--enable-languages=${lib.concatStrings (lib.intersperse "," langs)}"
       (lib.withFeature (isl != null) "isl")
       "--without-headers"
       "--with-gnu-as"

--- a/pkgs/development/compilers/gcc/ng/common/libgrust/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgrust/default.nix
@@ -1,0 +1,190 @@
+{
+  lib,
+  stdenv,
+  grust,
+  gcc_meta,
+  release_version,
+  version,
+  monorepoSrc ? null,
+  buildPackages,
+  autoreconfHook269,
+  libiberty,
+  libgcc,
+  libbacktrace,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libgrust";
+  inherit version;
+
+  src = monorepoSrc;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  strictDeps = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [
+    autoreconfHook269
+    libiberty
+    grust
+  ];
+
+  autoreconfFlags = "--install --force --verbose . libgrust";
+
+  postUnpack = ''
+    mkdir -p ./build
+    buildRoot=$(readlink -e "./build")
+  '';
+
+  postPatch = ''
+    sourceRoot=$(readlink -e "./libgrust")
+  '';
+
+  enableParallelBuilding = true;
+
+  preConfigure =
+    ''
+      cd "$buildRoot"
+
+      mkdir -p build-${stdenv.buildPlatform.config}/libiberty/
+      cd build-${stdenv.buildPlatform.config}/libiberty/
+      ln -s ${libiberty}/lib/libiberty.a ./
+
+      mkdir -p "$buildRoot/gcc"
+      cd "$buildRoot/gcc"
+
+      (
+      export AS_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc "$AS_FOR_BUILD"}
+      export CC_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc "$CC_FOR_BUILD"}
+      export CPP_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc "$CPP_FOR_BUILD"}
+      export CXX_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc "$CXX_FOR_BUILD"}
+      export LD_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc.bintools "$LD_FOR_BUILD"}
+
+      export AS=$AS_FOR_BUILD
+      export CC=$CC_FOR_BUILD
+      export CPP=$CPP_FOR_BUILD
+      export CXX=$CXX_FOR_BUILD
+      export LD=$LD_FOR_BUILD
+
+      export AS_FOR_TARGET=${lib.getExe' stdenv.cc "$AS"}
+      export CC_FOR_TARGET=${lib.getExe' stdenv.cc "$CC"}
+      export CPP_FOR_TARGET=${lib.getExe' stdenv.cc "$CPP"}
+      export LD_FOR_TARGET=${lib.getExe' stdenv.cc.bintools "$LD"}
+
+      export NIX_CFLAGS_COMPILE_FOR_BUILD+=' -DGENERATOR_FILE=1'
+
+      "$sourceRoot/../gcc/configure" $topLevelConfigureFlags
+
+      make \
+        config.h
+      )
+      mkdir -p "$buildRoot/gcc/include"
+
+      mkdir -p "$buildRoot/gcc/libbacktrace/.libs"
+      cp ${libbacktrace}/lib/libbacktrace.a "$buildRoot/gcc/libbacktrace/.libs/libbacktrace.a"
+      cp -r ${libbacktrace}/lib/*.la "$buildRoot/gcc/libbacktrace"
+      cp -r ${libbacktrace.dev}/include/*.h "$buildRoot/gcc/libbacktrace"
+
+      mkdir -p "$buildRoot/gcc/libgcc"
+      ln -s "${libgcc.dev}/include/gthr-default.h" "$buildRoot/gcc/libgcc"
+
+      mkdir -p "$buildRoot/gcc/${stdenv.hostPlatform.config}/libgrust"
+      ln -s "$buildRoot/gcc/libbacktrace" "$buildRoot/gcc/${stdenv.buildPlatform.config}/libbacktrace"
+      ln -s "$buildRoot/gcc/libgcc" "$buildRoot/gcc/${stdenv.buildPlatform.config}/libgcc"
+      cd "$buildRoot/gcc/${stdenv.hostPlatform.config}/libgrust"
+      configureScript=$sourceRoot/configure
+      chmod +x "$configureScript"
+
+      export AS_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc "$AS_FOR_BUILD"}
+      export CC_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc "$CC_FOR_BUILD"}
+      export CPP_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc "$CPP_FOR_BUILD"}
+      export CXX_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc "$CXX_FOR_BUILD"}
+      export LD_FOR_BUILD=${lib.getExe' buildPackages.stdenv.cc.bintools "$LD_FOR_BUILD"}
+
+      export AS=${lib.getExe' stdenv.cc "$AS"}
+      export CC=${lib.getExe' stdenv.cc "$CC"}
+      export CPP=${lib.getExe' stdenv.cc "$CPP"}
+      export CXX=${lib.getExe' stdenv.cc "$CXX"}
+      export LD=${lib.getExe' stdenv.cc.bintools "$LD"}
+
+      export AS_FOR_TARGET=${lib.getExe' stdenv.cc "$AS_FOR_TARGET"}
+      export CC_FOR_TARGET=${lib.getExe' stdenv.cc "$CC_FOR_TARGET"}
+      export CPP_FOR_TARGET=${lib.getExe' stdenv.cc "$CPP_FOR_TARGET"}
+      export LD_FOR_TARGET=${lib.getExe' stdenv.cc.bintools "$LD_FOR_TARGET"}
+    ''
+    + lib.optionalString stdenv.hostPlatform.isMusl ''
+      NIX_CFLAGS_COMPILE_OLD=$NIX_CFLAGS_COMPILE
+      NIX_CFLAGS_COMPILE+=' -isystem ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${version}/include-fixed'
+    '';
+
+  topLevelConfigureFlags =
+    [
+      "--build=${stdenv.buildPlatform.config}"
+      "--host=${stdenv.buildPlatform.config}"
+      "--target=${stdenv.hostPlatform.config}"
+
+      "--disable-bootstrap"
+      "--disable-multilib"
+      "--with-multilib-list="
+      "--enable-languages=fortran"
+
+      "--disable-fixincludes"
+      "--disable-intl"
+      "--disable-lto"
+      "--disable-libatomic"
+      "--disable-libbacktrace"
+      "--disable-libcpp"
+      "--disable-libssp"
+      "--disable-libquadmath"
+      "--disable-libgomp"
+      "--disable-libvtv"
+      "--disable-vtable-verify"
+
+      "--with-system-zlib"
+    ]
+    ++ lib.optional (stdenv.hostPlatform.libc == "glibc")
+      # Cheat and use previous stage's glibc to avoid infinite recursion. As
+      # of GCC 11, libgcc only cares if the version is greater than 2.19,
+      # which is quite ancient, so this little lie should be fine.
+      "--with-glibc-version=${buildPackages.glibc.version}";
+
+  configurePlatforms = [
+    "build"
+    "host"
+  ];
+
+  configureFlags = [
+    "--disable-dependency-tracking"
+    "gcc_cv_target_thread_file=single"
+    # $CC cannot link binaries, let alone run then
+    "cross_compiling=true"
+  ];
+
+  # Set the variable back the way it was, see corresponding code in
+  # `preConfigure`.
+  postConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
+    NIX_CFLAGS_COMPILE=$NIX_CFLAGS_COMPILE_OLD
+  '';
+
+  makeFlags = [ "MULTIBUILDTOP:=../" ];
+
+  postInstall = ''
+    moveToOutput "lib/gcc/${stdenv.hostPlatform.config}/${version}/include" "$dev"
+    mkdir -p "$out/lib" "$dev/include"
+    ln -s "$out/lib/gcc/${stdenv.hostPlatform.config}/${version}"/* "$out/lib"
+    ln -s "$dev/lib/gcc/${stdenv.hostPlatform.config}/${version}/include"/* "$dev/include/"
+  '';
+
+  doCheck = true;
+
+  passthru = {
+    isGNU = true;
+  };
+
+  meta = gcc_meta // {
+    homepage = "https://gcc.gnu.org/";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
