### PR TITLE
 lldap-bootstrap: init 0.6.2, lldap: add ensure options 

### DIFF
--- a/nixos/tests/lldap.nix
+++ b/nixos/tests/lldap.nix
@@ -1,6 +1,9 @@
 { ... }:
 let
   adminPassword = "mySecretPassword";
+  alicePassword = "AlicePassword";
+  bobPassword = "BobPassword";
+  charliePassword = "CharliePassword";
 in
 {
   name = "lldap";
@@ -26,7 +29,7 @@ in
           {
             services.lldap.settings = {
               ldap_user_pass = lib.mkForce null;
-              ldap_user_pass_file = lib.mkForce (toString (pkgs.writeText "adminPasswordFile" adminPassword));
+              ldap_user_pass_file = toString (pkgs.writeText "adminPasswordFile" adminPassword);
               force_ldap_user_pass_reset = "always";
             };
           };
@@ -40,13 +43,110 @@ in
               force_ldap_user_pass_reset = false;
             };
           };
+
+        withAlice.configuration =
+          { ... }:
+          {
+            services.lldap = {
+              enforceUsers = true;
+              enforceUserMemberships = true;
+              enforceGroups = true;
+
+              # This password was set in the "differentAdminPassword" specialisation.
+              ensureAdminPasswordFile = toString (pkgs.writeText "adminPasswordFile" adminPassword);
+
+              ensureUsers = {
+                alice = {
+                  email = "alice@example.com";
+                  password_file = toString (pkgs.writeText "alicePasswordFile" alicePassword);
+                  groups = [ "mygroup" ];
+                };
+              };
+
+              ensureGroups = {
+                mygroup = { };
+              };
+            };
+          };
+
+        withBob.configuration =
+          { ... }:
+          {
+            services.lldap = {
+              enforceUsers = true;
+              enforceUserMemberships = true;
+              enforceGroups = true;
+
+              # This time we check that ensureAdminPasswordFile correctly defaults to `settings.ldap_user_pass_file`
+              settings = {
+                ldap_user_pass = lib.mkForce "password";
+                force_ldap_user_pass_reset = "always";
+              };
+
+              ensureUsers = {
+                bob = {
+                  email = "bob@example.com";
+                  password_file = toString (pkgs.writeText "bobPasswordFile" bobPassword);
+                  groups = [ "bobgroup" ];
+                  displayName = "Bob";
+                };
+              };
+
+              ensureGroups = {
+                bobgroup = { };
+              };
+            };
+          };
+
+        withAttributes.configuration =
+          { ... }:
+          {
+            services.lldap = {
+              enforceUsers = true;
+              enforceUserMemberships = true;
+              enforceGroups = true;
+
+              settings = {
+                ldap_user_pass = lib.mkForce adminPassword;
+                force_ldap_user_pass_reset = "always";
+              };
+
+              ensureUsers = {
+                charlie = {
+                  email = "charlie@example.com";
+                  password_file = toString (pkgs.writeText "charliePasswordFile" charliePassword);
+                  groups = [ "othergroup" ];
+                  displayName = "Charlie";
+                  myattribute = 2;
+                };
+              };
+
+              ensureGroups = {
+                othergroup = {
+                  mygroupattribute = "Managed by NixOS";
+                };
+              };
+
+              ensureUserFields = {
+                myattribute = {
+                  attributeType = "INTEGER";
+                };
+              };
+
+              ensureGroupFields = {
+                mygroupattribute = {
+                  attributeType = "STRING";
+                };
+              };
+            };
+          };
       };
     };
 
   testScript =
     { nodes, ... }:
     let
-      specializations = "${nodes.machine.system.build.toplevel}/specialisation";
+      specialisations = "${nodes.machine.system.build.toplevel}/specialisation";
     in
     ''
       machine.wait_for_unit("lldap.service")
@@ -56,6 +156,9 @@ in
       machine.succeed("curl --location --fail http://localhost:17170/")
 
       adminPassword="${adminPassword}"
+      alicePassword="${alicePassword}"
+      bobPassword="${bobPassword}"
+      charliePassword="${charliePassword}"
 
       def try_login(user, password, expect_success=True):
           cmd = f'ldapsearch -H ldap://localhost:3890 -D uid={user},ou=people,dc=example,dc=com -b "ou=people,dc=example,dc=com" -w {password}'
@@ -70,18 +173,50 @@ in
                   raise Exception("Expected failure, had success")
           return response
 
+      def parse_ldapsearch_output(output):
+          return {n:v for (n, v) in (x.split(': ', 2) for x in output.splitlines() if x != "")}
+
       with subtest("default admin password"):
           try_login("admin", "password",    expect_success=True)
           try_login("admin", adminPassword, expect_success=False)
 
       with subtest("different admin password"):
