### PR TITLE
zoom-us: drop extraPreBwrapCmds, replace maintainers

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -152,8 +152,9 @@ let
       license = lib.licenses.unfree;
       platforms = builtins.attrNames srcs;
       maintainers = with lib.maintainers; [
-        danbst
-        tadfisher
+        philiptaron
+        ryan4yin
+        yarny
       ];
       mainProgram = "zoom";
     };

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -245,10 +245,6 @@ let
     version = versions.${system} or throwSystem;
 
     targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
-    extraPreBwrapCmds = ''
-      unset QT_PLUGIN_PATH
-      unset LANG  # would break settings dialog on non-"en_XX" locales
-    '';
     extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
     runScript = "/opt/zoom/ZoomLauncher";
 


### PR DESCRIPTION
* As per [this suggestion](https://github.com/NixOS/nixpkgs/pull/422532#issuecomment-3063246677): No longer unset `QT_PLUGIN_PATH` & `LANG`, as this is no longer necessary, [according to my own experiments](https://github.com/NixOS/nixpkgs/pull/422532#pullrequestreview-2989636069)

  This change should be tested in various envrionments; it is very possible that those workarounds are still needed in some configurations.

* As [per](https://github.com/NixOS/nixpkgs/pull/414415#issuecomment-2991231318) [this](https://github.com/NixOS/nixpkgs/pull/414415#issuecomment-2991687929) [conversation](https://github.com/NixOS/nixpkgs/pull/414415#issuecomment-2993525297): Replace inactive maintainers @danbst & @tadfisher with @philiptaron & @ryan4yin & @Yarny0 = myself.

  Please comment here whether you approve or oppose that move.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

More: Tested with Plasma5/X11/Pulseaudio on a NixOS 25.05 machine (unchecked means "not tested"):

- [x] sidebar loads (albeit empty on my installation, cf. https://github.com/NixOS/nixpkgs/issues/344931 )
- [x] audio is "detected" by zoom: microphone VU-meter shows amplitude
- [x] audio is produced: "Test speaker" generates audible ting-a-ling
- [x] other participant's audio in video conference is audible
- [x] other participants can hear me
- [x] sending camera picture in video conference works
- [x] participant's camera video is received in video conference
- [x] screen sharing sends screen to other participants
- [ ] participant's shared screen is displayed
- [x] "Participants" dialog box is shown (cf. https://github.com/NixOS/nixpkgs/issues/116355 )
- [x] settings dialog is shown/useable  (cf. https://github.com/NixOS/nixpkgs/pull/410244 )
- [x] SSO works: Zoom starts Firefox, then Firefox calls back to Zoom after login, as usual
- [x] reading team chat messages works as expected
- [x] writing team chat messages works
- [ ] sidebar shows content
- [ ] Pipewire
- [ ] Wayland
- [ ] xdg-desktop-portal (cf. https://github.com/NixOS/nixpkgs/issues/359533 )
- [ ] Darwin

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `e5412ce31b31071654e51b8cbd69af7eb5132fc0`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>zoom-us</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc