### PR TITLE
urh: 2.9.8 -> 2.9.8-unstable-2025-07-07

### DIFF
--- a/pkgs/by-name/ur/urh/package.nix
+++ b/pkgs/by-name/ur/urh/package.nix
@@ -20,7 +20,7 @@
 python3Packages.buildPythonApplication rec {
   pname = "urh";
   version = "2.9.8-unstable-2025-07-07";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jopohl";
@@ -28,6 +28,8 @@ python3Packages.buildPythonApplication rec {
     rev = "9061187d326f39de126dd1b8cc943aa33c36ae8d";
     hash = "sha256-MjgEa33geZ8Icn7H/Zxvux6rMnSOFcMuwG5n/5cwuMI=";
   };
+
+  build-system = [ python3Packages.setuptools ];
 
   nativeBuildInputs = [
     qt5.wrapQtAppsHook
@@ -46,7 +48,7 @@ python3Packages.buildPythonApplication rec {
     ++ lib.optional USRPSupport uhd
     ++ lib.optional stdenv.hostPlatform.isLinux qt5.qtwayland;
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     pyqt5
     numpy
     psutil
@@ -87,11 +89,11 @@ python3Packages.buildPythonApplication rec {
     install -Dm644 data/icons/appicon.png $out/share/pixmaps/urh.png
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/jopohl/urh";
     description = "Universal Radio Hacker: investigate wireless protocols like a boss";
-    license = licenses.gpl3;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ fpletz ];
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ fpletz ];
   };
 }

--- a/pkgs/by-name/ur/urh/package.nix
+++ b/pkgs/by-name/ur/urh/package.nix
@@ -9,7 +9,6 @@
   limesuite,
   libiio,
   libbladeRF,
-  imagemagick,
   makeDesktopItem,
   copyDesktopItems,
   qt5,
@@ -20,14 +19,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "urh";
-  version = "2.9.8";
+  version = "2.9.8-unstable-2025-07-07";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "jopohl";
     repo = "urh";
-    tag = "v${version}";
-    hash = "sha256-r3d80dzGwgf5Tuwt1IWGcmNbblwBNKTKKm+GGx1r2HE=";
+    rev = "9061187d326f39de126dd1b8cc943aa33c36ae8d";
+    hash = "sha256-MjgEa33geZ8Icn7H/Zxvux6rMnSOFcMuwG5n/5cwuMI=";
   };
 
   nativeBuildInputs = [
@@ -49,7 +48,7 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [
     pyqt5
-    numpy_1
+    numpy
     psutil
     cython
     pyzmq


### PR DESCRIPTION
Closes #425439

Diff: https://github.com/jopohl/urh/compare/v2.9.8..9061187d326f39de126dd1b8cc943aa33c36ae8d

Latest master has fixed compatibility with numpy2. We could either manually apply all the patches, make a patch ourselves or just follow unstable until a new version is released. I've decided to go with the latter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
