### PR TITLE
build-support/php: drop unused `moreutils` dependency

### DIFF
--- a/pkgs/build-support/php/builders/v1/hooks/default.nix
+++ b/pkgs/build-support/php/builders/v1/hooks/default.nix
@@ -17,7 +17,7 @@ in
 {
   composerRepositoryHook = makeSetupHook {
     name = "composer-repository-hook.sh";
-    propagatedBuildInputs = [
+    propagatedNativeBuildInputs = [
       jq
       cacert
     ];
@@ -28,7 +28,7 @@ in
 
   composerInstallHook = makeSetupHook {
     name = "composer-install-hook.sh";
-    propagatedBuildInputs = [
+    propagatedNativeBuildInputs = [
       jq
       cacert
     ];
@@ -42,7 +42,7 @@ in
 
   composerWithPluginVendorHook = makeSetupHook {
     name = "composer-with-plugin-vendor-hook.sh";
-    propagatedBuildInputs = [
+    propagatedNativeBuildInputs = [
       jq
       cacert
     ];

--- a/pkgs/build-support/php/builders/v1/hooks/default.nix
+++ b/pkgs/build-support/php/builders/v1/hooks/default.nix
@@ -3,7 +3,6 @@
   makeSetupHook,
   jq,
   writeShellApplication,
-  moreutils,
   cacert,
   buildPackages,
 }:
@@ -20,7 +19,6 @@ in
     name = "composer-repository-hook.sh";
     propagatedBuildInputs = [
       jq
-      moreutils
       cacert
     ];
     substitutions = {
@@ -32,7 +30,6 @@ in
     name = "composer-install-hook.sh";
     propagatedBuildInputs = [
       jq
-      moreutils
       cacert
     ];
     substitutions = {
@@ -47,7 +44,6 @@ in
     name = "composer-with-plugin-vendor-hook.sh";
     propagatedBuildInputs = [
       jq
-      moreutils
       cacert
     ];
     substitutions = {

--- a/pkgs/build-support/php/builders/v2/hooks/default.nix
+++ b/pkgs/build-support/php/builders/v2/hooks/default.nix
@@ -3,7 +3,6 @@
   makeSetupHook,
   jq,
   writeShellApplication,
-  moreutils,
   cacert,
   buildPackages,
 }:
@@ -20,7 +19,6 @@ in
     name = "composer-vendor-hook.sh";
     propagatedBuildInputs = [
       jq
-      moreutils
       cacert
     ];
     substitutions = {
@@ -32,7 +30,6 @@ in
     name = "composer-install-hook.sh";
     propagatedBuildInputs = [
       jq
-      moreutils
       cacert
     ];
     substitutions = {

--- a/pkgs/build-support/php/builders/v2/hooks/default.nix
+++ b/pkgs/build-support/php/builders/v2/hooks/default.nix
@@ -17,7 +17,7 @@ in
 {
   composerVendorHook = makeSetupHook {
     name = "composer-vendor-hook.sh";
-    propagatedBuildInputs = [
+    propagatedNativeBuildInputs = [
       jq
       cacert
     ];
@@ -28,7 +28,7 @@ in
 
   composerInstallHook = makeSetupHook {
     name = "composer-install-hook.sh";
-    propagatedBuildInputs = [
+    propagatedNativeBuildInputs = [
       jq
       cacert
     ];

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -740,6 +740,7 @@ rec {
       name ? lib.warn "calling makeSetupHook without passing a name is deprecated." "hook",
       # hooks go in nativeBuildInputs so these will be nativeBuildInputs
       propagatedBuildInputs ? [ ],
+      propagatedNativeBuildInputs ? [ ],
       # these will be buildInputs
       depsTargetTargetPropagated ? [ ],
       meta ? { },
@@ -758,6 +759,7 @@ rec {
           inherit meta;
           inherit depsTargetTargetPropagated;
           inherit propagatedBuildInputs;
+          inherit propagatedNativeBuildInputs;
           strictDeps = true;
           # TODO 2023-01, no backport: simplify to inherit passthru;
           passthru =


### PR DESCRIPTION
I (@onny) discovered this issue while trying to diagnose what's going on with https://github.com/NixOS/nixpkgs/issues/424426.

These setup hooks do not make use of `moreutils`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
