### PR TITLE
libguestfs: 1.54.1 -> 1.56.1, libguestfs-appliance: 1.54.0 -> 1.56.0

### DIFF
--- a/pkgs/by-name/li/libguestfs-appliance/package.nix
+++ b/pkgs/by-name/li/libguestfs-appliance/package.nix
@@ -6,11 +6,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "libguestfs-appliance";
-  version = "1.54.0";
+  version = "1.56.0";
 
   src = fetchurl {
     url = "http://download.libguestfs.org/binaries/appliance/appliance-${version}.tar.xz";
-    hash = "sha256-D7f4Cnjx+OmLfqQWmauyXZiSjayG9TCmxftj0iOPFso=";
+    hash = "sha256-YbJlNaogMyutdtc7d+etyJvdd//yE8tedsZfkGXJr54=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/li/libguestfs/package.nix
+++ b/pkgs/by-name/li/libguestfs/package.nix
@@ -11,8 +11,6 @@
   cpio,
   gperf,
   cdrkit,
-  flex,
-  bison,
   qemu,
   pcre2,
   augeas,
@@ -29,10 +27,9 @@
   db,
   gmp,
   readline,
-  file,
   numactl,
   libapparmor,
-  jansson,
+  json_c,
   getopt,
   perlPackages,
   python3,
@@ -48,11 +45,11 @@ assert appliance == null || lib.isDerivation appliance;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libguestfs";
-  version = "1.54.1";
+  version = "1.56.1";
 
   src = fetchurl {
     url = "https://libguestfs.org/download/${lib.versions.majorMinor finalAttrs.version}-stable/libguestfs-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-bj/GrBkmdfe8KEClYbs2o209Wo36f4jqL1P4z2AqF34=";
+    hash = "sha256-nK3VUK4xLy/+JDt3N9P0bVa+71Ob7IODyoyw0/32LvU=";
   };
 
   strictDeps = true;
@@ -60,10 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     [
       autoreconfHook
       removeReferencesTo
-      bison
       cdrkit
       cpio
-      flex
       getopt
       gperf
       makeWrapper
@@ -86,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libxcrypt
     ncurses
-    jansson
+    json_c
     pcre2
     augeas
     libxml2
@@ -100,7 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
     libvirt
     gmp
     readline
-    file
     hivex
     db
     numactl
@@ -111,7 +105,6 @@ stdenv.mkDerivation (finalAttrs: {
     zstd
     ocamlPackages.ocamlbuild
     ocamlPackages.ocaml_libvirt
-    ocamlPackages.ounit
     ocamlPackages.augeas
     ocamlPackages.ocamlbuild
   ] ++ lib.optional javaSupport jdk;
@@ -194,6 +187,7 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl21Plus
     ];
     homepage = "https://libguestfs.org/";
+    changelog = "https://libguestfs.org/guestfs-release-notes-${lib.versions.majorMinor finalAttrs.version}.1.html";
     maintainers = with lib.maintainers; [
       offline
       lukts30


### PR DESCRIPTION
https://libguestfs.org/guestfs-release-notes-1.56.1.html
https://github.com/libguestfs/libguestfs/compare/refs/tags/v1.54.1...refs/tags/v1.56.1

## `nixpkgs-review` result

All build failures appear to be unrelated.

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `2753c27a8a6d984b260509350a9d91da07f36368`

---
### `x86_64-linux`
<details>
  <summary>:x: 5 packages failed to build:</summary>
  <ul>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>vagrant</li>
    <li>virt-v2v</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>guestfs-tools</li>
    <li>libguestfs (python313Packages.guestfs)</li>
    <li>libguestfs-appliance</li>
    <li>libguestfs-with-appliance</li>
    <li>libguestfs-with-appliance.guestfsd</li>
    <li>libguestfs.guestfsd (python313Packages.guestfs.guestfsd)</li>
    <li>python312Packages.guestfs</li>
    <li>python312Packages.guestfs.guestfsd</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc