### PR TITLE
lldap: document settings related to passwords and secrets

### DIFF
--- a/nixos/tests/lldap.nix
+++ b/nixos/tests/lldap.nix
@@ -1,4 +1,7 @@
 { ... }:
+let
+  adminPassword = "mySecretPassword";
+in
 {
   name = "lldap";
 
@@ -7,23 +10,74 @@
     {
       services.lldap = {
         enable = true;
+
         settings = {
           verbose = true;
           ldap_base_dn = "dc=example,dc=com";
         };
       };
       environment.systemPackages = [ pkgs.openldap ];
+
+      specialisation = {
+        differentAdminPassword.configuration =
+          { ... }:
+          {
+            services.lldap.settings = {
+              ldap_user_pass_file = toString (pkgs.writeText "adminPasswordFile" adminPassword);
+              force_ldap_user_pass_reset = "always";
+            };
+          };
+
+        changeAdminPassword.configuration =
+          { ... }:
+          {
+            services.lldap.settings = {
+              ldap_user_pass_file = toString (pkgs.writeText "adminPasswordFile" "password");
+              force_ldap_user_pass_reset = false;
+            };
+          };
+      };
     };
 
-  testScript = ''
-    machine.wait_for_unit("lldap.service")
-    machine.wait_for_open_port(3890)
-    machine.wait_for_open_port(17170)
+  testScript =
+    { nodes, ... }:
+    let
+      specializations = "${nodes.machine.system.build.toplevel}/specialisation";
+    in
+    ''
+      machine.wait_for_unit("lldap.service")
+      machine.wait_for_open_port(3890)
+      machine.wait_for_open_port(17170)
 
-    machine.succeed("curl --location --fail http://localhost:17170/")
+      machine.succeed("curl --location --fail http://localhost:17170/")
 
-    print(
-      machine.succeed('ldapsearch -H ldap://localhost:3890 -D uid=admin,ou=people,dc=example,dc=com -b "ou=people,dc=example,dc=com" -w password')
-    )
-  '';
+      adminPassword="${adminPassword}"
+
+      def try_login(user, password, expect_success=True):
+          cmd = f'ldapsearch -H ldap://localhost:3890 -D uid={user},ou=people,dc=example,dc=com -b "ou=people,dc=example,dc=com" -w {password}'
+          code, response = machine.execute(cmd)
+          print(cmd)
+          print(response)
+          if expect_success:
+              if code != 0:
+                  raise Exception(f"Expected success, had failure {code}")
+          else:
+              if code == 0:
+                  raise Exception("Expected failure, had success")
+          return response
+
+      with subtest("default admin password"):
+          try_login("admin", "password",    expect_success=True)
+          try_login("admin", adminPassword, expect_success=False)
+
+      with subtest("different admin password"):
+          machine.succeed('${specializations}/differentAdminPassword/bin/switch-to-configuration test')
+          try_login("admin", "password",    expect_success=False)
+          try_login("admin", adminPassword, expect_success=True)
+
+      with subtest("change admin password has no effect"):
+          machine.succeed('${specializations}/differentAdminPassword/bin/switch-to-configuration test')
+          try_login("admin", "password",    expect_success=False)
+          try_login("admin", adminPassword, expect_success=True)
+    '';
 }


### PR DESCRIPTION
Provides first class support for secrets used by LLDAP: the admin password and the jwt secret. Also provides first class support for the option to replace the secrets on each service start.

This PR precedes PR https://github.com/NixOS/nixpkgs/pull/425923 which adds first class support for the LLDAP [bootstrap](https://github.com/lldap/lldap/blob/main/example_configs/bootstrap/bootstrap.md) script.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
