### PR TITLE
mphidflash: init at version 1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11415,6 +11415,12 @@
     github = "jaredmontoya";
     githubId = 49511278;
   };
+  jaschutte = {
+    email = "snore-prize-landed@duck.com";
+    github = "jaschutte";
+    githubId = 34577095;
+    name = "James Schutte";
+  };
   jasoncarr = {
     email = "jcarr250@gmail.com";
     github = "jasoncarr0";

--- a/pkgs/by-name/mp/mphidflash/package.nix
+++ b/pkgs/by-name/mp/mphidflash/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libusb-compat-0_1,
+}:
+
+stdenv.mkDerivation {
+  pname = "mphidflash";
+  version = "1.8-unstable-2020-05-05";
+
+  src = fetchFromGitHub {
+    owner = "AdamLaurie";
+    repo = "mphidflash";
+    rev = "d65bedd3f564a5d91b29e06b4a5885c32780acc5";
+    hash = "sha256-akQjkkbGxkurBifTZuI+iVs8O2i8MM0LgMUYztg5hzE=";
+  };
+
+  nativeBuildInputs = [ libusb-compat-0_1 ];
+
+  buildFlags = [ "mphidflash64" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp binaries/mphidflash-1.8-linux-64 $out/bin/mphidflash
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Command-line tool for communicating with Microchips USB HID-Bootloader and downloading new firmware";
+    homepage = "https://github.com/AdamLaurie/mphidflash";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.jaschutte ];
+    platforms = lib.platforms.linux;
+    mainProgram = "mphidflash";
+  };
+}


### PR DESCRIPTION
Creates a package for mphidflash. Despite mphidflash being an older tool not really being updated anymore, it remains very useful for flashing older PIC devices.

More information can be found here:
https://github.com/AdamLaurie/mphidflash

I also add myself as a maintainer to the maintainers list and set myself as package maintainer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.
