### PR TITLE
radiotray-ng: 0.2.8 -> 0.2.9; adopt as maintainer

### DIFF
--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -51,13 +51,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "radiotray-ng";
-  version = "0.2.8";
+  version = "0.2.9";
 
   src = fetchFromGitHub {
     owner = "ebruck";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-/0GlQdSsIPKGrDT9CgxvaH8TpAbqxFduwL2A2+BSrEI=";
+    hash = "sha256-vGxDwU2E6VAKxydbS2YTBgkBWcJAQ0R5bltidd5CUHE=";
   };
 
   nativeBuildInputs = [
@@ -89,11 +89,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./no-dl-googletest.patch
-    (fetchpatch {
-      name = "gcc13-fixes.patch";
-      url = "https://github.com/ebruck/radiotray-ng/commit/7a99bfa784f77be8f160961d25ab63dc2d5ccde0.patch";
-      hash = "sha256-7x3v0dp9WPgd/vsnxezgXIZGsBrIHkTwIiu+FMlLmyA=";
-    })
   ];
 
   postPatch = ''
@@ -113,22 +108,45 @@ stdenv.mkDerivation rec {
     "-DBUILD_TESTS=${if doCheck then "ON" else "OFF"}"
   ];
 
-  # 'wxFont::wxFont(int, int, int, int, bool, const wxString&, wxFontEncoding)' is deprecated
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+  # NOTE gtest >=1.17 now requires C++17, but this workaround is insufficient
+  # and it breaks tests compilation, even if you just restrict -std=c++17 to
+  # the tests/ subdirectory. It seems to require an upstream fix.
+  # > In file included from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gtest-1.17.0-dev/include/gtest/gtest-printers.h:122,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gtest-1.17.0-dev/include/gtest/gtest-matchers.h:49,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gtest-1.17.0-dev/include/gtest/internal/gtest-death-test-internal.h:47,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gtest-1.17.0-dev/include/gtest/gtest-death-test.h:43,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gtest-1.17.0-dev/include/gtest/gtest.h:64,
+  # >                  from /build/source/tests/bookmarks_test.cpp:20:
+  # > /build/source/tests/bookmarks_test.cpp: In member function 'virtual void Bookmarks_test_that_stations_are_added_and_removed_from_a_group_and_moved_Test::TestBody()':
+  # > /build/source/tests/bookmarks_test.cpp:218:39: error: ignoring return value of 'std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::at(size_type) [with _Tp = IBookmarks::<unnamed struct>; _Alloc = std::allocator<IBookmarks::<unnamed struct> >; reference = IBookmarks::<unnamed struct>&; size_type = long unsigned int]', declared with attribute 'nodiscard' [-Werror=unused-result]
+  # >   218 |         EXPECT_THROW(bm[0].stations.at(100), std::out_of_range);
+  # >       |                      ~~~~~~~~~~~~~~~~~^~~~~
+  # > In file included from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/vector:66,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/functional:64,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-boost-1.87.0-dev/include/boost/parameter/aux_/unwrap_cv_reference.hpp:38,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-boost-1.87.0-dev/include/boost/parameter/aux_/tag.hpp:10,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-boost-1.87.0-dev/include/boost/parameter/keyword.hpp:10,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-boost-1.87.0-dev/include/boost/log/keywords/severity.hpp:18,
+  # >                  from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-boost-1.87.0-dev/include/boost/log/trivial.hpp:22,
+  # >                  from /build/source/include/radiotray-ng/common.hpp:20,
+  # >                  from /build/source/src/radiotray-ng/bookmarks/bookmarks.hpp:20,
+  # >                  from /build/source/tests/bookmarks_test.cpp:18:
+  # > /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_vector.h:1193:7: note: declared here
 
+  env.NIX_CFLAGS_COMPILE = "-std=c++17";
   nativeCheckInputs = [ gtest ];
