### PR TITLE
lima: fix guestagents resolvement with resolve-argv0

### DIFF
--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -74,7 +74,8 @@ buildGoModule (finalAttrs: {
       mkdir -p $out
       cp -r _output/* $out
       wrapProgram $out/bin/limactl \
-        --prefix PATH : ${lib.makeBinPath [ qemu ]}
+        --prefix PATH : ${lib.makeBinPath [ qemu ]}\
+        --argv0
     ''
     + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
       installShellCompletion --cmd limactl \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

According to its [code](https://github.com/lima-vm/lima/blob/13813176b1a01c4d6945e4dd73a3f7ae6a3dce7c/pkg/usrlocalsharelima/usrlocalsharelima.go#L22-L28), lima uses argv0 to determine the `share/lima` folder's route, which causes error in nix when `limactl` in PATH is a soft-link.

```bash
$ limactl start
INFO[0000] Using the existing instance "default"        
INFO[0000] Starting the instance "default" with VM driver "vz" 
FATA[0000] failed to find "lima-guestagent.Linux-aarch64" binary for "/run/current-system/sw/bin/limactl", attempted [/run/current-system/sw/bin/lima-guestagent.Linux-aarch64 /run/current-system/sw/share/lima/lima-guestagent.Linux-aarch64] 
```

[Using an empty `--argv0` in `makeWrapper` will set the real executable as argv0](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper.sh#L14-L15), which solves the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
