### PR TITLE
jetbrains.jdk*: Update Jetbrains Java Runtime packages 

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/17.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/17.nix
@@ -43,32 +43,27 @@ let
 in
 openjdk17.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
-  javaVersion = "17.0.11";
-  build = "1207.24";
+  javaVersion = "17.0.15";
+  build = "1381";
   # To get the new tag:
   # git clone https://github.com/jetbrains/jetbrainsruntime
   # cd jetbrainsruntime
-  # git reset --hard [revision]
-  # git log --simplify-by-decoration --decorate=short --pretty=short | grep "jbr-" --color=never | cut -d "(" -f2 | cut -d ")" -f1 | awk '{print $2}' | sort -t "-" -k 2 -g | tail -n 1 | tr -d ","
-  openjdkTag = "jbr-17.0.8+7";
+  # git tag --points-at [revision]
+  # Look for the line that starts with jbr-
+  openjdkTag = "jbr-17.0.15+6";
   version = "${javaVersion}-b${build}";
 
   src = fetchFromGitHub {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    hash = "sha256-a7cJF2iCW/1GK0/GmVbaY5pYcn3YtZy5ngFkyAGRhu0=";
+    hash = "sha256-Ckv2SNugHK75Af+ZzI91+QodOHIa5TMcjVQYsO45mQo=";
   };
 
   env = {
     BOOT_JDK = openjdk17-bootstrap.home;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-    SOURCE_DATE_EPOCH = 1715809405;
-    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU (toString [
-      "-Wno-error=format-overflow"
-      "-Wno-error=template-id-cdtor"
-      "-Wno-error=calloc-transposed-args"
-    ]);
+    SOURCE_DATE_EPOCH = 1745907200;
   };
 
   patches = [ ];

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -27,6 +27,8 @@
   wayland,
   udev,
   fontconfig,
+  shaderc,
+  vulkan-headers,
 }:
 
 assert debugBuild -> withJcef;
@@ -42,27 +44,27 @@ let
 in
 jdk.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
-  javaVersion = "21.0.6";
-  build = "895.109";
+  javaVersion = "21.0.7";
+  build = "1038.58";
   # To get the new tag:
   # git clone https://github.com/jetbrains/jetbrainsruntime
   # cd jetbrainsruntime
-  # git checkout jbr-release-${javaVersion}b${build}
-  # git log --simplify-by-decoration --decorate=short --pretty=short | grep "jbr-" --color=never | cut -d "(" -f2 | cut -d ")" -f1 | awk '{print $2}' | sort -t "-" -k 2 -g | tail -n 1 | tr -d ","
-  openjdkTag = "jbr-21.0.6+7";
+  # git tag --points-at [revision]
+  # Look for the line that starts with jbr-
+  openjdkTag = "jbr-release-21.0.7b1038.58";
   version = "${javaVersion}-b${build}";
 
   src = fetchFromGitHub {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    hash = "sha256-Neh0PGer4JnNaForBKRlGPLft5cae5GktreyPRNjFCk=";
+    hash = "sha256-sGAMrE9gAt73jgLlNW8p5Lz37gFiK4ZvMQ8giE2Ia54=";
   };
 
   env = {
     BOOT_JDK = jdk.home;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-    SOURCE_DATE_EPOCH = 1726275531;
+    SOURCE_DATE_EPOCH = 1745907200;
   };
 
   patches = [ ];
@@ -170,8 +172,14 @@ jdk.overrideAttrs (oldAttrs: rec {
     autoconf
     unzip
     rsync
+    shaderc # glslc
   ]
   ++ oldAttrs.nativeBuildInputs;
+
+  buildInputs = [
+    vulkan-headers
+  ]
+  ++ oldAttrs.buildInputs or [ ];
 
   meta = with lib; {
     description = "OpenJDK fork to better support Jetbrains's products";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Upgrade `jetbrains.jdk-17-*` to `jb17.0.15-b1381`
- Upgrade `jetbrains.jdk` to `jb21.0.7-b1038.58`

This also fixes the build failures introduced by https://github.com/NixOS/nixpkgs/commit/4f3fd5b70e2fb50670f11e1da9d6310dcaf3f667, at least on x86_64.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## Prior Art

This PR should in theory supersede #425529 and #425814. #419026 also attempts to fix the runtime while upgrading other jetbrains packages.

I believe the approach in this PR is the "most-correct" and minimally invasive one with the added benefit of upgrading the Jetbrains runtime packages to newer versions.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
