### PR TITLE
pinentry-kwallet: init at 3.03

### DIFF
--- a/pkgs/by-name/pi/pinentry-kwallet/package.nix
+++ b/pkgs/by-name/pi/pinentry-kwallet/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  runCommandLocal,
+  kwalletcli,
+}:
+let
+  bin = "pinentry-kwallet";
+  bin' = lib.getExe' kwalletcli bin;
+in
+runCommandLocal bin
+  {
+    pname = "pinentry-kwallet";
+    inherit (kwalletcli) version;
+    meta = {
+      description = "Pinentry program for GnuPG that uses KWallet to store passphrases";
+      # Note: this meta value is why another package is required. The module will execute the mainProgram as pinentry.
+      mainProgram = bin;
+      inherit (kwalletcli.meta) homepage license maintainers;
+    };
+  }
+  ''
+    mkdir -p $out/bin
+    test -e ${bin'}
+    ln -s ${bin'} $out/bin/${bin}
+  ''


### PR DESCRIPTION
This PR is an attempt to revive and merge #344299. It incorporates feedback on that PR (https://github.com/NixOS/nixpkgs/pull/344299#issuecomment-2975828670).

pinentry-kwallet is a pinentry program for GnuPG that uses KWallet to store passphrases. This allows automatically unlocking GnuPG keys on login. This package is a thin wrapper that symlinks to the pinentry-kwallet binary in the kwalletcli package to make it compatible with the `programs.gnupg.agent.pinentryPackage` option in NixOS.

I am using it in my own config like so:
https://github.com/fnune/home.nix/blob/6f58a7cfcd0aad7c5b0732de84605aa769e3cc26/os/plasma.nix#L38

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
