### PR TITLE
temurin-jfx-bin-{17,21,25}: init

### DIFF
--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -139,6 +139,9 @@ stdenv.mkDerivation {
     '';
 
   preBuild = ''
+    # two seconds after the default
+    # Error: --date 1980-01-01T00:00:00Z is out of the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
+    export SOURCE_DATE_EPOCH=315532802
     export NUMBER_OF_PROCESSORS=$NIX_BUILD_CORES
     export NIX_CFLAGS_COMPILE="$(pkg-config --cflags glib-2.0) $NIX_CFLAGS_COMPILE"
   '';

--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation {
     data = ./. + "/${featureVersion}/deps.json";
   };
 
-  gradleBuildTask = "sdk";
+  gradleBuildTask = "jmods";
 
   stripDebugList = [ "." ];
 
@@ -145,6 +145,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     cp -r build/modular-sdk $out
+    cp -r build/jmods $out/jmods
   '';
 
   postFixup = ''

--- a/pkgs/by-name/te/temurin-jfx-bin/package.nix
+++ b/pkgs/by-name/te/temurin-jfx-bin/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  temurin-bin,
+  openjfx,
+
+  autoPatchelfHook,
+}:
+stdenv.mkDerivation {
+  pname = "temurin-jfx-bin";
+  inherit (temurin-bin) version;
+
+  dontUnpack = true;
+
+  buildInputs = [ temurin-bin ];
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  installPhase = ''
+    jfxDir="${openjfx}/jmods"
+    jdkDir="${temurin-bin}/jmods"
+    jmods="$(find "$jdkDir" "$jfxDir" -maxdepth 1 -type f -printf '%f\n' | sed 's/\.jmod$//' | tr '\n' ',')"
+
+    jlink \
+      --module-path "$jdkDir":"$jfxDir" \
+      --add-modules "$jmods" \
+      --output $out
+
+    mkdir -p $out/jmods
+    cp -r "$jfxDir"/* "$jdkDir"/* $out/jmods
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    [ "$($out/bin/jshell -s \
+      <<< 'import javafx.application.*;' 2>&1 \
+      | grep -Eic 'error|does not exist')" == 0 ]
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Temurin with JavaFX support patched in";
+    license = with lib.licenses; [
+      gpl2
+      classpathException20
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode # prebuilt java binaries
+      binaryBytecode # linked classes
+      fromSource # openjfx code
+    ];
+    # No jmods available since JEP 493
+    broken = lib.versionAtLeast temurin-bin.version "24";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4413,15 +4413,27 @@ with pkgs;
   ### DEVELOPMENT / COMPILERS
   temurin-bin-25 = javaPackages.compiler.temurin-bin.jdk-25;
   temurin-jre-bin-25 = javaPackages.compiler.temurin-bin.jre-25;
+  temurin-jfx-bin-25 = temurin-jfx-bin.override {
+    temurin-bin = temurin-bin-25;
+    openjfx = openjfx25;
+  };
 
   temurin-bin-23 = javaPackages.compiler.temurin-bin.jdk-23;
   temurin-jre-bin-23 = javaPackages.compiler.temurin-bin.jre-23;
 
   temurin-bin-21 = javaPackages.compiler.temurin-bin.jdk-21;
   temurin-jre-bin-21 = javaPackages.compiler.temurin-bin.jre-21;
+  temurin-jfx-bin-21 = temurin-jfx-bin.override {
+    temurin-bin = temurin-bin-21;
+    openjfx = openjfx21;
+  };
 
   temurin-bin-17 = javaPackages.compiler.temurin-bin.jdk-17;
   temurin-jre-bin-17 = javaPackages.compiler.temurin-bin.jre-17;
+  temurin-jfx-bin-17 = temurin-jfx-bin.override {
+    temurin-bin = temurin-bin-17;
+    openjfx = openjfx17;
+  };
 
   temurin-bin-11 = javaPackages.compiler.temurin-bin.jdk-11;
   temurin-jre-bin-11 = javaPackages.compiler.temurin-bin.jre-11;


### PR DESCRIPTION
The 25 version is broken at the moment, because `temurin-bin-25` does not output its jmods for some reason.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
