### PR TITLE
python3Packages.ffmpy: unbreak build with uv-build >=0.8.0

### DIFF
--- a/pkgs/development/python-modules/ffmpy/default.nix
+++ b/pkgs/development/python-modules/ffmpy/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ffmpy" ];
 
-  nativeBuildInputs = [ uv-build ];
+  build-system = [ uv-build ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/ffmpy/default.nix
+++ b/pkgs/development/python-modules/ffmpy/default.nix
@@ -25,14 +25,15 @@ buildPythonPackage rec {
   };
 
   postPatch =
+    # Default to store ffmpeg.
     ''
-      # default to store ffmpeg
       substituteInPlace ffmpy/ffmpy.py \
         --replace-fail \
           'executable: str = "ffmpeg",' \
-          'executable: str = "${ffmpeg-headless}/bin/ffmpeg",'
-
-      #  The tests test a mock that does not behave like ffmpeg. If we default to the nix-store ffmpeg they fail.
+          'executable: str = "${lib.getExe ffmpeg-headless}",'
+    ''
+    # The tests test a mock that does not behave like ffmpeg. If we default to the nix-store ffmpeg they fail.
+    + ''
       for fname in tests/*.py; do
         echo >>"$fname" 'FFmpeg.__init__.__defaults__ = ("ffmpeg", *FFmpeg.__init__.__defaults__[1:])'
       done

--- a/pkgs/development/python-modules/ffmpy/default.nix
+++ b/pkgs/development/python-modules/ffmpy/default.nix
@@ -24,18 +24,24 @@ buildPythonPackage rec {
     hash = "sha256-U20mBg+428kkka6NY9qc7X8jH8A5bKa++g2+PTn/MYg=";
   };
 
-  postPatch = ''
-    # default to store ffmpeg
-    substituteInPlace ffmpy/ffmpy.py \
-      --replace-fail \
-        'executable: str = "ffmpeg",' \
-        'executable: str = "${ffmpeg-headless}/bin/ffmpeg",'
+  postPatch =
+    ''
+      # default to store ffmpeg
+      substituteInPlace ffmpy/ffmpy.py \
+        --replace-fail \
+          'executable: str = "ffmpeg",' \
+          'executable: str = "${ffmpeg-headless}/bin/ffmpeg",'
 
-    #  The tests test a mock that does not behave like ffmpeg. If we default to the nix-store ffmpeg they fail.
-    for fname in tests/*.py; do
-      echo >>"$fname" 'FFmpeg.__init__.__defaults__ = ("ffmpeg", *FFmpeg.__init__.__defaults__[1:])'
-    done
-  '';
+      #  The tests test a mock that does not behave like ffmpeg. If we default to the nix-store ffmpeg they fail.
+      for fname in tests/*.py; do
+        echo >>"$fname" 'FFmpeg.__init__.__defaults__ = ("ffmpeg", *FFmpeg.__init__.__defaults__[1:])'
+      done
+    ''
+    # uv-build in nixpkgs is now at 0.8.0, which otherwise breaks the constraint set by the package.
+    + ''
+      substituteInPlace pyproject.toml \
+        --replace-fail 'requires = ["uv_build>=0.7.9,<0.8.0"]' 'requires = ["uv_build>=0.7.9,<0.9.0"]'
+    '';
 
   pythonImportsCheck = [ "ffmpy" ];
 


### PR DESCRIPTION
Ensure `python3Packages.ffmpy` continues to build after #426319 is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
