### PR TITLE
terminator-mcp-agent: init at 0.8.1

### DIFF
--- a/pkgs/by-name/te/terminator-mcp-agent/package.nix
+++ b/pkgs/by-name/te/terminator-mcp-agent/package.nix
@@ -1,0 +1,241 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  nodejs,
+  stdenv,
+  makeWrapper,
+  autoPatchelfHook,
+  versionCheckHook,
+  testers,
+  # Linux dependencies
+  xorg,
+  libxkbcommon,
+  fontconfig,
+  freetype,
+  at-spi2-core,
+  libGL,
+  libGLU,
+  mesa,
+  libglvnd,
+  pipewire,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "terminator-mcp-agent";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "mediar-ai";
+    repo = "terminator";
+    rev = "117cefaab19886ccd835b879f35f4d170d73a4ae";
+    hash = "sha256-dkKzEOMbBYZB5DTi50tO/IuP9n4wsNShH6lif+Bl7Gk=";
+  };
+
+  # Platform-specific binary sources
+  platformBinary = let
+    sources = {
+      "x86_64-linux" = {
+        url = "https://registry.npmjs.org/terminator-mcp-linux-x64-gnu/-/terminator-mcp-linux-x64-gnu-${finalAttrs.version}.tgz";
+        hash = "sha256-G+sjKWwYJtxrqiuFBv9PwTuSS4vrb5YchkKBcE/hPyg=";
+      };
+      "x86_64-darwin" = {
+        url = "https://registry.npmjs.org/terminator-mcp-darwin-x64/-/terminator-mcp-darwin-x64-${finalAttrs.version}.tgz";
+        hash = "sha256-Pq8hva7v0ZThBV5jJ+X0xbspgXuKqXP4kKHLWzrrRw4=";
+      };
+      "aarch64-darwin" = {
+        url = "https://registry.npmjs.org/terminator-mcp-darwin-arm64/-/terminator-mcp-darwin-arm64-${finalAttrs.version}.tgz";
+        hash = "sha256-T3OsckuQA220cM6AzueBepiCtJhp8G1hVdq1Yaofm68=";
+      };
+    };
+    platformData = sources.${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}. Supported platforms: ${lib.concatStringsSep ", " (lib.attrNames sources)}");
+  in
+    fetchurl platformData;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  nativeInstallCheckInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    versionCheckHook
+  ];
+
+  buildInputs = [
+    nodejs
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    xorg.libX11
+    xorg.libXrandr
+    xorg.libXi
+    xorg.libXext
+    xorg.libXtst
+    libxkbcommon
+    fontconfig
+    freetype
+    at-spi2-core
+    # Additional graphics libraries
+    libGL
+    libGLU
+    mesa
+    libglvnd
+    pipewire
+  ];
+
+  # No build phase needed, just install
+  dontBuild = true;
+  dontConfigure = true;
+  dontUnpack = false; # We need to unpack for the Node.js files
+
+  installPhase = ''
+    runHook preInstall
+    
+    mkdir -p $out/bin $out/lib/terminator-mcp-agent
+    
+    # Install the Node.js wrapper and config files
+    cp terminator-mcp-agent/index.js $out/lib/terminator-mcp-agent/
+    cp terminator-mcp-agent/config.js $out/lib/terminator-mcp-agent/
+    cp terminator-mcp-agent/package.json $out/lib/terminator-mcp-agent/
+    
+    # Extract and install the platform-specific binary
+    mkdir -p /tmp/terminator-extract
+    tar -xzf ${finalAttrs.platformBinary} -C /tmp/terminator-extract
+    
+    # Copy the binary (try common locations)
+    if [ -f /tmp/terminator-extract/package/bin/terminator-mcp-agent ]; then
+      cp /tmp/terminator-extract/package/bin/terminator-mcp-agent $out/bin/
+    elif [ -f /tmp/terminator-extract/package/terminator-mcp-agent ]; then
+      cp /tmp/terminator-extract/package/terminator-mcp-agent $out/bin/
+    else
+      echo "Could not find terminator-mcp-agent binary in platform package" >&2
+      echo "Contents of extracted package:" >&2
+      find /tmp/terminator-extract -type f -name "*terminator*" || true
+      exit 1
+    fi
+    
+    chmod +x $out/bin/terminator-mcp-agent
+    
+    # Create a Node.js wrapper script
+    cat > $out/bin/terminator-mcp-agent-nodejs << 'EOF'
+#!/usr/bin/env node
+const path = require('path');
+const { spawn } = require('child_process');
+
+// Set up paths
+const libDir = path.join(__dirname, '..', 'lib', 'terminator-mcp-agent');
+const binaryPath = path.join(__dirname, 'terminator-mcp-agent');
+
+// Load the configuration module
+const config = require(path.join(libDir, 'config.js'));
+
+// Get command line arguments
+const args = process.argv.slice(2);
+
+// Handle --add-to-app configuration
+if (args.includes('--add-to-app')) {
+  const appIndex = args.indexOf('--add-to-app') + 1;
+  const app = args[appIndex] && !args[appIndex].startsWith('--') ? args[appIndex] : undefined;
+  
+  if (!app) {
+    console.log('Configuration mode requires specifying an app');
+    console.log('Usage: terminator-mcp-agent-nodejs --add-to-app <app-name>');
+    console.log('Supported apps: claude, cursor, zed, etc.');
+    process.exit(1);
+  }
+  
+  try {
+    const currentConfig = config.readConfig(app);
+    currentConfig.mcpServers = currentConfig.mcpServers || {};
+    currentConfig.mcpServers['terminator-mcp-agent'] = {
+      command: binaryPath,
+      args: []
+    };
+    config.writeConfig(currentConfig, app);
+    console.log('Configured MCP for ' + app);
+  } catch (e) {
+    console.error('Failed to configure MCP for ' + app + ':', e.message);
+    process.exit(1);
+  }
+  
+  process.exit(0);
+}
+
+// Otherwise, run the binary directly
+const child = spawn(binaryPath, args, {
+  stdio: 'inherit',
+  shell: false
+});
+
+child.on('exit', (code) => {
+  process.exit(code);
+});
+
+// Handle signals
+process.on('SIGINT', () => {
+  if (child && !child.killed) {
+    child.kill('SIGINT');
+  }
+});
+
+process.on('SIGTERM', () => {
+  if (child && !child.killed) {
+    child.kill('SIGTERM');
+  }
+});
+EOF
+    
+    chmod +x $out/bin/terminator-mcp-agent-nodejs
+    
+    # Wrap both binaries
+    wrapProgram $out/bin/terminator-mcp-agent \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]}
+    
+    wrapProgram $out/bin/terminator-mcp-agent-nodejs \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+      --set NODE_PATH $out/lib/terminator-mcp-agent
+    
+    runHook postInstall
+  '';
+
+  # Version checking (only on Linux for now due to cross-compilation issues)
+  doInstallCheck = stdenv.hostPlatform.isLinux;
+  versionCheckProgram = "${placeholder "out"}/bin/terminator-mcp-agent";
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    tests = {
+      version = testers.testVersion { 
+        package = finalAttrs.finalPackage; 
+        command = "terminator-mcp-agent --version";
+      };
+      nodejs-wrapper = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "terminator-mcp-agent-nodejs --help";
+        version = "Usage: terminator-mcp-agent";
+      };
+    };
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Cross-platform Model Context Protocol (MCP) agent for desktop automation";
+    longDescription = ''
+      Terminator MCP Agent is a Model Context Protocol server that provides desktop
+      GUI automation capabilities for Windows, macOS, and Linux. It allows AI agents
+      to interact with desktop applications programmatically through the MCP protocol.
+      
+      This package uses pre-built binaries from the npm distribution for reliability
+      and includes both the native binary and a Node.js wrapper for easy integration
+      with AI applications that support the Model Context Protocol.
+    '';
+    homepage = "https://github.com/mediar-ai/terminator";
+    changelog = "https://github.com/mediar-ai/terminator/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsl11; # Business Source License 1.1 - requires NIXPKGS_ALLOW_UNFREE=1
+    maintainers = with lib.maintainers; [ connerohnesorge ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "terminator-mcp-agent-nodejs";
+  };
+})

