### PR TITLE
kiro: init at 0.2.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27098,6 +27098,12 @@
     githubId = 4779365;
     name = "Johannes Mayrhofer";
   };
+  vuks = {
+    email = "vuks@allthingslinux.org";
+    github = "Vuks69";
+    githubId = 51289041;
+    name = "Vuks";
+  };
   vyorkin = {
     email = "vasiliy.yorkin@gmail.com";
     github = "vyorkin";

--- a/pkgs/by-name/ki/kiro/package.nix
+++ b/pkgs/by-name/ki/kiro/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  vscode-generic,
+  fetchurl,
+  extraCommandLineArgs ? "",
+  useVSCodeRipgrep ? stdenv.hostPlatform.isDarwin,
+}:
+
+let
+  sources = (lib.importJSON ./sources.json).${stdenv.hostPlatform.system};
+in
+(callPackage vscode-generic {
+  inherit useVSCodeRipgrep;
+  commandLineArgs = extraCommandLineArgs;
+
+  version = "0.2.13";
+  pname = "kiro";
+
+  # You can find the current VSCode version in the About dialog:
+  # workbench.action.showAboutDialog (Help: About)
+  vscodeVersion = "1.94.0";
+
+  executableName = "kiro";
+  longName = "Kiro";
+  shortName = "kiro";
+  libraryName = "kiro";
+  iconName = "kiro";
+
+  src = fetchurl {
+    url = sources.url;
+    hash = sources.hash;
+  };
+  sourceRoot = "Kiro";
+  patchVSCodePath = true;
+
+  tests = { };
+  updateScript = ./update.sh;
+
+  meta = {
+    description = "IDE for Agentic AI workflows based on VS Code";
+    homepage = "https://kiro.dev";
+    license = lib.licenses.amazonsl;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ vuks ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "kiro";
+  };
+
+}).overrideAttrs
+  (oldAttrs: {
+    passthru = (oldAttrs.passthru or { }) // {
+      inherit sources;
+    };
+  })

--- a/pkgs/by-name/ki/kiro/sources.json
+++ b/pkgs/by-name/ki/kiro/sources.json
@@ -1,0 +1,14 @@
+{
+  "x86_64-linux": {
+    "url": "https://prod.download.desktop.kiro.dev/releases/202508150626--distro-linux-x64-tar-gz/202508150626-distro-linux-x64.tar.gz",
+    "hash": "sha256-ORgN7gOyHGkO/ewqy62H0oNweZz7ViUAuEtXM1WgYIE="
+  },
+  "x86_64-darwin": {
+    "url": "https://prod.download.desktop.kiro.dev/releases/202508150626-Kiro-dmg-darwin-x64.dmg",
+    "hash": "sha256-8lIiMfDxp8VuRG/tiuojtOksc6oGT0+ZPpSAriRmKYU="
+  },
+  "aarch64-darwin": {
+    "url": "https://prod.download.desktop.kiro.dev/releases/202508150626-Kiro-dmg-darwin-arm64.dmg",
+    "hash": "sha256-2WGLIspDErwa1CZmSTTFa4aNCi6T/8x3vDNalNsm4xQ="
+  }
+}

