### PR TITLE
pomerium: 0.29.4 -> 0.30.3

### DIFF
--- a/pkgs/by-name/po/pomerium/0001-envoy-allow-specification-of-external-binary.patch
+++ b/pkgs/by-name/po/pomerium/0001-envoy-allow-specification-of-external-binary.patch
@@ -1,4 +1,4 @@
-From dfb6e2797e7c9166c8dd3dc0d87a4d91474244c7 Mon Sep 17 00:00:00 2001
+From 640d11fae5bcf1fa8c1a54facbe168a256cacc1b Mon Sep 17 00:00:00 2001
 From: Morgan Helton <mhelton@gmail.com>
 Date: Sun, 26 May 2024 12:17:01 -0500
 Subject: [PATCH] envoy: allow specification of external binary
@@ -8,7 +8,7 @@ Subject: [PATCH] envoy: allow specification of external binary
  1 file changed, 16 insertions(+), 4 deletions(-)
 
 diff --git a/pkg/envoy/envoy.go b/pkg/envoy/envoy.go
-index 8224f364..bb8b6506 100644
+index 85c725629..4a726a44b 100644
 --- a/pkg/envoy/envoy.go
 +++ b/pkg/envoy/envoy.go
 @@ -8,9 +8,9 @@ import (
@@ -21,8 +21,8 @@ index 8224f364..bb8b6506 100644
 -	"path"
  	"path/filepath"
  	"regexp"
- 	"strconv"
-@@ -35,8 +35,17 @@ import (
+ 	"runtime"
+@@ -36,8 +36,17 @@ import (
  
  const (
  	configFileName = "envoy-config.yaml"
@@ -40,7 +40,7 @@ index 8224f364..bb8b6506 100644
  // A Server is a pomerium proxy implemented via envoy.
  type Server struct {
  	ServerOptions
-@@ -94,14 +103,17 @@ func NewServer(ctx context.Context, src config.Source, builder *envoyconfig.Buil
+@@ -95,14 +104,17 @@ func NewServer(ctx context.Context, src config.Source, builder *envoyconfig.Buil
  		log.Ctx(ctx).Debug().Err(err).Msg("couldn't preserve RLIMIT_NOFILE before starting Envoy")
  	}
  
@@ -62,5 +62,5 @@ index 8224f364..bb8b6506 100644
  		grpcPort:      src.GetConfig().GRPCPort,
  		httpPort:      src.GetConfig().HTTPPort,
 -- 
-2.48.1
+2.49.0
 

--- a/pkgs/by-name/po/pomerium/package.nix
+++ b/pkgs/by-name/po/pomerium/package.nix
@@ -1,5 +1,5 @@
 {
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   lib,
   envoy,
@@ -17,17 +17,17 @@ let
     mapAttrsToList
     ;
 in
-buildGo123Module rec {
+buildGoModule rec {
   pname = "pomerium";
-  version = "0.29.4";
+  version = "0.30.3";
   src = fetchFromGitHub {
     owner = "pomerium";
     repo = "pomerium";
     rev = "v${version}";
-    hash = "sha256-Oj/wC3rr7CAw2iB0H8yUvzv5VCEIo8kc5sZrxFX6NrI=";
+    hash = "sha256-Rjv4GjyUs9sH+P5kYimxFnE2SBosEWbc7PbKIaVFxsI=";
   };
 
-  vendorHash = "sha256-K9LcGvANajoVKEDIswahD0mT5845qGZzafmWMKkVn8Q=";
+  vendorHash = "sha256-+SvKF54rkBY2wBZOYKuIV30BVqRqICuiPya+HApne1s=";
 
   ui = mkYarnPackage {
     inherit version;

--- a/pkgs/by-name/po/pomerium/yarn-hash
+++ b/pkgs/by-name/po/pomerium/yarn-hash
@@ -1,1 +1,1 @@
-1fqb1bcsg0k6xazr6v19jav11fl99mm3p9w53hl5xflb974m2lg0
+07zzvqfinl7qqmwh00izvfc0xch2rjr4s8b1ca9ay26krd4d4sap


### PR DESCRIPTION
https://github.com/pomerium/pomerium/compare/v0.29.4...v0.30.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
