### PR TITLE
mods: general improvements to the mods package

### DIFF
--- a/pkgs/by-name/mo/mods/package.nix
+++ b/pkgs/by-name/mo/mods/package.nix
@@ -15,7 +15,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "charmbracelet";
     repo = "mods";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-wzLYkcgUWPzghJEhYRh7HH19Rqov1RJAxdgp3AGnOTY=";
   };
 

--- a/pkgs/by-name/mo/mods/package.nix
+++ b/pkgs/by-name/mo/mods/package.nix
@@ -8,14 +8,14 @@
   mods,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "mods";
   version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "charmbracelet";
     repo = "mods";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-wzLYkcgUWPzghJEhYRh7HH19Rqov1RJAxdgp3AGnOTY=";
   };
 
@@ -28,7 +28,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X=main.Version=${version}"
+    "-X=main.Version=${finalAttrs.version}"
   ];
 
   # These tests require internet access.
@@ -67,4 +67,4 @@ buildGoModule rec {
     ];
     mainProgram = "mods";
   };
-}
+})

--- a/pkgs/by-name/mo/mods/package.nix
+++ b/pkgs/by-name/mo/mods/package.nix
@@ -1,11 +1,14 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   installShellFiles,
   fetchFromGitHub,
   gitUpdater,
   testers,
   mods,
+  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
 }:
 
 buildGoModule (finalAttrs: {
@@ -21,7 +24,7 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-L+4vkh7u6uMm5ICMk8ke5RVY1oYeKMYWVYYq9YqpKiw=";
 
-  nativeBuildInputs = [
+  nativeBuildInputs = lib.optionals (installManPages || installShellCompletions) [
     installShellFiles
   ];
 
@@ -46,16 +49,20 @@ buildGoModule (finalAttrs: {
     };
   };
 
-  postInstall = ''
-    export HOME=$(mktemp -d)
-    $out/bin/mods man > mods.1
-    $out/bin/mods completion bash > mods.bash
-    $out/bin/mods completion fish > mods.fish
-    $out/bin/mods completion zsh > mods.zsh
-
-    installManPage mods.1
-    installShellCompletion mods.{bash,fish,zsh}
-  '';
+  postInstall =
+    ''
+      export HOME=$(mktemp -d)
+    ''
+    + lib.optionalString installManPages ''
+      $out/bin/mods man > ./mods.1
+      installManPage ./mods.1
+    ''
+    + lib.optionalString installShellCompletions ''
+      installShellCompletion --cmd mods \
+        --bash <($out/bin/mods completion bash) \
+        --fish <($out/bin/mods completion fish) \
+        --zsh <($out/bin/mods completion zsh)
+    '';
 
   meta = {
     description = "AI on the command line";

--- a/pkgs/by-name/mo/mods/package.nix
+++ b/pkgs/by-name/mo/mods/package.nix
@@ -71,6 +71,7 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       dit7ya
       caarlos0
+      delafthi
     ];
     mainProgram = "mods";
   };


### PR DESCRIPTION
- Replaced `rec` with `finalAttrs`
- Replaced `rev` with `tag`
- Improved installation of man pages and shell completions

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin -> issue for building on darwin explained in #425603. Fix is also in there.
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