--- a/pkgs/by-name/ki/kiro/update.sh
+++ b/pkgs/by-name/ki/kiro/update.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq
+# shellcheck shell=bash
+
+set -euo pipefail
+
+# Script configuration
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+PACKAGE_NIX="${SCRIPT_DIR}/package.nix"
+SOURCES_JSON="${SCRIPT_DIR}/sources.json"
+
+# Platform configuration
+declare -A PLATFORM_URLS=(
+    ["x86_64-linux"]="https://prod.download.desktop.kiro.dev/stable/metadata-linux-x64-stable.json"
+    ["x86_64-darwin"]="https://prod.download.desktop.kiro.dev/stable/metadata-dmg-darwin-x64-stable.json"
+    ["aarch64-darwin"]="https://prod.download.desktop.kiro.dev/stable/metadata-dmg-darwin-arm64-stable.json"
+)
+
+# Data storage
+declare -A platform_versions
+declare -A platform_urls
+declare -A platform_hashes
+
+# Error handling
+error_exit() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+# Script execution starts here
+echo "Starting Kiro update process..."
+
+# Fetch metadata for all platforms
+echo "Fetching platform information..."
+for platform in "${!PLATFORM_URLS[@]}"; do
+    url="${PLATFORM_URLS[$platform]}"
+    echo "Fetching metadata for $platform..."
+
+    if ! response=$(curl -fsSL "$url"); then
+        error_exit "Failed to fetch metadata for $platform from $url"
+    fi
+
+    # Extract file URL and version from metadata
+    file_url=$(echo "$response" | jq -r '
+        .releases[0].updateTo
+        | select(.url | test("\\.(tar|dmg)(\\.|$)"))
+        | .url' | head -1)
+
+    if [[ -z "$file_url" || "$file_url" == "null" ]]; then
+        error_exit "Could not find a valid file URL for $platform in metadata"
+    fi
+
+    version=$(echo "$response" | jq -r '.currentRelease')
+    if [[ -z "$version" || "$version" == "null" ]]; then
+        error_exit "Could not extract version for $platform from metadata"
+    fi
+
+    platform_versions["$platform"]="$version"
+    platform_urls["$platform"]="$file_url"
+done
+
+# Determine the maximum version
+max_version=""
+for platform in "${!platform_versions[@]}"; do
+    version="${platform_versions[$platform]}"
+    if [[ -z "$max_version" ]] || [[ "$version" > "$max_version" ]]; then
+        max_version="$version"
+    fi
+done
+echo "Latest version across all platforms: $max_version"
+
+# Check if update is needed
+if [[ ! -f "$PACKAGE_NIX" ]]; then
+    error_exit "package.nix not found at $PACKAGE_NIX"
+fi
+current_version=$(grep -E '^  version = ' "$PACKAGE_NIX" | cut -d'"' -f2)
+if [[ -z "$current_version" ]]; then
+    error_exit "Could not extract current version from package.nix"
+fi
+if [[ "$max_version" == "$current_version" ]]; then
+    echo "No update needed. Current version is already the latest: $current_version"
+    exit 0
+fi
+
+echo "Updating to version: $max_version"
+echo "Calculating hashes..."
+for platform in "${!platform_urls[@]}"; do
+    echo "  Calculating hash for $platform..."
+    platform_hashes["$platform"]=$(nix hash convert --hash-algo sha256 "$(nix-prefetch-url "${platform_urls[$platform]}")")
+done
+
+# Update package.nix and generate sources.json
+echo "Updating package.nix..."
+sed -i "s/version = \".*\"/version = \"$max_version\"/" "$PACKAGE_NIX"
+
+echo "Generating sources.json..."
+json_content="{}"
+for platform in "${!platform_urls[@]}"; do
+    json_content=$(echo "$json_content" | jq --arg platform "$platform" \
+        --arg url "${platform_urls[$platform]}" \
+        --arg hash "${platform_hashes[$platform]}" \
+        '. + {($platform): {url: $url, hash: $hash}}')
+done
+echo "$json_content" >"$SOURCES_JSON"
+
+echo "Successfully updated package.nix to version $max_version"
+echo "Hashes calculated and updated:"
+for platform in "${!platform_hashes[@]}"; do
+    echo "  $platform: ${platform_hashes[$platform]}"
+done

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13807,6 +13807,12 @@ with pkgs;
     nodejs = nodejs_20;
   };
 
+  kiro = callPackage ../by-name/ki/kiro/package.nix {
+    vscode-generic = ../applications/editors/vscode/generic.nix;
+  };
+  kiro-fhs = kiro.fhs;
+  kiro-fhsWithPackages = kiro.fhsWithPackages;
+
   whispers = with python3Packages; toPythonApplication whispers;
 
   # Should always be the version with the most features


### PR DESCRIPTION
Functioning package. Login works, editor and LLM integration works.
resolves kirodotdev/Kiro/issues/169
duplicates #425565 - ~~@deftdawg, feel free to use this PR as you see fit as I don't really have the intention of maintaining this at the time (created this for personal use and saw it wasn't yet on nixpkgs, before you posted your PR)~~ this PR is used instead of the mentioned one.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
