### PR TITLE
python3Packages.nifty: 8.5.7 -> 9.1.0

### DIFF
--- a/pkgs/development/python-modules/nifty/default.nix
+++ b/pkgs/development/python-modules/nifty/default.nix
@@ -24,44 +24,50 @@
   pytest-xdist,
   mpiCheckPhaseHook,
   openssh,
-}:
 
+  # CUDA
+  config,
+  cudaSupport ? config.cudaSupport,
+  cudaPackages,
+}:
 buildPythonPackage rec {
-  pname = "nifty8";
-  version = "8.5.7";
+  pname = "nifty";
+  version = "9.1.0";
   pyproject = true;
 
   src = fetchFromGitLab {
     domain = "gitlab.mpcdf.mpg.de";
     owner = "ift";
     repo = "nifty";
-    tag = "v${version}";
-    hash = "sha256-5KPmM1UaXnS/ZEsnyFyxvDk4Nc4m6AT5FDgmCG6U6YU=";
+    tag = version;
+    hash = "";
   };
 
-  # nifty8.re is the jax-backed version of nifty8 (the regular one uses numpy).
+  # nifty.re is the jax-backed version of nifty (the regular one uses numpy/cupy).
   # It is not compatible with the latest jax update:
   # https://gitlab.mpcdf.mpg.de/ift/nifty/-/issues/414
   # While the issue is being fixed by upstream, we completely remove this package from the source and the tests.
   postPatch = ''
-    rm -r src/re
+    rm -r nifty/re
     rm -r test/test_re
   '';
 
   build-system = [ setuptools ];
 
-  dependencies = [
-    astropy
-    ducc0
-    h5py
-    jax
-    jaxlib
-    matplotlib
-    mpi4py
-    mpi
-    numpy
-    scipy
-  ];
+  dependencies =
+    [
+      ducc0
+      h5py
+      matplotlib
+      mpi4py
+      mpi
+      numpy
+      scipy
+    ]
+    + lib.optionals cudaSupport [
+      cupy
+      cudaPackages.cudatoolkit
+    ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -96,11 +102,11 @@ buildPythonPackage rec {
         ${lib.getExe' mpi "mpirun"} -n 2 --bind-to none python3 -m pytest test/test_mpi
       '';
 
-  pythonImportsCheck = [ "nifty8" ];
+  pythonImportsCheck = [ "nifty" ];
 
   meta = {
     homepage = "https://gitlab.mpcdf.mpg.de/ift/nifty";
-    changelog = "https://gitlab.mpcdf.mpg.de/ift/nifty/-/blob/v${version}/ChangeLog.md";
+    changelog = "https://gitlab.mpcdf.mpg.de/ift/nifty/-/blob/${version}/ChangeLog.md";
     description = "Bayesian Imaging library for high-dimensional posteriors";
     longDescription = ''
       NIFTy, "Numerical Information Field Theory", is a Bayesian imaging library.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10298,7 +10298,7 @@ self: super: with self; {
 
   nidaqmx = callPackage ../development/python-modules/nidaqmx { };
 
-  nifty8 = callPackage ../development/python-modules/nifty8 { };
+  nifty = callPackage ../development/python-modules/nifty { };
 
   nikola = callPackage ../development/python-modules/nikola { };
 


### PR DESCRIPTION
This updates the python package nifty. Previously it has been distributed under the name `nifty8` (see e.g. https://pypi.org/project/nifty8/). With the version bump to version 9.x.x it has been renamed to `nifty` (see also https://pypi.org/project/nifty/).
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
