### PR TITLE
rapidraw: init at 1.2.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24532,6 +24532,12 @@
     githubId = 28858039;
     name = "Tuomas Mäkinen";
   };
+  taciturnaxolotl = {
+    email = "me@dunkirk.sh";
+    github = "taciturnaxolotl";
+    githubId = 92754843;
+    name = "Kieran Klukas";
+  };
   tadfisher = {
     email = "tadfisher@gmail.com";
     github = "tadfisher";

--- a/pkgs/by-name/ra/rapidraw/package.nix
+++ b/pkgs/by-name/ra/rapidraw/package.nix
@@ -1,0 +1,129 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  rustPlatform,
+  makeWrapper,
+  pkg-config,
+  wrapGAppsHook4,
+  openssl,
+  onnxruntime,
+  webkitgtk_4_1,
+  gtk3,
+  glib,
+  gdk-pixbuf,
+  libappindicator,
+  cairo,
+  pango,
+  xorg,
+  libxkbcommon,
+  vulkan-loader,
+  libjpeg,
+  libpng,
+  zlib,
+  libGL,
+  dbus,
+  gvfs,
+  libheif,
+  glib-networking,
+  nodejs_20,
+  npmHooks,
+  cargo-tauri,
+  writableTmpDirAsHomeHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rapidraw";
+  version = "1.2.12";
+
+  src = fetchFromGitHub {
+    owner = "CyberTimon";
+    repo = "RapidRAW";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KF7HXkR6Iuwxh/S3M3BojzAau/tVE+3Lycp4SYI1GG4=";
+  };
+
+  cargoHash = "sha256-3YeAK7FaBs70DqAoQQlCoqakgPUehE83+bedCwFGFVk=";
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-MULxH6gmHC58XdQe4ePvHcXP7/7fYNHgGHHltkODQ6w=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+    wrapGAppsHook4
+    nodejs_20
+    npmHooks.npmConfigHook
+    cargo-tauri.hook
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    nodejs_20
+    glib-networking
+    openssl
+    webkitgtk_4_1
+    gtk3
+    glib
+    gdk-pixbuf
+    libappindicator
+    cairo
+    pango
+    xorg.libX11
+    xorg.libXi
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libxcb
+    xorg.libXfixes
+    libxkbcommon
+    vulkan-loader
+    libjpeg
+    libpng
+    zlib
+    libGL
+    dbus
+    gvfs
+    libheif
+    onnxruntime
+    wrapGAppsHook4
+  ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+
+  # Set HOME for npm to avoid permission issues and add node_modules to path
+  preBuild = ''
+    export PATH="$PWD/node_modules/.bin:$PATH"
+
+    # Configure Tauri to use lowercase binary name
+    substituteInPlace src-tauri/tauri.conf.json \
+      --replace '  "identifier": "com.rapidraw.app",' '  "identifier": "com.rapidraw.app", "mainBinaryName": "rapidraw",'
+  '';
+
+  dontWrapGApps = true;
+
+  # needs to be declared twice annoyingly
+  ORT_STRATEGY = "system";
+
+  postFixup = ''
+    wrapGApp $out/bin/rapidraw \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs} \
+      --set ORT_STRATEGY "system" \
+      --set ORT_DYLIB_PATH "${onnxruntime}/lib/libonnxruntime.so"
+
+    rm -rf $out/lib/RapidRAW/resources
+  '';
+
+  meta = {
+    description = "Blazingly-fast, non-destructive, and GPU-accelerated RAW image editor built with performance in mind";
+    homepage = "https://github.com/CyberTimon/RapidRAW";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "rapidraw";
+    maintainers = with lib.maintainers; [ taciturnaxolotl ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Added [rapidraw](https://github.com/CyberTimon/RapidRAW) (from the readme: "RapidRAW is a modern, high-performance alternative to Adobe Lightroom®. It delivers a simple, beautiful editing experience in a lightweight package (under 30MB) for Windows, macOS, and Linux.") since it has over 1.7k stars and would be a useful tool to use. Also added myself to `maintainers-list.nix`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin (have a friend who is testing)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
