### PR TITLE
extractpdfmark: fix build with gettext 0.25

### DIFF
--- a/pkgs/by-name/ex/extractpdfmark/gettext-0.25.patch
+++ b/pkgs/by-name/ex/extractpdfmark/gettext-0.25.patch
@@ -1,0 +1,15 @@
+diff --git a/configure.ac b/configure.ac
+index 2e7d562..c8dd741 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -7,6 +7,10 @@ AC_INIT([Extract PDFmark], [1.1.1], , [extractpdfmark],
+ AM_INIT_AUTOMAKE([foreign])
+ AC_CONFIG_SRCDIR([src/main.cc])
+ AC_CONFIG_HEADERS([config.h])
++AC_CONFIG_MACRO_DIRS([m4])
++
++AM_GNU_GETTEXT_VERSION([0.25])
++AM_GNU_GETTEXT([external])
+ 
+ PACKAGE_COPYRIGHT="Copyright (C) 2016-2022 Masamichi Hosoda"
+ PACKAGE_LICENSE="License: GPL3+"

--- a/pkgs/by-name/ex/extractpdfmark/package.nix
+++ b/pkgs/by-name/ex/extractpdfmark/package.nix
@@ -20,21 +20,27 @@ stdenv.mkDerivation rec {
     hash = "sha256-pNc/SWAtQWMbB2+lIQkJdBYSZ97iJXK71mS59qQa7Hs=";
   };
 
+  patches = [
+    ./gettext-0.25.patch
+  ];
+
+  strictDeps = true;
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
   ];
+
   buildInputs = [
-    ghostscript
     poppler
-    texlive.combined.scheme-minimal
   ];
 
-  postPatch = ''
-    touch config.rpath
-  '';
-
   doCheck = true;
+
+  nativeCheckInputs = [
+    ghostscript
+    texlive.combined.scheme-minimal
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/trueroad/extractpdfmark";


### PR DESCRIPTION
Related: https://github.com/NixOS/nixpkgs/pull/405793

`touch config.rpath` no longer seems to be needed after applying the patch. Not sure why...

I also added `strictDeps = true;` too and moved the test dependencies into their proper place.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
