### PR TITLE
[Backport release-25.05] froide-govplan: 0-unstable-2025-01-27 -> 0-unstable-2025-06-25

### DIFF
--- a/nixos/modules/services/web-apps/froide-govplan.nix
+++ b/nixos/modules/services/web-apps/froide-govplan.nix
@@ -191,7 +191,7 @@ in
           wantedBy = [ "multi-user.target" ];
           environment =
             {
-              PYTHONPATH = pkg.pythonPath;
+              PYTHONPATH = "${pkg.pythonPath}:${pkg}/${pkg.python.sitePackages}";
               GDAL_LIBRARY_PATH = "${pkgs.gdal}/lib/libgdal.so";
               GEOS_LIBRARY_PATH = "${pkgs.geos}/lib/libgeos_c.so";
             }

--- a/nixos/modules/services/web-apps/froide-govplan.nix
+++ b/nixos/modules/services/web-apps/froide-govplan.nix
@@ -182,6 +182,7 @@ in
             StateDirectory = lib.mkIf (cfg.dataDir == "/var/lib/froide-govplan") "froide-govplan";
             User = "govplan";
             Group = "govplan";
+            TimeoutStartSec = "5m";
           };
           after = [
             "postgresql.service"

--- a/pkgs/by-name/fr/froide-govplan/package.nix
+++ b/pkgs/by-name/fr/froide-govplan/package.nix
@@ -14,13 +14,14 @@
 let
   python = python3Packages.python.override {
     packageOverrides = self: super: {
-      django = super.django.override { withGdal = true; };
+      django_5 = super.django_5.override { withGdal = true; };
+      django = super.django_5;
     };
   };
 in
 python.pkgs.buildPythonApplication rec {
   pname = "froide-govplan";
-  version = "0-unstable-2025-01-27";
+  version = "0-unstable-2025-06-25";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -28,8 +29,8 @@ python.pkgs.buildPythonApplication rec {
     repo = "froide-govplan";
     # No tagged release yet
     # https://github.com/okfde/froide-govplan/issues/15
-    rev = "f1763807614b8c54a9214359a2a1e442ca58cb6d";
-    hash = "sha256-Y7/qjhu3y9E55ZDmDf5HUk9JVcUTvi9KnqavqwNixTM=";
+    rev = "9c325e70a84f26fea37b5a34f24d19fd82ea62ff";
+    hash = "sha256-OD4vvKt0FLuiAVGwpspWLB2ZuM1UJkZdv2YcbKKYk9A=";
   };
 
   patches = [
@@ -69,7 +70,6 @@ python.pkgs.buildPythonApplication rec {
   build-inputs = [ gdal ];
 
   dependencies = with python.pkgs; [
-    bleach
     django-admin-sortable2
     django-cms
     django-filer
@@ -93,6 +93,7 @@ python.pkgs.buildPythonApplication rec {
         };
       })
     ))
+    nh3
     psycopg
   ];
 
