### PR TITLE
mailmap: add Martin Häcker

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,6 +18,7 @@ Jörg Thalheim <joerg@thalheim.io> <Mic92@users.noreply.github.com>
 Lin Jian <me@linj.tech> <linj.dev@outlook.com>
 Lin Jian <me@linj.tech> <75130626+jian-lin@users.noreply.github.com>
 Martin Weinelt <hexa@darmstadt.ccc.de> <mweinelt@users.noreply.github.com>
+Martin Häcker <spamfaenger@gmx.de> <spamfaenger@gmx.de>
 moni <lythe1107@gmail.com> <lythe1107@icloud.com>
 R. RyanTM <ryantm-bot@ryantm.com>
 Robert Hensing <robert@roberthensing.nl> <roberth@users.noreply.github.com>


### PR DESCRIPTION
## Things done

I'm trying to clean up after myself, as I initially committed with my standard GitHub user name, which contains unicode characters that reverse the name - because I use that to track when and if GitHub and other tools finally get around to fixing that.

However, I do not want to annoy this project and its users with this behavior. Still, there are already quite som commits under this name, so I would like to clean that up as best I can.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
