### PR TITLE
orbvis: init at 0.3.2

### DIFF
--- a/pkgs/by-name/or/orbvis/package.nix
+++ b/pkgs/by-name/or/orbvis/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  gtk3,
+  curl,
+  libepoxy,
+  meson,
+  ninja,
+  wrapGAppsHook3,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "orbvis";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "wojciech-graj";
+    repo = "orbvis";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kPbRhm+HymY6DuR4JgE6qTTYKGIqVxvwxtveu7dOOO0=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtk3
+    curl
+    libepoxy
+  ];
+
+  postInstall = ''
+    install -Dm444 $src/flatpak/io.github.wojciech_graj.OrbVis.desktop -t $out/share/applications
+    install -Dm444 $src/flatpak/128x128/io.github.wojciech_graj.OrbVis.png -t $out/share/icons/hicolor/128x128/apps
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "View and propagate the full CelesTrak satellite catalog in realtime";
+    homepage = "https://github.com/wojciech-graj/OrbVis";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ thtrf ];
+    mainProgram = "orbvis";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
View and propagate the full CelesTrak satellite catalog in realtime.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
