### PR TITLE
python3Packages.click: 8.1.8 -> 8.2.1

### DIFF
--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -4,7 +4,6 @@
   pythonOlder,
   fetchFromGitHub,
   pytestCheckHook,
-  less,
 
   # large-rebuild downstream dependencies and applications
   flask,
@@ -33,44 +32,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    less
   ];
 
   disabledTests = [
-    # test fails with filename normalization on zfs
-    "test_file_surrogates"
     # for some reason the tests fail to execute cat, even though they run with less just fine,
     # even adding coreutils to nativeCheckInputs explicitly does not change anything
-    "test_echo_via_pager[test0-cat]"
-    "test_echo_via_pager[test0-cat ]"
-    "test_echo_via_pager[test0- cat ]"
-    "test_echo_via_pager[test1-cat]"
-    "test_echo_via_pager[test1-cat ]"
-    "test_echo_via_pager[test1- cat ]"
-    "test_echo_via_pager[test2-cat]"
-    "test_echo_via_pager[test2-cat ]"
-    "test_echo_via_pager[test2- cat ]"
-    "test_echo_via_pager[test3-cat]"
-    "test_echo_via_pager[test3-cat ]"
-    "test_echo_via_pager[test3- cat ]"
-    "test_echo_via_pager[test4-cat]"
-    "test_echo_via_pager[test4-cat ]"
-    "test_echo_via_pager[test4- cat ]"
-    "test_echo_via_pager[test5-cat]"
-    "test_echo_via_pager[test5-cat ]"
-    "test_echo_via_pager[test5- cat ]"
-    "test_echo_via_pager[test6-cat]"
-    "test_echo_via_pager[test6-cat ]"
-    "test_echo_via_pager[test6- cat ]"
-    "test_echo_via_pager[test7-cat]"
-    "test_echo_via_pager[test7-cat ]"
-    "test_echo_via_pager[test7- cat ]"
-    "test_echo_via_pager[test8-cat]"
-    "test_echo_via_pager[test8-cat ]"
-    "test_echo_via_pager[test8- cat ]"
-    "test_echo_via_pager[test9-cat]"
-    "test_echo_via_pager[test9-cat ]"
-    "test_echo_via_pager[test9- cat ]"
+    "test_echo_via_pager"
   ];
 
   passthru.tests = {


### PR DESCRIPTION
Updates Click to 8.2.1. Diff: https://github.com/pallets/click/compare/refs/tags/8.1.8...refs/tags/8.2.0

Release notes:
- https://github.com/pallets/click/releases/tag/8.2.0
- https://github.com/pallets/click/releases/tag/8.2.1

Note that 8.2.0 was a breaking change. I honestly have no idea how to properly test this, currently I have a nixpkgs-review build running locally and just wait what happens tomorrow morning, I don't expect it to pass, even if it works it would probably take months to build on my PC. What feels like half of nixpkgs seems to indirectly depend on Click (~40k packages, including nix itself!).

So I would love some advice on how updates like this are usually handled! I'm opening this more to have a discussion / or to have it for the future. I don't even know if/think any package in nixpkgs already needs 8.2.0, I just have some in a project I'm working on that do, which is why I ran into this problem.

At least typer was updated with support in 0.16.0. See PR https://github.com/NixOS/nixpkgs/pull/425677.
I cherry-picked some commits from there to here for now - we should of course just merge that PR instead). Just the last commit in here is the actual update of Click.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
