### PR TITLE
workflows/build: avoid downloading from cachix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,31 +66,33 @@ jobs:
           name: nixpkgs-ci
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
+      - run: nix-env --install -f pinned -A nix-build-uncached
+
       - name: Build shell
         if: contains(matrix.builds, 'shell')
-        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A shell
+        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A shell
 
       - name: Build NixOS manual
         if: |
           contains(matrix.builds, 'manual-nixos') && !cancelled() &&
           contains(fromJSON(inputs.baseBranch).type, 'primary')
-        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A manual-nixos --argstr system ${{ matrix.system }} --out-link nixos-manual
+        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A manual-nixos --argstr system ${{ matrix.system }} --out-link nixos-manual
 
       - name: Build Nixpkgs manual
         if: contains(matrix.builds, 'manual-nixpkgs') && !cancelled()
-        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A manual-nixpkgs -A manual-nixpkgs-tests
+        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A manual-nixpkgs -A manual-nixpkgs-tests
 
       - name: Build Nixpkgs manual tests
         if: contains(matrix.builds, 'manual-nixpkgs-tests') && !cancelled()
-        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A manual-nixpkgs-tests
+        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A manual-nixpkgs-tests
 
       - name: Build lib tests
         if: contains(matrix.builds, 'lib-tests') && !cancelled()
-        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A lib-tests
+        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A lib-tests
 
       - name: Build tarball
         if: contains(matrix.builds, 'tarball') && !cancelled()
-        run: nix-build untrusted/ci --arg nixpkgs ./pinned -A tarball
+        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A tarball
 
       - name: Upload NixOS manual
         if: |
@@ -100,4 +102,3 @@ jobs:
         with:
           name: nixos-manual-${{ matrix.system }}
           path: nixos-manual
-          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,22 +26,21 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-24.04
-            system: x86_64-linux
+            name: x86_64-linux
+            systems: x86_64-linux
             builds: [shell, manual-nixos, lib-tests, tarball]
             desc: shell, docs, lib, tarball
           - runner: ubuntu-24.04-arm
-            system: aarch64-linux
+            name: aarch64-linux
+            systems: aarch64-linux
             builds: [shell, manual-nixos, manual-nixpkgs, manual-nixpkgs-tests]
             desc: shell, docs
-          - runner: macos-13
-            system: x86_64-darwin
-            builds: [shell]
-            desc: shell
           - runner: macos-14
-            system: aarch64-darwin
+            name: darwin
+            systems: aarch64-darwin x86_64-darwin
             builds: [shell]
             desc: shell
-    name: '${{ matrix.system }}: ${{ matrix.desc }}'
+    name: '${{ matrix.name }}: ${{ matrix.desc }}'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     steps:
@@ -70,13 +69,13 @@ jobs:
 
       - name: Build shell
         if: contains(matrix.builds, 'shell')
-        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A shell
+        run: echo "${{ matrix.systems }}" | xargs -n1 nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A shell --argstr system
 
       - name: Build NixOS manual
         if: |
           contains(matrix.builds, 'manual-nixos') && !cancelled() &&
           contains(fromJSON(inputs.baseBranch).type, 'primary')
-        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A manual-nixos --argstr system ${{ matrix.system }} --out-link nixos-manual
+        run: nix-build-uncached untrusted/ci --arg nixpkgs ./pinned -A manual-nixos --out-link nixos-manual
 
       - name: Build Nixpkgs manual
         if: contains(matrix.builds, 'manual-nixpkgs') && !cancelled()
@@ -100,5 +99,5 @@ jobs:
           contains(fromJSON(inputs.baseBranch).type, 'primary')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: nixos-manual-${{ matrix.system }}
+          name: nixos-manual-${{ matrix.name }}
           path: nixos-manual


### PR DESCRIPTION
This avoids downloading results from cachix, when they don't need to be rebuild, which just wastes time and resources. At the same time we run both x86_64-darwin and aarch64-darwin on a single darwin runner, potentially via Rosetta. This is due to the [upcoming deprecation of x86_64-darwin runners](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/) for GHA, but also saves quite some resources.

The runtime for the 4 jobs changes as follows:
- x86_64-linux: 2:41 -> 2:27
- aarch64-linux: 1:05 -> 0.59 (had to rebuild the nixpkgs manual, not sure whether something is off there - this would be lower once merged)
- x86_64-darwin: 3:29 -> *gone*
- aarch64-darwin: 1:54 -> 1:30

The numbers are quite noisy from run to run, especially for the darwin runner. These have much slower network. The numbers include the first two commits, which are from #432516.

## Things done

- [x] Tested in CI in this PR via `pull_request`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