@@ -103,7 +104,7 @@ python.pkgs.buildPythonApplication rec {
     cp -r project $out/${python.sitePackages}/froide_govplan/
     cp -r froide_govplan/locale $out/${python.sitePackages}/froide_govplan/
     makeWrapper $out/${python.sitePackages}/froide_govplan/manage.py $out/bin/froide-govplan \
-      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --prefix PYTHONPATH : ${passthru.pythonPath}:$out/${python.sitePackages} \
       --set GDAL_LIBRARY_PATH "${gdal}/lib/libgdal.so" \
       --set GEOS_LIBRARY_PATH "${geos}/lib/libgeos_c.so"
   '';
@@ -112,8 +113,8 @@ python.pkgs.buildPythonApplication rec {
     tests = {
       inherit (nixosTests) froide-govplan;
     };
-    python = python;
-    pythonPath = "${python.pkgs.makePythonPath dependencies}:${froide-govplan}/${python.sitePackages}";
+    inherit python;
+    pythonPath = "${python.pkgs.makePythonPath dependencies}";
   };
 
   meta = {

--- a/pkgs/by-name/fr/froide/package.nix
+++ b/pkgs/by-name/fr/froide/package.nix
@@ -51,10 +51,16 @@ python.pkgs.buildPythonApplication rec {
 
   patches = [ ./django_42_storages.patch ];
 
-  # Relax dependency pinning
-  # Channels: https://github.com/okfde/froide/issues/995
   pythonRelaxDeps = [
+    # Relax dependency pinning
+    # Channels: https://github.com/okfde/froide/issues/995
     "channels"
+    "django-celery-beat"
+    "django-leaflet"
+    "django"
+    "pikepdf"
+    "pypdf"
+    "reportlab"
   ];
 
   build-system = [ python.pkgs.setuptools ];

--- a/pkgs/by-name/fr/froide/package.nix
+++ b/pkgs/by-name/fr/froide/package.nix
@@ -15,20 +15,38 @@
 let
 
   python = python3Packages.python.override {
-    packageOverrides = self: super: { django = super.django.override { withGdal = true; }; };
+    packageOverrides = self: super: {
+      django_5 = super.django_5.override { withGdal = true; };
+      django = super.django_5;
+      # custom python module part of froide
+      dogtail = super.buildPythonPackage {
+        pname = "dogtail";
+        version = "0-unstable-2024-11-27";
+        pyproject = true;
+
+        src = fetchFromGitHub {
+          owner = "okfde";
+          repo = "dogtail";
+          rev = "d2f341cab0f05ef4e193f0158fe5a64aadc5bae6";
+          hash = "sha256-2lQZgvFXAz6q/3NpBcwckUologWxKmwXI0ZG5nylajg=";
+        };
+
+        build-system = with super; [ setuptools ];
+      };
+    };
   };
 
 in
 python.pkgs.buildPythonApplication rec {
   pname = "froide";
-  version = "0-unstable-2025-04-25";
+  version = "0-unstable-2025-07-01";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "okfde";
     repo = "froide";
-    rev = "9e4838fc5f17a0506af42ad5fd1ebc66cff4b92a";
-    hash = "sha256-0EC6oCaiK7gw5ikemskiK3qOlflGHzlG4giDQNj9tBQ=";
+    rev = "362bddb5a8fdfe762d59cdebd29016568c9531b2";
+    hash = "sha256-c8I/FvXQSkAeacxMQJCpCMKFueNEnLI4R0ElqRbVbNg=";
   };
 
   patches = [ ./django_42_storages.patch ];
@@ -48,11 +66,9 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   dependencies = with python.pkgs; [
-    bleach
     celery
     celery-singleton
     channels
-    coreapi
     dj-database-url
     django
     django-celery-beat
@@ -63,9 +79,6 @@ python.pkgs.buildPythonApplication rec {
     django-elasticsearch-dsl
     django-filingcabinet
     django-filter
-    # Project discontinued upstream
-    # https://github.com/okfde/froide/issues/893
-    django-fsm
     django-json-widget
     django-leaflet
     django-mfa3
@@ -86,6 +99,7 @@ python.pkgs.buildPythonApplication rec {
     geoip2
     icalendar
     markdown
+    nh3
     phonenumbers
     pillow
     pikepdf
@@ -104,7 +118,7 @@ python.pkgs.buildPythonApplication rec {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit pname version src;
-    hash = "sha256-IeuQoiI/r9AKLZgKkZx0C+qE9ueWuC39Y77MB08zSAc=";
+    hash = "sha256-g7YX2fVXGmb3Qq9NNCb294bk4/0khcIZVSskYbE8Mdw=";
   };
 
   postBuild = ''
@@ -114,7 +128,7 @@ python.pkgs.buildPythonApplication rec {
   postInstall = ''
     cp -r build manage.py $out/${python.sitePackages}/froide/
     makeWrapper $out/${python.sitePackages}/froide/manage.py $out/bin/froide \
-      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --prefix PYTHONPATH : "${python3Packages.makePythonPath dependencies}" \
       --set GDAL_LIBRARY_PATH "${gdal}/lib/libgdal.so" \
       --set GEOS_LIBRARY_PATH "${geos}/lib/libgeos_c.so"
   '';
@@ -129,6 +143,7 @@ python.pkgs.buildPythonApplication rec {
 
   checkInputs = with python.pkgs; [
     beautifulsoup4
+    pytest-asyncio
     pytest-factoryboy
     time-machine
   ];
@@ -156,6 +171,9 @@ python.pkgs.buildPythonApplication rec {
     "test_bouncing_email"
     "test_multiple_partial"
     "test_logfile_rotation"
+    # Test hangs
+    "test_collapsed_menu"
+    "test_make_request_logged_out_with_existing_account"
   ];
 
   preCheck =

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -169,7 +169,17 @@ python.pkgs.buildPythonApplication rec {
       concurrent-log-handler
       dateparser
       django_5
-      django-allauth
+      # django-allauth version 65.9.X not yet supported
+      # See https://github.com/paperless-ngx/paperless-ngx/issues/10336
+      (django-allauth.overrideAttrs (
+        new: prev: rec {
+          version = "65.7.0";
+          src = prev.src.override {
+            tag = version;
+            hash = "sha256-1HmEJ5E4Vp/CoyzUegqQXpzKUuz3dLx2EEv7dk8fq8w=";
+          };
+        }
+      ))
       django-auditlog
       django-celery-results
       django-compression-middleware

--- a/pkgs/development/python-modules/dj-rest-auth/default.nix
+++ b/pkgs/development/python-modules/dj-rest-auth/default.nix
@@ -11,6 +11,8 @@
   responses,
   setuptools,
   unittest-xml-reporting,
+  pytestCheckHook,
+  pytest-django,
 }:
 
 buildPythonPackage rec {
@@ -31,6 +33,13 @@ buildPythonPackage rec {
       name = "djangorestframework-simplejwt_5.5_compatibility.patch";
       url = "https://github.com/iMerica/dj-rest-auth/commit/cc5587e4e3f327697709f3f0d491650bff5464e7.diff";
       hash = "sha256-2LahibxuNECAfjqsbNs2ezaWt1VH0ZBNwSNWCZwIe8I=";
+    })
+    # Add compatibility with django-allauth v65.4
+    # See https://github.com/iMerica/dj-rest-auth/pull/681
+    (fetchpatch {
+      name = "django-allauth_65.4_compatibility.patch";
+      url = "https://github.com/iMerica/dj-rest-auth/commit/59b8cab7e2f4e3f2fdc11ab3b027a32cad45deef.patch";
+      hash = "sha256-CH85vB3EOQvFxx+ZP2LYI4LEvaZ+ccLdXZGuAvEfStc=";
     })
   ];
 
@@ -55,25 +64,36 @@ buildPythonPackage rec {
     unittest-xml-reporting
   ] ++ optional-dependencies.with_social;
 
+  checkInputs = [
+    pytestCheckHook
+    pytest-django
+  ];
+
+  env.DJANGO_SETTINGS_MODULE = "dj_rest_auth.tests.settings";
+
   preCheck = ''
-    # Test connects to graph.facebook.com
-    substituteInPlace dj_rest_auth/tests/test_serializers.py \
-      --replace-fail "def test_http_error" "def dont_test_http_error"
+    # Make tests module available for the checkPhase
+    export PYTHONPATH=$out/${python.sitePackages}/dj_rest_auth:$PYTHONPATH
   '';
 
-  checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} runtests.py
-    runHook postCheck
-  '';
+  disabledTests = [
+    # Test connects to graph.facebook.com
+    "TestSocialLoginSerializer"
+  ];
+
+  disabledTestPaths = [
+    # Test fails with > django-allauth 65.4
+    # See: https://github.com/iMerica/dj-rest-auth/pull/681#issuecomment-3034953311
+    "dj_rest_auth/tests/test_social.py"
+  ];
 
   pythonImportsCheck = [ "dj_rest_auth" ];
 
-  meta = with lib; {
+  meta = {
     description = "Authentication for Django Rest Framework";
     homepage = "https://github.com/iMerica/dj-rest-auth";
     changelog = "https://github.com/iMerica/dj-rest-auth/releases/tag/${version}";
-    license = licenses.mit;
-    maintainers = [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ onny ];
   };
 }

--- a/pkgs/development/python-modules/django-allauth/default.nix
+++ b/pkgs/development/python-modules/django-allauth/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchFromGitea,
   pythonOlder,
   python,
 
@@ -40,16 +40,17 @@
 
 buildPythonPackage rec {
   pname = "django-allauth";
-  version = "65.7.0";
+  version = "65.9.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
-  src = fetchFromGitHub {
-    owner = "pennersr";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "allauth";
     repo = "django-allauth";
     tag = version;
-    hash = "sha256-1HmEJ5E4Vp/CoyzUegqQXpzKUuz3dLx2EEv7dk8fq8w=";
+    hash = "sha256-gusA9TnsgSSnWBPwHsNYeESD9nX5DWh4HqMgcsoJRw0=";
   };
 
   nativeBuildInputs = [ gettext ];
@@ -101,10 +102,10 @@ buildPythonPackage rec {
   passthru.tests = { inherit dj-rest-auth; };
 
   meta = {
-    changelog = "https://github.com/pennersr/django-allauth/blob/${version}/ChangeLog.rst";
     description = "Integrated set of Django applications addressing authentication, registration, account management as well as 3rd party (social) account authentication";
-    downloadPage = "https://github.com/pennersr/django-allauth";
-    homepage = "https://www.intenct.nl/projects/django-allauth";
+    changelog = "https://codeberg.org/allauth/django-allauth/src/tag/${version}/ChangeLog.rst";
+    downloadPage = "https://codeberg.org/allauth/django-allauth";
+    homepage = "https://allauth.org";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ derdennisop ];
   };

--- a/pkgs/development/python-modules/django-filingcabinet/default.nix
+++ b/pkgs/development/python-modules/django-filingcabinet/default.nix
@@ -37,7 +37,7 @@
 
 buildPythonPackage rec {
   pname = "django-filingcabinet";
-  version = "0.17-unstable-2025-04-10";
+  version = "0.17-unstable-2025-07-01";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -45,8 +45,8 @@ buildPythonPackage rec {
     repo = "django-filingcabinet";
     # No release tagged yet on GitHub
     # https://github.com/okfde/django-filingcabinet/issues/69
-    rev = "64b7b4ad804067e2f16e8a0f165c139e3ffe5fb5";
-    hash = "sha256-48Peui/5N/GfzWS1EJ5uKeKEoPjX+fPEXzG2owxsDaE=";
+    rev = "ff39722209acf70bc73fa7074c16ed8a787fceea";
+    hash = "sha256-9SrMWBTk7RQCbVPHOU5rB/pi286hb6UONaLmBOtx6X0=";
   };
 
   postPatch = ''
@@ -94,7 +94,7 @@ buildPythonPackage rec {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit pname version src;
-    hash = "sha256-uMO2iEOi9ACYdIM8Thf7+y1KpHQEqVxO3yxZ8RaGFXA=";
+    hash = "sha256-kvLV/pCX/wQHG0ttrjSro7/CoQ5K1T0aFChafQOwvNw=";
   };
 
   postBuild = ''

--- a/pkgs/development/python-modules/django-mfa3/default.nix
+++ b/pkgs/development/python-modules/django-mfa3/default.nix
@@ -5,21 +5,21 @@
   django,
   setuptools,
   pyotp,
-  fido2,
+  fido2_2,
   qrcode,
   python,
 }:
 
 buildPythonPackage rec {
   pname = "django-mfa3";
-  version = "0.15.1";
+  version = "1.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "xi";
     repo = "django-mfa3";
     tag = version;
-    hash = "sha256-HcurgGSzPnKVRpL9NVq0vkCmYDvj/HoWYVbnIrK5pSI=";
+    hash = "sha256-bgIzrSM8KP6uQHvn393NWYw9DODdHLMqKn6pgw3EG/w=";
   };
 
   build-system = [ setuptools ];
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   dependencies = [
     django
     pyotp
-    fido2
+    fido2_2
     qrcode
   ];
 

--- a/pkgs/development/python-modules/fido2/2.nix
+++ b/pkgs/development/python-modules/fido2/2.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  cryptography,
+  fetchPypi,
+  poetry-core,
+  pyscard,
+  pythonOlder,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "fido2";
+  version = "2.0.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-MGHNBec7Og72r8O4A9V8gmqi1qlzLRar1ydzYfWOeWQ=";
+  };
+
+  build-system = [ poetry-core ];
+
+  pythonRelaxDeps = [ "cryptography" ];
+
+  dependencies = [ cryptography ];
+
+  optional-dependencies = {
+    pcsc = [ pyscard ];
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  unittestFlagsArray = [ "-v" ];
+
+  # Disable tests which require physical device
+  pytestFlagsArray = [ "--no-device" ];
+
+  pythonImportsCheck = [ "fido2" ];
+
+  meta = {
+    description = "Provides library functionality for FIDO 2.0, including communication with a device over USB";
+    homepage = "https://github.com/Yubico/python-fido2";
+    changelog = "https://github.com/Yubico/python-fido2/releases/tag/${version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ prusnak ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4913,6 +4913,8 @@ self: super: with self; {
 
   fido2 = callPackage ../development/python-modules/fido2 { };
 
+  fido2_2 = callPackage ../development/python-modules/fido2/2.nix { };
+
   fields = callPackage ../development/python-modules/fields { };
 
   file-read-backwards = callPackage ../development/python-modules/file-read-backwards { };


### PR DESCRIPTION
Also fixes RiscV cross-compile for froide-govplan and froide

Changes

- froide-govplan: https://github.com/okfde/froide-govplan/compare/f1763807614b8c54a9214359a2a1e442ca58cb6d...9c325e70a84f26fea37b5a34f24d19fd82ea62ff
- froide https://github.com/okfde/froide/compare/9e4838fc5f17a0506af42ad5fd1ebc66cff4b92a...362bddb5a8fdfe762d59cdebd29016568c9531b2
- django-allauth -> 65.7.0 -> 65.9.0 https://codeberg.org/allauth/django-allauth/src/tag/65.9.0/ChangeLog.rst
- fido2_2: init at 2.0.0 https://github.com/Yubico/python-fido2/releases/tag/2.0.0
- django-mfa3 0.15.1 -> 1.0.0 https://github.com/xi/django-mfa3/compare/0.15.1...1.0.0
- django-filingcabinet https://github.com/okfde/django-filingcabinet/compare/64b7b4ad804067e2f16e8a0f165c139e3ffe5fb5...ff39722209acf70bc73fa7074c16ed8a787fceea
- dj-rest-auth: Fix compatibility with newer django-allauth
- paperless-ngx: Pin django-allauth version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