--- a/pkgs/by-name/te/terminator-mcp-agent/update.sh
+++ b/pkgs/by-name/te/terminator-mcp-agent/update.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts nix
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Get latest tag from GitHub API (since releases are not up to date)
+latest_tag=$(curl -s "https://api.github.com/repos/mediar-ai/terminator/tags" | jq -r '.[0].name')
+
+# Remove 'v' prefix if present
+latest_version=${latest_tag#v}
+
+echo "Latest version: $latest_version"
+
+# Get current version from package.nix
+current_version=$(grep -o 'version = "[^"]*"' package.nix | cut -d'"' -f2)
+
+echo "Current version: $current_version"
+
+if [ "$latest_version" = "$current_version" ]; then
+    echo "Already up to date"
+    exit 0
+fi
+
+# Update the version in package.nix using sed
+sed -i "s/version = \"[^\"]*\"/version = \"$latest_version\"/" package.nix
+
+echo "Updated version from $current_version to $latest_version"
+
+# Update platform binary hashes
+declare -A platform_urls=(
+    ["linux-x64-gnu"]="terminator-mcp-linux-x64-gnu"
+    ["darwin-x64"]="terminator-mcp-darwin-x64"
+    ["darwin-arm64"]="terminator-mcp-darwin-arm64"
+)
+
+for platform in "${!platform_urls[@]}"; do
+    url_name="${platform_urls[$platform]}"
+    
+    echo "Updating hash for $platform..."
+    
+    # Construct the URL
+    url="https://registry.npmjs.org/$url_name/-/$url_name-$latest_version.tgz"
+    
+    # Get the hash
+    hash=$(nix-prefetch-url "$url" 2>/dev/null || echo "")
+    
+    if [ -n "$hash" ]; then
+        # Convert to SRI format
+        sri_hash=$(nix-hash --to-sri --type sha256 "$hash")
+        
+        # Update the hash for this specific URL pattern - more targeted replacement
+        # First update the URL version
+        sed -i "s|$url_name-[^/]*/[^/]*|$url_name-$latest_version|g" package.nix
+        
+        # Then update the hash that appears after this URL
+        sed -i "/$url_name-$latest_version/,/hash = /s/hash = \"[^\"]*\"/hash = \"$sri_hash\"/" package.nix
+        
+        echo "Updated $platform hash to $sri_hash"
+    else
+        echo "Warning: Could not fetch hash for $platform"
+    fi
+done
+
+echo "Updated terminator-mcp-agent to version $latest_version"


### PR DESCRIPTION
Add terminator-mcp-agent, a cross-platform Model Context Protocol (MCP)
agent for desktop automation. This package provides desktop GUI automation
capabilities for Windows, macOS, and Linux, allowing AI agents to interact
with desktop applications programmatically through the MCP protocol.

Key features:
- Cross-platform binary distribution via pre-built npm packages
- Native binary (terminator-mcp-agent) for core MCP server functionality
- Node.js wrapper (terminator-mcp-agent-nodejs) for easy MCP client integration
- Comprehensive Linux graphics dependencies (EGL, Mesa, Pipewire, X11)
- Automated version checking and testing infrastructure
- Support for configuration integration with MCP clients (Claude, Cursor, Zed, etc.)

Technical implementation:
- Uses stdenv.mkDerivation with fetchurl for platform-specific binaries
- Includes strictDeps for build hygiene and cross-compilation support
- Implements versionCheckHook for automated version validation
- Provides comprehensive passthru.tests for version and wrapper testing
- Includes updateScript for automated maintenance
- Follows modern nixpkgs conventions (finalAttrs, sourceProvenance)

License: Business Source License 1.1 (requires NIXPKGS_ALLOW_UNFREE=1)
Platforms: x86_64-linux, x86_64-darwin, aarch64-darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
