### PR TITLE
laigter: init at 1.12.1

### DIFF
--- a/pkgs/by-name/la/laigter/package.nix
+++ b/pkgs/by-name/la/laigter/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt6,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "laigter";
+  version = "1.12.1";
+
+  src = fetchFromGitHub {
+    owner = "azagaya";
+    repo = "laigter";
+    tag = finalAttrs.version;
+    hash = "sha256-1QSvUTOKKKx4LVHezYzXs8Z7IAYLSTzuEt0RA37T6UU";
+  };
+
+  strictDeps = true;
+  buildInputs = [ qt6.qtbase ];
+  nativeBuildInputs = [
+    qt6.qmake
+    qt6.wrapQtAppsHook
+  ];
+  enableParallelBuilding = true;
+
+  qmakeFlags = [
+    # XXX: Qmake assumes that "lrelease" is in "${qt6.qtbase}/bin", so we need
+    # to override the location.
+    # Issue: https://github.com/NixOS/nixpkgs/issues/214765
+    "QT_TOOL.lrelease.binary=${lib.getDev qt6.qttools}/bin/lrelease"
+  ];
+
+  meta = {
+    description = "Automatic normal map generator for sprites";
+    changelog = with finalAttrs.src; "${meta.homepage}/releases/tag/${tag}";
+    homepage = "https://azagaya.itch.io/laigter";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "laigter";
+    maintainers = [ lib.maintainers.aszlig ];
+  };
+})


### PR DESCRIPTION
I was evaluating options for generating normal maps for 2D sprites and stumbled on [Laigter](https://azagaya.itch.io/laigter) (which exactly does that). Since I wasn't able to "nix run" it, I decided to make sure I can do that in the future :smiley:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
