### PR TITLE
depmod: add override option

### DIFF
--- a/nixos/lib/make-multi-disk-zfs-image.nix
+++ b/nixos/lib/make-multi-disk-zfs-image.nix
@@ -122,13 +122,10 @@ let
     rootPaths = [ config.system.build.toplevel ] ++ (lib.optional includeChannel channelSources);
   };
 
-  modulesTree = pkgs.aggregateModules (
-    with config.boot;
-    [
-      kernelPackages.kernel
-      kernelPackages.${pkgs.zfs.kernelModuleAttribute}
-    ]
-  );
+  modulesTree = pkgs.aggregateModules (with config.boot; [
+    kernelPackages.kernel
+    kernelPackages.${pkgs.zfs.kernelModuleAttribute}
+  ]) config.boot.kernelPackages.kernel.version null;
 
   tools = lib.makeBinPath (
     with pkgs;

--- a/nixos/lib/make-single-disk-zfs-image.nix
+++ b/nixos/lib/make-single-disk-zfs-image.nix
@@ -110,13 +110,10 @@ let
     rootPaths = [ config.system.build.toplevel ] ++ (lib.optional includeChannel channelSources);
   };
 
-  modulesTree = pkgs.aggregateModules (
-    with config.boot;
-    [
-      kernelPackages.kernel
-      kernelPackages.${pkgs.zfs.kernelModuleAttribute}
-    ]
-  );
+  modulesTree = pkgs.aggregateModules (with config.boot; [
+    kernelPackages.kernel
+    kernelPackages.${pkgs.zfs.kernelModuleAttribute}
+  ]) config.boot.kernelPackages.kernel.version null;
 
   tools = lib.makeBinPath (
     with pkgs;

--- a/pkgs/os-specific/linux/kmod/aggregator.nix
+++ b/pkgs/os-specific/linux/kmod/aggregator.nix
@@ -1,11 +1,55 @@
 {
   stdenvNoCC,
+  lib,
   kmod,
   modules,
   buildEnv,
+  writeTextFile,
+  kernelVersion,
   name ? "kernel-modules",
+  depmodConfig ? null,
 }:
+let
+  getRelativeOverridePath =
+    entry:
+    let
+      # check if the modulePath is inside the aggregator environmnet. If not, throw an error
+      checkModuleExists =
+        x:
+        lib.throwIf
+          (
+            (lib.lists.findFirst (
+              a:
+              lib.path.hasPrefix (/. + builtins.unsafeDiscardStringContext a.outPath) (
+                /. + builtins.unsafeDiscardStringContext x.modulePackage
+              )
+            ) null modules) == null
+          )
+          "The modulePath for your ${x.moduleName} depmod override is not available. Add ${x.modulePackage} to `boot.extraModulePackages`."
+          (checkModuleRelativePathIsInStore x);
 
+      checkModuleRelativePathIsInStore =
+        x:
+        let
+          moduleStorePath = "${x.modulePackage}" + "/lib/modules/${kernelVersion}" + "/${x.modulePath}";
+        in
+        lib.throwIfNot (builtins.pathExists moduleStorePath) "${moduleStorePath} does not exist in store" x;
+    in
+    (checkModuleExists entry).modulePath;
+
+  genDepmodConfOverridesList = builtins.map (
+    x: "override ${x.moduleName} * ${getRelativeOverridePath x}"
+  ) depmodConfig.overrides;
+
+  depmodConfFile = writeTextFile {
+    name = "depmod.conf";
+    text = lib.optionalString (!(builtins.isNull depmodConfig)) (
+      builtins.concatStringsSep "\n" genDepmodConfOverridesList
+    );
+
+    preferLocalBuild = true;
+  };
+in
 buildEnv {
   inherit name;
 
@@ -30,11 +74,13 @@ buildEnv {
 
     shopt -s extglob
 
+    cp ${depmodConfFile} $out/lib/modules/$kernelVersion/depmod.conf
+
     # Regenerate the depmod map files.  Be sure to pass an explicit
     # kernel version number, otherwise depmod will use `uname -r'.
     if test -w $out/lib/modules/$kernelVersion; then
         rm -f $out/lib/modules/$kernelVersion/modules.!(builtin*|order*)
-        ${kmod}/bin/depmod -b $out -C $out/etc/depmod.d -a $kernelVersion
+        ${kmod}/bin/depmod --config ${depmodConfFile} -b $out -a $kernelVersion
     fi
   '';
 }

--- a/pkgs/os-specific/linux/kmod/depmod-config-generator.nix
+++ b/pkgs/os-specific/linux/kmod/depmod-config-generator.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  modules,
+  writeTextFile,
+  kernelVersion,
+  depmodConfig ? null,
+}:
+#####
+# Create a depmod config file.
+# During the creation check if the entries are valid. If not throw an error
+#####
+let
+  getRelativeOverridePath =
+    entry:
+    let
+      # check if the modulePath is inside the aggregator environment (`modules`). If not, throw an error as the depmod reference is not possible
+      checkModuleExists =
+        x:
+        lib.throwIf
+          (
+            (lib.lists.findFirst (
+              a:
+              lib.path.hasPrefix (/. + builtins.unsafeDiscardStringContext a.outPath) (
+                /. + builtins.unsafeDiscardStringContext x.modulePackage
+              )
+            ) null modules) == null
+          )
+          "The modulePath for your ${x.moduleName} depmod override is not available. Add ${x.modulePackage} to `boot.extraModulePackages`."
+          (checkModuleRelativePathIsInStore x);
+
+      # check if the set modulePath of an entry exists in the aggregator environment (`modules`). If not, throw an error
+      checkModuleRelativePathIsInStore =
+        x:
+        let
+          moduleStorePath = "${x.modulePackage}" + "/lib/modules/${kernelVersion}" + "/${x.modulePath}";
+        in
+        lib.throwIfNot (builtins.pathExists moduleStorePath) "${moduleStorePath} does not exist in store" x;
+    in
+    (checkModuleExists entry).modulePath;
+
+  # create a list of depmod override config lines
+  genDepmodConfOverridesList = builtins.map (
+    x: "override ${x.moduleName} * ${getRelativeOverridePath x}"
+  ) depmodConfig.overrides;
+in
+writeTextFile {
+  name = "depmod.conf";
+  text = lib.optionalString (!(builtins.isNull depmodConfig)) (
+    builtins.concatStringsSep "\n" genDepmodConfOverridesList
+  );
+
+  preferLocalBuild = true;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10644,10 +10644,10 @@ with pkgs;
       };
 
   aggregateModules =
-    modules:
+    modules: kernelVersion: depmodConfig:
     callPackage ../os-specific/linux/kmod/aggregator.nix {
       inherit (buildPackages) kmod;
-      inherit modules;
+      inherit modules kernelVersion depmodConfig;
     };
 
   nushell = callPackage ../shells/nushell { };


### PR DESCRIPTION
**Description**
This PR allows to override a kernel module using depmod e.g., to prefer an out-of-tree kernel module over one shipped with the kernel

**Changes**
- Add `boot.depmod.overrides` option
- depmod no longer reads config from `$out/etc/depmod.d` (which seems to never have been documented). `$out/etc/depmod.d` has been introduced in https://github.com/NixOS/nixpkgs/commit/a0e4ee31116bc235cdb5430f9c253231403f0596.

**What this PR does**
- This PR allows to create a depmod configuration that is then used by depmod. Currently only overrides are implemented allowing to prefer e.g., an out-of-tree kernel module.
- This PR checks if the package containing the preferred module is part of the kernel closure. If not, an error message is shown that the package should be added to `boot.extraModulePackages`.
- This PR checks if the relative path to the preferred module exist. Otherwise an error message is shown.
- Additionally the generated depmod configuration is added to the merged kernel module store path, allowing depmod debugging.

**This PR is required for**
- https://github.com/NixOS/nixpkgs/pull/421925

**Related Issues**
- https://github.com/NixOS/nixpkgs/issues/213658

If you would like to see how the new option is used, let me know.

**TODOs**
- [ ] Check if both `nixos/lib/make-single-disk-zfs-image.nix` and  `nixos/lib/make-multi-disk-zfs-image.nix`still work

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
