### PR TITLE
libtins: force C++17 for gtest

### DIFF
--- a/pkgs/by-name/li/libtins/0001-force-cpp-17.patch
+++ b/pkgs/by-name/li/libtins/0001-force-cpp-17.patch
@@ -1,4 +1,4 @@
-This change bypasses all the code that attempts to see which C++11 features are enabled in your specific C++11 compiler.  C++14 is required for gtest 1.13+.
+This change bypasses all the code that attempts to see which C++11 features are enabled in your specific C++11 compiler.  C++17 is required for gtest 1.17+.
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 902233e676ee..49ac8a1010a4 100644
 --- a/CMakeLists.txt
@@ -20,7 +20,7 @@ index 902233e676ee..49ac8a1010a4 100644
 -    ENDIF()
 +    SET(TINS_HAVE_CXX11 ON)
 +    MESSAGE(STATUS "Using C++11 features")
-+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
++    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
  ELSE(LIBTINS_ENABLE_CXX11)
      MESSAGE(
          WARNING

--- a/pkgs/by-name/li/libtins/package.nix
+++ b/pkgs/by-name/li/libtins/package.nix
@@ -21,9 +21,11 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Required for gtest 1.13+, see also upstream report at:
-    # https://github.com/mfontanini/libtins/issues/529
-    ./0001-force-cpp-14.patch
+    # Required for gtest 1.17+:
+    # https://github.com/NixOS/nixpkgs/issues/425358
+    # See also an upstream report for gtest 1.13+ and C++14:
+    # https://github.com/mfontanini/libtins/issues/
+    ./0001-force-cpp-17.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
Fixes #425358

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
