### PR TITLE
strawberry: remove libgpod dependency/feature

### DIFF
--- a/pkgs/applications/audio/strawberry/default.nix
+++ b/pkgs/applications/audio/strawberry/default.nix
@@ -13,7 +13,6 @@
   libXdmcp,
   libcdio,
   libebur128,
-  libgpod,
   libidn2,
   libmtp,
   libpthreadstubs,
@@ -36,10 +35,6 @@
   rapidjson,
 }:
 
-let
-  inherit (lib) optionals;
-
-in
 stdenv.mkDerivation rec {
   pname = "strawberry";
   version = "1.2.11";
@@ -78,8 +73,7 @@ stdenv.mkDerivation rec {
       sparsehash
       rapidjson
     ]
-    ++ optionals stdenv.hostPlatform.isLinux [
-      libgpod
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       libpulseaudio
       libselinux
       libsepol
@@ -103,9 +97,11 @@ stdenv.mkDerivation rec {
       qttools
       wrapQtAppsHook
     ]
-    ++ optionals stdenv.hostPlatform.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       util-linux
     ];
+
+  cmakeFlags = [ (lib.cmakeBool "ENABLE_GPOD" false) ];
 
   postInstall = ''
     qtWrapperArgs+=(


### PR DESCRIPTION
Motivated by the gettext breakage ... but a library this old, abandoned, and only relevant for hardware many years out of sale/warranty is unlikely to be needed by many (any?).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
