### PR TITLE
aider-chat: 0.85.1 -> 0.85.2, fix tree-sitter query

### DIFF
--- a/pkgs/by-name/ai/aider-chat/fix-tree-sitter.patch
+++ b/pkgs/by-name/ai/aider-chat/fix-tree-sitter.patch
@@ -1,0 +1,21 @@
+diff --git a/aider/repomap.py b/aider/repomap.py
+index 23eee239..0a40f2e6 100644
+--- a/aider/repomap.py
++++ b/aider/repomap.py
+@@ -16,6 +16,7 @@ from grep_ast import TreeContext, filename_to_lang
+ from pygments.lexers import guess_lexer_for_filename
+ from pygments.token import Token
+ from tqdm import tqdm
++from tree_sitter import QueryCursor
+ 
+ from aider.dump import dump
+ from aider.special import filter_important_files
+@@ -286,7 +287,7 @@ class RepoMap:
+ 
+         # Run the tags queries
+         query = language.query(query_scm)
+-        captures = query.captures(tree.root_node)
++        captures = QueryCursor(query).captures(tree.root_node)
+ 
+         saw = set()
+         if USING_TSL_PACK:

--- a/pkgs/by-name/ai/aider-chat/package.nix
+++ b/pkgs/by-name/ai/aider-chat/package.nix
@@ -146,6 +146,8 @@ let
     ];
 
     patches = [
+      ./fix-tree-sitter.patch
+
       (replaceVars ./fix-flake8-invoke.patch {
         flake8 = lib.getExe python3Packages.flake8;
       })
@@ -154,7 +156,6 @@ let
     disabledTestPaths = [
       # Tests require network access
       "tests/scrape/test_scrape.py"
-      "tests/basic/test_repomap.py"
       # Expected 'mock' to have been called once
       "tests/help/test_help.py"
     ];
@@ -164,7 +165,6 @@ let
         # Tests require network
         "test_urls"
         "test_get_commit_message_with_custom_prompt"
-        "test_cmd_tokens_output"
         # FileNotFoundError
         "test_get_commit_message"
         # Expected 'launch_gui' to have been called once

--- a/pkgs/by-name/ai/aider-chat/package.nix
+++ b/pkgs/by-name/ai/aider-chat/package.nix
@@ -19,7 +19,7 @@ let
     d.stopwords
   ]);
 
-  version = "0.85.1";
+  version = "0.85.2";
   aider-chat = python3Packages.buildPythonApplication {
     pname = "aider-chat";
     inherit version;
@@ -29,7 +29,7 @@ let
       owner = "Aider-AI";
       repo = "aider";
       tag = "v${version}";
-      hash = "sha256-T2v07AFhrpq9a3XEU2B2orSu0afZFUsb3FRTBcJHDoQ=";
+      hash = "sha256-J2xCx1edbu8mEGzNq2PKMxPCMlMZkArEwz6338Sm1tw=";
     };
 
     pythonRelaxDeps = true;

--- a/pkgs/by-name/ai/aider-chat/package.nix
+++ b/pkgs/by-name/ai/aider-chat/package.nix
@@ -222,15 +222,16 @@ let
     passthru = {
       withOptional =
         {
-          withPlaywright ? false,
-          withBrowser ? false,
-          withHelp ? false,
-          withBedrock ? false,
           withAll ? false,
+          withPlaywright ? withAll,
+          withBrowser ? withAll,
+          withHelp ? withAll,
+          withBedrock ? withAll,
           ...
         }:
         aider-chat.overridePythonAttrs (
           {
+            pname,
             dependencies,
             makeWrapperArgs,
             propagatedBuildInputs ? [ ],
@@ -238,20 +239,27 @@ let
           }:
 
           {
+            pname =
+              pname
+              + lib.optionalString withPlaywright "-playwright"
+              + lib.optionalString withBrowser "-browser"
+              + lib.optionalString withHelp "-help"
+              + lib.optionalString withBedrock "-bedrock";
+
             dependencies =
               dependencies
-              ++ lib.optionals (withAll || withPlaywright) aider-chat.optional-dependencies.playwright
-              ++ lib.optionals (withAll || withBrowser) aider-chat.optional-dependencies.browser
-              ++ lib.optionals (withAll || withHelp) aider-chat.optional-dependencies.help
-              ++ lib.optionals (withAll || withBedrock) aider-chat.optional-dependencies.bedrock;
+              ++ lib.optionals withPlaywright aider-chat.optional-dependencies.playwright
+              ++ lib.optionals withBrowser aider-chat.optional-dependencies.browser
+              ++ lib.optionals withHelp aider-chat.optional-dependencies.help
+              ++ lib.optionals withBedrock aider-chat.optional-dependencies.bedrock;
 
             propagatedBuildInputs =
               propagatedBuildInputs
-              ++ lib.optionals (withAll || withPlaywright) [ playwright-driver.browsers ];
+              ++ lib.optionals withPlaywright [ playwright-driver.browsers ];
 
             makeWrapperArgs =
               makeWrapperArgs
-              ++ lib.optionals (withAll || withPlaywright) [
+              ++ lib.optionals withPlaywright [
                 "--set"
                 "PLAYWRIGHT_BROWSERS_PATH"
                 "${playwright-driver.browsers}"
@@ -259,7 +267,7 @@ let
                 "PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS"
                 "true"
               ]
-              ++ lib.optionals (withAll || withHelp) [
+              ++ lib.optionals withHelp [
                 "--set"
                 "NLTK_DATA"
                 "${aider-nltk-data}"


### PR DESCRIPTION
- fix tree-sitter query: upstream implementation incompatible with py-tree-sitter in nixpkgs (Aider-AI/aider#4354, thanks @sarahec)
- 0.85.1 -> 0.85.2
- update variants pname

close #425560
close #425804
revert #425531 (These tests do not require network access. the failures are caused by a tree-sitter issue.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
