### PR TITLE
readstat: fix build failure

### DIFF
--- a/pkgs/by-name/re/readstat/package.nix
+++ b/pkgs/by-name/re/readstat/package.nix
@@ -5,7 +5,7 @@
   fetchpatch,
   autoreconfHook,
   pkg-config,
-  libiconv,
+  libtool,
 }:
 
 stdenv.mkDerivation rec {
@@ -20,6 +20,14 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Remove `gettext` requirement
+    # https://github.com/WizardMac/ReadStat/issues/341
+    (fetchpatch {
+      url = "https://github.com/WizardMac/ReadStat/pull/342/commits/b5512b32d3b3c39e2f0c322df1339a3c61f73712.patch";
+      hash = "sha256-k1yeplrx3pFPl5qzLfsAaj+qunv1BqOZypA05xSolaQ=";
+    })
+
+    # Add (void) to remove -Wstrict-prototypes warnings
     (fetchpatch {
       url = "https://github.com/WizardMac/ReadStat/commit/211c342a1cfe46fb7fb984730dd7a29ff4752f35.patch";
       hash = "sha256-nkaEgusylVu7NtzSzBklBuOnqO9qJPovf0qn9tTE6ls=";
@@ -36,9 +44,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    libtool
   ];
-
-  buildInputs = [ libiconv ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Related: https://github.com/NixOS/nixpkgs/pull/405793

Build failure in Hydra https://hydra.nixos.org/eval/1816863?filter=readstat&compare=1816860&full=

> libtoolize: Consider adding '-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
> autoreconf: configure.ac: not using Intltool
> autoreconf: configure.ac: not using Gtkdoc
> autoreconf: running: aclocal --force
> configure.ac:43: warning: macro 'AM_ICONV' not found in library
> autoreconf: running: /nix/store/lsy7k7f43r9kwpgjh70siy1l15kv1jds-autoconf-2.72/bin/autoconf --force
> configure.ac:43: error: possibly undefined macro: AM_ICONV
>       If this token and others are legitimate, please use m4_pattern_allow.
>       See the Autoconf documentation.
> autoreconf: error: /nix/store/lsy7k7f43r9kwpgjh70siy1l15kv1jds-autoconf-2.72/bin/autoconf failed with exit status: 1

gettext 0.25 has been breaking older autoconf setups. Turns out we don't need it, it was there to supply `iconv()` which the app isn't using.

### Changes

1. File upstream bug and patch. Apply patch.
2. Fix invocation of `autoreconf` to find `m4`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
