### PR TITLE
toml2nix-py: init at 1.0.0

### DIFF
--- a/pkgs/by-name/to/toml2nix-py/package.nix
+++ b/pkgs/by-name/to/toml2nix-py/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "toml2nix-py";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "erooke";
+    repo = "toml2nix";
+    tag = "v${version}";
+    hash = "sha256-9v5oyVcfaZ8l+YrPQSKJezIZJ/uF9Mew9hocm3nggVI=";
+  };
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  meta = {
+    description = "Convert toml config files to nix";
+    mainProgram = "toml2nix";
+    homepage = "https://github.com/erooke/toml2nix";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ erooke ];
+  };
+}


### PR DESCRIPTION
Adds [toml2nix](https://github.com/erooke/toml2nix) to the package set at the request of a [user](https://github.com/erooke/toml2nix/issues/1). `toml2nix` converts toml config files to nix config files.

There is program called `toml2nix` in nixpkgs which appears to be unmaintained. The last version was published January 2019 and the repository listed on crates no longer seems to exist: https://nest.pijul.com/pmeunier/toml2nix

Not sure what the operating procedure around that is; I introduced this as `toml2nix-py` as that felt the least offensive. If reviewers (or @figsoda) think it makes more sense to usurp the currently existing `toml2nix` let me know, I have no strong feelings one way or the other.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
