### PR TITLE
bitcoin and bitcoin-knots (gpg) verification

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-knots/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchFromGitHub,
   autoreconfHook,
   pkg-config,
   util-linux,
@@ -21,6 +22,14 @@
   python3,
   withGui,
   withWallet ? true,
+  gnupg,
+  # Signatures from the following GPG public keys checked during verification of the source code.
+  # The list can be found at https://github.com/bitcoinknots/guix.sigs/tree/knots/builder-keys
+  builderKeys ? [
+    "1A3E761F19D2CC7785C5502EA291A2C45D0C504A" # luke-jr.gpg
+    "32FE1E61B1C711186CA378DEFD8981F1BC41ABB9" # oomahq.gpg
+    "CACC7CBB26B3D2EE8FC2F2BC0E37EBAB8574F005" # leo-haf.gpg
+  ],
 }:
 
 stdenv.mkDerivation rec {
@@ -35,6 +44,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    gnupg
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ util-linux ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ hexdump ]
@@ -57,6 +67,53 @@ stdenv.mkDerivation rec {
     qtbase
     qttools
   ];
+
+  preUnpack =
+    let
+      majorVersion = lib.versions.major version;
+
+      publicKeys = fetchFromGitHub {
+        owner = "bitcoinknots";
+        repo = "guix.sigs";
+        rev = "b998306d462f39b6077518521700d7156fec76b8";
+        sha256 = "sha256-q4tumAfTr828AZNOa9ia7Y0PYoe6W47V/7SEApTzl3w=";
+      };
+
+      checksums = fetchurl {
+        url = "https://bitcoinknots.org/files/${majorVersion}.x/${version}/SHA256SUMS";
+        hash = "sha256-xWJKaZBLm9H6AuMBSC21FLy/5TRUI0AQVIUF/2PvDhs=";
+      };
+
+      signatures = fetchurl {
+        url = "https://bitcoinknots.org/files/${majorVersion}.x/${version}/SHA256SUMS.asc";
+        hash = "sha256-SywdBEzZqsf2aDeOs7J9n513RTCm+TJA/QYP5+h7Ifo=";
+      };
+
+      verifyBuilderKeys =
+        let
+          script = publicKey: ''
+            echo "Checking if public key ${publicKey} signed the checksum file..."
+            grep "^\[GNUPG:\] VALIDSIG .* ${publicKey}$" verify.log > /dev/null
+            echo "OK"
+          '';
+        in
+        builtins.concatStringsSep "\n" (builtins.map script builderKeys);
+    in
+    ''
+      pushd $(mktemp -d)
+      export GNUPGHOME=$PWD/gnupg
+      mkdir -m 700 -p $GNUPGHOME
+      gpg --no-autostart --batch --import ${publicKeys}/builder-keys/*
+      ln -s ${checksums} ./SHA256SUMS
+      ln -s ${signatures} ./SHA256SUMS.asc
+      ln -s $src ./bitcoin-${version}.tar.gz
+      gpg --no-autostart --batch --verify --status-fd 1 SHA256SUMS.asc SHA256SUMS > verify.log
+      ${verifyBuilderKeys}
+      grep bitcoin-${version}.tar.gz SHA256SUMS > SHA256SUMS.filtered
+      echo "Verifying the checksum of bitcoin-${version}.tar.gz..."
+      sha256sum -c SHA256SUMS.filtered
+      popd
+    '';
 
   configureFlags = [
     "--with-boost-libdir=${boost.out}/lib"

--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchFromGitHub,
   cmake,
   pkg-config,
   installShellFiles,
@@ -23,6 +24,16 @@
   withGui,
   withWallet ? true,
   enableTracing ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic,
+  gnupg,
+  # Signatures from the following GPG public keys checked during verification of the source code.
+  # The list can be found at https://github.com/bitcoin-core/guix.sigs/tree/main/builder-keys
+  builderKeys ? [
+    "152812300785C96444D3334D17565732E08E5E41" # achow101.gpg
+    "9EDAFF80E080659604F4A76B2EBB056FD847F8A7" # Emzy.gpg
+    "71A3B16735405025D447E8F274810B012346C9A6" # laanwj.gpg
+    "6B002C6EA3F91B1B0DF0C9BC8F617F1200A6D25C" # glozow.gpg
+    "D1DBF2C4B96F2DEBF4C16654410108112E7EA81F" # hebasto.gpg
+  ],
 }:
 
 let
@@ -48,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     installShellFiles
+    gnupg
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
     autoSignDarwinBinariesHook
@@ -69,6 +81,51 @@ stdenv.mkDerivation (finalAttrs: {
     qtbase
     qttools
   ];
+
+  preUnpack =
+    let
+      publicKeys = fetchFromGitHub {
+        owner = "bitcoin-core";
+        repo = "guix.sigs";
+        rev = "a788388207bd244d5ab07b31ecd6c126f213a6c6";
+        sha256 = "sha256-gbenuEWP6pqY9ywPd/yZy6QfWI7jvSObwto27DRXjGI=";
+      };
+
+      checksums = fetchurl {
+        url = "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/SHA256SUMS";
+        hash = "sha256-lOwVH0UqIhOT0I9rAvswuqy+tZ8ZRhH0kGnn9VCbRv4=";
+      };
+
+      signatures = fetchurl {
+        url = "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/SHA256SUMS.asc";
+        hash = "sha256-s05cRmZ9aoPdSZTaz6D6qmVwX6OprqxynPn5vZQ7bbw=";
+      };
+
+      verifyBuilderKeys =
+        let
+          script = publicKey: ''
+            echo "Checking if public key ${publicKey} signed the checksum file..."
+            grep "^\[GNUPG:\] VALIDSIG .* ${publicKey}$" verify.log > /dev/null
+            echo "OK"
+          '';
+        in
+        builtins.concatStringsSep "\n" (builtins.map script builderKeys);
+    in
+    ''
+      pushd $(mktemp -d)
+      export GNUPGHOME=$PWD/gnupg
+      mkdir -m 700 -p $GNUPGHOME
+      gpg --no-autostart --batch --import ${publicKeys}/builder-keys/*
+      ln -s ${checksums} ./SHA256SUMS
+      ln -s ${signatures} ./SHA256SUMS.asc
+      ln -s $src ./bitcoin-${finalAttrs.version}.tar.gz
+      gpg --no-autostart --batch --verify --status-fd 1 SHA256SUMS.asc SHA256SUMS > verify.log
+      ${verifyBuilderKeys}
+      grep bitcoin-${finalAttrs.version}.tar.gz SHA256SUMS > SHA256SUMS.filtered
+      echo "Verifying the checksum of bitcoin-${finalAttrs.version}.tar.gz..."
+      sha256sum -c SHA256SUMS.filtered
+      popd
+    '';
 
   postInstall = ''
     cd ..


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This change adds automatic GPG verification of the bitcoin and bitcoin-knots packages. Closes #415905 

## Background

Both bitcoin (core) and bitcoin knots provide a method to verify releases, including the source code archive file. In a nutshell:

1. A SHA256 digest is generated for all of the release artifacts.
2. A number of the developers sign the digest using GPG keys which are publicly available, producing a signature of the digest.
3. Users are encouraged to verify the digest of the downloaded release artifacts, and the digest signatures.

## Implementation

This change implements a `preUnpack` phase to verify the digest of the source tarball and the digest signatures. It's worth nothing that this change introduces some consequences:

1. The digest (aka. checkum) and signature files are two additional inputs which will need to have their hashes updated, every release.
2. The _guix-sigs_ repository, which contains the GPG keys, will need to be updated periodically to keep up with key changes. It's not clear how often this will need to happen.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
