### PR TITLE
haskell.compiler: (make built) add libnuma paths to pkg db

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -368,6 +368,12 @@ stdenv.mkDerivation (
           sha256 = "1rmv3132xhxbka97v0rx7r6larx5f5nnvs4mgm9q3rmgpjyd1vf9";
           includes = [ "libraries/ghci/ghci.cabal.in" ];
         })
+
+        # Correctly record libnuma's library and include directories in the
+        # package db. This fixes linking whenever stdenv and propagation won't
+        # quite pass the correct -L flags to the linker, e.g. when using GHC
+        # outside of stdenv/nixpkgs or build->build compilation in pkgsStatic.
+        ./ghc-8.10-9.2-rts-package-db-libnuma-dirs.patch
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # Make Block.h compile with c++ compilers. Remove with the next release

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -305,6 +305,17 @@ stdenv.mkDerivation (
 
         # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129
         ./docs-sphinx-7.patch
+
+        # Correctly record libnuma's library and include directories in the
+        # package db. This fixes linking whenever stdenv and propagation won't
+        # quite pass the correct -L flags to the linker, e.g. when using GHC
+        # outside of stdenv/nixpkgs or build->build compilation in pkgsStatic.
+        (
+          if lib.versionAtLeast version "9.4" then
+            ./ghc-9.4-rts-package-db-libnuma-dirs.patch
+          else
+            ./ghc-8.10-9.2-rts-package-db-libnuma-dirs.patch
+        )
       ]
 
       # Before GHC 9.6, GHC, when used to compile C sources (i.e. to drive the CC), would first

--- a/pkgs/development/compilers/ghc/ghc-8.10-9.2-rts-package-db-libnuma-dirs.patch
+++ b/pkgs/development/compilers/ghc/ghc-8.10-9.2-rts-package-db-libnuma-dirs.patch
@@ -1,0 +1,85 @@
+From adef13bb81cdb49a8da8a22db261e48d8c4bbb5d Mon Sep 17 00:00:00 2001
+From: sterni <sternenseemann@systemli.org>
+Date: Thu, 17 Jul 2025 21:21:29 +0200
+Subject: [PATCH] rts: record libnuma include and lib dirs in package conf
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The --with-libnuma-libraries and --with-libnuma-includes flags were
+originally introduced for hadrian in def486c90ef6f37d81d0d9c6df7544
+and curiously never supported by the make build system — even though
+the addition was made in the 9.0 series and even backported to the
+8.10 series.
+
+While the make build system knows when to link against libnuma, it won't
+enforce its specific directories by adding them to rts.conf in the
+package db. This commit implements this retroactively for the make build
+system, modeled after how make does the same sort of thing for Libdw.
+---
+ mk/config.mk.in     | 4 ++++
+ rts/ghc.mk          | 8 ++++++++
+ rts/package.conf.in | 5 +++--
+ 3 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/mk/config.mk.in b/mk/config.mk.in
+index 35f6e2d087..d2b1329eb5 100644
+--- a/mk/config.mk.in
++++ b/mk/config.mk.in
+@@ -333,6 +333,10 @@ LibdwIncludeDir=@LibdwIncludeDir@
+ #     rts/Libdw.c:set_initial_registers()
+ GhcRtsWithLibdw=$(strip $(if $(filter $(TargetArch_CPP),i386 x86_64 s390x),@UseLibdw@,NO))
+ 
++UseLibNuma=@UseLibNuma@
++LibNumaLibDir=@LibNumaLibDir@
++LibNumaIncludeDir=@LibNumaIncludeDir@
++
+ ################################################################################
+ #
+ #		Paths (see paths.mk)
+diff --git a/rts/ghc.mk b/rts/ghc.mk
+index 9c535def5a..7782c4b768 100644
+--- a/rts/ghc.mk
++++ b/rts/ghc.mk
+@@ -576,6 +576,14 @@ rts_PACKAGE_CPP_OPTS += -DLIBDW_INCLUDE_DIR=
+ rts_PACKAGE_CPP_OPTS += -DLIBDW_LIB_DIR=
+ endif
+ 
++ifeq "$(UseLibNuma)" "YES"
++rts_PACKAGE_CPP_OPTS += -DLIBNUMA_INCLUDE_DIR=$(LibNumaIncludeDir)
++rts_PACKAGE_CPP_OPTS += -DLIBNUMA_LIB_DIR=$(LibNumaLibDir)
++else
++rts_PACKAGE_CPP_OPTS += -DLIBNUMA_INCLUDE_DIR=
++rts_PACKAGE_CPP_OPTS += -DLIBNUMA_LIB_DIR=
++endif
++
+ # -----------------------------------------------------------------------------
+ # dependencies
+ 
+diff --git a/rts/package.conf.in b/rts/package.conf.in
+index 9bdbf3659a..46f728b09a 100644
+--- a/rts/package.conf.in
++++ b/rts/package.conf.in
+@@ -18,9 +18,9 @@ hidden-modules:
+ import-dirs:
+ 
+ #if defined(INSTALLING)
+-library-dirs:           LIB_DIR"/rts" FFI_LIB_DIR LIBDW_LIB_DIR
++library-dirs:           LIB_DIR"/rts" FFI_LIB_DIR LIBDW_LIB_DIR LIBNUMA_LIB_DIR
+ #else /* !INSTALLING */
+-library-dirs:           TOP"/rts/dist/build" FFI_LIB_DIR LIBDW_LIB_DIR
++library-dirs:           TOP"/rts/dist/build" FFI_LIB_DIR LIBDW_LIB_DIR LIBNUMA_LIB_DIR
+ #endif
+ 
+ hs-libraries:   "HSrts" FFI_LIB
+@@ -76,6 +76,7 @@ include-dirs:           TOP"/rts/dist/build"
+                         FFI_INCLUDE_DIR
+                         LIBDW_INCLUDE_DIR
+                         TOP"/includes/dist-install/build"
++                        LIBNUMA_INCLUDE_DIR
+ #endif
+ 
+ includes:               Stg.h
+-- 
+2.49.0
+

