### PR TITLE
emacsPackages.eaf: init at 0-unstable-2025-07-26

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -17,6 +17,10 @@ lib.packagesFromDirectoryRecursive {
 
   elpaca = callPackage ./manual-packages/elpaca { inherit (pkgs) git; };
 
+  emacs-application-framework = callPackage ./manual-packages/emacs-application-framework {
+    inherit (pkgs) git;
+  };
+
   lsp-bridge = callPackage ./manual-packages/lsp-bridge {
     inherit (pkgs)
       basedpyright

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-pdf-viewer/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-pdf-viewer/package.nix
@@ -1,0 +1,46 @@
+{
+  # Basic
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  # Updater
+  unstableGitUpdater,
+}:
+
+melpaBuild {
+
+  pname = "eaf-pdf-viewer";
+  version = "0-unstable-2025-07-26";
+
+  src = fetchFromGitHub {
+    owner = "emacs-eaf";
+    repo = "eaf-pdf-viewer";
+    rev = "ff08a6b48faac2d231fb1cfe968cec7e41bbeb98";
+    hash = "sha256-7JAWgCECHnMGPH9GM8pi9lDzR+B4T6xgYQCor032zbM=";
+  };
+
+  files = ''
+    ("*.el"
+     "*.py")
+  '';
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+    eafPythonDeps =
+      ps: with ps; [
+        packaging
+        pymupdf
+      ];
+    eafOtherDeps = [ ];
+  };
+
+  meta = {
+    description = "Fastest PDF Viewer in Emacs";
+    homepage = "https://github.com/emacs-eaf/eaf-pdf-viewer";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      thattemperature
+    ];
+  };
+
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf/package.nix
@@ -1,0 +1,17 @@
+{
+  emacs-application-framework,
+}:
+
+let
+
+  withApplications =
+    enabledApps:
+    emacs-application-framework.override {
+      inherit enabledApps;
+    };
+
+in
+
+{
+  inherit withApplications;
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/emacs-application-framework/default.nix
@@ -1,0 +1,134 @@
+{
+  # Basic
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  symlinkJoin,
+  # Python dependency
+  python3,
+  # Emacs dependencies
+  all-the-icons,
+  # Other dependencies
+  git,
+  nodejs,
+  wmctrl,
+  xdotool,
+  # Updater
+  unstableGitUpdater,
+  # Sub-applications in the framework
+  enabledApps ? [ ],
+}:
+
+let
+
+  appPythonDeps = builtins.map (item: item.eafPythonDeps) enabledApps;
+  appOtherDeps = builtins.map (item: item.eafOtherDeps) enabledApps;
+
+  pythonPackageLists = [
+    (
+      ps: with ps; [
+        epc
+        lxml
+        pyqt6
+        pyqt6-sip
+        pyqt6-webengine
+        sexpdata
+        tld
+      ]
+    )
+  ]
+  ++ appPythonDeps;
+  pythonPkgs = ps: builtins.concatLists (builtins.map (f: f ps) pythonPackageLists);
+  pythonEnv = python3.withPackages pythonPkgs;
+
+  otherPackageLists = [
+    [
+      git
+      nodejs
+      wmctrl
+      xdotool
+    ]
+  ]
+  ++ appOtherDeps;
+  otherPkgs = builtins.concatLists (otherPackageLists);
+
+  appsDrv = symlinkJoin {
+    name = "emacs-application-framework-apps";
+    paths = enabledApps;
+  };
+  depsBin = symlinkJoin {
+    name = "emacs-application-framework-deps-bin";
+    paths = otherPkgs;
+  };
+
+in
+
+melpaBuild (finalAttrs: {
+
+  pname = "eaf";
+  version = "0-unstable-2025-08-01";
+
+  src = fetchFromGitHub {
+    owner = "emacs-eaf";
+    repo = "emacs-application-framework";
+    rev = "f7431199fb3143f4487213b7ea6a16a3d037b2ff";
+    hash = "sha256-qpaLizkxuOKd/9kfym3+xAssVm+sV3IlxLCApv+yUz8=";
+  };
+
+  packageRequires = [
+    all-the-icons
+  ];
+
+  postPatch = ''
+    substituteInPlace eaf.el \
+      --replace-fail "\"python.exe\" \"python3\"" \
+                     "\"python.exe\" \"${pythonEnv.interpreter}\""
+  '';
+
+  files = ''
+    ("*.el"
+     "*.py"
+     "applications.json"
+     "core"
+     "extension")
+  '';
+
+  preInstall = ''
+    EMACSLOADPATH="$EMACSLOADPATH:core/"
+  '';
+
+  postInstall = ''
+    LISPDIR=$out/share/emacs/site-lisp/elpa/${finalAttrs.ename}-${finalAttrs.melpaVersion}
+    APPLISPDIR=${appsDrv}/share/emacs/site-lisp/elpa
+    if [ -d $APPLISPDIR ]; then
+      cp -r $APPLISPDIR/. \
+            $LISPDIR/app/
+    fi
+
+    NATDIR=$out/share/emacs/native-lisp
+    APPNATDIR=${appsDrv}/share/emacs/native-lisp
+    if [ -d $APPNATDIR ]; then
+      cp -r $APPNATDIR/. \
+            $NATDIR/
+    fi
+
+    mkdir -p $out/bin/
+    for item in ${depsBin}/bin/*; do
+      # Some symbolic links point to another symbolic link
+      ln -s $(readlink -f $item) \
+            $out/bin/$(basename $item)
+    done
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Extensible framework of Emacs";
+    homepage = "https://github.com/emacs-eaf/emacs-application-framework";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      thattemperature
+    ];
+  };
+
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This package is required by issue #278177

This is not a typical Emacs package. It is only a framework, and the actual functions are provided by its apps. Now it has about twenty apps, so I think it is important to let user choose which apps should install. While the framework is high coupling with its apps so I cannot make them separated items in emacsPackages. My solution is using `withApps`, which likes `withPackages`. One should call this package by something likes `(eaf.withApps (eapps: [eapps.<app-name>]))`,

I have written some apps' derivations and tested their functionality. But I think that putting all of them into one pull request will makes it too long for code reviewers. So I'd like to add apps in later pull requests. However, this may make some codes in this pull request hard to understand for reviewers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
