### PR TITLE
cxxmatrix: init at 0-unstable-2024-06-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7553,6 +7553,12 @@
     name = "Zhenbo Li";
     matrix = "@zhenbo:matrix.org";
   };
+  enk-it = {
+    email = "gladysh.danil@gmail.com";
+    github = "enk-it";
+    githubId = 107684176;
+    name = "Gladysh Daniil";
+  };
   enorris = {
     name = "Eric Norris";
     email = "erictnorris@gmail.com";

--- a/pkgs/by-name/cx/cxxmatrix/package.nix
+++ b/pkgs/by-name/cx/cxxmatrix/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gawk,
+}:
+
+stdenv.mkDerivation {
+  pname = "cxxmatrix";
+  version = "0-unstable-2024-06-17";
+
+  src = fetchFromGitHub {
+    owner = "akinomyoga";
+    repo = "cxxmatrix";
+    rev = "c8d4ecfb8b6c22bb93f3e10a9d203209ba193591";
+    hash = "sha256-5f0frZc5okqBhSU5wuv33DflvK9enBjmTSaUviaAFGo=";
+  };
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  buildInputs = [ gawk ];
+
+  meta = {
+    description = "C++ Matrix: The Matrix Reloaded in Terminals (Number falls, Banners, Matrix rains, Conway's Game of Life and Mandelbrot set)";
+    homepage = "https://github.com/akinomyoga/cxxmatrix";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ enk-it ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Things done

I've been using this little project when i was on archlinux and missed it a lot on nixos, so i decided to maintain it here. I've added myself to contributors, added cxxmatrix/package.nix in corresponding directory and tried building it with
```sh
nix-env -f . -iA cxxmatrix
```
in the root of my nixpkgs fork.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
