### PR TITLE
nixos/atalkd: init

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -851,6 +851,12 @@
   "modules-services-akkoma-distributed-deployment": [
     "index.html#modules-services-akkoma-distributed-deployment"
   ],
+  "module-services-atalkd": [
+    "index.html#module-services-atalkd"
+  ],
+  "module-services-atalkd-basic-usage": [
+    "index.html#module-services-atalkd-basic-usage"
+  ],
   "module-services-systemd-lock-handler": [
     "index.html#module-services-systemd-lock-handler"
   ],

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1069,6 +1069,7 @@
   ./services/networking/anubis.nix
   ./services/networking/aria2.nix
   ./services/networking/asterisk.nix
+  ./services/networking/atalkd.nix
   ./services/networking/atftpd.nix
   ./services/networking/atticd.nix
   ./services/networking/autossh.nix

--- a/nixos/modules/services/networking/atalkd.md
+++ b/nixos/modules/services/networking/atalkd.md
@@ -1,0 +1,18 @@
+# atalkd {#module-services-atalkd}
+
+atalkd (AppleTalk daemon) is a component inside of the suite of software provided by Netatalk. It allows for the creation of AppleTalk networks, typically speaking over a Linux ethernet network interface, that can still be seen by classic macintosh computers. Using the NixOS module, you can specify a set of network interfaces that you wish to speak AppleTalk on, and the corresponding ATALKD.CONF(5) values to go along with it.
+
+## Basic Usage {#module-services-atalkd-basic-usage}
+
+A minimal configuration looks like this:
+
+```nix
+{
+  services.atalkd = {
+    enable = true;
+    interfaces.wlan0.config = "-router -phase 2 -net 1 -addr 1.48 -zone \"Default\"";
+  };
+}
+```
+
+It is also valid to use atalkd without setting `services.netatalk.interfaces` to any value, only providing `services.atalkd.enable = true`. In this case it will inherit the behavior of the upstream application when an empty config file is found, which is to listen on and use all interfaces.

--- a/nixos/modules/services/networking/atalkd.nix
+++ b/nixos/modules/services/networking/atalkd.nix
@@ -1,0 +1,98 @@
+{
+  config,
+  pkgs,
+  lib,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.atalkd;
+
+  # Generate atalkd.conf only if configFile isn't manually specified
+  atalkdConfFile = pkgs.writeText "atalkd.conf" (
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (
+        iface: ifaceCfg: iface + (if ifaceCfg.config != null then " ${ifaceCfg.config}" else "")
+      ) cfg.interfaces
+    )
+  );
+in
+{
+  options.services.atalkd = {
+    enable = lib.mkEnableOption "the AppleTalk daemon";
+
+    configFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = atalkdConfFile;
+      defaultText = "/nix/store/xxx-atalkd.conf";
+      description = ''
+        Optional path to a custom `atalkd.conf` file. When set, this overrides the generated
+        configuration from `services.atalkd.interfaces`.
+      '';
+    };
+
+    interfaces = lib.mkOption {
+      description = "Per-interface configuration for atalkd.";
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options.config = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = "Optional configuration string for this interface.";
+          };
+        }
+      );
+      default = { };
+    };
+  };
+
+  config =
+    let
+      interfaces = map (iface: "sys-subsystem-net-devices-${utils.escapeSystemdPath iface}.device") (
+        builtins.attrNames cfg.interfaces
+      );
+    in
+    lib.mkIf cfg.enable {
+      system.requiredKernelConfig = [
+        (config.lib.kernelConfig.isEnabled "APPLETALK")
+      ];
+      systemd.services.netatalk.partOf = [ "atalkd.service" ];
+      systemd.services.netatalk.after = interfaces;
+      systemd.services.netatalk.requires = interfaces;
+      systemd.services.atalkd =
+        let
+          interfaces = map (iface: "sys-subsystem-net-devices-${utils.escapeSystemdPath iface}.device") (
+            builtins.attrNames cfg.interfaces
+          );
+        in
+        {
+
+          description = "atalkd AppleTalk daemon";
+          unitConfig.Documentation = "man:atalkd.conf(5) man:atalkd(8)";
+          after = interfaces;
+          wants = [ "network.target" ];
+          before = [ "netatalk.service" ];
+          requires = interfaces;
+
+          wantedBy = [ "multi-user.target" ];
+
+          path = [ pkgs.netatalk ];
+
+          serviceConfig = {
+            Type = "forking";
+            GuessMainPID = "no";
+            DynamicUser = true;
+            AmbientCapabilities = [ "CAP_NET_ADMIN" ];
+            RuntimeDirectory = "atalkd";
+            PIDFile = "/run/atalkd/atalkd";
+            BindPaths = [ "/run/atalkd:/run/lock" ];
+            ExecStart = "${pkgs.netatalk}/bin/atalkd -f ${cfg.configFile}";
+            Restart = "always";
+          };
+        };
+    };
+
+  meta.maintainers = with lib.maintainers; [ matthewcroughan ];
+  meta.doc = ./atalkd.md;
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I've tested this extensively with real hardware, emulators and sheep_net (https://github.com/NixOS/nixpkgs/pull/423744)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
