### PR TITLE
nomachine-client: 8.13.1 -> 9.1.24

### DIFF
--- a/pkgs/by-name/no/nomachine-client/package.nix
+++ b/pkgs/by-name/no/nomachine-client/package.nix
@@ -9,10 +9,10 @@
   libpulseaudio,
 }:
 let
-  versionMajor = "8.13";
-  versionMinor = "1";
-  versionBuild_x86_64 = "1";
-  versionBuild_i686 = "1";
+  versionMajor = "9.0";
+  versionMinor = "188";
+  versionBuild_x86_64 = "11";
+  versionBuild_i686 = "11";
 in
 stdenv.mkDerivation rec {
   pname = "nomachine-client";
@@ -22,12 +22,12 @@ stdenv.mkDerivation rec {
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
-        sha256 = "sha256-8rxlxdtGU8avpvYJr+bpnsy5v91sqtlij/MCGWrcanY=";
+        sha256 = "sha256-+p8gSHqP6HTcrw0sMsD5WIPliiYzyQOUAF3lLABDmdA=";
       }
     else if stdenv.hostPlatform.system == "i686-linux" then
       fetchurl {
         url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
-        sha256 = "sha256-Ekyxc4wODjqWhp0aINhaPGLy9lh6Rt9AmxIt1ulE8Go=";
+        sha256 = "sha256-kibteY8UR32w6n3rfRagc+uvrZIifxP16BCB6AwJY08=";
       }
     else
       throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";

--- a/pkgs/by-name/no/nomachine-client/package.nix
+++ b/pkgs/by-name/no/nomachine-client/package.nix
@@ -9,10 +9,10 @@
   libpulseaudio,
 }:
 let
-  versionMajor = "9.0";
-  versionMinor = "188";
-  versionBuild_x86_64 = "11";
-  versionBuild_i686 = "11";
+  versionMajor = "9.1";
+  versionMinor = "24";
+  versionBuild_x86_64 = "6";
+  versionBuild_i686 = "6";
 in
 stdenv.mkDerivation rec {
   pname = "nomachine-client";
@@ -22,12 +22,12 @@ stdenv.mkDerivation rec {
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
-        sha256 = "sha256-+p8gSHqP6HTcrw0sMsD5WIPliiYzyQOUAF3lLABDmdA=";
+        sha256 = "sha256-y5w2kcs0KEiYwFyglRgLIFYgqnmHATF6/Y8zm9aDnx8=";
       }
     else if stdenv.hostPlatform.system == "i686-linux" then
       fetchurl {
         url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
-        sha256 = "sha256-kibteY8UR32w6n3rfRagc+uvrZIifxP16BCB6AwJY08=";
+        sha256 = "sha256-60GobS5cOKfsnx8prm5oOYHTcw5iNIFHqfeBMAYFXns=";
       }
     else
       throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";


### PR DESCRIPTION
<!--
^ Made changes to package.nix to build nomachine-client 9.0.188 - nixpkgs currently has version 8.13.1 ^

Key features in this version 9 are:
NoMachine Network
Two-factor authentication
Integrated VPN out-of-the-box
New Cloud Server Cluster and Enterprise Terminal Server Cluster 
Tunnel all traffic through the Cloud Server

-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
