### PR TITLE
python3Packages.plopp: 25.06.0 -> 25.07.0

### DIFF
--- a/pkgs/development/python-modules/plopp/default.nix
+++ b/pkgs/development/python-modules/plopp/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   setuptools,
@@ -44,6 +45,13 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-SwF0bUU/DAAJ5+0WvZgwqEw6IoaqdbKj0GkCgffGclA=";
   };
+  patches = [
+    # https://github.com/scipp/plopp/issues/472
+    (fetchpatch {
+      url = "https://github.com/scipp/plopp/commit/7af8cbee85796005f2fea79171ae44aba9a8cfc7.patch";
+      hash = "sha256-uyCV/2tSvcnnw+ak6fT99ru+UrTZXsS3b4YGeXVykAY=";
+    })
+  ];
 
   build-system = [
     setuptools
@@ -103,11 +111,6 @@ buildPythonPackage rec {
             };
       };
   };
-
-  pytestFlagsArray = [
-    # https://github.com/scipp/plopp/issues/472
-    "-Wignore::DeprecationWarning"
-  ];
 
   pythonImportsCheck = [
     "plopp"

--- a/pkgs/development/python-modules/plopp/default.nix
+++ b/pkgs/development/python-modules/plopp/default.nix
@@ -35,7 +35,7 @@
 
 buildPythonPackage rec {
   pname = "plopp";
-  version = "25.06.0";
+  version = "25.07.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -103,6 +103,11 @@ buildPythonPackage rec {
             };
       };
   };
+
+  pytestFlagsArray = [
+    # https://github.com/scipp/plopp/issues/472
+    "-Wignore::DeprecationWarning"
+  ];
 
   pythonImportsCheck = [
     "plopp"


### PR DESCRIPTION
changelog: https://github.com/scipp/plopp/releases/tag/25.07.0
diff: https://github.com/scipp/plopp/compare/25.06.0...25.07.0

Also, disabled `DeprecationWarning` as this was breaking a test. https://github.com/scipp/plopp/issues/472


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
