### PR TITLE
slacky: 0.0.5 -> 0.0.6, add electron ozone flags

### DIFF
--- a/pkgs/by-name/sl/slacky/package.nix
+++ b/pkgs/by-name/sl/slacky/package.nix
@@ -33,7 +33,6 @@ buildNpmPackage (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    electron
     copyDesktopItems
   ];
 
@@ -42,7 +41,8 @@ buildNpmPackage (finalAttrs: {
   postInstall = ''
     mkdir -p $out/share/icons
     ln -s $out/lib/node_modules/slacky/build/icons/icon.png $out/share/icons/slacky.png
-    makeWrapper ${electron}/bin/electron $out/bin/slacky \
+    makeWrapper ${lib.getExe electron} $out/bin/slacky \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --add-flags $out/lib/node_modules/slacky/
   '';
 

--- a/pkgs/by-name/sl/slacky/package.nix
+++ b/pkgs/by-name/sl/slacky/package.nix
@@ -71,7 +71,7 @@ buildNpmPackage (finalAttrs: {
     changelog = "https://github.com/andirsun/Slacky/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ awwpotato ];
-    platforms = [ "aarch64-linux" ];
+    platforms = lib.platforms.linux;
     mainProgram = "slacky";
   };
 })

--- a/pkgs/by-name/sl/slacky/package.nix
+++ b/pkgs/by-name/sl/slacky/package.nix
@@ -9,18 +9,28 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "slacky";
-  version = "0.0.5";
+  version = "0.0.6";
 
   src = fetchFromGitHub {
     owner = "andirsun";
     repo = "Slacky";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nDxmzZqi7xEe4hnY6iXJg+613lSKElWxvF3w8bRDW90=";
+    hash = "sha256-70mexW+8+0hvVr2PYGtQuBiTh6xo2WFDqLzeCZilgaE=";
   };
 
-  npmDepsHash = "sha256-9+4cxeQw2Elug+xIgzNvpaSMgDVlBFz/+TW1jJwDm40=";
+  npmDepsHash = "sha256-Vqpg+j2mIv5XKzX//ptt9gT+SWPXpVSKSCM+E5cmuCQ=";
 
-  npmPackFlags = [ "--ignore-scripts" ];
+  npmPackFlags = [
+    "--ignore-scripts"
+  ];
+
+  makeCacheWritable = true;
+
+  npmFlags = [
+    "--legacy-peer-deps"
+  ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     electron


### PR DESCRIPTION
- Bump `slacky` to 0.0.6
- add electron ozone flags for Wayland


Closes https://github.com/NixOS/nixpkgs/issues/426435
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
