### PR TITLE
libyuv: Apply patch to fix ARGBToRGB565DitherRow_C on big-endian

### DIFF
--- a/pkgs/by-name/li/libyuv/dither-honour-byte-order.patch
+++ b/pkgs/by-name/li/libyuv/dither-honour-byte-order.patch
@@ -1,0 +1,32 @@
+diff '--color=auto' -ruN a/source/row_common.cc b/source/row_common.cc
+--- a/source/row_common.cc	2025-07-15 17:55:24.611751521 +0200
++++ b/source/row_common.cc	2025-07-15 18:01:57.808312551 +0200
+@@ -104,8 +104,13 @@
+ #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || \
+     defined(_M_IX86) || defined(__arm__) || defined(_M_ARM) ||     \
+     (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
++#define WRITE16(p, v) *(uint16_t*)(p) = v
+ #define WRITEWORD(p, v) *(uint32_t*)(p) = v
+ #else
++static inline void WRITE16(uint8_t* p, uint16_t v) {
++  p[0] = (uint8_t)(v & 255);
++  p[1] = (uint8_t)((v >> 8) & 255);
++}
+ static inline void WRITEWORD(uint8_t* p, uint32_t v) {
+   p[0] = (uint8_t)(v & 255);
+   p[1] = (uint8_t)((v >> 8) & 255);
+@@ -408,10 +413,10 @@
+     uint8_t b1 = STATIC_CAST(uint8_t, clamp255(src_argb[4] + dither1) >> 3);
+     uint8_t g1 = STATIC_CAST(uint8_t, clamp255(src_argb[5] + dither1) >> 2);
+     uint8_t r1 = STATIC_CAST(uint8_t, clamp255(src_argb[6] + dither1) >> 3);
+-    *(uint16_t*)(dst_rgb + 0) =
+-        STATIC_CAST(uint16_t, b0 | (g0 << 5) | (r0 << 11));
+-    *(uint16_t*)(dst_rgb + 2) =
+-        STATIC_CAST(uint16_t, b1 | (g1 << 5) | (r1 << 11));
++    WRITE16((dst_rgb + 0),
++        STATIC_CAST(uint16_t, b0 | (g0 << 5) | (r0 << 11)));
++    WRITE16((dst_rgb + 2),
++        STATIC_CAST(uint16_t, b1 | (g1 << 5) | (r1 << 11)));
+     dst_rgb += 4;
+     src_argb += 8;
+   }

--- a/pkgs/by-name/li/libyuv/package.nix
+++ b/pkgs/by-name/li/libyuv/package.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation {
     hash = "sha256-4Irs+hlAvr6v5UKXmKHhg4IK3cTWdsFWxt1QTS0rizU=";
   };
 
+  patches = [
+    # Fixes wrong byte order in ARGBToRGB565DitherRow_C on big-endian
+    ./dither-honour-byte-order.patch
+  ];
+
   nativeBuildInputs = [
     cmake
   ];


### PR DESCRIPTION
Makes `LibYUVConvertTest.Test{,No}Dither` pass.

Before:

```
[ RUN      ] LibYUVConvertTest.TestNoDither
/build/libyuv-b7a8576/unit_test/convert_argb_test.cc:1189: Failure
Expected equality of these values:
  dst_rgb565[i]
    Which is: 'a' (97, 0x61)
  dst_rgb565dither[i]
    Which is: '\x2' (2)

/build/libyuv-b7a8576/unit_test/convert_argb_test.cc:1189: Failure
Expected equality of these values:
  dst_rgb565[i]
    Which is: '\x2' (2)
  dst_rgb565dither[i]
    Which is: 'a' (97, 0x61)

/build/libyuv-b7a8576/unit_test/convert_argb_test.cc:1189: Failure
Expected equality of these values:
  dst_rgb565[i]
    Which is: '\x18' (24)
  dst_rgb565dither[i]
    Which is: 'o' (111, 0x6F)

/build/libyuv-b7a8576/unit_test/convert_argb_test.cc:1189: Failure
Expected equality of these values:
  dst_rgb565[i]
    Which is: 'o' (111, 0x6F)
  dst_rgb565dither[i]
    Which is: '\x18' (24)
[...]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
