### PR TITLE
python3Packages.plotnine: 0.14.6 -> 0.15.0

### DIFF
--- a/pkgs/development/python-modules/plotnine/default.nix
+++ b/pkgs/development/python-modules/plotnine/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   setuptools-scm,
@@ -10,7 +11,6 @@
   matplotlib,
   mizani,
   pandas,
-  patsy,
   scipy,
   statsmodels,
 
@@ -24,41 +24,30 @@
 
 buildPythonPackage rec {
   pname = "plotnine";
-  version = "0.14.6";
+  version = "0.15.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "has2k1";
     repo = "plotnine";
     tag = "v${version}";
-    hash = "sha256-nTMu0zx13XepqQyrJrAvBCjjHdY02tlXlFk2kITHZfI=";
+    hash = "sha256-HhsJE5XoQjkIVExsfikTBArh9uq8ob4g2O0byYOsOh8=";
   };
-
-  # Fixes: TypeError: hue_pal.__init__() got an unexpected keyword argument 'color_space'
-  #
-  # In the mizani 0.14.0 release, hue_pal was changed to use HCL color space from HSL (or HSLuv) space.
-  # The previous functionality is still available with hls_pal.
-  postPatch = ''
-    substituteInPlace plotnine/scales/scale_color.py \
-      --replace-fail \
-        "from mizani.palettes import hue_pal" \
-        "from mizani.palettes import hls_pal" \
-      --replace-fail \
-        "hue_pal(" \
-        "hls_pal("
-  '';
 
   build-system = [ setuptools-scm ];
 
-  pythonRelaxDeps = [
-    "mizani"
+  patches = [
+    (fetchpatch {
+      name = "fix-composition-error-messages.patch";
+      url = "https://github.com/has2k1/plotnine/commit/097192de42d690c227b26ae7638accac0db14589.patch";
+      hash = "sha256-wxfJ36QH0PYdotgqrdE9sKAzKpcIYw7I8uNGhC6J0Gg=";
+    })
   ];
 
   dependencies = [
     matplotlib
     mizani
     pandas
-    patsy
     scipy
     statsmodels
   ];
@@ -77,6 +66,12 @@ buildPythonPackage rec {
     # Tries to change locale. The issued warning causes this test to fail.
     # UserWarning: Could not set locale to English/United States. Some date-related tests may fail
     "test_no_after_scale_warning"
+
+    # Assertion Errors:
+    # Generated plot images do not exactly match the expected files.
+    # After manually checking, this is caused by extremely subtle differences in label placement.
+    # See https://github.com/has2k1/plotnine/issues/627
+    "test_aesthetics"
   ];
 
   disabledTestPaths = [
@@ -99,6 +94,8 @@ buildPythonPackage rec {
     "tests/test_geom_map.py"
     "tests/test_geom_path_line_step.py"
     "tests/test_geom_point.py"
+    "tests/test_geom_pointdensity.py"
+    "tests/test_geom_polygon.py"
     "tests/test_geom_raster.py"
     "tests/test_geom_rect_tile.py"
     "tests/test_geom_ribbon_area.py"
@@ -107,11 +104,13 @@ buildPythonPackage rec {
     "tests/test_geom_text_label.py"
     "tests/test_geom_violin.py"
     "tests/test_layout.py"
+    "tests/test_plot_composition.py"
     "tests/test_position.py"
     "tests/test_qplot.py"
     "tests/test_scale_internals.py"
     "tests/test_scale_labelling.py"
     "tests/test_stat_ecdf.py"
+    "tests/test_stat_ellipse.py"
     "tests/test_stat_function.py"
     "tests/test_stat_summary.py"
     "tests/test_theme.py"


### PR DESCRIPTION
changelog: https://github.com/has2k1/plotnine/releases/tag/v0.15.0
diff: https://github.com/has2k1/plotnine/compare/v0.14.6...v0.15.0

1. Removed old `mizani` fixes as no longer needed.
2. Discovered additional tests that are failing due to minor differences in system typography.
3. Discovered tests that are failing likely due to a broken custom `toString`, filed  https://github.com/has2k1/plotnine/issues/955

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
