### PR TITLE
srcOnly: differentiate between computed and passed `drvAttrs` via `overrideAttrs`

### DIFF
--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -50,7 +50,8 @@ let
     ];
     separateDebugInfo = false;
 
-    dontUnpack = false;
+    dontUnpack = lib.warnIf (args.dontUnpack or false
+    ) "srcOnly: derivation has dontUnpack set, overriding" false;
 
     dontInstall = false;
     installPhase = "cp -pr --reflink=auto -- . $out";
@@ -59,4 +60,4 @@ let
   stdenv = args.stdenv or (lib.warn "srcOnly: stdenv not provided, using stdenvNoCC" stdenvNoCC);
   drv = stdenv.mkDerivation (args // argsToOverride);
 in
-lib.warnIf (args.dontUnpack or false) "srcOnly: derivation has dontUnpack set, overriding" drv
+drv

--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -37,8 +37,7 @@
 
 attrs:
 let
-  args = attrs.drvAttrs or attrs;
-  argsToOverride = {
+  argsToOverride = args: {
     name = "${args.name or "${args.pname}-${args.version}"}-source";
 
     outputs = [ "out" ];
@@ -56,8 +55,27 @@ let
     dontInstall = false;
     installPhase = "cp -pr --reflink=auto -- . $out";
   };
-
-  stdenv = args.stdenv or (lib.warn "srcOnly: stdenv not provided, using stdenvNoCC" stdenvNoCC);
-  drv = stdenv.mkDerivation (args // argsToOverride);
 in
-drv
+
+# If we are passed a derivation (based on stdenv*), we can use overrideAttrs to
+# update the arguments to mkDerivation. This gives us the proper awareness of
+# what arguments were effectively passed *to* mkDerivation as opposed to
+# builtins.derivation (by mkDerivation). For example, stdenv.mkDerivation
+# accepts an `env` attribute set which is postprocessed before being passed to
+# builtins.derivation. This can lead to evaluation failures, if we assume
+# that drvAttrs is equivalent to the arguments passed to mkDerivation.
+# See https://github.com/NixOS/nixpkgs/issues/269539.
+if lib.isDerivation attrs && attrs ? overrideAttrs then
+  attrs.overrideAttrs (_finalAttrs: prevAttrs: argsToOverride prevAttrs)
+else
+  let
+    # TODO(@sternenseemann): remove drvAttrs special casing
+    # If we don't have overrideAttrs, it is extremely unlikely that we are seeing
+    # a derivation constructed by stdenv.mkDerivation. Since srcOnly assumes
+    # that we are using stdenv's setup.sh, it therefore doesn't make sense to
+    # have derivation specific logic in this branch.
+    args = attrs.drvAttrs or attrs;
+    stdenv = args.stdenv or (lib.warn "srcOnly: stdenv not provided, using stdenvNoCC" stdenvNoCC);
+    drv = stdenv.mkDerivation (args // argsToOverride args);
+  in
+  drv

--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -38,27 +38,25 @@
 attrs:
 let
   args = attrs.drvAttrs or attrs;
-  name = args.name or "${args.pname}-${args.version}";
+  argsToOverride = {
+    name = "${args.name or "${args.pname}-${args.version}"}-source";
+
+    outputs = [ "out" ];
+
+    phases = [
+      "unpackPhase"
+      "patchPhase"
+      "installPhase"
+    ];
+    separateDebugInfo = false;
+
+    dontUnpack = false;
+
+    dontInstall = false;
+    installPhase = "cp -pr --reflink=auto -- . $out";
+  };
+
   stdenv = args.stdenv or (lib.warn "srcOnly: stdenv not provided, using stdenvNoCC" stdenvNoCC);
-  drv = stdenv.mkDerivation (
-    args
-    // {
-      name = "${name}-source";
-
-      outputs = [ "out" ];
-
-      phases = [
-        "unpackPhase"
-        "patchPhase"
-        "installPhase"
-      ];
-      separateDebugInfo = false;
-
-      dontUnpack = false;
-
-      dontInstall = false;
-      installPhase = "cp -pr --reflink=auto -- . $out";
-    }
-  );
+  drv = stdenv.mkDerivation (args // argsToOverride);
 in
 lib.warnIf (args.dontUnpack or false) "srcOnly: derivation has dontUnpack set, overriding" drv

--- a/pkgs/build-support/src-only/tests.nix
+++ b/pkgs/build-support/src-only/tests.nix
@@ -5,6 +5,8 @@
   hello,
   emptyDirectory,
   zlib,
+  git,
+  withCFlags,
   stdenv,
   testers,
 }:
@@ -19,13 +21,15 @@ let
     let
       drv' = drv.overrideAttrs (
         _finalAttrs: prevAttrs: {
-          passthru = prevAttrs.passthru // {
+          passthru = prevAttrs.passthru or { } // {
             passedAttrs = prevAttrs;
           };
         }
       );
     in
     drv'.passedAttrs // { inherit (drv') stdenv; };
+
+  canEvalDrv = drv: (builtins.tryEval drv.drvPath).success;
 
   emptySrc = srcOnly emptyDirectory;
   zlibSrc = srcOnly zlib;
@@ -35,6 +39,9 @@ let
   # zlibSrcFreeform = # ???;
   helloSrc = srcOnly hello;
   helloSrcEquiv = srcOnly (getEquivAttrs hello);
