### PR TITLE
lixPackageSets.lix_2_9{1,2}: drop

### DIFF
--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -131,47 +131,6 @@ in
 lib.makeExtensible (self: {
   inherit makeLixScope;
 
-  lix_2_91 = self.makeLixScope {
-    attrName = "lix_2_91";
-
-    lix-args = rec {
-      version = "2.91.3";
-
-      src = fetchFromGitHub {
-        owner = "lix-project";
-        repo = "lix";
-        rev = version;
-        hash = "sha256-b5d+HnPcyHz0ZJW1+LZl4qm4LGTB/TiaDFQVlVL2xpE=";
-      };
-
-      patches = [
-        # Support for lowdown >= 1.4, https://gerrit.lix.systems/c/lix/+/3731
-        (fetchpatch2 {
-          name = "lix-2.91-lowdown-1.4.0.patch";
-          url = "https://git.lix.systems/lix-project/lix/commit/ecff59d77371b21fef229c33ebb629bc49a8fad5.patch";
-          sha256 = "sha256-2M5oId5kObwzpw67rddAPI2RbWPEVlGBrMUXZWqqmEo=";
-        })
-      ];
-
-      docCargoDeps = rustPlatform.fetchCargoVendor {
-        name = "lix-doc-${version}";
-        inherit src;
-        sourceRoot = "${src.name or src}/lix-doc";
-        hash = "sha256-U820gvcbQIBaFr2OWPidfFIDXycDFGgXX1NpWDDqENs=";
-      };
-    };
-
-    nix-eval-jobs-args = {
-      version = "2.91.0";
-      src = fetchgit {
-        url = "https://git.lix.systems/lix-project/nix-eval-jobs.git";
-        # https://git.lix.systems/lix-project/nix-eval-jobs/commits/branch/release-2.91
-        rev = "1f98b0c016a6285f29ad278fa5cd82b8f470d66a";
-        hash = "sha256-ZJKOC/iLuO8qjPi9/ql69Vgh3NIu0tU6CSI0vbiCrKA=";
-      };
-    };
-  };
-
   lix_2_92 = self.makeLixScope {
     attrName = "lix_2_92";
 
@@ -279,7 +238,6 @@ lib.makeExtensible (self: {
           self.${version}.lix;
     in
     lib.dontRecurseIntoAttrs {
-      lix_2_91 = mkAlias "lix_2_91";
       # NOTE: Do not add new versions of Lix here.
       stable = mkAlias "stable";
       latest = mkAlias "latest";

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -128,70 +128,24 @@ let
         };
     };
 in
-lib.makeExtensible (self: {
-  inherit makeLixScope;
+lib.makeExtensible (
+  self:
+  {
+    inherit makeLixScope;
 
-  lix_2_92 = self.makeLixScope {
-    attrName = "lix_2_92";
+    lix_2_93 = self.makeLixScope {
+      attrName = "lix_2_93";
 
-    lix-args = rec {
-      version = "2.92.3";
+      lix-args = rec {
+        version = "2.93.3";
 
-      src = fetchFromGitHub {
-        owner = "lix-project";
-        repo = "lix";
-        rev = version;
-        hash = "sha256-iP2iUDxA99RcgQyZROs7bQw8pqxa1vFudRqjAIHg9Iw=";
-      };
-
-      patches = [
-        # Support for lowdown >= 1.4, https://gerrit.lix.systems/c/lix/+/3731
-        (fetchpatch2 {
-          name = "lix-lowdown-1.4.0.patch";
-          url = "https://git.lix.systems/lix-project/lix/commit/858de5f47a1bfd33835ec97794ece339a88490f1.patch";
-          hash = "sha256-FfLO2dFSWV1qwcupIg8dYEhCHir2XX6/Hs89eLwd+SY=";
-        })
-      ];
-
-      cargoDeps = rustPlatform.fetchCargoVendor {
-        name = "lix-${version}";
-        inherit src;
-        hash = "sha256-YMyNOXdlx0I30SkcmdW/6DU0BYc3ZOa2FMJSKMkr7I8=";
-      };
-    };
-
-    nix-eval-jobs-args = rec {
-      version = "2.92.0";
-      src = fetchgit {
-        url = "https://git.lix.systems/lix-project/nix-eval-jobs.git";
-        rev = version;
-        hash = "sha256-tPr61X9v/OMVt7VXOs1RRStciwN8gDGxEKx+h0/Fg48=";
-      };
-    };
-  };
-
-  lix_2_93 = self.makeLixScope {
-    attrName = "lix_2_93";
-
-    lix-args = rec {
-      version = "2.93.3";
-
-      src = fetchFromGitea {
-        domain = "git.lix.systems";
-        owner = "lix-project";
-        repo = "lix";
-        rev = version;
-        hash = "sha256-Oqw04eboDM8rrUgAXiT7w5F2uGrQdt8sGX+Mk6mVXZQ=";
-      };
-
-      patches = [
-        # Support for lowdown >= 1.4, https://gerrit.lix.systems/c/lix/+/3731
-        (fetchpatch2 {
-          name = "lix-lowdown-1.4.0.patch";
-          url = "https://git.lix.systems/lix-project/lix/commit/858de5f47a1bfd33835ec97794ece339a88490f1.patch";
-          hash = "sha256-FfLO2dFSWV1qwcupIg8dYEhCHir2XX6/Hs89eLwd+SY=";
-        })
-      ];
+        src = fetchFromGitea {
+          domain = "git.lix.systems";
+          owner = "lix-project";
+          repo = "lix";
+          rev = version;
+          hash = "sha256-Oqw04eboDM8rrUgAXiT7w5F2uGrQdt8sGX+Mk6mVXZQ=";
+        };
 
       cargoDeps = rustPlatform.fetchCargoVendor {
         name = "lix-${version}";


### PR DESCRIPTION
~~## Lix 2.90 series~~

~~Lix 2.90 is vulnerable to critical CVEs, known vulnerabilities warnings
were emitted. Users should have migrated by then.~~

~~There's no reason to keep it in-tree anymore.~~

This was already dropped in a previous PR.

## Lix 2.91 series

Lix 2.91 has been one of our historical LTS releases given that the Lix
2.92 series suffered from an unfortunate curl upstream bug and it took a
lot of time to fix it, in addition of other papercuts with SSH
connections.

Lix 2.91 is the last release not containing the asyncification work we
started.

Lix 2.92 latest minors sorted out these issues and possess bits of
asyncification, it's a much easier target for HEAD cherry-picks because
it also renamed the directory `src/nix` to `lix/`.

Plans are the following:

* Lix 2.92 is skipped.
* Lix 2.93 is the new stable.
* Lix 2.94 is the next stable.

Once NixOS 25.11 releases, Lix 2.92 will be dropped.

Lix 2.92 suffers from slight performance issues that are made up in Lix
2.93, your mileage may vary.

## Lix 2.92 series

Lix 2.92 is also dropped as we concluded that it is safe to skip over to 2.93 directly which we consider to be strongly stable. This simplifies maintenance for the Lix team.

If you are a user that discovers major regression in your workflows that worked in Lix 2.92, please contact or reach out the Lix team.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Add aliases for dropped packages
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
