### PR TITLE
Fix link syntax in Markdown files

### DIFF
--- a/doc/stdenv/passthru.chapter.md
+++ b/doc/stdenv/passthru.chapter.md
@@ -53,7 +53,7 @@ They fall in one of these categories:
 
   These tend to entail support from the derivation or the `passthru` attribute in question.
   Common examples of this type are `passthru.optional-dependencies`, `passthru.withPlugins`, and `passthru.withPackages`.
-  All of those allow associating the package with a set of components built for that specific package, such as when building Python runtime environments using (`python.withPackages`)[#python.withpackages-function].
+  All of those allow associating the package with a set of components built for that specific package, such as when building Python runtime environments using [`python.withPackages`](#python.withpackages-function).
 
 Attributes that apply only to particular [build helpers](#part-builders) or [language ecosystems](#chap-language-support) are documented there.
 

--- a/nixos/modules/services/web-apps/ocis.md
+++ b/nixos/modules/services/web-apps/ocis.md
@@ -104,7 +104,7 @@ values, and
 [`services.ocis.environmentFile`][mod-envFile] for
 sensitive values.
 
-Configuration in (`services.ocis.environment`)[mod-env] overrides those from
+Configuration in [`services.ocis.environment`][mod-env] overrides those from
 [`services.ocis.environmentFile`][mod-envFile] and will have highest
 precedence
 


### PR DESCRIPTION
- **nixos/services: fix Markdown link syntax in web-apps/ocis.md**
- **doc: fix Markdown link syntax in stdenv/passthru.chapter.md**

Fixed typos after reading https://nixos.org/manual/nixpkgs/unstable/#sec-common-passthru-attributes.

No other instances with

```sh
rg -g '*.md' -F ')['
```

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
