### PR TITLE
docling-serve: 0.14.0 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/docling-core/default.nix
+++ b/pkgs/development/python-modules/docling-core/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "docling-core";
-  version = "2.43.0";
+  version = "2.38.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-core";
     tag = "v${version}";
-    hash = "sha256-c9TaX4INfTfR3ZpmXbOteHr2R2jAbVzvMk8tO1XV4Nc=";
+    hash = "sha256-zfpinXjZrGp5SF5IXLSP/A9Kb1WzqXXtIhhk/G3nY4k=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/docling-jobkit/default.nix
+++ b/pkgs/development/python-modules/docling-jobkit/default.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+  poetry-core,
+
+  # dependencies
+  docling,
+  pydantic-settings,
+  typer,
+  boto3,
+  pandas,
+  fastparquet,
+  pyarrow,
+  httpx,
+
+  # optional dependencies
+  tesserocr,
+  rapidocr-onnxruntime,
+  onnxruntime,
+  ray,
+
+  # tests
+  pytestCheckHook,
+  pytest-asyncio,
+  writableTmpDirAsHomeHook,
+
+  # options
+  withTesserocr ? false,
+  withRapidocr ? false,
+  withRay ? false,
+}:
+
+buildPythonPackage rec {
+  pname = "docling-jobkit";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "docling-project";
+    repo = "docling-jobkit";
+    tag = "v${version}";
+    hash = "sha256-V+Sc/eEuv0Q3q/wjGpkraD6ZR4Kfhorc3meg7fy0LTA=";
+  };
+
+  build-system = [
+    hatchling
+    poetry-core
+  ];
+
+  dependencies =
+    [
+      docling
+      pydantic-settings
+      typer
+      boto3
+      pandas
+      fastparquet
+      pyarrow
+      httpx
+    ]
+    ++ lib.optionals withTesserocr optional-dependencies.tesserocr
+    ++ lib.optionals withRapidocr optional-dependencies.rapidocr
+    ++ lib.optionals withRay optional-dependencies.ray;
+
+  optional-dependencies = {
+    tesserocr = [ tesserocr ];
+    rapidocr = [
+      rapidocr-onnxruntime
+      onnxruntime
+    ];
+    ray = [ ray ];
+  };
+
+  pythonRelaxDeps = [
+    "boto3"
+    "pyarrow"
+  ];
+
+  pythonImportsCheck = [
+    "docling"
+    "docling_jobkit"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = [
+    # requires network access
+    "test_convert_url"
+    "test_convert_file"
+    "test_convert_warmup"
+  ];
+
+  meta = {
+    changelog = "https://github.com/docling-project/docling-jobkit/blob/${src.tag}/CHANGELOG.md";
+    description = "Running a distributed job processing documents with Docling";
+    homepage = "https://github.com/docling-project/docling-jobkit";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ codgician ];
+  };
+}

--- a/pkgs/development/python-modules/docling-serve/default.nix
+++ b/pkgs/development/python-modules/docling-serve/default.nix
@@ -6,10 +6,12 @@
   setuptools-scm,
   # python dependencies
   docling,
+  docling-jobkit,
   fastapi,
   httpx,
   pydantic-settings,
   python-multipart,
+  scalar-fastapi,
   uvicorn,
   websockets,
   tesserocr,
@@ -29,20 +31,15 @@
 
 buildPythonPackage rec {
   pname = "docling-serve";
-  version = "0.14.0";
+  version = "1.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-serve";
     tag = "v${version}";
-    hash = "sha256-R8W/FXKj2wLJOcjwIsna/2wFOLGM80Qr3WlYPJTTSNU=";
+    hash = "sha256-kvtsutdQXk9mxx90fHXlzxFXrA7v+TdlgjrKCSFuuVU=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail '"kfp[kubernetes]>=2.10.0",' ""
-  '';
 
   build-system = [
     hatchling
@@ -60,10 +57,12 @@ buildPythonPackage rec {
   dependencies =
     [
       docling
+      (docling-jobkit.override { inherit withTesserocr withRapidocr; })
       fastapi
       httpx
       pydantic-settings
       python-multipart
+      scalar-fastapi
       typer
       uvicorn
       websockets

--- a/pkgs/development/python-modules/docling/default.nix
+++ b/pkgs/development/python-modules/docling/default.nix
@@ -52,14 +52,14 @@
 
 buildPythonPackage rec {
   pname = "docling";
-  version = "2.41.0";
+  version = "2.38.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling";
     tag = "v${version}";
-    hash = "sha256-GD052HCqBLs+KUkOUOVdlXxS6+PD2pthGtz+zdQ6QnM=";
+    hash = "sha256-ITRpWO7PEtfg5kM9LF3koZgzuPtLxoGFhorMlXlwSdI=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/scalar-fastapi/default.nix
+++ b/pkgs/development/python-modules/scalar-fastapi/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # python dependencies
+  annotated-types,
+  anyio,
+  fastapi,
+  idna,
+  pydantic,
+  sniffio,
+  starlette,
+  typing-extensions,
+
+  # tests
+  pytestCheckHook,
+  httpx,
+}:
+
+buildPythonPackage rec {
+  pname = "scalar-fastapi";
+  version = "1.2.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "scalar_fastapi";
+    inherit version;
+    hash = "sha256-r5GoX6f7Ru078WcRvGNyhyYDxL1w4yjbfHvlf+ZF/sc=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    annotated-types
+    anyio
+    fastapi
+    idna
+    pydantic
+    sniffio
+    starlette
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "scalar_fastapi"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    httpx
+  ];
+
+  meta = {
+    description = "A plugin for FastAPI to render a reference for your OpenAPI document";
+    homepage = "https://github.com/scalar/scalar/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ codgician ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15951,6 +15951,8 @@ self: super: with self; {
 
   sbom4files = callPackage ../development/python-modules/sbom4files { };
 
+  scalar-fastapi = callPackage ../development/python-modules/scalar-fastapi { };
+
   scalene = callPackage ../development/python-modules/scalene { };
 
   scales = callPackage ../development/python-modules/scales { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4192,6 +4192,8 @@ self: super: with self; {
 
   docling-ibm-models = callPackage ../development/python-modules/docling-ibm-models { };
 
+  docling-jobkit = callPackage ../development/python-modules/docling-jobkit { };
+
   docling-parse = callPackage ../development/python-modules/docling-parse {
     loguru-cpp = pkgs.loguru;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Bumped docling-serve: 0.14.0 -> 1.0.0
* Packaged two dependency introduced by new version of docling-serve:
  * scalar-fastapi: init at 1.2.2
  * docling-jobkit: init at 1.1.0
* docling-core: remove pillow from python relax deps as the version now matches the criteria
* ⚠️ **Downgraded** docling-core to 0.38.1 to fix #426428. I wasn't able to find the root cause on what is causing the test issue with docling-core >= 0.38.2 so proposing this as a temporary mitigation. This version works great for other docling-* packages in Nixpkgs. Open on more inputs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
