### PR TITLE
python3Packages.aider-chat: disable additional tests that require network access

### DIFF
--- a/pkgs/development/python-modules/aider-chat/default.nix
+++ b/pkgs/development/python-modules/aider-chat/default.nix
@@ -264,6 +264,7 @@ let
     disabledTestPaths = [
       # Tests require network access
       "tests/scrape/test_scrape.py"
+      "tests/basic/test_repomap.py"
       # Expected 'mock' to have been called once
       "tests/help/test_help.py"
     ];
@@ -273,6 +274,7 @@ let
         # Tests require network
         "test_urls"
         "test_get_commit_message_with_custom_prompt"
+        "test_cmd_tokens_output"
         # FileNotFoundError
         "test_get_commit_message"
         # Expected 'launch_gui' to have been called once


### PR DESCRIPTION
Disable tests that require access to litellm GitHub repository.
It seems that `aider-chat-full` failed to build because of dependencies, not the package itself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `3a501b6a430182bc2cdd289b4633fb54ba9cb2f0`

---
### `x86_64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>aider-chat-full</li>
    <li>aider-chat-full.dist</li>
    <li>aider-chat-with-playwright</li>
    <li>aider-chat-with-playwright.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 9 packages built:</summary>
  <ul>
    <li>aider-chat (python312Packages.aider-chat)</li>
    <li>aider-chat-with-bedrock</li>
    <li>aider-chat-with-bedrock.dist</li>
    <li>aider-chat-with-browser</li>
    <li>aider-chat-with-browser.dist</li>
    <li>aider-chat-with-help</li>
    <li>aider-chat-with-help.dist</li>
    <li>aider-chat.dist (python312Packages.aider-chat.dist)</li>
    <li>vimPlugins.aider-nvim</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
