### PR TITLE
nixos/peertube: only include whisper when transcription is enabled

### DIFF
--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -164,7 +164,39 @@ in
     };
 
     settings = lib.mkOption {
-      type = settingsFormat.type;
+      type = lib.types.submodule (
+        { config, ... }:
+        {
+          freeformType = settingsFormat.type;
+          options = {
+            video_transcription = {
+              enabled = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = "Enable automatic transcription of videos.";
+              };
+              engine_path = lib.mkOption {
+                type = with lib.types; either path str;
+                default =
+                  if config.video_transcription.enabled then
+                    lib.getExe pkgs.whisper-ctranslate2
+                  else
+                    # This will be in the error message when someone enables
+                    # transcription manually in the web UI and tries to run a
+                    # transcription job.
+                    "Set `services.peertube.settings.video_transcription.enabled = true`.";
+                defaultText = lib.literalExpression ''
+                  if config.services.peertube.settings.video_transcription.enabled then
+                    lib.getExe pkgs.whisper-ctranslate2
+                  else
+                    "Set `services.peertube.settings.video_transcription.enabled = true`."
+                '';
+                description = "Custom engine path for local transcription.";
+              };
+            };
+          };
+        }
+      );
       example = lib.literalExpression ''
         {
           listen = {
@@ -423,7 +455,6 @@ in
         };
         video_transcription = {
           engine = lib.mkDefault "whisper-ctranslate2";
-          engine_path = lib.mkDefault (lib.getExe pkgs.whisper-ctranslate2);
         };
       }
       (lib.mkIf cfg.redis.enableUnixSocket {


### PR DESCRIPTION
`whisper-ctranslate2` has a large closure size with unique dependencies.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
