### PR TITLE
nixos/dependency-track: fix default JVM heap size

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -112,6 +112,8 @@
 
 - `services.clamsmtp` is unmaintained and was removed from Nixpkgs.
 
+- `services.dependency-track` removed its configuration of the JVM heap size. This lets the JVM choose its maximum heap size automatically, which should work much better in practice for most users. For deployments on systems with little RAM, it may now be necessary to manually configure a maximum heap size using  {option}`services.dependency-track.javaArgs`.
+
 - `services.dnscrypt-proxy2` gains a `package` option to specify dnscrypt-proxy package to use.
 
 - `services.gitea` supports sending notifications with sendmail again. To do this, activate the parameter `services.gitea.mailerUseSendmail` and configure SMTP server.

--- a/nixos/modules/services/web-apps/dependency-track.nix
+++ b/nixos/modules/services/web-apps/dependency-track.nix
@@ -76,8 +76,12 @@ in
 
     javaArgs = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ "-Xmx4G" ];
-      description = "Java options passed to JVM";
+      default = [ ];
+      example = lib.literalExpression ''[ "-Xmx16G" ] '';
+      description = ''
+        Java options passed to JVM. Configuring this is usually not necessary, but for small systems
+        it can be useful to tweak the JVM heap size.
+      '';
     };
 
     database = {

--- a/nixos/tests/dependency-track.nix
+++ b/nixos/tests/dependency-track.nix
@@ -37,6 +37,11 @@ in
         };
         services.dependency-track = {
           enable = true;
+
+          # The Java VM defaults (correctly) to tiny heap on this tiny
+          # VM, but that's not enough to start dependency-track.
+          javaArgs = [ "-Xmx4G" ];
+
           port = dependencyTrackPort;
           nginx.domain = "localhost";
           database.passwordFile = "${pkgs.writeText "dbPassword" ''hunter2'THE'''H''''E''}";


### PR DESCRIPTION
The default of 4GB is too low for a production setup and causes DependencyTrack to hit `java.lang.OutOfMemoryError`. This causes Dependency Track to enter a weird state where it will throw 502 and 504 errors.

The initial 4GB was set to make Dependency Track run in the (too small) VM in the NixOS integration test. Move the explicit heap configuration there. For the service itself, we now don't set a limit. This means the JVM will choose its maximum heap on its own, which does a much better job for realistic scenarios.

I added a release note, because people who run Dependency Track on very tiny VMs/machines may experience issues.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
