### PR TITLE
python3Packages.pikepdf: 9.8.1 -> 9.11.0

### DIFF
--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -25,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "pikepdf";
-  version = "9.8.1";
+  version = "9.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-gFaGHml1F5i+w68xapmPHYUK760rT4GJzTWTkDsIwC8=";
+    hash = "sha256-mdH7bFfUzjSOOIhRK4GpizohFB82s8v9N2yEX2X/dms=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/pikepdf/paths.patch
+++ b/pkgs/development/python-modules/pikepdf/paths.patch
@@ -1,18 +1,18 @@
 diff --git a/src/pikepdf/_methods.py b/src/pikepdf/_methods.py
-index da40043f..4f566f01 100644
+index 62939b47..d4807ef2 100644
 --- a/src/pikepdf/_methods.py
 +++ b/src/pikepdf/_methods.py
-@@ -74,7 +74,7 @@ def _mudraw(buffer, fmt) -> bytes:
-         tmp_in.flush()
+@@ -69,7 +69,7 @@ def _single_page_pdf(page: Page) -> bytes:
  
-         proc = run(
--            ['mutool', 'draw', '-F', fmt, '-o', '-', tmp_in.name],
-+            ['@mutool@', 'draw', '-F', fmt, '-o', '-', tmp_in.name],
-             capture_output=True,
-             check=True,
-         )
+ def _run_mudraw(in_path: Path, out_pattern: Path) -> Path:
+     run(
+-        ['mutool', 'draw', '-o', str(out_pattern), str(in_path)],
++        ['@mutool@', 'draw', '-o', str(out_pattern), str(in_path)],
+         check=True,
+     )
+     out_path = out_pattern.with_name(out_pattern.name.format(1))  # Replace %d with 1
 diff --git a/src/pikepdf/jbig2.py b/src/pikepdf/jbig2.py
-index 901f3b6f..45551820 100644
+index aff8c657..5bcf1b4f 100644
 --- a/src/pikepdf/jbig2.py
 +++ b/src/pikepdf/jbig2.py
 @@ -72,7 +72,7 @@ class JBIG2Decoder(JBIG2DecoderInterface):
@@ -25,7 +25,7 @@ index 901f3b6f..45551820 100644
                  "--format",
                  "png",
 @@ -101,7 +101,7 @@ class JBIG2Decoder(JBIG2DecoderInterface):
-     def _version(self) -> Version:
+     def _version(self) -> Version | None:
          try:
              proc = self._run(
 -                ['jbig2dec', '--version'],


### PR DESCRIPTION
Diff: https://github.com/pikepdf/pikepdf/compare/refs/tags/v9.8.1...refs/tags/v9.11.0

Changelog: https://github.com/pikepdf/pikepdf/blob/v9.11.0/docs/releasenotes/version9.md

depends on https://github.com/NixOS/nixpkgs/pull/442242
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
