### PR TITLE
python3Packages.pytorch-scatter: init at 2.1.2

### DIFF
--- a/pkgs/development/python-modules/pytorch-scatter/default.nix
+++ b/pkgs/development/python-modules/pytorch-scatter/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  autoAddDriverRunpath,
+  which,
+  wheel,
+  packaging,
+  pytestCheckHook,
+  setuptools,
+
+  pybind11,
+  torch,
+
+  cudaPackages ? { },
+}:
+
+let
+  inherit (torch) cudaCapabilities cudaSupport;
+
+  cudaLibs = [
+    cudaPackages.cuda_cccl
+    cudaPackages.cuda_cudart
+    cudaPackages.cuda_nvcc
+    cudaPackages.libcusparse
+    cudaPackages.libcublas
+    cudaPackages.libcusolver
+  ];
+
+  cudaIncludes = lib.concatMapStringsSep " " (l: "-I${lib.getInclude l}/include") cudaLibs;
+  cudaLibDirs = lib.concatMapStringsSep " " (l: "-L${lib.getLib l}/lib") cudaLibs;
+in
+buildPythonPackage rec {
+  pname = "pytorch_scatter";
+  version = "2.1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rusty1s";
+    repo = "pytorch_scatter";
+    tag = version;
+    hash = "sha256-dmJrsWoFsqFlrgfbFHeD5f//qUg0elmksIZG8vXXShc=";
+  };
+
+  preConfigure = ''
+    export NVCC_THREADS="$NIX_BUILD_CORES"
+    export MAX_JOBS="$NIX_BUILD_CORES"
+  '';
+
+  preBuild = lib.optionalString cudaSupport ''
+    export FORCE_CUDA=1
+    export NVCC_FLAGS="${cudaIncludes} ${cudaLibDirs}"
+    export TORCH_CUDA_ARCH_LIST="${lib.concatStringsSep ";" cudaCapabilities}"
+    export CUDA_VERSION=${cudaPackages.cudaMajorMinorVersion}
+    export CC=${cudaPackages.backendStdenv.cc}/bin/cc
+    export CXX=${cudaPackages.backendStdenv.cc}/bin/c++
+  '';
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [
+    packaging
+    torch
+    wheel
+    which
+  ]
+  ++ lib.optionals cudaSupport (
+    [
+      autoAddDriverRunpath
+    ]
+    ++ cudaLibs
+  );
+
+  buildInputs = [
+    pybind11
+  ]
+  ++ lib.optionals cudaSupport cudaLibs;
+
+  dependencies = [ torch ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  preCheck = ''
+    # Ensure tests import the installed module, not the source subdir
+    rm -rf torch_scatter
+  '';
+
+  pythonImportsCheck = [ "torch_scatter" ];
+
+  meta = {
+    description = "Small extension library of highly optimized sparse update (scatter and segment) operations for use in PyTorch";
+    homepage = "https://github.com/rusty1s/pytorch_scatter";
+    changelog = "https://github.com/rusty1s/pytorch_scatter/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jherland ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15306,6 +15306,8 @@ self: super: with self; {
 
   pytorch-pfn-extras = callPackage ../development/python-modules/pytorch-pfn-extras { };
 
+  pytorch-scatter = callPackage ../development/python-modules/pytorch-scatter { };
+
   pytorch-tabnet = callPackage ../development/python-modules/pytorch-tabnet { };
 
   pytorch3d = callPackage ../development/python-modules/pytorch3d { };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
