### PR TITLE
foks-server: init at 0.1.5

### DIFF
--- a/pkgs/by-name/fo/foks-server/package.nix
+++ b/pkgs/by-name/fo/foks-server/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  buildNpmPackage,
+  pcsclite,
+  pkg-config,
+  nix-update-script,
+  stdenv,
+  tailwindcss_4,
+  templ,
+  uglify-js,
+  versionCheckHook,
+}:
+
+let
+  src = fetchFromGitHub {
+    owner = "foks-proj";
+    repo = "go-foks";
+    tag = "v${version}";
+    hash = "sha256-/+Z/afzj5y4CVU3qRymSIUzCabT2jAEBlKKoYgKlPRE=";
+  };
+  version = "0.1.5";
+  templFoks = templ.overrideAttrs (old: {
+    pname = "templ-foks";
+    version = "0.3.833";
+    src = old.src.override {
+      hash = "sha256-4K1MpsM3OuamXRYOllDsxxgpMRseFGviC4RJzNA7Cu8=";
+    };
+    vendorHash = "sha256-OPADot7Lkn9IBjFCfbrqs3es3F6QnWNjSOHxONjG4MM=";
+  });
+  foksNodeModules = buildNpmPackage {
+    pname = "foks-node-modules";
+    inherit version src;
+    npmDepsHash = "sha256-mASu3taprCYP+muRh4b+qUTce7YTdISf/QnmSvUy6Mo=";
+    dontNpmBuild = true;
+    sourceRoot = "${src.name}/server/web/frontend";
+    installPhase = ''
+      mkdir -p $out
+      cp -r node_modules $out/node_modules
+    '';
+  };
+in
+buildGoModule (finalAttrs: {
+  pname = "foks-server";
+  inherit version src;
+
+  vendorHash = "sha256-nTHsYMQjVaQM+g2MM++/BDVYfzIM4CaMM6eK5GQE6Cc=";
+
+  postPatch =
+    # Generate templates
+    ''
+      pushd ./server/web/templates
+      ${templFoks}/bin/templ generate
+      popd
+    ''
+    # Generate tailwind
+    + ''
+      pushd ./server/web/frontend
+      mkdir -p ../static/css
+      ${lib.getExe tailwindcss_4} -i ./css/input.css -o ../static/css/style.min.css --minify
+      ${lib.getExe tailwindcss_4} -i ./css/input.css -o ../static/css/style.css
+      ${lib.getExe uglify-js} -c < ../static/js/foks.js > ../static/js/foks.min.js
+      popd
+    ''
+    # Copy htmx dependency from node modules
+    + ''
+      pushd ./server/web/static
+      mkdir -p ./js
+      cp ${foksNodeModules}/node_modules/htmx.org/dist/htmx.js ./js/htmx.js
+      cp ${foksNodeModules}/node_modules/htmx.org/dist/htmx.min.js ./js/htmx.min.js
+      popd
+    '';
+  subPackages = [
+    "server/foks-server"
+    "server/foks-tool"
+  ];
+  excludedPackages = [ "client" ];
+
+  buildInputs = lib.optionals (stdenv.hostPlatform.isLinux) [ pcsclite ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  ldflags = [
+    "-X main.LinkerVersion=v${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Federated key management and distribution system";
+    homepage = "https://foks.pub";
+    downloadPage = "https://github.com/foks-proj/go-foks";
+    changelog = "https://github.com/foks-proj/go-foks/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ poptart ];
+    mainProgram = "foks-server";
+  };
+})


### PR DESCRIPTION
Adds the foks federated key management and distribution system server.

This is the server component of #424406
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
