### PR TITLE
gerbolyze: use pyproject = true, clean up

### DIFF
--- a/pkgs/by-name/ge/gerbolyze/package.nix
+++ b/pkgs/by-name/ge/gerbolyze/package.nix
@@ -23,18 +23,11 @@ let
 
     sourceRoot = "${src.name}/svg-flatten";
 
-    postPatch = ''
-      substituteInPlace Makefile \
-        --replace "$(INSTALL) $(BUILDDIR)/$(BINARY) $(PREFIX)/bin" \
-        "$(INSTALL) $(BUILDDIR)/$(BINARY) $(PREFIX)/bin/svg-flatten" \
+    preInstall = ''
+      mkdir -p $out/bin
     '';
 
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/bin
-      PREFIX=$out make install
-      runHook postInstall
-    '';
+    installFlags = [ "PREFIX=$(out)" ];
 
     meta = with lib; {
       description = "svg-flatten SVG downconverter";
@@ -49,35 +42,34 @@ in
 python3Packages.buildPythonApplication rec {
   inherit version src;
   pname = "gerbolyze";
+  pyproject = true;
 
-  format = "setuptools";
+  build-system = with python3Packages; [ setuptools ];
 
-  nativeBuildInputs = [
-    python3Packages.setuptools
+  pythonRemoveDeps = [
+    # we already provide svg-flatten through a binary on the PATH
+    "svg-flatten-wasi"
   ];
 
-  propagatedBuildInputs = [
-    python3Packages.beautifulsoup4
-    python3Packages.click
-    python3Packages.numpy
-    python3Packages.scipy
-    python3Packages.python-slugify
-    python3Packages.lxml
-    python3Packages.gerbonara
-    resvg
-    svg-flatten
+  dependencies = with python3Packages; [
+    beautifulsoup4
+    click
+    numpy
+    python-slugify
+    lxml
+    gerbonara
   ];
 
   preConfigure = ''
     # setup.py tries to execute a call to git in a subprocess, this avoids it.
     substituteInPlace setup.py \
-      --replace "version = get_version()," \
-                "version = '${version}'," \
+      --replace-fail "version = get_version()," \
+                     "version = '${version}'," \
 
     # setup.py tries to execute a call to git in a subprocess, this avoids it.
     substituteInPlace setup.py \
-      --replace "long_description=format_readme_for_pypi()," \
-                "long_description='\n'.join(Path('README.rst').read_text().splitlines()),"
+      --replace-fail "long_description=format_readme_for_pypi()," \
+                     "long_description='\n'.join(Path('README.rst').read_text().splitlines()),"
   '';
 
   pythonImportsCheck = [ "gerbolyze" ];
@@ -86,6 +78,15 @@ python3Packages.buildPythonApplication rec {
     python3Packages.pytestCheckHook
     resvg
     svg-flatten
+  ];
+
+  makeWrapperArgs = [
+    "--prefix PATH: ${
+      lib.makeBinPath [
+        resvg
+        svg-flatten
+      ]
+    }"
   ];
 
   passthru.updateScript = gitUpdater {


### PR DESCRIPTION
For `svg-flatten`:
The patch didn't actually apply (because `$()` inside double quotes actually just runs commands. If single quotes were used, it would have worked).
That patch wasn't really necessary anyways: the thing that made the installation work was `mkdir -p $out/bin`.

In any case, I also removed the custom install phase, and used `preInstall` + `installFlags` instead.

For the main package:

I migrated to use `pyproject = true` with setuptools explicitly added as a build-time dependency.

The new logic has stricter dependency check: it tries to make sure every listed dependency is actually installed.
`svg-flatten-wasi` is supposed to be just optional, but was declared as a dependency so I removed it.
Also, `scipy` no longer seemed to be a requirement.

I moved the python packages from `propagatedBuildInputs` to `dependencies`.

The non-python packages were moved to `makeWrapperArgs` to explicitly show that they are just used from the PATH.
(I know this is the same as if I just kept them in `propagatedBuildInputs`, but AFAICT that logic was only supposed to be used by python packages)

Also, I used `--replace-fail` instead of `--replace`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
