### PR TITLE
maintainers: drop amorsillo

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1445,12 +1445,6 @@
     githubId = 5149377;
     name = "Amine Chikhaoui";
   };
-  amorsillo = {
-    email = "andrew.morsillo@gmail.com";
-    github = "evelant";
-    githubId = 858965;
-    name = "Andrew Morsillo";
-  };
   amozeo = {
     email = "wroclaw223@outlook.com";
     github = "amozeo";

--- a/pkgs/by-name/ev/evemu/package.nix
+++ b/pkgs/by-name/ev/evemu/package.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation rec {
       lgpl3Only
       gpl3Only
     ];
-    maintainers = [ maintainers.amorsillo ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -165,7 +165,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "GUI password manager with strong cryptography";
     homepage = "http://www.keepass.info/";
     maintainers = with lib.maintainers; [
-      amorsillo
       obadz
     ];
     platforms = with lib.platforms; all;

--- a/pkgs/by-name/li/libevdev/package.nix
+++ b/pkgs/by-name/li/libevdev/package.nix
@@ -25,6 +25,5 @@ stdenv.mkDerivation rec {
     homepage = "https://www.freedesktop.org/software/libevdev/doc/latest/index.html";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = [ maintainers.amorsillo ];
   };
 }

--- a/pkgs/by-name/sp/spideroak/package.nix
+++ b/pkgs/by-name/sp/spideroak/package.nix
@@ -78,7 +78,6 @@ stdenv.mkDerivation {
     description = "Secure online backup and sychronization";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ amorsillo ];
     platforms = lib.platforms.linux;
     mainProgram = "spideroak";
   };


### PR DESCRIPTION
Inactive since August 2024. Last maintainer related activity ~ pre 2020. Also not a member of the NixOS org (anymore).

Dropping according to maintainer guidelines: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#how-to-lose-maintainer-status

Data:
- Pings without reaction: https://github.com/NixOS/nixpkgs/issues?q=involves%3Aevelant%20-commenter%3Aevelant%20-reviewed-by%3Aevelant%20-author%3Aevelant
- Activity: https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aevelant%20OR%20reviewed-by%3Aevelant%20OR%20author%3Aevelant%20sort%3Aupdated-desc

@evelant if you'd like to stay a maintainer, please respond within a week. In that case, please also request invite to the NixOS org again, as described in https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#tools-for-maintainers. Otherwise you can't be pinged for review at all.