### PR TITLE
.github/PULL_REQUEST_TEMPLATE: shorten

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,9 +15,6 @@ For new packages please briefly describe the package or provide a link to its ho
   - [ ] aarch64-linux
   - [ ] x86_64-darwin
   - [ ] aarch64-darwin
-- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
-  - [ ] `sandbox = relaxed`
-  - [ ] `sandbox = true`
 - [ ] Tested, as applicable:
   - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,18 +16,30 @@ For new packages please briefly describe the package or provide a link to its ho
   - [ ] x86_64-darwin
   - [ ] aarch64-darwin
 - [ ] Tested, as applicable:
-  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
-  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
-  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
-  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
-- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
+  - [NixOS test(s)] (look inside [nixos/tests])
+  - and/or [package tests]
+  - or, for functions and "core" functionality, tests in [lib/tests] or [pkgs/test]
+  - made sure NixOS tests are [linked] to the relevant packages
+- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage]
 - [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
-- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
+- Nixpkgs Release Notes (or backporting 25.05 Nixpkgs Release notes)
   - [ ] (Package updates) Added a release notes entry if the change is major or breaking
-- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
+- NixOS Release Notes (or backporting 25.05 NixOS Release notes)
   - [ ] (Module updates) Added a release notes entry if the change is significant
   - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
-- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.
+- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other contributing documentation in corresponding paths.
+
+[NixOS test(s)]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
+[package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
+[linked]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package
+[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
+
+[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
+[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
+[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
+[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
+[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
+[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,6 @@ For new packages please briefly describe the package or provide a link to its ho
   - [NixOS test(s)] (look inside [nixos/tests])
   - and/or [package tests]
   - or, for functions and "core" functionality, tests in [lib/tests] or [pkgs/test]
-  - made sure NixOS tests are [linked] to the relevant packages
 - [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage]
 - [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
 - Nixpkgs Release Notes (or backporting 25.05 Nixpkgs Release notes)
@@ -31,7 +30,6 @@ For new packages please briefly describe the package or provide a link to its ho
 
 [NixOS test(s)]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
 [package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
-[linked]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package
 [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
 
 [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,17 +29,6 @@ For new packages please briefly describe the package or provide a link to its ho
   - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.
 
-<!--
-To help with the large amounts of pull requests, we would appreciate your
-reviews of other pull requests, especially simple package updates. Just leave a
-comment describing what you have tested in the relevant package/service.
-Reviewing helps to reduce the average time-to-merge for everyone.
-Thanks a lot if you do!
-
-List of open PRs: https://github.com/NixOS/nixpkgs/pulls
-Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
--->
-
 ---
 
 Add a :+1: [reaction] to [pull requests you find important].

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,26 +10,26 @@ For new packages please briefly describe the package or provide a link to its ho
 
 <!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
 
-- Built on platform(s)
+- Built on platform:
   - [ ] x86_64-linux
   - [ ] aarch64-linux
   - [ ] x86_64-darwin
   - [ ] aarch64-darwin
-- [ ] Tested, as applicable:
-  - [NixOS test(s)] (look inside [nixos/tests])
-  - and/or [package tests]
-  - or, for functions and "core" functionality, tests in [lib/tests] or [pkgs/test]
-- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage]
-- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
-- Nixpkgs Release Notes (or backporting 25.05 Nixpkgs Release notes)
-  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
-- NixOS Release Notes (or backporting 25.05 NixOS Release notes)
-  - [ ] (Module updates) Added a release notes entry if the change is significant
-  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
-- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other contributing documentation in corresponding paths.
+- Tested, as applicable:
+  - [ ] [NixOS tests] in [nixos/tests].
+  - [ ] [Package tests] at `passthru.tests`.
+  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
+- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
+- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
+- Nixpkgs Release Notes
+  - [ ] Package update: when the change is major or breaking.
+- NixOS Release Notes
+  - [ ] Module addition: when adding a new NixOS module.
+  - [ ] Module update: when the change is significant.
+- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.
 
-[NixOS test(s)]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
-[package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
+[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
+[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
 [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
 
 [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
The current template is just way too long to be useful. It's especially hard to read while still drafting the PR in the textbox. This PR improves this. Yes, some things are cut short, but we don't need to cover everything in this template. That's why we have the contribution guidelines. And we all know that we must regularly point to these guidelines anyway, so leaving a few details out here won't make a big difference that way. But it will make a big difference for readability.

TODO:
- ~~[ ] The first commit needs adjustment on r-ryantm's side, where the footer is already added as well: https://github.com/nix-community/nixpkgs-update/pull/481~~

## Things done

<!-- Please check what applies. Not all of these are hard requirements. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested:
  - [ ] [NixOS test][1] in [nixos/tests][2]
  - [ ] [package tests][3] at `passthru.tests`
  - [ ] tests in [lib/tests][4] or [pkgs/test][5] for functions and "core" functionality
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage][7].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [Nixpkgs 25.11 Release Notes][nixpkgs-25.11]
  - [ ] Package update: when the change is major or breaking.
- [NixOS 25.11 Release Notes][nixos-25.11]
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md][A], [pkgs/README.md][B], [maintainers/README.md][C] and others READMEs.

[1]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[2]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[3]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[4]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[5]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[6]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package
[7]: https://github.com/Mic92/nixpkgs-review#usage

[nixos-25.11]: https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md
[nixpkgs-25.11]: https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md

[A]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[B]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[C]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
