### PR TITLE
python3Packages.mozjpeg-lossless-optimization: rename from snake case, do some cleanup

### DIFF
--- a/pkgs/by-name/kc/kcc/package.nix
+++ b/pkgs/by-name/kc/kcc/package.nix
@@ -46,7 +46,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     python-slugify
     raven
     requests
-    mozjpeg_lossless_optimization
+    mozjpeg-lossless-optimization
     natsort
     distro
     numpy

--- a/pkgs/development/python-modules/mozjpeg-lossless-optimization/default.nix
+++ b/pkgs/development/python-modules/mozjpeg-lossless-optimization/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  python3Packages,
   fetchFromGitHub,
   buildPythonPackage,
   mozjpeg,
@@ -18,7 +17,6 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "wanadev";
     repo = "mozjpeg-lossless-optimization";
-    # https://github.com/NixOS/nixpkgs/issues/26302
     tag = "v${version}";
     hash = "sha256-0w0e7QbYi3W6MahY8fnI+dYkQHqheOXQn3mJN/UfHlk=";
     fetchSubmodules = true;
@@ -27,17 +25,22 @@ buildPythonPackage rec {
   # This package needs cmake, but it is not the default builder
   dontUseCmakeConfigure = true;
 
-  buildInputs = [ mozjpeg ];
-  nativeBuildInputs = [ cmake ];
-  propagatedBuildInputs = [ cffi ];
+  build-system = [
+    cffi
+    cmake
+    setuptools
+  ];
+
+  dependencies = [ cffi ];
 
   # https://github.com/NixOS/nixpkgs/issues/255262
   preCheck = ''
     rm -r mozjpeg_lossless_optimization
   '';
 
-  build-system = [ setuptools ];
   nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "mozjpeg_lossless_optimization" ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/development/python-modules/mozjpeg-lossless-optimization/default.nix
+++ b/pkgs/development/python-modules/mozjpeg-lossless-optimization/default.nix
@@ -11,7 +11,7 @@
   cffi,
 }:
 buildPythonPackage rec {
-  pname = "mozjpeg_lossless_optimization";
+  pname = "mozjpeg-lossless-optimization";
   version = "1.3.2";
   pyproject = true;
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -368,6 +368,7 @@ mapAliases {
   monarchmoney = throw "'monarchmoney' has been renamed to/replaced by 'monarchmoneycommunity'"; # Added 2026-03-05
   monkeytype = throw "'monkeytype' has been removed as it was unmaintained upstream"; # Added 2026-04-19
   moretools = "'moretools' has been removed because it is unmaintained"; # Added 2026-01-19
+  mozjpeg_lossless_optimization = throw "'mozjpeg_lossless_optimization' has been renamed to/replaced by 'mozjpeg-lossless-optimization'"; # Added 2026-06-07
   mpire = throw "'mpire' has been removed because it is unused in Nixpkgs"; # Added 2026-06-22
   msldap-bad = throw "'msldap-bad' has been renamed to/replaced by 'badldap'"; # added 2025-11-06
   mullvad-closest = throw "'mullvad-closest' has been removed as it was unmaintained. Consider using 'mullvad-compass' instead."; # Added 2026-01-13

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10541,8 +10541,8 @@ self: super: with self; {
 
   mozilla-django-oidc = callPackage ../development/python-modules/mozilla-django-oidc { };
 
-  mozjpeg_lossless_optimization =
-    callPackage ../development/python-modules/mozjpeg_lossless_optimization
+  mozjpeg-lossless-optimization =
+    callPackage ../development/python-modules/mozjpeg-lossless-optimization
       { };
 
   mpd2 = callPackage ../development/python-modules/mpd2 { };


### PR DESCRIPTION
Not sure why it was added with a snake_case name: even pypi has it as skewer-case ([link](https://pypi.org/project/mozjpeg-lossless-optimization/))


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
