### PR TITLE
make-{iso9660-image,squashfs,system-tarball}: drop references to build closure

### DIFF
--- a/nixos/lib/make-iso9660-image.nix
+++ b/nixos/lib/make-iso9660-image.nix
@@ -76,6 +76,10 @@ stdenv.mkDerivation {
   name = isoName;
   __structuredAttrs = true;
 
+  # the image will be self-contained so we can drop references
+  # to the closure that was used to build it
+  unsafeDiscardReferences.out = true;
+
   buildCommandPath = ./make-iso9660-image.sh;
   nativeBuildInputs = [
     xorriso

--- a/nixos/lib/make-squashfs.nix
+++ b/nixos/lib/make-squashfs.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation {
   name = "${fileName}${lib.optionalString (!hydraBuildProduct) ".img"}";
   __structuredAttrs = true;
 
+  # the image will be self-contained so we can drop references
+  # to the closure that was used to build it
+  unsafeDiscardReferences.out = true;
+
   nativeBuildInputs = [ squashfsTools ];
 
   buildCommand =

--- a/nixos/lib/make-system-tarball.nix
+++ b/nixos/lib/make-system-tarball.nix
@@ -41,6 +41,10 @@ stdenv.mkDerivation {
   name = "tarball";
   __structuredAttrs = true;
 
+  # the tarball will be self-contained so we can drop references
+  # to the closure that was used to build it
+  unsafeDiscardReferences.out = true;
+
   buildCommandPath = ./make-system-tarball.sh;
   nativeBuildInputs = extraInputs;
 

--- a/nixos/lib/make-system-tarball.nix
+++ b/nixos/lib/make-system-tarball.nix
@@ -39,7 +39,9 @@ in
 
 stdenv.mkDerivation {
   name = "tarball";
-  builder = ./make-system-tarball.sh;
+  __structuredAttrs = true;
+
+  buildCommandPath = ./make-system-tarball.sh;
   nativeBuildInputs = extraInputs;
 
   inherit
@@ -49,11 +51,9 @@ stdenv.mkDerivation {
     compressCommand
     ;
 
-  # !!! should use XML.
   sources = map (x: x.source) contents;
   targets = map (x: x.target) contents;
 
-  # !!! should use XML.
   inherit symlinks objects;
 
   closureInfo = closureInfo {

--- a/nixos/lib/make-system-tarball.sh
+++ b/nixos/lib/make-system-tarball.sh
@@ -1,10 +1,3 @@
-sources_=($sources)
-targets_=($targets)
-
-objects=($objects)
-symlinks=($symlinks)
-
-
 # Remove the initial slash from a path, since genisofs likes it that way.
 stripSlash() {
     res="$1"
@@ -12,10 +5,10 @@ stripSlash() {
 }
 
 # Add the individual files.
-for ((i = 0; i < ${#targets_[@]}; i++)); do
-    stripSlash "${targets_[$i]}"
+for ((i = 0; i < ${#targets[@]}; i++)); do
+    stripSlash "${targets[$i]}"
     mkdir -p "$(dirname "$res")"
-    cp -a "${sources_[$i]}" "$res"
+    cp -a "${sources[$i]}" "$res"
 done
 
 


### PR DESCRIPTION
This PR sets `unsafeDiscardReferences.out = true;` on `make-iso9660-image`, `make-squashfs` and `make-system-tarball` which means that the outputs don't depend on the build closure as they are all self-contained.

I've tested this PR works for `make-iso9660-image` by running:

```
nix flake archive --to ssh-ng://example.com && ssh example.com nix build --print-build-logs --print-out-paths $(nix flake metadata --json | jq -r '.path')#nixosConfigurations.default.config.system.build.images.iso && nix copy --from ssh-ng://example.com $(nix flake metadata --json | jq -r '.path')#nixosConfigurations.default.config.system.build.images.iso
```

Prior to this PR, `nix copy` would copy the entire build closure, however after this PR, `nix copy` only copies the final store path.

To test `make-system-tarball`, I used the attribute path `system.build.images.kexec` instead.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
