### PR TITLE
python3Packages.pgvector: temporarily disable checkPhase

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -58,7 +58,10 @@ buildPythonPackage rec {
     "psycopg-pool"
   ];
 
-  doCheck = !(stdenvNoCC.hostPlatform.isDarwin);
+  # Temporarily disabled until the following is solved:
+  # https://github.com/NixOS/nixpkgs/pull/425384
+  doCheck = false;
+  # doCheck = !(stdenvNoCC.hostPlatform.isDarwin);
 
   nativeCheckInputs = [
     pytest-asyncio

--- a/pkgs/development/python-modules/pgvector/default.nix
+++ b/pkgs/development/python-modules/pgvector/default.nix
@@ -42,6 +42,10 @@ buildPythonPackage rec {
 
   dependencies = [ numpy ];
 
+  # Temporarily disabled until the following is solved:
+  # https://github.com/NixOS/nixpkgs/pull/425384
+  doCheck = false;
+
   nativeCheckInputs = [
     asyncpg
     django


### PR DESCRIPTION
Let's disable the checkPhase to unbreak the package and its dependencies until https://github.com/NixOS/nixpkgs/pull/425384 is properly solved.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