-          machine.succeed('${specializations}/differentAdminPassword/bin/switch-to-configuration test')
+          machine.succeed('${specialisations}/differentAdminPassword/bin/switch-to-configuration test')
           try_login("admin", "password",    expect_success=False)
           try_login("admin", adminPassword, expect_success=True)
 
       with subtest("change admin password has no effect"):
-          machine.succeed('${specializations}/differentAdminPassword/bin/switch-to-configuration test')
+          machine.succeed('${specialisations}/differentAdminPassword/bin/switch-to-configuration test')
           try_login("admin", "password",    expect_success=False)
           try_login("admin", adminPassword, expect_success=True)
+
+      with subtest("with alice"):
+          machine.succeed('${specialisations}/withAlice/bin/switch-to-configuration test')
+          try_login("alice", "password",    expect_success=False)
+          try_login("alice", alicePassword, expect_success=True)
+          try_login("bob",   "password",    expect_success=False)
+          try_login("bob",   bobPassword,   expect_success=False)
+
+      with subtest("with bob"):
+          machine.succeed('${specialisations}/withBob/bin/switch-to-configuration test')
+          try_login("alice", "password",    expect_success=False)
+          try_login("alice", alicePassword, expect_success=False)
+          try_login("bob",   "password",    expect_success=False)
+          try_login("bob",   bobPassword,   expect_success=True)
+
+      with subtest("with attributes"):
+          machine.succeed('${specialisations}/withAttributes/bin/switch-to-configuration test')
+
+          response = machine.succeed(f'ldapsearch -LLL -H ldap://localhost:3890 -D uid=admin,ou=people,dc=example,dc=com -b "dc=example,dc=com" -w {adminPassword} "(uid=charlie)"')
+          print(response)
+          charlie = parse_ldapsearch_output(response)
+          if charlie.get('myattribute') != "2":
+              raise Exception(f'Unexpected value for attribute "myattribute": {charlie.get('myattribute')}')
+
+          response = machine.succeed(f'ldapsearch -LLL -H ldap://localhost:3890 -D uid=admin,ou=people,dc=example,dc=com -b "dc=example,dc=com" -w {adminPassword} "(cn=othergroup)"')
+          print(response)
+          othergroup = parse_ldapsearch_output(response)
+          if othergroup.get('mygroupattribute') != "Managed by NixOS":
+              raise Exception(f'Unexpected value for attribute "mygroupattribute": {othergroup.get('mygroupattribute')}')
     '';
 }

--- a/pkgs/by-name/ll/lldap-bootstrap/package.nix
+++ b/pkgs/by-name/ll/lldap-bootstrap/package.nix
@@ -1,0 +1,57 @@
+{
+  curl,
+  fetchFromGitHub,
+  jq,
+  jo,
+  lib,
+  lldap,
+  lldap-bootstrap,
+  makeWrapper,
+  stdenv,
+}:
+let
+  version = "0.6.2";
+in
+stdenv.mkDerivation {
+  pname = "lldap-bootstrap";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "lldap";
+    repo = "lldap";
+    rev = "v${version}";
+    hash = "sha256-UBQWOrHika8X24tYdFfY8ETPh9zvI7/HV5j4aK8Uq+Y=";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./scripts/bootstrap.sh $out/bin/lldap-bootstrap
+
+    wrapProgram $out/bin/lldap-bootstrap \
+      --set LLDAP_SET_PASSWORD_PATH ${lldap}/bin/lldap_set_password \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          curl
+          jq
+          jo
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Bootstrap script for LLDAP";
+    homepage = "https://github.com/lldap/lldap";
+    changelog = "https://github.com/lldap/lldap/blob/v${lldap-bootstrap.version}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      bendlas
+      ibizaman
+    ];
+    mainProgram = "lldap-bootstrap";
+  };
+}


### PR DESCRIPTION
~This PR requires https://github.com/NixOS/nixpkgs/pull/425912 and https://github.com/NixOS/nixpkgs/pull/425918 to be merged first.~ EDIT: Done!

This PR adds support for the bootstrap script provided in LLDAP.

~It relies on a not yet merged upstream PR https://github.com/lldap/lldap/pull/1218.~ ~It relies on another PR https://github.com/lldap/lldap/pull/1223. That's why the `lldap-bootstrap` script still relies on my fork of LLDAP.~ EDIT: all upstream PRs are merged. The PR adds support for specifying the password as a path to a file, instead of embedding it directly in the json file. This is best practice.

I explained what I though was important in comments, but I could've missed something.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
