### PR TITLE
resumed: update to 6.0.0, add update script, fix "---version" and add version test, use finalAttrs

### DIFF
--- a/pkgs/by-name/re/resumed/package.nix
+++ b/pkgs/by-name/re/resumed/package.nix
@@ -6,14 +6,14 @@
   chromium,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "resumed";
   version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "rbardini";
     repo = "resumed";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-K9F6ZxtqAQSc5Dqeoysish+xeRqDcDG/6Ynx7bTJfl8=";
   };
 
@@ -39,4 +39,4 @@ buildNpmPackage rec {
     maintainers = with maintainers; [ ambroisie ];
     mainProgram = "resumed";
   };
-}
+})

--- a/pkgs/by-name/re/resumed/package.nix
+++ b/pkgs/by-name/re/resumed/package.nix
@@ -3,20 +3,32 @@
   buildNpmPackage,
   fetchFromGitHub,
   nix-update-script,
+  chromium,
 }:
 
 buildNpmPackage rec {
   pname = "resumed";
-  version = "4.1.0";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "rbardini";
     repo = "resumed";
     rev = "v${version}";
-    hash = "sha256-kDv6kOVY8IfztmLeby2NgB5q0DtP1ajMselvr1EDQJ8=";
+    hash = "sha256-K9F6ZxtqAQSc5Dqeoysish+xeRqDcDG/6Ynx7bTJfl8=";
   };
 
-  npmDepsHash = "sha256-7Wdf8NaizgIExeX+Kc8wn5f20al0bnxRpFoPy6p40jw=";
+  npmDepsHash = "sha256-UElS1pEzPv0FnvMGCnqEFBi7JzE8QWRFynkAPHy35FY=";
+
+  dontNpmPrune = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/resumed \
+      --set PUPPETEER_EXECUTABLE_PATH ${lib.getExe chromium}
+  '';
+
+  env = {
+    PUPPETEER_SKIP_DOWNLOAD = true;
+  };
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/re/resumed/package.nix
+++ b/pkgs/by-name/re/resumed/package.nix
@@ -3,6 +3,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   nix-update-script,
+  testers,
   chromium,
 }:
 
@@ -19,6 +20,10 @@ buildNpmPackage (finalAttrs: {
 
   npmDepsHash = "sha256-UElS1pEzPv0FnvMGCnqEFBi7JzE8QWRFynkAPHy35FY=";
 
+  postPatch = ''
+    sed -i 's/"version": ".*"/"version": "${finalAttrs.version}"/' package.json
+  '';
+
   dontNpmPrune = true;
 
   postInstall = ''
@@ -30,7 +35,13 @@ buildNpmPackage (finalAttrs: {
     PUPPETEER_SKIP_DOWNLOAD = true;
   };
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests.version = testers.testVersion {
+      inherit (finalAttrs) version;
+      package = finalAttrs.finalPackage;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     description = "Lightweight JSON Resume builder, no-frills alternative to resume-cli";

--- a/pkgs/by-name/re/resumed/package.nix
+++ b/pkgs/by-name/re/resumed/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildNpmPackage rec {
@@ -16,6 +17,8 @@ buildNpmPackage rec {
   };
 
   npmDepsHash = "sha256-7Wdf8NaizgIExeX+Kc8wn5f20al0bnxRpFoPy6p40jw=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Lightweight JSON Resume builder, no-frills alternative to resume-cli";


### PR DESCRIPTION
- update resumed to the latest version
- add an update script
- switch to the finalAttrs pattern
- fix `resumed --version` output
- add a version test

I did not do more testing than running it with "--help" and "--version", so it's a draft for now.

Let me know if any of the steps/commits in the pr should be in a separate pr or squashed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
