### PR TITLE
kiro: init at 202507140012

### DIFF
--- a/pkgs/by-name/ki/kiro/package.nix
+++ b/pkgs/by-name/ki/kiro/package.nix
@@ -1,0 +1,80 @@
+{ pkgs }:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "kiro";
+  version = "202507140012";
+
+  src = pkgs.fetchurl {
+    url = "https://prod.download.desktop.kiro.dev/releases/202507140012--distro-linux-x64-tar-gz/202507140012-distro-linux-x64.tar.gz";
+    sha256 = "0za8zpfffhww8qrd7z7qd63n5sg8df7n4wl6ab3xz26xg7ydrdp9";
+  };
+
+  nativeBuildInputs = [
+    pkgs.autoPatchelfHook
+    pkgs.makeWrapper
+  ];
+
+  buildInputs = with pkgs; [
+    glib
+    nss
+    nspr
+    dbus
+    atk
+    at-spi2-atk
+    cups
+    libdrm
+    gtk3
+    pango
+    cairo
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    mesa
+    expat
+    xorg.libxcb
+    libxkbcommon
+    xorg.libxkbfile
+    alsa-lib
+    at-spi2-core
+    libglvnd
+    electron
+  ];
+
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out/lib/kiro
+    cp -r ./* $out/lib/kiro/
+
+    # Patch ELF files before removing bundled Electron components
+    find $out/lib/kiro -type f -exec patchelf --set-rpath "${pkgs.lib.makeLibraryPath buildInputs}" {} \; || true
+
+    # Remove bundled Electron components
+    rm $out/lib/kiro/kiro
+    rm $out/lib/kiro/chrome_crashpad_handler
+    rm $out/lib/kiro/chrome-sandbox
+    rm $out/lib/kiro/libEGL.so
+    rm $out/lib/kiro/libGLESv2.so
+    rm $out/lib/kiro/libvk_swiftshader.so
+    rm $out/lib/kiro/libvulkan.so.1
+    rm $out/lib/kiro/libffmpeg.so
+
+    # Ensure resources are in the correct place for system electron
+    mv $out/lib/kiro/resources $out/lib/kiro/electron-resources
+
+    # Create wrapper for system electron
+    makeWrapper ${pkgs.electron}/bin/electron $out/bin/kiro \
+      --add-flags "$out/lib/kiro/electron-resources/app --no-sandbox --disable-gpu-sandbox"
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Kiro is an development environment that uses AI agents";
+    homepage = "https://kiro.dev/";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ deftdawg ];
+  };
+}


### PR DESCRIPTION
DRAFT: currently the desktop application starts, however login does not start a browser to allow the user to complete login, so it will need some modification before it can be further tested.

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/b6ab6dc4-f9f5-4854-8cfd-d964e1feb29f" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
