### PR TITLE
high-tide: fix stream error

### DIFF
--- a/pkgs/by-name/hi/high-tide/package.nix
+++ b/pkgs/by-name/hi/high-tide/package.nix
@@ -13,6 +13,7 @@
   libsecret,
   libportal,
   nix-update-script,
+  glib-networking,
 }:
 
 python313Packages.buildPythonApplication rec {
@@ -40,6 +41,7 @@ python313Packages.buildPythonApplication rec {
     [
       libadwaita
       libportal
+      glib-networking
     ]
     ++ (with gst_all_1; [
       gstreamer


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```shell
/nix/store/lrjjlwyam9d4ljk01865a6z9ijyzm78m-high-tide-0.1.7/share/high-tide/high_tide/lib/player_object.py:266: Warning: Source ID 685 was not found when attempting to remove it
  GLib.source_remove(self.update_timer)
0:00:06.265732036 62515 0x6505f80017a0 WARN                 basesrc gstbasesrc.c:3187:gst_base_src_loop:<souphttpsrc0> error: Internal data stream error.
0:00:06.265747703 62515 0x6505f80017a0 WARN                 basesrc gstbasesrc.c:3187:gst_base_src_loop:<souphttpsrc0> error: streaming stopped, reason error (-5)
0:00:06.265784110 62515 0x6505f80017a0 WARN                typefind gsttypefindelement.c:1012:gst_type_find_element_chain_do_typefinding:<typefindelement0> error: Stream doesn't contain enough data.
0:00:06.265804556 62515 0x6505f80017a0 WARN                typefind gsttypefindelement.c:1012:gst_type_find_element_chain_do_typefinding:<typefindelement0> error: Can't typefind stream
Error: Internal data stream error.
Debug info: ../libs/gst/base/gstbasesrc.c(3187): gst_base_src_loop (): /GstPipeline:dash-player/GstPlayBin3:playbin/GstURIDecodeBin3:uridecodebin3/GstURISourceBin:urisourcebin0/GstSoupHTTPSrc:souphttpsrc0:
streaming stopped, reason error (-5)
Error: Stream doesn't contain enough data.
Debug info: ../plugins/elements/gsttypefindelement.c(1012): gst_type_find_element_chain_do_typefinding (): /GstPipeline:dash-player/GstPlayBin3:playbin/GstURIDecodeBin3:uridecodebin3/GstURISourceBin:urisourcebin0/GstTypeFindElement:typefindelement0:
Can't typefind stream
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