--- a/pkgs/development/compilers/ghc/ghc-9.4-rts-package-db-libnuma-dirs.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4-rts-package-db-libnuma-dirs.patch
@@ -1,0 +1,85 @@
+From f9625ba94522bec93b4c5d46ee5fd97f537a7dfa Mon Sep 17 00:00:00 2001
+From: sterni <sternenseemann@systemli.org>
+Date: Thu, 17 Jul 2025 21:21:29 +0200
+Subject: [PATCH] rts: record libnuma include and lib dirs in package conf
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The --with-libnuma-libraries and --with-libnuma-includes flags were
+originally introduced for hadrian in def486c90ef6f37d81d0d9c6df7544
+and curiously never supported by the make build system — even though
+the addition was made in the 9.0 series and even backported to the
+8.10 series.
+
+While the make build system knows when to link against libnuma, it won't
+enforce its specific directories by adding them to rts.conf in the
+package db. This commit implements this retroactively for the make build
+system, modeled after how make does the same sort of thing for Libdw.
+---
+ mk/config.mk.in     | 4 ++++
+ rts/ghc.mk          | 8 ++++++++
+ rts/package.conf.in | 5 +++--
+ 3 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/mk/config.mk.in b/mk/config.mk.in
+index 2ff2bea9b6..d95f927dbd 100644
+--- a/mk/config.mk.in
++++ b/mk/config.mk.in
+@@ -324,6 +324,10 @@ LibdwIncludeDir=@LibdwIncludeDir@
+ #     rts/Libdw.c:set_initial_registers()
+ GhcRtsWithLibdw=$(strip $(if $(filter $(TargetArch_CPP),i386 x86_64 s390x),@UseLibdw@,NO))
+ 
++UseLibNuma=@UseLibNuma@
++LibNumaLibDir=@LibNumaLibDir@
++LibNumaIncludeDir=@LibNumaIncludeDir@
++
+ ################################################################################
+ #
+ #		Paths (see paths.mk)
+diff --git a/rts/ghc.mk b/rts/ghc.mk
+index 36a82f9f2c..854bb8e013 100644
+--- a/rts/ghc.mk
++++ b/rts/ghc.mk
+@@ -573,6 +573,14 @@ rts_PACKAGE_CPP_OPTS += -DLIBDW_INCLUDE_DIR=
+ rts_PACKAGE_CPP_OPTS += -DLIBDW_LIB_DIR=
+ endif
+ 
++ifeq "$(UseLibNuma)" "YES"
++rts_PACKAGE_CPP_OPTS += -DLIBNUMA_INCLUDE_DIR=$(LibNumaIncludeDir)
++rts_PACKAGE_CPP_OPTS += -DLIBNUMA_LIB_DIR=$(LibNumaLibDir)
++else
++rts_PACKAGE_CPP_OPTS += -DLIBNUMA_INCLUDE_DIR=
++rts_PACKAGE_CPP_OPTS += -DLIBNUMA_LIB_DIR=
++endif
++
+ # -----------------------------------------------------------------------------
+ # dependencies
+ 
+diff --git a/rts/package.conf.in b/rts/package.conf.in
+index cb5a436f5c..9e5ae48adb 100644
+--- a/rts/package.conf.in
++++ b/rts/package.conf.in
+@@ -18,9 +18,9 @@ hidden-modules:
+ import-dirs:
+ 
+ #if defined(INSTALLING)
+-library-dirs:           LIB_DIR FFI_LIB_DIR LIBDW_LIB_DIR
++library-dirs:           LIB_DIR FFI_LIB_DIR LIBDW_LIB_DIR LIBNUMA_LIB_DIR
+ #else /* !INSTALLING */
+-library-dirs:           TOP"/rts/dist-install/build" FFI_LIB_DIR LIBDW_LIB_DIR
++library-dirs:           TOP"/rts/dist-install/build" FFI_LIB_DIR LIBDW_LIB_DIR LIBNUMA_LIB_DIR
+ #endif
+ 
+ hs-libraries:   "HSrts" FFI_LIB
+@@ -74,6 +74,7 @@ include-dirs:           TOP"/rts/include"
+                         TOP"/rts/dist-install/build/include"
+                         FFI_INCLUDE_DIR
+                         LIBDW_INCLUDE_DIR
++                        LIBNUMA_INCLUDE_DIR
+ #endif
+ 
+ includes:               Rts.h
+-- 
+2.49.0
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've tested that the patches apply for all changed GHCs. I've tested builds of GHC 9.4.8 (with numa enabled and disabled) as well as pkgsStatic.haskell.packages.native-bignum.ghc94.hello.


See also https://hydra.nixos.org/build/302807776.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
