### PR TITLE
postgresql.withPackages: propagate out from dev output

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -671,6 +671,9 @@ let
               substitute "${lib.getDev postgresql}/nix-support/pg_config.env" "$dev/nix-support/pg_config.env" \
                 --replace-fail "${postgresql}" "$out" \
                 --replace-fail "${postgresql.man}" "$out"
+
+              # populate nix-support/propagated-build-inputs
+              eval fixupPhase
             '';
 
           passthru = {


### PR DESCRIPTION
Currently the combination of `postgresql.withPackages` and `postgresqlTestHook` is broken, since the hook can't find the `postgresql` binaries:

```
/nix/store/04xc8i3h5qvbl17fm6dw9dfk3ls0fi5b-postgresql-test-hook/nix-support/setup-hook: line 52: type: initdb: not found
initdb not found. Did you add postgresql to the nativeCheckInputs?
```

This behavior as introduced by #422969, with the addition of a `dev` output. The used `buildEnv` helper doesn't run the regular `postFixupHook`, so `nix-support/propagated-build-inputs` doesn't get populated as usual by `multiple-outputs.sh`.

Fixes #425285

## Things done

Built the following packages for `x86_64-linux`:
<details>
  <summary>:x: 7 packages failed to build:</summary>
  <ul>
    <li>postgresql18Packages.omnigres</li>
    <li>postgresql18Packages.omnigres.passthru.tests.extension</li>
    <li>froide</li>
    <li>python312Packages.froide</li>
    <li>python313Packages.txtai</li>
    <li>python312Packages.txtai</li>
    <li>private-gpt.passthru.tests.private-gpt</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 5 tests built:</summary>
  <ul>
    <li>postgresql14Packages.omnigres.passthru.tests.extension</li>
    <li>postgresql16Packages.omnigres.passthru.tests.extension</li>
    <li>postgresql15Packages.omnigres.passthru.tests.extension</li>
    <li>postgresqlPackages.omnigres.passthru.tests.extension</li>
    <li>open-webui.passthru.tests.open-webui</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 24 packages built:</summary>
  <ul>
    <li>postgresql14Packages.omnigres</li>
    <li>postgresql15Packages.omnigres</li>
    <li>postgresqlPackages.omnigres</li>
    <li>postgresql_13_jit</li>
    <li>postgresql16Packages.omnigres</li>
    <li>postgresql_14_jit</li>
    <li>postgresql_15_jit</li>
    <li>postgresql_16_jit</li>
    <li>postgresql_jit</li>
    <li>postgresql_18_jit</li>
    <li>python312Packages.langgraph-checkpoint-postgres</li>
    <li>python312Packages.langgraph</li>
    <li>python312Packages.pgvector</li>
    <li>python312Packages.langgraph-prebuilt</li>
    <li>python312Packages.llama-index-vector-stores-postgres</li>
    <li>open-webui</li>
    <li>python313Packages.langgraph-prebuilt</li>
    <li>python313Packages.langgraph</li>
    <li>python313Packages.pgvector</li>
    <li>python313Packages.llama-index-vector-stores-postgres</li>
    <li>python313Packages.langgraph-checkpoint-postgres</li>
    <li>private-gpt</li>
    <li>python312Packages.private-gpt</li>
    <li>python313Packages.private-gpt</li>
  </ul>
</details>

----

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
