### PR TITLE
haskellPackages.Agda: set `mainProgram`

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -65,10 +65,10 @@ let
       }
       ''
         mkdir -p $out/bin
-        makeWrapper ${lib.getBin Agda}/bin/agda $out/bin/agda \
+        makeWrapper ${lib.getExe Agda} $out/bin/agda \
           ${lib.optionalString (ghc != null) ''--add-flags "--with-compiler=${ghc}/bin/ghc"''} \
           --add-flags "--library-file=${library-file}"
-        ln -s ${lib.getBin Agda}/bin/agda-mode $out/bin/agda-mode
+        ln -s ${lib.getExe' Agda "agda-mode"} $out/bin/agda-mode
       '';
 
   withPackages = arg: if isAttrs arg then withPackages' arg else withPackages' { pkgs = arg; };

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1362,6 +1362,8 @@ builtins.intersectAttrs super {
     # very useful.
     # Flag added in Agda 2.6.4.1, was always enabled before
     (enableCabalFlag "debug")
+    # Set the main program
+    (overrideCabal { mainProgram = "agda"; })
     # Split outputs to reduce closure size
     enableSeparateBinOutput
   ];


### PR DESCRIPTION
Set Agda's `mainProgram` to `agda`. It's not set by default because there is more than one executable (https://github.com/NixOS/cabal2nix/blob/e9e2ebd9ab5c89c6cd55dd2c568dd46086f2addb/cabal2nix/src/Distribution/Nixpkgs/Haskell/FromCabal.hs#L150-L156).

This rebuilds Agda because of the `NIX_MAIN_PROGRAM` environment variable.