### PR TITLE
python3Packages.drf-extra-fields: fix tests exclusion

### DIFF
--- a/pkgs/development/python-modules/drf-extra-fields/default.nix
+++ b/pkgs/development/python-modules/drf-extra-fields/default.nix
@@ -48,16 +48,18 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "drf_extra_fields" ];
 
-  disabledTests = lib.optionals (pythonAtLeast "3.13") [
-    # https://github.com/Hipo/drf-extra-fields/issues/210
-    "test_read_source_with_context"
-
-    # pytz causes the following tests to fail
-    "test_create"
-    "test_create_with_base64_prefix"
-    "test_create_with_webp_image"
-    "test_remove_with_empty_string"
-  ];
+  disabledTests =
+    [
+      # pytz causes the following tests to fail
+      "test_create"
+      "test_create_with_base64_prefix"
+      "test_create_with_webp_image"
+      "test_remove_with_empty_string"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      # https://github.com/Hipo/drf-extra-fields/issues/210
+      "test_read_source_with_context"
+    ];
 
   meta = {
     description = "Extra Fields for Django Rest Framework";


### PR DESCRIPTION
The pytz failure shouldn't depend on the Python version. This fixes the netbox-document plugin on NixOS 25.05.

This PR target master for consistency only, the important part that fixes the netbox-document plugin is the 25.05 backport.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `9f086440849df609fce12bcb64614d6e766c9a2e`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>python312Packages.drf-extra-fields</li>
    <li>python312Packages.drf-extra-fields.dist</li>
    <li>python312Packages.netbox-documents</li>
    <li>python312Packages.netbox-documents.dist</li>
    <li>python313Packages.drf-extra-fields</li>
    <li>python313Packages.drf-extra-fields.dist</li>
    <li>python313Packages.netbox-documents</li>
    <li>python313Packages.netbox-documents.dist</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