+
+  gitSrc = srcOnly git;
+  gitSrcEquiv = srcOnly (getEquivAttrs git);
 
   # The srcOnly <drv> invocation leaks a lot of attrs into the srcOnly derivation,
   # so for comparing with the freeform invocation, we need to make a selection.
@@ -71,6 +78,45 @@ let
     }
   );
 
+  # Test the issue reported in https://github.com/NixOS/nixpkgs/issues/269539
+  stdenvAdapterDrv =
+    let
+      drv = (withCFlags [ "-Werror" "-Wall" ] stdenv).mkDerivation {
+        name = "drv-using-stdenv-adapter";
+      };
+    in
+    # Confirm the issue we are trying to avoid exists
+    assert !(canEvalDrv (srcOnly drv.drvAttrs));
+    drv;
+  stdenvAdapterDrvSrc = srcOnly stdenvAdapterDrv;
+  stdenvAdapterDrvSrcEquiv = srcOnly (
+    getEquivAttrs stdenvAdapterDrv
+    // {
+      # The upside of using overrideAttrs is that any stdenv adapter related
+      # modifications are only applied once. Using the adapter here again would
+      # mean applying it twice in total (since withCFlags functions more or less
+      # like an automatic overrideAttrs).
+      inherit stdenv;
+    }
+  );
+
+  # Issue similar to https://github.com/NixOS/nixpkgs/issues/269539
+  structuredAttrsDrv =
+    let
+      drv = stdenv.mkDerivation {
+        name = "drv-using-structured-attrs";
+        src = emptyDirectory;
+
+        env.NIX_DEBUG = true;
+        __structuredAttrs = true;
+      };
+    in
+    # Confirm the issue we are trying to avoid exists
+    assert !(canEvalDrv (srcOnly drv.drvAttrs));
+    drv;
+  structuredAttrsDrvSrc = srcOnly structuredAttrsDrv;
+  structuredAttrsDrvSrcEquiv = srcOnly (getEquivAttrs structuredAttrsDrv);
+
 in
 
 runCommand "srcOnly-tests"
@@ -82,9 +128,19 @@ runCommand "srcOnly-tests"
       #   zlibSrcFreeform
       #   zlibSrc)
       (testers.testEqualDerivation "helloSrcEquiv == helloSrc" helloSrcEquiv helloSrc)
+      (testers.testEqualDerivation "helloSrcEquiv == helloSrc" helloSrcEquiv helloSrc)
+      (testers.testEqualDerivation "gitSrcEquiv == gitSrc" gitSrcEquiv gitSrc)
       (testers.testEqualDerivation "helloDrvSimpleSrcFreeform == helloDrvSimpleSrc"
         helloDrvSimpleSrcFreeform
         helloDrvSimpleSrc
+      )
+      (testers.testEqualDerivation "stdenvAdapterDrvSrcEquiv == stdenvAdapterDrvSrc"
+        stdenvAdapterDrvSrcEquiv
+        stdenvAdapterDrvSrc
+      )
+      (testers.testEqualDerivation "structuredAttrsDrvSrcEquiv == structuredAttrsDrvSrc"
+        structuredAttrsDrvSrcEquiv
+        structuredAttrsDrvSrc
       )
     ];
   }

--- a/pkgs/build-support/src-only/tests.nix
+++ b/pkgs/build-support/src-only/tests.nix
@@ -57,26 +57,16 @@ let
       ;
   };
   helloDrvSimpleSrc = srcOnly helloDrvSimple;
-  helloDrvSimpleSrcFreeform = srcOnly (
-    {
-      inherit (helloDrvSimple)
-        name
-        pname
-        version
-        src
-        patches
-        stdenv
-        ;
-    }
-    # __impureHostDeps get duplicated in helloDrvSimpleSrc (on darwin)
-    # This is harmless, but fails the test for what is arguably an
-    # unrelated non-problem, so we just work around it here.
-    # The inclusion of __impureHostDeps really shouldn't be required,
-    # and should be removed from this test.
-    // lib.optionalAttrs (helloDrvSimple ? __impureHostDeps) {
-      inherit (helloDrvSimple) __impureHostDeps;
-    }
-  );
+  helloDrvSimpleSrcFreeform = srcOnly ({
+    inherit (helloDrvSimple)
+      name
+      pname
+      version
+      src
+      patches
+      stdenv
+      ;
+  });
 
   # Test the issue reported in https://github.com/NixOS/nixpkgs/issues/269539
   stdenvAdapterDrv =


### PR DESCRIPTION
I'd recommend reviewing this PR commit-by-commit.

As mentioned in one commit, the initial change to tests.srcOnly can be moved to any position in the chain without the tests ever breaking, i.e. `getEquivAttrs` and `.drvAttrs` is equivalent for the derivations originally tested, but not for e.g. `pkgs.git`.

Because this PR fixes the duplication of `__impureHostDeps` by `srcOnly`, we unfortunately have to deal with a darwin rebuild, though I don't see how it would break anything. (I think practically everything that depends on the node infra somehow depends on `srcOnly nodejs` which exhibits this issue. Luckily, GHC uses `srcOnly` as a builder only, so we don't have a Haskell rebuild on our hands.)