### PR TITLE
v-analyzer: init at 0.0.6-unstable-2025-12-26

### DIFF
--- a/pkgs/by-name/v-/v-analyzer/package.nix
+++ b/pkgs/by-name/v-/v-analyzer/package.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  vlang,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "v-analyzer";
+  version = "0.0.6-unstable-2025-12-26";
+
+  src = fetchFromGitHub {
+    owner = "vlang";
+    repo = "v-analyzer";
+    rev = "5f6c9c414f6e1ca3b991830c2d32b4cb83bef383";
+    fetchSubmodules = true;
+    hash = "sha256-CnwTLaPlqJ7gBOPqbtyieRtwVJ1Em7xIQoEztmg5At0=";
+  };
+
+  nativeBuildInputs = [
+    vlang
+    writableTmpDirAsHomeHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p bin
+    v -prod . -o bin/v-analyzer
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp bin/v-analyzer $out/bin/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "@vlang language server, for all your editing needs like go-to-definition, code completion, type hints, and more";
+    homepage = "https://github.com/vlang/v-analyzer";
+    changelog = "https://github.com/vlang/v-analyzer/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cilki ];
+    platforms = lib.platforms.unix;
+    mainProgram = "v-analyzer";
+  };
+})

--- a/pkgs/by-name/v-/v-analyzer/package.nix
+++ b/pkgs/by-name/v-/v-analyzer/package.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  vlang,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "v-analyzer";
+  version = "0.0.6-unstable-2025-12-26";
+
+  src = fetchFromGitHub {
+    owner = "vlang";
+    repo = "v-analyzer";
+    rev = "5f6c9c414f6e1ca3b991830c2d32b4cb83bef383";
+    fetchSubmodules = true;
+    hash = "sha256-CnwTLaPlqJ7gBOPqbtyieRtwVJ1Em7xIQoEztmg5At0=";
+  };
+
+  nativeBuildInputs = [
+    vlang
+    writableTmpDirAsHomeHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p bin
+    v -prod . -o bin/v-analyzer
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp bin/v-analyzer $out/bin/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "vlang language server, for all your editing needs like go-to-definition, code completion, type hints, and more";
+    homepage = "https://github.com/vlang/v-analyzer";
+    changelog = "https://github.com/vlang/v-analyzer/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cilki ];
+    platforms = lib.platforms.unix;
+    mainProgram = "v-analyzer";
+  };
+})


### PR DESCRIPTION
Add initial v-analyzer package for IDE support with V. Closes #294566.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
