### PR TITLE
matrix-synapse: 1.133.0 -> 1.134.0

### DIFF
--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -74,7 +74,6 @@ let
     "systemd"
     "postgres"
     "url-preview"
-    "user-search"
   ];
 
   wantedExtras =
@@ -84,7 +83,6 @@ let
     ++ lib.optional (cfg.settings ? saml2_config) "saml2"
     ++ lib.optional (cfg.settings ? redis) "redis"
     ++ lib.optional (cfg.settings ? sentry) "sentry"
-    ++ lib.optional (cfg.settings ? user_directory) "user-search"
     ++ lib.optional (cfg.settings.url_preview_enabled) "url-preview"
     ++ lib.optional (cfg.settings.database.name == "psycopg2") "postgres";
 
@@ -674,7 +672,6 @@ in
               "sentry"       # Error tracking and performance metrics
               "systemd"      # Provide the JournalHandler used in the default log_config
               "url-preview"  # Support for oEmbed URL previews
-              "user-search"  # Support internationalized domain names in user-search
             ]
           '';
           description = ''

--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/package.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/package.nix
@@ -18,14 +18,14 @@ let
 in
 python3.pkgs.buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "1.133.0";
+  version = "1.134.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "element-hq";
     repo = "synapse";
     rev = "v${version}";
-    hash = "sha256-SCpLM/4sxE9xA781tgjrNNXpScCQOtgKnZKq64eCay8=";
+    hash = "sha256-q7+yVKFzyu8ccuroZsTSMRRKMwmr3TDojtXNx4bChTE";
   };
 
   patches = [
@@ -39,7 +39,7 @@ python3.pkgs.buildPythonApplication rec {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-qgQU041VlAFFgEg2RhbK6g+aike+HN0FYuvHYtufzW8=";
+    hash = "sha256-BfLj+cqS6zpX2qLb+Rur4cy7CyPH2KzdXaTXpNK20DM=";
   };
 
   postPatch = ''
@@ -147,9 +147,6 @@ python3.pkgs.buildPythonApplication rec {
     ];
     cache-memory = [
       pympler
-    ];
-    user-search = [
-      pyicu
     ];
   };
 

--- a/pkgs/by-name/ma/matrix-synapse/package.nix
+++ b/pkgs/by-name/ma/matrix-synapse/package.nix
@@ -7,7 +7,6 @@
     [
       "postgres"
       "url-preview"
-      "user-search"
     ]
     ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform matrix-synapse-unwrapped.python.pkgs.systemd) "systemd",
   plugins ? [ ],


### PR DESCRIPTION
Release notes: https://github.com/element-hq/synapse/releases/tag/v1.134.0
Full changelog: https://github.com/element-hq/synapse/compare/v1.133.0...v1.134.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
