### PR TITLE
.github/PULL_REQUEST_TEMPLATE: shorten inline comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,18 @@
 
 <!--
-^ Please summarise the changes you have done and explain why they are necessary here ^
-
-For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
-For new packages please briefly describe the package or provide a link to its homepage.
+Please summarise your changes and explain why they are necessary here.
 -->
 
 ## Things done
 
-<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
+<!-- Please check what applies. Not all of these are hard requirements. -->
 
 - Built on platform:
   - [ ] x86_64-linux
   - [ ] aarch64-linux
   - [ ] x86_64-darwin
   - [ ] aarch64-darwin
-- Tested, as applicable:
+- Tested:
   - [ ] [NixOS tests] in [nixos/tests].
   - [ ] [Package tests] at `passthru.tests`.
   - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.


### PR DESCRIPTION
The shorter the better, because they take space - and won't be read if too long.

The notes about the changelog or the upstream homepage are important.. but are too late to add here. They should *already* be in the commit message - and when they are, they will be in the PR template automatically. On a single commit PR, at least.

We'll somehow need to find a way to motivate authors to understand the contribution guidelines *first*, before they open the PR - so that they already have the changelog sorted out.

Also removed the duplicate "as applicable" from the Tested section. The notion of "only when applicable" is already communicated in the inline comment above.

This was too controversial for #425831.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
