### PR TITLE
electron{,-chromedriver}_35-bin: revert to existing release 35.7.0

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -23,14 +23,14 @@
     },
     "35": {
         "hashes": {
-            "aarch64-darwin": "3330a8d349689a341cf0f5f126388ce2c1678c6f8760ba6456eb92d6a6fb87c4",
-            "aarch64-linux": "148ede01556ac18a24d97db60a13346115993a73da40963968da2e951260474f",
-            "armv7l-linux": "fd5fda4137cf9d617c50315eb16710849419b5c60d9cc304b7b5615d8f0fa47f",
+            "aarch64-darwin": "5256f192ca519431a3e860213b0693d61e94aa45795824b63906b22a351bc946",
+            "aarch64-linux": "361a28f6786c6864abf2d5e3f78252bf894166d2374dae0e8136cea671cf7f81",
+            "armv7l-linux": "96358f42b232cb595db91a6d32f04539153b54a3867ac2db37e7c0d42ff4829a",
             "headers": "1w8qcgsbii6gizv31i1nkbhaipcr6r1x384wkwnxp60dk9a6cl59",
-            "x86_64-darwin": "517a770abc9072b2f5335cc0af763fe2e2953fa89d9564640eb75f0eccb2794a",
-            "x86_64-linux": "bddc5a6a1e496e9b87819315dcf188b9b0f7ea8f389d2f4b8326b8d7e0afe956"
+            "x86_64-darwin": "d03f88f68e62dc377ee06aae1dd4d8a22046df7a13450de5d88572ed32e413df",
+            "x86_64-linux": "8c667169cf7e85463677b44d96ec795ab05974a1f3224ad020542580d65c66a5"
         },
-        "version": "35.7.1"
+        "version": "35.7.0"
     },
     "36": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -23,14 +23,14 @@
     },
     "35": {
         "hashes": {
-            "aarch64-darwin": "2760c01ae0a292a1d20d3d2fab52120800d5734156e71671b458c6539fd24eee",
-            "aarch64-linux": "038555b79c6f0fdf287cbd1943f9c8109e24c88290d6c4b2947159287129daca",
-            "armv7l-linux": "1b9350313d5fdf4774a51d7b8a4149d49d3ca86e789e682794b0499b54e9ae3f",
+            "aarch64-darwin": "02f0b20ae36f97eb6a885ea9e70fce75a4a2cdb2f45cf2ecfa3d0413080b50d0",
+            "aarch64-linux": "fdd9185202404eea5975430545b5d7ee158d8f805f143ef877437248cb8b6b49",
+            "armv7l-linux": "874f3ce99e545e5cefc3f5570c415e7458cc75b8e0b4de4719c123398c79f51b",
             "headers": "1w8qcgsbii6gizv31i1nkbhaipcr6r1x384wkwnxp60dk9a6cl59",
-            "x86_64-darwin": "f9ff3b3eb747a2fa0e98e6c408a52e4272d05e477aaa3442debc587e823b385d",
-            "x86_64-linux": "29d379865c8b72645b3d81585af308ebb96cca0c500191bfd042f844d01fa9b8"
+            "x86_64-darwin": "7a3c8c8153f3aaa755bbe91c8dd6b542897efa6d7baf1cfbdde4ae6a6a0dd883",
+            "x86_64-linux": "8751624fd3edfc407d0e149dedbc57c614b396b46e0fa45123398e992d1762b5"
         },
-        "version": "35.7.1"
+        "version": "35.7.0"
     },
     "36": {
         "hashes": {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Continuing to fix things after:
- https://github.com/NixOS/nixpkgs/pull/424408
- https://github.com/NixOS/nixpkgs/pull/424572
- https://github.com/NixOS/nixpkgs/pull/424763

Thanks to @K900 and @yuyuyureka for their fast fixes over the weekend.

Upstream is working on fixing their releases https://github.com/electron/electron/issues/47716#issuecomment-3063755409.

Release `35.7.1` has been removed by upstream:
```
       > trying https://github.com/electron/electron/releases/download/v35.7.1/electron-v35.7.1-linux-x64.zip
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 404
```

The [git tag](https://github.com/electron/electron/tree/v35.7.1) for `v35.7.1` does still exist and hydra did build electron_35.source successfully.
- `electron_35`: https://hydra.nixos.org/build/302377698 (success)
- `electron_35-bin` logs: https://hydra.nixos.org/build/302377699/nixlog/5 (failed)


## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
