### PR TITLE
stdenv: assert that `env` is an attrset

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -27,6 +27,8 @@
 
 - `gnome-keyring` no longer ships with an SSH agent anymore because it has been deprecated upstream. You should use `gcr_4` instead, which provides the same features. More information on why this was done can be found on [the relevant GCR upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67).
 
+- `stdenv.mkDerivation` and other derivation builders that use it no longer allow the value of `env` to be anything but an attribute set, for the purpose of setting environment variables that are available to the [builder](https://nix.dev/manual/nix/latest/store/derivation/#builder) process. An environment variable called `env` can still be provided by means of `mkDerivation { env.env = ...; }`, though we recommend to use a more specific name than "env".
+
 - `conftest` since `0.60.0` has moved to use rego `v1` as default. To continue using `v0` use `--rego-version v0`. For more information about upgrading to Rego v1 syntax, see the [upstream docs](https://www.openpolicyagent.org/docs/latest/v0-upgrade/).
 
 - `tooling-language-server` has been renamed to `deputy` (both the package and binary), following the rename of the upstream project.

--- a/pkgs/by-name/ev/evil-winrm/package.nix
+++ b/pkgs/by-name/ev/evil-winrm/package.nix
@@ -6,7 +6,14 @@
   bundlerEnv,
   bundlerUpdateScript,
 }:
-
+let
+  rubyEnv = bundlerEnv {
+    name = "evil-winrm";
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+in
 stdenv.mkDerivation rec {
   pname = "evil-winrm";
   version = "3.5";
@@ -18,19 +25,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-8Lyo7BgypzrHMEcbYlxo/XWwOtBqs2tczYnc3+XEbeA=";
   };
 
-  env = bundlerEnv {
-    name = pname;
-    gemfile = ./Gemfile;
-    lockfile = ./Gemfile.lock;
-    gemset = ./gemset.nix;
-  };
-
   nativeBuildInputs = [
     makeWrapper
   ];
 
   buildInputs = [
-    env.wrappedRuby
+    rubyEnv.wrappedRuby
   ];
 
   installPhase = ''

--- a/pkgs/by-name/gh/ghi/package.nix
+++ b/pkgs/by-name/gh/ghi/package.nix
@@ -6,29 +6,30 @@
   bundlerEnv,
   tree,
 }:
-
-stdenv.mkDerivation (finalAttrs: {
-  pname = "ghi";
+let
   version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "drazisil";
     repo = "ghi";
-    rev = "refs/tags/${finalAttrs.version}";
+    tag = version;
     hash = "sha256-3V1lxI4VhP0jC3VSWyNS327gOCKowbbLB6ae1idpFFI=";
   };
 
-  env = bundlerEnv {
+  rubyEnv = bundlerEnv {
     name = "ghi";
-
-    gemfile = "${finalAttrs.src}/Gemfile";
-    lockfile = "${finalAttrs.src}/Gemfile.lock";
+    gemfile = "${src}/Gemfile";
+    lockfile = "${src}/Gemfile.lock";
     gemset = ./gemset.nix;
   };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ghi";
+  inherit version src;
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildInputs = [ finalAttrs.env.wrappedRuby ];
+  buildInputs = [ rubyEnv.wrappedRuby ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/js/jsduck/package.nix
+++ b/pkgs/by-name/js/jsduck/package.nix
@@ -5,26 +5,26 @@
   makeWrapper,
   bundlerUpdateScript,
 }:
-
-stdenv.mkDerivation rec {
-  pname = "jsduck";
-  version = (import ./gemset.nix).jsduck.version;
-
-  env = bundlerEnv {
-    name = pname;
+let
+  rubyEnv = bundlerEnv {
+    name = "jsduck";
     gemfile = ./Gemfile;
     lockfile = ./Gemfile.lock;
     gemset = ./gemset.nix;
   };
+in
+stdenv.mkDerivation {
+  pname = "jsduck";
+  version = (import ./gemset.nix).jsduck.version;
 
   dontUnpack = true;
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ env ];
+  buildInputs = [ rubyEnv ];
 
   installPhase = ''
     mkdir -p $out/bin
-    makeWrapper ${env}/bin/jsduck $out/bin/jsduck
+    makeWrapper ${rubyEnv}/bin/jsduck $out/bin/jsduck
   '';
 
   passthru.updateScript = bundlerUpdateScript "jsduck";

--- a/pkgs/by-name/ro/ronn/package.nix
+++ b/pkgs/by-name/ro/ronn/package.nix
@@ -7,15 +7,15 @@
   groff,
   callPackage,
 }:
-
-stdenv.mkDerivation rec {
-  pname = "ronn";
-  version = env.gems.ronn-ng.version;
-
-  env = bundlerEnv {
+let
+  rubyEnv = bundlerEnv {
     name = "ronn-gems";
     gemdir = ./.;
   };
+in
+stdenv.mkDerivation {
+  pname = "ronn";
+  version = rubyEnv.gems.ronn-ng.version;
 
   dontUnpack = true;
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     mkdir -p $out/bin
-    makeWrapper ${env}/bin/ronn $out/bin/ronn \
+    makeWrapper ${rubyEnv}/bin/ronn $out/bin/ronn \
       --set PATH ${groff}/bin
 
     runHook postInstall
@@ -46,6 +46,6 @@ stdenv.mkDerivation rec {
       zimbatm
       nicknovitski
     ];
-    platforms = env.ruby.meta.platforms;
+    platforms = rubyEnv.ruby.meta.platforms;
   };
 }

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -258,25 +258,6 @@ in
     stdenv' = bootStdenv;
   };
 
-  # Test compatibility with derivations using `env` as a regular variable.
-  test-env-derivation = bootStdenv.mkDerivation rec {
-    name = "test-env-derivation";
-    env = bootStdenv.mkDerivation {
-      name = "foo";
-      buildCommand = ''
-        mkdir "$out"
-        touch "$out/bar"
-      '';
-    };
-
-    passAsFile = [ "buildCommand" ];
-    buildCommand = ''
-      declare -p env
-      [[ $env == "${env}" ]]
-      touch "$out"
-    '';
-  };
-
   # Check that mkDerivation rejects MD5 hashes
   rejectedHashes = lib.recurseIntoAttrs {
     md5 =


### PR DESCRIPTION
Resolves #425858

This commit makes derivations built with `stdenv.mkDerivation` have an assert that ensures `env` is a non-derivation attrset.

Also drops a test that expects the behavior this PR is disallowing to be allowed.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
