### PR TITLE
ocamlPackages.merlin: 5.4.1 → 5.5; ocamlPackages.jsonrpc: 1.22.0 → 1.23.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -10,7 +10,7 @@
   ocaml,
   version ?
     if lib.versionAtLeast ocaml.version "5.3" then
-      "1.22.0"
+      "1.23.0"
     else if lib.versionAtLeast ocaml.version "5.2" then
       "1.21.0"
     else if lib.versionAtLeast ocaml.version "4.14" then
@@ -26,6 +26,11 @@
 let
   params =
     {
+      "1.23.0" = {
+        name = "lsp";
+        minimalOCamlVersion = "5.3";
+        sha256 = "sha256-fyvQI7VKgOrOFihtKIkcE2B2iUYFLJOZGKipzZU0Dn0=";
+      };
       "1.22.0" = {
         name = "lsp";
         minimalOCamlVersion = "5.2";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -24,7 +24,7 @@
   ocaml,
   version ?
     if lib.versionAtLeast ocaml.version "5.3" then
-      "1.22.0"
+      "1.23.0"
     else if lib.versionAtLeast ocaml.version "5.2" then
       "1.21.0"
     else if lib.versionAtLeast ocaml.version "4.14" then

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -20,15 +20,15 @@
       "4.12.1" = "4.7-412";
       "4.13.0" = "4.7-413";
       "4.13.1" = "4.7-413";
-      "4.14.0" = "4.18-414";
-      "4.14.1" = "4.18-414";
-      "4.14.2" = "4.18-414";
+      "4.14.0" = "4.19-414";
+      "4.14.1" = "4.19-414";
+      "4.14.2" = "4.19-414";
       "5.0.0" = "4.14-500";
       "5.1.0" = "4.17.1-501";
       "5.1.1" = "4.17.1-501";
       "5.2.0" = "5.3-502";
       "5.2.1" = "5.3-502";
-      "5.3.0" = "5.4.1-503";
+      "5.3.0" = "5.5-503";
     }
     ."${ocaml.version}",
 }:
@@ -42,9 +42,11 @@ let
     "4.16-414" = "sha256-xekZdfPfVoSeGzBvNWwxcJorE519V2NLjSHkcyZvzy0="; # Used by ocaml-lsp
     "4.16-501" = "sha256-2lvzCbBAZFwpKuRXLMagpwDb0rz8mWrBPI5cODbCHiY="; # Used by ocaml-lsp
     "4.18-414" = "sha256-9tb3omYUHjWMGoaWEsgTXIWRhdVH6julya17tn/jDME=";
+    "4.19-414" = "sha256-YKYw9ZIDqc5wR6XwTQ8jmUWWDaxvOBApIuMottJlc4Q=";
     "4.17.1-501" = "sha256-N2cHqocfCeljlFbT++S4miHJrXXHdOlMu75n+EKwpQA=";
     "5.3-502" = "sha256-LOpG8SOX+m4x7wwNT14Rwc/ZFu5JQgaUAFyV67OqJLw=";
     "5.4.1-503" = "sha256-SbO0x3jBISX8dAXnN5CwsxLV15dJ3XPUg4tlYqJTMCI=";
+    "5.5-503" = "sha256-Z9o7NPL+oHZ4JnMJ9h2kosbwgpjeDcWWVbjTD9gmmvE=";
   };
 
 in


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
