### PR TITLE
nixos/cntlm: fix config generator

### DIFF
--- a/nixos/modules/services/networking/cntlm.nix
+++ b/nixos/modules/services/networking/cntlm.nix
@@ -14,7 +14,7 @@ let
         ${cfg.configText}
       ''
     else
-      pkgs.writeText "lighttpd.conf" ''
+      pkgs.writeText "cntlm.conf" ''
         # Cntlm Authentication Proxy Configuration
         Username ${cfg.username}
         Domain ${cfg.domain}

--- a/nixos/modules/services/networking/cntlm.nix
+++ b/nixos/modules/services/networking/cntlm.nix
@@ -8,31 +8,56 @@ let
 
   cfg = config.services.cntlm;
 
+  needsPassNTLMv2 = builtins.elem cfg.authType ["NTLMv2"];
+  needsPassNT = builtins.elem cfg.authType ["NTLM2SR" "NT" "NTLM"];
+  needsPassLM = builtins.elem cfg.authType ["NTLM" "LM"];
+
+  buildConfig =
+    pkgs.runCommandNoCC "cntlm.conf" {} ''
+      set -euo pipefail
+      cat ${configPrelude} >$out
+      GENERATED=$(echo "${cfg.password}" | ${pkgs.cntlm}/bin/cntlm \
+        -u ${cfg.username} -d ${cfg.domain} -H)
+
+      ${lib.optionalString needsPassNTLMv2 ''
+        echo "$GENERATED" | grep 'PassNTLMv2 ' >>$out
+      ''}
+      ${lib.optionalString needsPassNT ''
+        echo "$GENERATED" | grep 'PassNT ' >>$out
+      ''}
+      ${lib.optionalString needsPassLM ''
+        echo "$GENERATED" | grep 'PassLM ' >>$out
+      ''}
+    '';
+
+  configPrelude = pkgs.writeText "cntlm-prelude.conf" ''
+    # Cntlm Authentication Proxy Configuration
+    Username ${cfg.username}
+    Domain ${cfg.domain}
+    Auth ${cfg.authType}
+    ${lib.optionalString (cfg.netbios_hostname != "") "Workstation ${cfg.netbios_hostname}"}
+    ${lib.concatMapStrings (entry: "Proxy ${entry}\n") cfg.proxy}
+    ${lib.optionalString (cfg.noproxy != [ ]) "NoProxy ${lib.concatStringsSep ", " cfg.noproxy}"}
+
+    ${lib.concatMapStrings (port: ''
+      Listen ${toString port}
+    '') cfg.port}
+
+    ${cfg.extraConfig}
+  '';
+
   configFile =
-    if cfg.configText != "" then
-      pkgs.writeText "cntlm.conf" ''
-        ${cfg.configText}
-      ''
+    if cfg.configFile != null then
+      cfg.configFile
     else
-      pkgs.writeText "cntlm.conf" ''
-        # Cntlm Authentication Proxy Configuration
-        Username ${cfg.username}
-        Domain ${cfg.domain}
-        Password ${cfg.password}
-        ${lib.optionalString (cfg.netbios_hostname != "") "Workstation ${cfg.netbios_hostname}"}
-        ${lib.concatMapStrings (entry: "Proxy ${entry}\n") cfg.proxy}
-        ${lib.optionalString (cfg.noproxy != [ ]) "NoProxy ${lib.concatStringsSep ", " cfg.noproxy}"}
-
-        ${lib.concatMapStrings (port: ''
-          Listen ${toString port}
-        '') cfg.port}
-
-        ${cfg.extraConfig}
-      '';
-
+      buildConfig;
 in
-
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "services" "cntlm" "configText" ] ''
+      Use services.cntlm.configFile in conjunction with a trivial builder, e.g. writeText
+    '')
+  ];
 
   options.services.cntlm = {
 
@@ -50,10 +75,23 @@ in
       description = "Proxy account domain/workgroup name.";
     };
 
+    authType = lib.mkOption {
+      type = lib.types.enum [
+        "NTLMv2"
+        "NTLM2SR"
+        "NT"
+        "NTLM"
+        "LM"
+      ];
+      description = "Authentication type for the ntlm proxy";
+    };
+
     password = lib.mkOption {
-      default = "/etc/cntlm.password";
       type = lib.types.str;
-      description = "Proxy account password. Note: use chmod 0600 on /etc/cntlm.password for security.";
+      description = ''
+        Proxy account password in plaintext. Will be hashed in accordance with the selected authType.
+        Note that hashed passwords will be world-readable in the Nix store.
+      '';
     };
 
     netbios_hostname = lib.mkOption {
@@ -100,10 +138,13 @@ in
       description = "Additional config appended to the end of the generated {file}`cntlm.conf`.";
     };
 
-    configText = lib.mkOption {
-      type = lib.types.lines;
-      default = "";
-      description = "Verbatim contents of {file}`cntlm.conf`.";
+    configFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to custom {file}`cntlm.conf`.
+        If unset, the config file will be generated based on the value of other options.
+      '';
     };
 
   };


### PR DESCRIPTION
Setting the 'Password' config file keyword to a path doesn't work.
Instead, cntlm expects hashed passwords with hashing algorithms based
on the selected authType. The config generator will now actually
facilitate that. See: man cntlm. https://linux.die.net/man/1/cntlm

For users that don't want hashed passwords in the nix store, the
services.cntlm.configFile option is now available.

services.cntlm.configText has been removed, as its functionality can
easily be replicated with configFile = pkgs.writeText ...

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

cc @qknight @carlosdagos

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
