### PR TITLE
stalwart-mail: 0.12.4 -> 0.13.1, stalwart-mail-webadmin: 0.1.28 -> 0.1.31

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -33,6 +33,8 @@
 
 - `conftest` since `0.60.0` has moved to use rego `v1` as default. To continue using `v0` use `--rego-version v0`. For more information about upgrading to Rego v1 syntax, see the [upstream docs](https://www.openpolicyagent.org/docs/latest/v0-upgrade/).
 
+- `stalwart-mail` since `0.13.0` "introduces a significant redesign of the MTA’s delivery and queueing subsystem". See [the upgrading announcement for the `0.13.0` release](https://github.com/stalwartlabs/stalwart/blob/89b561b5ca1c5a11f2a768b4a2cfef0f473b7a01/UPGRADING.md#upgrading-from-v012x-and-v011x-to-v013x).
+
 - The `archipelago-minecraft` package was removed, as upstream no longer provides support for the Minecraft APWorld.
 
 - `tooling-language-server` has been renamed to `deputy` (both the package and binary), following the rename of the upstream project.

--- a/nixos/modules/services/mail/stalwart-mail.nix
+++ b/nixos/modules/services/mail/stalwart-mail.nix
@@ -71,6 +71,23 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          !(
+            (lib.hasAttrByPath [ "settings" "queue" ] cfg)
+            && (builtins.any (lib.hasAttrByPath [
+              "value"
+              "next-hop"
+            ]) (lib.attrsToList cfg.settings.queue))
+          );
+        message = ''
+          Stalwart deprecated `next-hop` in favor of "virtual queues" `queue.strategy.route` \
+          with v0.13.0 see [Outbound Strategy](https://stalw.art/docs/mta/outbound/strategy/#configuration) \
+          and [release announcement](https://github.com/stalwartlabs/stalwart/blob/main/UPGRADING.md#upgrading-from-v012x-and-v011x-to-v013x).
+        '';
+      }
+    ];
 
     # Default config: all local
     services.stalwart-mail.settings = {

--- a/nixos/tests/stalwart/stalwart-mail-config.nix
+++ b/nixos/tests/stalwart/stalwart-mail-config.nix
@@ -50,7 +50,7 @@ in
       storage.lookup = "rocksdb";
 
       session.rcpt.directory = "'in-memory'";
-      queue.outbound.next-hop = "'local'";
+      queue.strategy.route = "'local'";
 
       store."rocksdb" = {
         type = "rocksdb";

--- a/pkgs/by-name/st/stalwart-mail/package.nix
+++ b/pkgs/by-name/st/stalwart-mail/package.nix
@@ -20,16 +20,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stalwart-mail" + (lib.optionalString stalwartEnterprise "-enterprise");
-  version = "0.12.4";
+  version = "0.13.1";
 
   src = fetchFromGitHub {
     owner = "stalwartlabs";
     repo = "stalwart";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MUbWGBbb8+b5cp+M5w27A/cHHkMcoEtkN13++FyBvbM=";
+    hash = "sha256-6zoI+yvE1Ep5jh9XthDqphm2zBA4UzhfK7VCKRWIH8g=";
   };
 
-  cargoHash = "sha256-G1c7hh0nScc4Cx7A1UUXv6slA6pP0fC6h00zR71BJIo=";
+  cargoHash = "sha256-t4BLko8vIVHZ44yeQoAhss3OxOlxJCErHm9h+FGG+28=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/st/stalwart-mail/package.nix
+++ b/pkgs/by-name/st/stalwart-mail/package.nix
@@ -113,6 +113,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     #   left: [1, 2, 2]
     #  right: [1, 2, 3]
     "--skip=smtp::queue::retry::queue_retry"
+    # thread 'smtp::queue::virtualq::virtual_queue' panicked at /build/source/crates/store/src/dispatch/store.rs:548:14:
+    # called `Result::unwrap()` on an `Err` value: Error(Event { inner: Store(MysqlError), keys: [(Reason, String("Input/output error: Input/output error: Connection refused (os error 111)")), (CausedBy, String("crates/store/src/dispatch/store.rs:301"))] })
+    "--skip=smtp::queue::virtualq::virtual_queue"
     # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
     "--skip=store::store_tests"
     # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent

--- a/pkgs/by-name/st/stalwart-mail/package.nix
+++ b/pkgs/by-name/st/stalwart-mail/package.nix
@@ -75,86 +75,86 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace "__PATH__" "$out"
   '';
 
-  checkFlags = [
+  checkFlags = lib.forEach [
     # Require running mysql, postgresql daemon
-    "--skip=directory::imap::imap_directory"
-    "--skip=directory::internal::internal_directory"
-    "--skip=directory::ldap::ldap_directory"
-    "--skip=directory::sql::sql_directory"
-    "--skip=directory::oidc::oidc_directory"
-    "--skip=store::blob::blob_tests"
-    "--skip=store::lookup::lookup_tests"
-    "--skip=smtp::lookup::sql::lookup_sql"
+    "directory::imap::imap_directory"
+    "directory::internal::internal_directory"
+    "directory::ldap::ldap_directory"
+    "directory::sql::sql_directory"
+    "directory::oidc::oidc_directory"
+    "store::blob::blob_tests"
+    "store::lookup::lookup_tests"
+    "smtp::lookup::sql::lookup_sql"
     # thread 'directory::smtp::lmtp_directory' panicked at tests/src/store/mod.rs:122:44:
     # called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
-    "--skip=directory::smtp::lmtp_directory"
+    "directory::smtp::lmtp_directory"
     # thread 'imap::imap_tests' panicked at tests/src/imap/mod.rs:436:14:
     # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
-    "--skip=imap::imap_tests"
+    "imap::imap_tests"
     # thread 'jmap::jmap_tests' panicked at tests/src/jmap/mod.rs:303:14:
     # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
-    "--skip=jmap::jmap_tests"
+    "jmap::jmap_tests"
     # Failed to read system DNS config: io error: No such file or directory (os error 2)
-    "--skip=smtp::inbound::data::data"
+    "smtp::inbound::data::data"
     # Expected "X-My-Header: true" but got Received: from foobar.net (unknown [10.0.0.123])
-    "--skip=smtp::inbound::scripts::sieve_scripts"
+    "smtp::inbound::scripts::sieve_scripts"
     # thread 'smtp::outbound::lmtp::lmtp_delivery' panicked at tests/src/smtp/session.rs:313:13:
     # Expected "<invalid@domain.org> (failed to lookup" but got From: "Mail Delivery Subsystem" <MAILER-DAEMON@localhost>
-    "--skip=smtp::outbound::lmtp::lmtp_delivery"
+    "smtp::outbound::lmtp::lmtp_delivery"
     # thread 'smtp::outbound::extensions::extensions' panicked at tests/src/smtp/inbound/mod.rs:45:23:
     # No queue event received.
-    "--skip=smtp::outbound::extensions::extensions"
+    "smtp::outbound::extensions::extensions"
     # panicked at tests/src/smtp/outbound/smtp.rs:173:5:
-    "--skip=smtp::outbound::smtp::smtp_delivery"
+    "smtp::outbound::smtp::smtp_delivery"
     # panicked at tests/src/smtp/outbound/lmtp.rs
-    "--skip=smtp::outbound::lmtp::lmtp_delivery"
+    "smtp::outbound::lmtp::lmtp_delivery"
     # thread 'smtp::queue::retry::queue_retry' panicked at tests/src/smtp/queue/retry.rs:119:5:
     # assertion `left == right` failed
     #   left: [1, 2, 2]
     #  right: [1, 2, 3]
-    "--skip=smtp::queue::retry::queue_retry"
+    "smtp::queue::retry::queue_retry"
     # thread 'smtp::queue::virtualq::virtual_queue' panicked at /build/source/crates/store/src/dispatch/store.rs:548:14:
     # called `Result::unwrap()` on an `Err` value: Error(Event { inner: Store(MysqlError), keys: [(Reason, String("Input/output error: Input/output error: Connection refused (os error 111)")), (CausedBy, String("crates/store/src/dispatch/store.rs:301"))] })
-    "--skip=smtp::queue::virtualq::virtual_queue"
+    "smtp::queue::virtualq::virtual_queue"
     # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
-    "--skip=store::store_tests"
+    "store::store_tests"
     # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
-    "--skip=cluster::cluster_tests"
+    "cluster::cluster_tests"
     # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
-    "--skip=webdav::webdav_tests"
+    "webdav::webdav_tests"
     # thread 'config::parser::tests::toml_parse' panicked at crates/utils/src/config/parser.rs:463:58:
     # called `Result::unwrap()` on an `Err` value: "Expected ['\\n'] but found '!' in value at line 70."
-    "--skip=config::parser::tests::toml_parse"
+    "config::parser::tests::toml_parse"
     # error[E0432]: unresolved import `r2d2_sqlite`
     # use of undeclared crate or module `r2d2_sqlite`
-    "--skip=backend::sqlite::pool::SqliteConnectionManager::with_init"
+    "backend::sqlite::pool::SqliteConnectionManager::with_init"
     # thread 'smtp::reporting::analyze::report_analyze' panicked at tests/src/smtp/reporting/analyze.rs:88:5:
     # assertion `left == right` failed
     #   left: 0
     #  right: 12
-    "--skip=smtp::reporting::analyze::report_analyze"
+    "smtp::reporting::analyze::report_analyze"
     # thread 'smtp::inbound::dmarc::dmarc' panicked at tests/src/smtp/inbound/mod.rs:59:26:
     # Expected empty queue but got Reload
-    "--skip=smtp::inbound::dmarc::dmarc"
+    "smtp::inbound::dmarc::dmarc"
     # thread 'smtp::queue::concurrent::concurrent_queue' panicked at tests/src/smtp/inbound/mod.rs:65:9:
     # assertion `left == right` failed
-    "--skip=smtp::queue::concurrent::concurrent_queue"
+    "smtp::queue::concurrent::concurrent_queue"
     # Failed to read system DNS config: io error: No such file or directory (os error 2)
-    "--skip=smtp::inbound::auth::auth"
+    "smtp::inbound::auth::auth"
     # Failed to read system DNS config: io error: No such file or directory (os error 2)
-    "--skip=smtp::inbound::antispam::antispam"
+    "smtp::inbound::antispam::antispam"
     # Failed to read system DNS config: io error: No such file or directory (os error 2)
-    "--skip=smtp::inbound::vrfy::vrfy_expn"
+    "smtp::inbound::vrfy::vrfy_expn"
     # thread 'smtp::management::queue::manage_queue' panicked at tests/src/smtp/inbound/mod.rs:45:23:
     # No queue event received.
     # NOTE: Test unreliable on high load systems
-    "--skip=smtp::management::queue::manage_queue"
+    "smtp::management::queue::manage_queue"
     # thread 'responses::tests::parse_responses' panicked at crates/dav-proto/src/responses/mod.rs:671:17:
     # assertion `left == right` failed: failed for 008.xml
     #   left: ElementEnd
     #  right: Bytes([...])
-    "--skip=responses::tests::parse_responses"
-  ];
+    "responses::tests::parse_responses"
+  ] (test: "--skip=${test}");
 
   doCheck = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
 

--- a/pkgs/by-name/st/stalwart-mail/webadmin.nix
+++ b/pkgs/by-name/st/stalwart-mail/webadmin.nix
@@ -17,13 +17,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "webadmin";
-  version = "0.1.28";
+  version = "0.1.31";
 
   src = fetchFromGitHub {
     owner = "stalwartlabs";
     repo = "webadmin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OgZ2qs84zVM2zNmBQSPnb9Uy4mahzNC81vbWM9wmrn4=";
+    hash = "sha256-4+R7QQT0cbKYe6WzgvzreOFULBnWdNcbPC27f4r+M0g=";
   };
 
   npmDeps = fetchNpmDeps {
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-na1HEueX8w7kuDp8LEtJ0nD1Yv39cyk6sEMpS1zix2s=";
   };
 
-  cargoHash = "sha256-rcgeSdCGIRvpz2xZPw0I753+D3zm9AYbtuUdMSp2I94=";
+  cargoHash = "sha256-Q05+wH9+NfkfmEDJFLuWVQ7wuDeEu9h1XmOMN6SYdyU=";
 
   postPatch = ''
     # Using local tailwindcss for compilation


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* stalwart-mail: Upgrade from `0.12.4`, skipping `0.12.5`, to `0.13.0`
   * 0.13.0 [breaking changes](https://github.com/stalwartlabs/stalwart/blob/main/UPGRADING.md#upgrading-from-v012x-and-v011x-to-v013x)
   * [changelog `v0.12.5`](https://github.com/stalwartlabs/stalwart/releases/tag/v0.12.5) (replaces #420056 and #424086)
   * [changelog `v0.13.1`](https://github.com/stalwartlabs/stalwart/releases/tag/v0.13.1) -> patch release due to some release bugs
 * stalwart-mail-webadmin:
    * Upgrade from `0.1.28` > `0.1.31`
    * No breaking changes there
    * [Changelog `v0.1.29`](https://github.com/stalwartlabs/webadmin/releases/tag/v0.1.29)
    * [Changelog `v0.1.30`](https://github.com/stalwartlabs/webadmin/releases/tag/v0.1.30)
    * [Changelog `v01.31`](https://github.com/stalwartlabs/webadmin/releases/tag/v0.1.31) 
    * Compatibility to `0.13.0` mostly

## Things done

- Release changes check in
  - [x] https://github.com/NixOS/nixpkgs/blob/82f8090f5547aca09fec694a0af6603ef638b746/nixos/tests/stalwart-mail.nix#L62 likely is now `route` instead of `next-hop`. https://github.com/stalwartlabs/website/commit/55f5e5290cfcba9c642d28eed2980c8f396836bc
  - [x] double check, if `--skip` `outbound` has changed -> it has not
  - [x] add assertion/deprecation warnings for the people that are defining the `queue.*.next-hop` through nix


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
