### PR TITLE
python3Packages.scrapy: 2.12.0 -> 2.13.3

### DIFF
--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -8,6 +8,7 @@
   defusedxml,
   fetchFromGitHub,
   glibcLocales,
+  hatchling,
   installShellFiles,
   itemadapter,
   itemloaders,
@@ -36,7 +37,7 @@
 
 buildPythonPackage rec {
   pname = "scrapy";
-  version = "2.12.0";
+  version = "2.13.3";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -45,11 +46,15 @@ buildPythonPackage rec {
     owner = "scrapy";
     repo = "scrapy";
     tag = version;
-    hash = "sha256-o3+57+bZRohgrld2EuoQDU2LioJu0jmaC/RPREvI1t8=";
+    hash = "sha256-M+Lko0O0xsEPHLghvIGHxIv22XBXaZsujJ2+bjBzGZ4=";
   };
 
   pythonRelaxDeps = [
     "defusedxml"
+  ];
+
+  build-system = [
+    hatchling
   ];
 
   nativeBuildInputs = [
@@ -95,6 +100,18 @@ buildPythonPackage rec {
     "tests/test_proxy_connect.py"
     "tests/test_utils_display.py"
     "tests/test_command_check.py"
+
+    # ConnectionRefusedError: [Errno 111] Connection refused
+    "tests/test_feedexport.py::TestFTPFeedStorage::test_append"
+    "tests/test_feedexport.py::TestFTPFeedStorage::test_append_active_mode"
+    "tests/test_feedexport.py::TestFTPFeedStorage::test_overwrite"
+    "tests/test_feedexport.py::TestFTPFeedStorage::test_overwrite_active_mode"
+
+    # this test is testing that the *first* deprecation warning is a specific one
+    # but for some reason we get other deprecation warnings appearing first
+    # but this isn't a material issue and the deprecation warning is still raised
+    "tests/test_spider_start.py::MainTestCase::test_start_deprecated_super"
+
     # Don't test the documentation
     "docs"
   ];


### PR DESCRIPTION
Resolves #425363

Updates scrapy to latest version, and disables a few new tests (4 that require network, 1 that I can't quite figure out the cause of but doesn't affect functionality - we get a deprecation warning in the wrong _order_)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
