### PR TITLE
WIP: jdk-dashboard

### DIFF
--- a/maintainers/scripts/jdk-dashboard.nix
+++ b/maintainers/scripts/jdk-dashboard.nix
@@ -1,0 +1,107 @@
+let
+  pkgs = import <nixpkgs> { };
+  lib = pkgs.lib;
+
+  jdkPackages = {
+    corretto = {
+      hasDefault = false;
+      versions = [
+        "11"
+        "17"
+        "21"
+      ];
+    };
+    #     jetbrains.jdk = {
+    #       hasDefault = false;
+    #       versions = [ "11" "17" "21"];
+    #     };
+    # graalvmPackages.graalvm-ce
+    #     graalvm-ce = {
+    #       hasDefault = true;
+    #       versions = [];
+    #     };
+    # graalvmPackages.graalvm-oracle
+    #     graalvm-oracle = {
+    #       hasDefault = true;
+    #       versions = [ "_17"];
+    #     };
+    openjdk = {
+      hasDefault = true;
+      versions = [
+        "11"
+        "17"
+        "21"
+        "24"
+      ];
+    };
+    semeru-bin = {
+      hasDefault = true;
+      # -8 is unsupported on aarch64-darwin where I'm developing
+      versions = [
+        "-11"
+        "-17"
+        "-21"
+      ];
+    };
+    semeru-jre-bin = {
+      hasDefault = true;
+      # -8 is unsupported on aarch64-darwin where I'm developing
+      versions = [
+        "-11"
+        "-17"
+        "-21"
+      ];
+    };
+    temurin-bin = {
+      hasDefault = true;
+      versions = [
+        "-23"
+        "-24"
+      ];
+    };
+    temurin-jre-bin = {
+      hasDefault = true;
+      # -8 is unsupported on aarch64-darwin where I'm developing
+      versions = [
+        "-11"
+        "-17"
+        "-21"
+        "-23"
+        "-24"
+      ];
+    };
+    zulu = {
+      hasDefault = true;
+      versions = [
+        "11"
+        "17"
+        "21"
+        "24"
+      ];
+    };
+  };
+
+  getVersion =
+    name:
+    let
+      pkg = builtins.getAttr name pkgs;
+    in
+    pkg.version or (pkg.meta.version or "unknown");
+
+  flattenVersions =
+    attrset:
+    lib.flatten (
+      lib.mapAttrsToList (name: value: lib.map (version: "${name}${version}") value.versions) attrset
+    );
+
+  flatPackages = flattenVersions jdkPackages;
+
+  versionMap = builtins.listToAttrs (
+    builtins.map (name: {
+      inherit name;
+      value = getVersion name;
+    }) flatPackages
+  );
+
+in
+versionMap

--- a/maintainers/scripts/jdk-dashboard.sh
+++ b/maintainers/scripts/jdk-dashboard.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+nix-instantiate --eval --strict --json "$(dirname "$0")"/jdk-dashboard.nix
+


### PR DESCRIPTION
This is *very* early work on a proof-of-concept for Issue #425860.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
