### PR TITLE
kcollectd: migrate to by-name

### DIFF
--- a/pkgs/by-name/kc/kcollectd/package.nix
+++ b/pkgs/by-name/kc/kcollectd/package.nix
@@ -2,29 +2,20 @@
   lib,
   fetchFromGitLab,
   stdenv,
-  wrapQtAppsHook,
-  qtbase,
   cmake,
-  kconfig,
-  kio,
-  kiconthemes,
-  kxmlgui,
-  ki18n,
-  kguiaddons,
-  extra-cmake-modules,
   boost,
   shared-mime-info,
   rrdtool,
-  breeze-icons,
+  kdePackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kcollectd";
   version = "0.12.2";
   src = fetchFromGitLab {
     owner = "aerusso";
-    repo = pname;
-    rev = "v${version}";
+    repo = "kcollectd";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-35zb5Kx0tRP5l0hILdomCu2YSQfng02mbyyAClm4uZs=";
   };
 
@@ -32,26 +23,31 @@ stdenv.mkDerivation rec {
     substituteInPlace kcollectd/rrd_interface.cc --replace-fail 'char *arg[] =' 'const char *arg[] ='
   '';
 
-  nativeBuildInputs = [
-    wrapQtAppsHook
-    cmake
-    extra-cmake-modules
-    shared-mime-info
-  ];
+  nativeBuildInputs =
+    [
+      shared-mime-info
+      cmake
+    ]
+    ++ (with kdePackages; [
+      wrapQtAppsHook
+      extra-cmake-modules
+    ]);
 
-  buildInputs = [
-    qtbase
-    kconfig
-    kio
-    kxmlgui
-    kiconthemes
-    ki18n
-    kguiaddons
-    boost
-    rrdtool
-    # otherwise some buttons are blank
-    breeze-icons
-  ];
+  buildInputs =
+    [
+      boost
+      rrdtool
+    ]
+    ++ (with kdePackages; [
+      qtbase
+      kconfig
+      kio
+      kxmlgui
+      kiconthemes
+      ki18n
+      kguiaddons
+      breeze-icons
+    ]);
 
   meta = with lib; {
     description = "Graphical frontend to collectd";
@@ -61,4 +57,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "kcollectd";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3580,8 +3580,6 @@ with pkgs;
 
   node2nix = nodePackages.node2nix;
 
-  kcollectd = kdePackages.callPackage ../tools/misc/kcollectd { };
-
   ktailctl = kdePackages.callPackage ../applications/networking/ktailctl { };
 
   ldapdomaindump = with python3Packages; toPythonApplication ldapdomaindump;


### PR DESCRIPTION
Migrate kcollectd to by-name
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
