### PR TITLE
robotframework-browser: init at 19.6.2

### DIFF
--- a/pkgs/by-name/gr/grpc-tools/package.nix
+++ b/pkgs/by-name/gr/grpc-tools/package.nix
@@ -25,6 +25,17 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -Dm755 -t $out/bin grpc_node_plugin
     install -Dm755 -t $out/bin deps/protobuf/protoc
+    # The node script creates two additional binaries that just forward their inputs to the above programs,
+    # but it seems unnecessary to install node etc just for this. So let's fake it using regular bash.
+    # https://github.com/grpc/grpc-node/blob/179dbfaeccc19bce786788a6b8e986990ab51329/packages/grpc-tools/package.json#L19-L21
+    cat >$out/bin/grpc_tools_node_protoc <<EOL
+    #/usr/bin/env bash
+    $out/bin/protoc --plugin=protoc-gen-grpc=$out/bin/grpc_node_plugin "\$@"
+    EOL
+    chmod +x $out/bin/grpc_tools_node_protoc
+    # grpc_tools_node_protoc_plugin seems to literally be the same as grpc_node_plugin
+    # except with a node wrapper
+    ln -s $out/bin/grpc_node_plugin $out/bin/grpc_tools_node_protoc_plugin
   '';
 
   passthru.updateScript = gitUpdater {

--- a/pkgs/development/python-modules/robotframework-browser/default.nix
+++ b/pkgs/development/python-modules/robotframework-browser/default.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  setuptools,
+  robotframework,
+  robotframework-pythonlibcore,
+  robotframework-assertion-engine,
+  grpcio,
+  overrides,
+  click,
+  seedir,
+  wrapt,
+  npmHooks,
+  nodejs,
+  fetchNpmDeps,
+  node-pre-gyp,
+  grpc-tools,
+  grpcio-tools, # needed to generate --grpc_python_out + imported
+  # For inv build
+  invoke, # cmake-like for python
+  mypy-protobuf,
+  robotstatuschecker,
+  pytest,
+  beautifulsoup4,
+  # To provide the binaries to the browsers + maintain the same version between playwright node
+  # and playwright browsers
+  playwright-driver,
+}:
+buildPythonPackage rec {
+  pname = "robotframework-browser";
+  version = "19.6.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MarketSquare";
+    repo = "robotframework-browser";
+    tag = "v${version}";
+    hash = "sha256-tSHaaSPiyjaw8OvlYyAT7VFcH/ymMRoNQzjZJIE2WU4=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    hash = "sha256-zwEheWpvrKQZYqSarKuBvW/YGhayqs9oMU16bqK7Z/A=";
+  };
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    nodejs
+    node-pre-gyp
+    # For inv build. Maybe not really needed for build only
+    invoke # cmake-like for python
+    grpcio-tools # needed to generate --grpc_python_out
+    grpc-tools # same for -m grpc_tools.protoc
+    mypy-protobuf
+    robotstatuschecker
+    pytest
+    beautifulsoup4
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    robotframework
+    robotframework-pythonlibcore
+    robotframework-assertion-engine
+    grpcio
+    overrides
+    click
+    seedir
+    wrapt
+  ];
+
+  # We fake a run of rfbrowser init
+  # + grpc_tools_node_protoc already includes the plugin and is not runnable via npm
+  # since nix directly builds it from C++ sources to avoid to use pre-build binaries
+  # downloaded by npm
+  patchPhase = ''
+    runHook prePatch
+    substituteInPlace ./Browser/playwright.py \
+      --replace-fail '(installation_dir / "node_modules").is_dir()' 'True'
+    substituteInPlace ./tasks.py \
+      --replace-fail 'c.run("pip install -U pip")' 'return' \
+      --replace-fail 'npm run grpc_tools_node_protoc' 'grpc_tools_node_protoc' \
+      --replace-fail ' -- ' ' '
+    substituteInPlace ./package.json \
+      --replace-fail '"grpc-tools": "^1.13.0",' ' '
+    sed -i '/--plugin=protoc-gen-grpc/d' ./tasks.py
+    runHook postPatch
+  '';
+
+  preBuild = ''
+    inv build -d -e
+  '';
+
+  # - We first maintain the same version for playwright node and playwright binaries since playwright node
+  #   hardcode the browser version. See https://discourse.nixos.org/t/replace-npm-deps-with-nix-deps/66394/3
+  # - Then, makeWrapperArgs can't be used (not a script here but a library) so we manually set PLAYWRIGHT_BROWSERS_PATH
+  # to forward the path to browser binaries
+  postInstall = ''
+    rm -rf node_modules/playwright
+    ln -s ${playwright-driver} node_modules/playwright
+    cp -r node_modules $out/lib
+    cat >> $out/lib/python3.13/site-packages/Browser/__init__.py <<EOF
+    import os
+    if not "PLAYWRIGHT_BROWSERS_PATH" in os.environ:
+        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = "${playwright-driver.browsers}"
+    if not "PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS" in os.environ:
+        os.environ["PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS"] = "true"
+    EOF
+  '';
+
+  meta = {
+    description = "Robot Framework Browser library powered by Playwright";
+    homepage = "https://robotframework-browser.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ tobiasBora ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15745,6 +15745,8 @@ self: super: with self; {
     callPackage ../development/python-modules/robotframework-assertion-engine
       { };
 
+  robotframework-browser = callPackage ../development/python-modules/robotframework-browser { };
+
   robotframework-databaselibrary =
     callPackage ../development/python-modules/robotframework-databaselibrary
       { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix https://github.com/NixOS/nixpkgs/issues/292321, it should work now.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

To test, start a shell with
```
(pkgs.python3.withPackages (ps: with ps; [
      robotframework robotframework-browser
    ]))
```
create a file `test.robot`:
```
*** Settings ***
Library   Browser

*** Test Cases ***
Example Test
    New Page    https://playwright.dev
    Get Text    h1    contains    Playwright
```
and run:
```
$ robot test.robot
```
all tests should pass.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