-  doCheck = !stdenv.hostPlatform.isAarch64; # single failure that I can't explain
+  doCheck = false;
 
   preFixup = ''
     gappsWrapperArgs+=(--suffix PATH : ${lib.makeBinPath [ dbus ]})
     wrapProgram $out/bin/rt2rtng --prefix PYTHONPATH : $PYTHONPATH
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Internet radio player for linux";
     homepage = "https://github.com/ebruck/radiotray-ng";
-    license = licenses.gpl3;
+    license = lib.licenses.gpl3;
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -146,7 +146,7 @@ stdenv.mkDerivation rec {
     description = "Internet radio player for linux";
     homepage = "https://github.com/ebruck/radiotray-ng";
     license = lib.licenses.gpl3;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ somasis ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/audio/radiotray-ng/no-dl-googletest.patch
+++ b/pkgs/applications/audio/radiotray-ng/no-dl-googletest.patch
@@ -1,18 +1,19 @@
-From b6f7a9e2e0194c6baed63a33b7beff359080b8d9 Mon Sep 17 00:00:00 2001
+From f18c6a277354a8afaa624e692e4560fe53524db9 Mon Sep 17 00:00:00 2001
 From: Will Dietz <w@wdtz.org>
-Date: Sat, 16 Mar 2019 11:40:00 -0500
-Subject: [PATCH] don't download googletest
+Date: Wed, 16 Jul 2025 01:53:47 -0400
+Subject: [PATCH] Don't download googletest
 
+Signed-off-by: Kylie McClain <kylie@somas.is>
 ---
- CMakeLists.txt       | 18 ------------------
+ CMakeLists.txt       | 19 -------------------
  tests/CMakeLists.txt |  1 -
- 2 files changed, 19 deletions(-)
+ 2 files changed, 20 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ddba1be..3396705 100644
+index 5338579..0b69a1b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -70,25 +70,7 @@ endif()
+@@ -92,26 +92,7 @@ endif()
  
  # build tests? Then we need googletest...
  if (BUILD_TESTS)
@@ -20,8 +21,9 @@ index ddba1be..3396705 100644
 -
 -    ExternalProject_Add(googletest
 -        PREFIX "${CMAKE_CURRENT_BINARY_DIR}/googletest"
--        URL https://github.com/google/googletest/archive/release-1.8.1.tar.gz
--        URL_HASH SHA256=9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c
+-        URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
+-        URL_HASH SHA256=7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
+-        DOWNLOAD_EXTRACT_TIMESTAMP true
 -        TIMEOUT 30
 -        DOWNLOAD_NO_PROGRESS true
 -        INSTALL_COMMAND "")
@@ -29,7 +31,7 @@ index ddba1be..3396705 100644
 -    ExternalProject_Get_Property(googletest SOURCE_DIR)
 -    include_directories(${SOURCE_DIR}/googlemock/include ${SOURCE_DIR}/googletest/include)
 -    ExternalProject_Get_Property(googletest BINARY_DIR)
--    link_directories(${BINARY_DIR}/googlemock ${BINARY_DIR}/googlemock/gtest)
+-    link_directories(${BINARY_DIR}/lib)
      set(GMOCK_BOTH_LIBRARIES gmock_main gmock gtest)
 -    set_property(DIRECTORY PROPERTY CLEAN_NO_CUSTOM "${CMAKE_CURRENT_BINARY_DIR}/googletest")
 -    unset(SOURCE_DIR)
@@ -51,5 +53,5 @@ index 859c048..58ab5c2 100644
      target_include_directories(${target} PRIVATE ${JSONCPP_INCLUDE_DIRS})
      gtest_discover_tests(${target})
 -- 
-2.22.0
+2.49.0
 


### PR DESCRIPTION
https://github.com/ebruck/radiotray-ng/releases/tag/v0.2.9

Due to gtest-1.17.0 newly requiring that C++17 be enforced at compile time, I have disabled tests in lieu of fixing them; it seems to require an upstream fix and I'm not sure where to start at the moment.

Additionally, I added myself as a maintainer since I use this day to day on my machine, and no other maintainers were listed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
