### PR TITLE
radiotray-ng: 0.2.8 -> 0.2.9; fix build

### DIFF
--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -55,8 +55,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ebruck";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-rRD/IfVnOxowr2mO2BB2hcHK5ByZSmTbcgYdULogYUs=";
+    tag = "v${version}";
+    hash = "sha256-rRD/IfVnOxowr2mO2BB2hcHK5ByZSmTbcgYdULogYUs=";
   };
 
   nativeBuildInputs = [
@@ -119,11 +119,11 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/rt2rtng --prefix PYTHONPATH : $PYTHONPATH
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Internet radio player for linux";
     homepage = "https://github.com/ebruck/radiotray-ng";
-    license = licenses.gpl3;
+    license = lib.licenses.gpl3;
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   # Transport
@@ -51,13 +50,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "radiotray-ng";
-  version = "0.2.8";
+  version = "0.2.9";
 
   src = fetchFromGitHub {
     owner = "ebruck";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-/0GlQdSsIPKGrDT9CgxvaH8TpAbqxFduwL2A2+BSrEI=";
+    sha256 = "sha256-rRD/IfVnOxowr2mO2BB2hcHK5ByZSmTbcgYdULogYUs=";
   };
 
   nativeBuildInputs = [
@@ -89,11 +88,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./no-dl-googletest.patch
-    (fetchpatch {
-      name = "gcc13-fixes.patch";
-      url = "https://github.com/ebruck/radiotray-ng/commit/7a99bfa784f77be8f160961d25ab63dc2d5ccde0.patch";
-      hash = "sha256-7x3v0dp9WPgd/vsnxezgXIZGsBrIHkTwIiu+FMlLmyA=";
-    })
+    ./tests-c++17.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/audio/radiotray-ng/no-dl-googletest.patch
+++ b/pkgs/applications/audio/radiotray-ng/no-dl-googletest.patch
@@ -1,27 +1,18 @@
-From b6f7a9e2e0194c6baed63a33b7beff359080b8d9 Mon Sep 17 00:00:00 2001
-From: Will Dietz <w@wdtz.org>
-Date: Sat, 16 Mar 2019 11:40:00 -0500
-Subject: [PATCH] don't download googletest
-
----
- CMakeLists.txt       | 18 ------------------
- tests/CMakeLists.txt |  1 -
- 2 files changed, 19 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ddba1be..3396705 100644
+index 5338579..a28e58f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -70,25 +70,7 @@ endif()
- 
+@@ -92,25 +92,7 @@ endif()
+
  # build tests? Then we need googletest...
  if (BUILD_TESTS)
 -    include(ExternalProject)
 -
 -    ExternalProject_Add(googletest
 -        PREFIX "${CMAKE_CURRENT_BINARY_DIR}/googletest"
--        URL https://github.com/google/googletest/archive/release-1.8.1.tar.gz
--        URL_HASH SHA256=9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c
+-        URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
+-        URL_HASH SHA256=7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
+-        DOWNLOAD_EXTRACT_TIMESTAMP true
 -        TIMEOUT 30
 -        DOWNLOAD_NO_PROGRESS true
 -        INSTALL_COMMAND "")
@@ -29,27 +20,23 @@ index ddba1be..3396705 100644
 -    ExternalProject_Get_Property(googletest SOURCE_DIR)
 -    include_directories(${SOURCE_DIR}/googlemock/include ${SOURCE_DIR}/googletest/include)
 -    ExternalProject_Get_Property(googletest BINARY_DIR)
--    link_directories(${BINARY_DIR}/googlemock ${BINARY_DIR}/googlemock/gtest)
+-    link_directories(${BINARY_DIR}/lib)
      set(GMOCK_BOTH_LIBRARIES gmock_main gmock gtest)
 -    set_property(DIRECTORY PROPERTY CLEAN_NO_CUSTOM "${CMAKE_CURRENT_BINARY_DIR}/googletest")
 -    unset(SOURCE_DIR)
 -    unset(BINARY_DIR)
--
+
      enable_testing()
      add_subdirectory(tests)
-     add_subdirectory(tests/runners/)
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
 index 859c048..58ab5c2 100644
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
 @@ -2,7 +2,6 @@ include(GoogleTest)
- 
+
  function(add_gmock_test target)
      add_executable(${target} ${ARGN})
 -    add_dependencies(${target} googletest)
      target_link_libraries(${target} config playlist bookmarks event_bus ${GMOCK_BOTH_LIBRARIES} ${XDG_BASEDIR_LIBRARIES} ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${JSONCPP_LIBRARIES} pthread)
      target_include_directories(${target} PRIVATE ${JSONCPP_INCLUDE_DIRS})
      gtest_discover_tests(${target})
--- 
-2.22.0
-

--- a/pkgs/applications/audio/radiotray-ng/tests-c++17.patch
+++ b/pkgs/applications/audio/radiotray-ng/tests-c++17.patch
@@ -1,0 +1,25 @@
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 58ab5c2..4f56a25 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -1,5 +1,7 @@
+ include(GoogleTest)
+ 
++set(CMAKE_CXX_STANDARD 17)
++
+ function(add_gmock_test target)
+     add_executable(${target} ${ARGN})
+     target_link_libraries(${target} config playlist bookmarks event_bus ${GMOCK_BOTH_LIBRARIES} ${XDG_BASEDIR_LIBRARIES} ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${JSONCPP_LIBRARIES} pthread)
+diff --git a/tests/bookmarks_test.cpp b/tests/bookmarks_test.cpp
+index 2d72356..97f898a 100644
+--- a/tests/bookmarks_test.cpp
++++ b/tests/bookmarks_test.cpp
+@@ -215,7 +215,7 @@ TEST(Bookmarks, test_that_stations_are_added_and_removed_from_a_group_and_moved)
+ 	ASSERT_FALSE(bm[0].stations[0].notifications);
+ 
+ 	// vector only throws when using at()
+-	EXPECT_THROW(bm[0].stations.at(100), std::out_of_range);
++	EXPECT_THROW(static_cast<void>(bm[0].stations.at(100)), std::out_of_range);
+ 	EXPECT_THROW(bm[1], std::out_of_range);
+ }
+ 


### PR DESCRIPTION
Closes #425752

Changelog: https://github.com/ebruck/radiotray-ng/releases/tag/v0.2.9

Seems to work fine:
<img width="410" height="566" alt="image" src="https://github.com/user-attachments/assets/9c1cd9ec-2a32-43d2-a7c6-8f96afc1d227" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
