### PR TITLE
python3Packages.wand: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/wand/default.nix
+++ b/pkgs/development/python-modules/wand/default.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   buildPythonPackage,
   fetchPypi,
@@ -29,13 +30,18 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = [
-    # https://github.com/emcconville/wand/issues/558
-    "test_forward_fourier_transform"
-    "test_inverse_fourier_transform"
-    # our imagemagick doesn't set MagickReleaseDate
-    "test_configure_options"
-  ];
+  disabledTests =
+    [
+      # https://github.com/emcconville/wand/issues/558
+      "test_forward_fourier_transform"
+      "test_inverse_fourier_transform"
+      # our imagemagick doesn't set MagickReleaseDate
+      "test_configure_options"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # AssertionError: assert wand.color.Color('srgb(255,0,1.41553e-14)') == wand.color.Color('srgb(255,0,0)')
+      "test_sparse_color"
+    ];
 
   passthru.imagemagick = imagemagickBig;
 


### PR DESCRIPTION
Skipped a test that seems to only be failing on darwin:
```
       > =================================== FAILURES ===================================
       > ______________________________ test_sparse_color _______________________________
       >
       >     def test_sparse_color():
       >         with Image(width=10, height=10, background=Color('WHITE')) as img:
       >             colors = {'#F00': (0, 0), '#00F': (9, 9)}
       >             img.sparse_color('barycentric', colors)
       > >           assert img[0, 0] == Color('#F00')
       > E           AssertionError: assert wand.color.Color('srgb(255,0,1.41553e-14)') == wand.color.Color('srgb(255,0,0)')
       > E            +  where wand.color.Color('srgb(255,0,0)') = Color('#F00')
       >
       > tests/image_methods_test.py:2096: AssertionError
       > =========================== short test summary info ============================
       > FAILED tests/image_methods_test.py::test_sparse_color - AssertionError: assert wand.color.Color('srgb(255,0,1.41553e-14)') == wand....
       > ============ 1 failed, 560 passed, 6 skipped, 3 deselected in 7.31s ============
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
