### PR TITLE
analyze-build, intercept-build, scan-build: init at 19.1.7

### DIFF
--- a/pkgs/by-name/an/analyze-build/package.nix
+++ b/pkgs/by-name/an/analyze-build/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  llvmPackages,
+  python3,
+}:
+let
+  inherit (llvmPackages) clang-unwrapped;
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "analyze-build";
+  inherit (clang-unwrapped) version;
+
+  format = "other";
+
+  src = clang-unwrapped + "/bin";
+
+  dontUnpack = true;
+
+  dependencies = with python3.pkgs; [
+    libscanbuild
+  ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    install "$src/analyze-build" "$out/bin/"
+  '';
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ clang-unwrapped ])
+  ];
+
+  meta = {
+    description = "run Clang static analyzer against a project with compilation database";
+    homepage = "https://github.com/llvm/llvm-project/tree/llvmorg-${version}/clang/tools/scan-build-py/";
+    mainProgram = "scan-build";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [ RossSmyth ];
+    platforms = lib.intersectLists python3.meta.platforms clang-unwrapped.meta.platforms;
+  };
+}

--- a/pkgs/by-name/in/intercept-build/package.nix
+++ b/pkgs/by-name/in/intercept-build/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  llvmPackages,
+  python3,
+}:
+let
+  inherit (llvmPackages) clang-unwrapped;
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "intercept-build";
+  inherit (clang-unwrapped) version;
+
+  format = "other";
+
+  src = clang-unwrapped + "/bin";
+
+  dontUnpack = true;
+
+  dependencies = with python3.pkgs; [
+    libscanbuild
+  ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    install "$src/intercept-build" "$out/bin"
+  '';
+
+  meta = {
+    description = "intercepts the build process to generate a compilation database";
+    homepage = "https://github.com/llvm/llvm-project/tree/llvmorg-${version}/clang/tools/scan-build-py/";
+    mainProgram = "intercept-build";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [ RossSmyth ];
+  };
+}

--- a/pkgs/by-name/sc/scan-build-py/package.nix
+++ b/pkgs/by-name/sc/scan-build-py/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  llvmPackages,
+  python3,
+}:
+let
+  inherit (llvmPackages) clang-unwrapped;
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "scan-build-py";
+  inherit (clang-unwrapped) version;
+
+  format = "other";
+
+  src = clang-unwrapped + "/bin";
+
+  dontUnpack = true;
+
+  dependencies = with python3.pkgs; [
+    libscanbuild
+  ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    install "$src/scan-build-py" "$out/bin/scan-build-py"
+  '';
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [ clang-unwrapped ])
+  ];
+
+  meta = {
+    description = "intercepts the build process to generate a compilation database";
+    homepage = "https://github.com/llvm/llvm-project/tree/llvmorg-${version}/clang/tools/scan-build-py/";
+    mainProgram = "scan-build-py";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [ RossSmyth ];
+    platforms = lib.intersectLists python3.meta.platforms clang-unwrapped.meta.platforms;
+  };
+}

--- a/pkgs/development/python-modules/libear/default.nix
+++ b/pkgs/development/python-modules/libear/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  llvmPackages,
+  buildPythonPackage,
+}:
+let
+  inherit (llvmPackages) clang-unwrapped;
+in
+buildPythonPackage rec {
+  pname = "libear";
+  inherit (clang-unwrapped) version;
+
+  format = "other";
+
+  src = clang-unwrapped.lib + "/lib/libear";
+
+  dontUnpack = true;
+
+  installPhase = ''
+    LIBPATH="$(toPythonPath "$out")/libear"
+    mkdir -p "$LIBPATH"
+
+    install -t "$LIBPATH" $src/*
+  '';
+
+  pythonImportsCheck = [ "libear" ];
+
+  meta = {
+    description = "Hooks into build systems to listen to which files are opened";
+    homepage = "https://github.com/llvm/llvm-project/tree/llvmorg-${version}/clang/tools/scan-build-py/lib/libear";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [ RossSmyth ];
+  };
+}

--- a/pkgs/development/python-modules/libscanbuild/default.nix
+++ b/pkgs/development/python-modules/libscanbuild/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  llvmPackages,
+  buildPythonPackage,
+  libear,
+}:
+let
+  inherit (llvmPackages) clang-unwrapped;
+in
+buildPythonPackage rec {
+  pname = "libscanbuild";
+  inherit (clang-unwrapped) version;
+
+  format = "other";
+
+  src = clang-unwrapped.lib + "/lib/libscanbuild";
+
+  dontUnpack = true;
+
+  dependencies = [
+    libear
+  ];
+
+  installPhase = ''
+    LIBPATH="$(toPythonPath "$out")/libscanbuild"
+    mkdir -p "$LIBPATH"
+
+    cp -r "$src/"* "$LIBPATH"
+  '';
+
+  pythonImportsCheck = [ "libscanbuild" ];
+
+  meta = {
+    description = "Captures all child process creation and log information about it";
+    homepage = "https://github.com/llvm/llvm-project/tree/llvmorg-${version}/clang/tools/scan-build-py/lib/libscanbuild";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+    ];
+    maintainers = with lib.maintainers; [ RossSmyth ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8038,6 +8038,8 @@ self: super: with self; {
     (p: p.py)
   ];
 
+  libear = callPackage ../development/python-modules/libear { };
+
   libevdev = callPackage ../development/python-modules/libevdev { };
 
   libfdt = toPythonModule (

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8175,6 +8175,8 @@ self: super: with self; {
     }
   );
 
+  libscanbuild = callPackage ../development/python-modules/libscanbuild { };
+
   libselinux = lib.pipe pkgs.libselinux [
     toPythonModule
     (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

These are some tools bundled with Clang. They need a little bit of care to get running.

Currently Clang does not have Python in its `buildInputs`, so their shebangs are not fixed-up, even though they are in the `/bin`. So currently they are impossible to run. They also require a couple libraries that are also in the clang

## Things done

1. Add python3Packages.libear
2. Add python3Packages.libscanbuild
3. Add intercept-build
4. Add scan-build
5. Add analyze-build

Which are all really just different views of `libscanbuild`. 

There are tests, but since I don't want to include the entire LLVM source dir in the closure.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
