### PR TITLE
lutgen-studio: init at 0.3.0

### DIFF
--- a/pkgs/by-name/lu/lutgen-studio/package.nix
+++ b/pkgs/by-name/lu/lutgen-studio/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+
+  fontconfig,
+  libGL,
+  libxkbcommon,
+  openssl,
+  wayland,
+  xorg,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lutgen-studio";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ozwaldorf";
+    repo = "lutgen-rs";
+    tag = "lutgen-studio-v${version}";
+    hash = "sha256-ENhaJTbaAv52YFNjce9Ln/LQvP/Nw2Tk5eMmr8mKwQ0=";
+  };
+
+  cargoHash = "sha256-PEso+fTH1DndRUPULYIDMAqnrfz8W9iVVxZ7W2N/I5U=";
+
+  cargoBuildFlags = [
+    "--bin"
+    "lutgen-studio"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "lutgen-studio"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall =
+    let
+      # Include dynamically loaded libraries
+      LD_LIBRARY_PATH = lib.makeLibraryPath [
+        fontconfig
+        libGL
+        libxkbcommon
+        openssl
+        wayland
+        xorg.libXcursor
+        xorg.libXrandr
+        xorg.libXi
+        xorg.libX11
+      ];
+    in
+    ''
+      wrapProgram "$out/bin/lutgen-studio" \
+        --set LD_LIBRARY_PATH "${LD_LIBRARY_PATH}"
+    '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^lutgen-studio-v([0-9.]+)$" ];
+  };
+
+  meta = {
+    description = "Official GUI for Lutgen, the best way to apply popular colorschemes to any image or wallpaper";
+    homepage = "https://github.com/ozwaldorf/lutgen-rs";
+    maintainers = with lib.maintainers; [ ozwaldorf ];
+    mainProgram = "lutgen-studio";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds Lutgen Studio, the official GUI for lutgen! Replaces #423502 

<img alt="Lutgen Studio" src="https://github.com/user-attachments/assets/436ece7a-b59f-404d-a6d6-6c0e754355f2" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] 86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
