### PR TITLE
[Backport release-25.05] agda: use `getBin Agda` instead of `Agda.bin`

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -65,10 +65,10 @@ let
       }
       ''
         mkdir -p $out/bin
-        makeWrapper ${Agda.bin}/bin/agda $out/bin/agda \
+        makeWrapper ${lib.getBin Agda}/bin/agda $out/bin/agda \
           --add-flags "--with-compiler=${ghc}/bin/ghc" \
           --add-flags "--library-file=${library-file}"
-        ln -s ${Agda.bin}/bin/agda-mode $out/bin/agda-mode
+        ln -s ${lib.getBin Agda}/bin/agda-mode $out/bin/agda-mode
       '';
 
   withPackages = arg: if isAttrs arg then withPackages' arg else withPackages' { pkgs = arg; };


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/425820