### PR TITLE
docling: 2.31.2 -> 2.41.0

### DIFF
--- a/pkgs/development/python-modules/docling-core/default.nix
+++ b/pkgs/development/python-modules/docling-core/default.nix
@@ -5,6 +5,7 @@
 
   # build-system
   poetry-core,
+  setuptools,
 
   # dependencies
   jsonref,
@@ -28,18 +29,19 @@
 
 buildPythonPackage rec {
   pname = "docling-core";
-  version = "2.31.2";
+  version = "2.43.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-core";
     tag = "v${version}";
-    hash = "sha256-O0GfEoWImDjehCPb8erBdY2gYalj2im8rxdJKEsbUs4=";
+    hash = "sha256-c9TaX4INfTfR3ZpmXbOteHr2R2jAbVzvMk8tO1XV4Nc=";
   };
 
   build-system = [
     poetry-core
+    setuptools
   ];
 
   dependencies = [
@@ -59,7 +61,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "pillow"
-    "typer"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/docling-ibm-models/default.nix
+++ b/pkgs/development/python-modules/docling-ibm-models/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -15,6 +14,7 @@
   opencv-python-headless,
   pillow,
   pydantic,
+  rtree,
   safetensors,
   torch,
   torchvision,
@@ -29,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "docling-ibm-models";
-  version = "3.4.4";
+  version = "3.8.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-ibm-models";
     tag = "v${version}";
-    hash = "sha256-a2y4vXgALPRtLhdH0Tqqht1gpdcfa1Gv4puthKDMk7U=";
+    hash = "sha256-Yogg71CXQTdF5OUbdbma1rQxtLudTLjyOIFe2LS9CpI=";
   };
 
   build-system = [
@@ -51,6 +51,7 @@ buildPythonPackage rec {
     opencv-python-headless
     pillow
     pydantic
+    rtree
     safetensors
     torch
     torchvision

--- a/pkgs/development/python-modules/docling-serve/default.nix
+++ b/pkgs/development/python-modules/docling-serve/default.nix
@@ -13,6 +13,7 @@
   uvicorn,
   websockets,
   tesserocr,
+  typer,
   rapidocr-onnxruntime,
   onnxruntime,
   torch,
@@ -28,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "docling-serve";
-  version = "0.11.0";
+  version = "0.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-serve";
     tag = "v${version}";
-    hash = "sha256-dPCD7Ovc6Xiga+gYOwg0mJIIhHywVOyxKIAFF5XUsYw=";
+    hash = "sha256-R8W/FXKj2wLJOcjwIsna/2wFOLGM80Qr3WlYPJTTSNU=";
   };
 
   postPatch = ''
@@ -53,7 +54,7 @@ buildPythonPackage rec {
   ];
 
   pythonRemoveDeps = [
-    "mlx-vlm" # not yet avainable on nixpkgs
+    "mlx-vlm" # not yet available on nixpkgs
   ];
 
   dependencies =
@@ -63,6 +64,7 @@ buildPythonPackage rec {
       httpx
       pydantic-settings
       python-multipart
+      typer
       uvicorn
       websockets
     ]

--- a/pkgs/development/python-modules/docling/default.nix
+++ b/pkgs/development/python-modules/docling/default.nix
@@ -52,14 +52,14 @@
 
 buildPythonPackage rec {
   pname = "docling";
-  version = "2.31.2";
+  version = "2.41.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling";
     tag = "v${version}";
-    hash = "sha256-a2PZORT4Umf6AI3yEDDcUD0tm22Ahzm7Dwij/5ZUjNs=";
+    hash = "sha256-GD052HCqBLs+KUkOUOVdlXxS6+PD2pthGtz+zdQ6QnM=";
   };
 
   build-system = [
@@ -102,7 +102,6 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "pillow"
-    "typer"
   ];
 
   optional-dependencies = {
@@ -160,10 +159,14 @@ buildPythonPackage rec {
     "test_convert_stream"
     "test_compare_legacy_output"
     "test_ocr_coverage_threshold"
+    "test_formula_conversion_with_page_range"
 
     # requires network access
     "test_page_range"
     "test_parser_backends"
+    "test_confidence"
+    "test_e2e_webp_conversions"
+    "test_asr_pipeline_conversion"
 
     # AssertionError: pred_itxt==true_itxt
     "test_e2e_valid_csv_conversions"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR bumps docling and its related packages:

* docling-ibm-models: 3.4.4 -> 3.8.1
* docling-core: 2.31.2 -> 2.43.0
* docling: 2.31.2 -> 2.41.0
* docking-serve: 0.11.0 -> 0.14.0

Please note that docking-serve is not bumped to the latest version, because since 0.15.0 it introduced a dependency that is not yet in nixpkgs: [scalar-fastapi](https://github.com/scalar/scalar). I may look into packaging this later in a separate PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
