### PR TITLE
python3.pkgs.sphinx-version-warning: Fix build with sphinx-prompt=1.10.0

### DIFF
--- a/pkgs/development/python-modules/sphinx-hoverxref/default.nix
+++ b/pkgs/development/python-modules/sphinx-hoverxref/default.nix
@@ -34,6 +34,10 @@ buildPythonPackage rec {
     hash = "sha256-DJ+mHu9IeEYEyf/SD+nDNtWpTf6z7tQzG0ogaECDpkU=";
   };
 
+  postPatch = ''
+    substituteInPlace docs/conf.py --replace-fail "sphinx-prompt" "sphinx_prompt"
+  '';
+
   nativeBuildInputs = [
     flit-core
 

--- a/pkgs/development/python-modules/sphinx-prompt/default.nix
+++ b/pkgs/development/python-modules/sphinx-prompt/default.nix
@@ -18,42 +18,28 @@
 
 buildPythonPackage rec {
   pname = "sphinx-prompt";
-  version = "1.7.0"; # read before updating past 1.7.0 https://github.com/sbrunner/sphinx-prompt/issues/398
-  format = "pyproject";
+  version = "1.10.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sbrunner";
     repo = "sphinx-prompt";
     tag = version;
-    hash = "sha256-/XxUSsW8Bowks7P+d6iTlklyMIfTb2otXva/VtRVAkM=";
+    hash = "sha256-JKCTn2YkdyGLvchMT9C61PxjYxuQFzt3SjCE9JvgtVc=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace '"poetry-plugin-tweak-dependencies-version", ' ""
-  '';
-
-  nativeBuildInputs = [
+  build-system = [
     poetry-core
     poetry-dynamic-versioning
   ];
 
-  pythonRelaxDeps = [
-    "docutils"
-    "pygments"
-    "Sphinx"
-  ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     docutils
     pygments
     sphinx
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-
-  # versions >=1.8.0 cannot be build from source
-  passthru.skipBulkUpdate = true;
 
   meta = with lib; {
     description = "Sphinx extension for creating unselectable prompt";

--- a/pkgs/development/python-modules/sphinx-version-warning/default.nix
+++ b/pkgs/development/python-modules/sphinx-version-warning/default.nix
@@ -29,6 +29,10 @@ buildPythonPackage {
     "doc"
   ];
 
+  postPatch = ''
+    substituteInPlace docs/conf.py --replace-fail "sphinx-prompt" "sphinx_prompt"
+  '';
+
   src = fetchFromGitHub {
     owner = "humitos";
     repo = "sphinx-version-warning";


### PR DESCRIPTION
# python3.pkgs.sphinx-version-warning: Fix build with sphinx-prompt=1.10.0

```
python3.pkgs.sphinx-version-warning: Fix build with sphinx-prompt=1.10.0
python3Packages.sphinx-prompt: 1.7.0 -> 1.10.0
```

## Build info of packages affected directly
### python3Packages.sphinx-prompt

<details><summary>content of python3Packages.sphinx-prompt.dist</summary>

```
/nix/store/sy980qhpswdf76p989z1bk2z1c8m07dn-python3.13-sphinx-prompt-1.10.0-dist
└── sphinx_prompt-0.0.0-py3-none-any.whl

1 directory, 1 file
```
</details>

<details><summary>content of python3Packages.sphinx-prompt.out</summary>

```
/nix/store/amhyapn94m9mjq1y01g9h9nzmrzqi4vp-python3.13-sphinx-prompt-1.10.0
├── lib
│   └── python3.13
│       └── site-packages
│           ├── sphinx_prompt
│           │   ├── __init__.py
│           │   ├── __pycache__
│           │   │   ├── __init__.cpython-313.opt-1.pyc
│           │   │   └── __init__.cpython-313.pyc
│           │   └── py.typed
│           └── sphinx_prompt-0.0.0.dist-info
│               ├── LICENSE
│               ├── METADATA
│               ├── RECORD
│               └── WHEEL
└── nix-support
    └── propagated-build-inputs

8 directories, 9 files
```
</details>

<details><summary>build log of python3Packages.sphinx-prompt</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing pytest-check-hook
Using pytestCheckPhase
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/49kbnm7gfg2lagd4w3vacz26kwzimmvs-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/tests/test_sphinx_prompt.py"
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
substituteStream() in derivation python3.13-sphinx-prompt-1.10.0: WARNING: '--replace' is deprecated, use --replace-{fail,warn,quiet}. (file 'pyproject.toml')
substituteStream() in derivation python3.13-sphinx-prompt-1.10.0: WARNING: pattern \"poetry-plugin-tweak-dependencies-version\"\,\  doesn't match anything in file 'pyproject.toml'
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing pypaBuildPhase
Setting POETRY_DYNAMIC_VERSIONING_BYPASS to 1.10.0
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
* Building wheel...
Successfully built sphinx_prompt-0.0.0-py3-none-any.whl
Finished creating a wheel...
/build/source/dist /build/source
Unpacking to: unpacked/sphinx_prompt-0.0.0...OK
Repacking wheel as ./sphinx_prompt-0.0.0-py3-none-any.whl...OK
/build/source
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for sphinx_prompt-0.0.0-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Executing pypaInstallPhase
Successfully installed sphinx_prompt-0.0.0-py3-none-any.whl
Finished executing pypaInstallPhase
Running phase: pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/amhyapn94m9mjq1y01g9h9nzmrzqi4vp-python3.13-sphinx-prompt-1.10.0
checking for references to /build/ in /nix/store/amhyapn94m9mjq1y01g9h9nzmrzqi4vp-python3.13-sphinx-prompt-1.10.0...
patching script interpreter paths in /nix/store/amhyapn94m9mjq1y01g9h9nzmrzqi4vp-python3.13-sphinx-prompt-1.10.0
/nix/store/amhyapn94m9mjq1y01g9h9nzmrzqi4vp-python3.13-sphinx-prompt-1.10.0/lib/python3.13/site-packages/sphinx_prompt/__init__.py: interpreter directive changed from "#!/usr/bin/python" to "/nix/store/djck7mx6jad1w0yy6zings96dyxanls6-python3-3.13.5/bin/python"
stripping (with command strip and flags -S -p) in  /nix/store/amhyapn94m9mjq1y01g9h9nzmrzqi4vp-python3.13-sphinx-prompt-1.10.0/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/sy980qhpswdf76p989z1bk2z1c8m07dn-python3.13-sphinx-prompt-1.10.0-dist
checking for references to /build/ in /nix/store/sy980qhpswdf76p989z1bk2z1c8m07dn-python3.13-sphinx-prompt-1.10.0-dist...
patching script interpreter paths in /nix/store/sy980qhpswdf76p989z1bk2z1c8m07dn-python3.13-sphinx-prompt-1.10.0-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
Running phase: installCheckPhase
@nix { "action": "setPhase", "phase": "installCheckPhase" }
no Makefile or custom installCheckPhase, doing nothing
Running phase: pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
Running phase: pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
Running phase: pythonImportsCheckPhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
Executing pythonImportsCheckPhase
Running phase: pytestCheckPhase
@nix { "action": "setPhase", "phase": "pytestCheckPhase" }
Executing pytestCheckPhase
pytest flags: -m pytest
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-8.3.5, pluggy-1.6.0
rootdir: /build/source
configfile: pyproject.toml
collecting ... 
collected 12 items                                                             

tests/test_sphinx_prompt.py ............                                 [100%]

============================== 12 passed in 0.10s ==============================
Finished executing pytestCheckPhase
Running phase: pytestcachePhase
@nix { "action": "setPhase", "phase": "pytestcachePhase" }
Running phase: pytestRemoveBytecodePhase
@nix { "action": "setPhase", "phase": "pytestRemoveBytecodePhase" }
```
</details>
### python3.pkgs.sphinx-version-warning

<details><summary>content of python3.pkgs.sphinx-version-warning.dist</summary>

```
/nix/store/snqfq2wxcir0z30d8nbi86npq4pzgf8h-python3.13-sphinx-version-warning-unstable-2019-08-10-dist
└── sphinx_version_warning-1.1.2.dev0-py3-none-any.whl

1 directory, 1 file
```
</details>

<details><summary>content of python3.pkgs.sphinx-version-warning.doc</summary>

```
/nix/store/8hlpjzys2m0vswhhpz74pmwhyia0wqvk-python3.13-sphinx-version-warning-unstable-2019-08-10-doc
└── share
    └── doc
        └── python3.13-sphinx-version-warning-unstable-2019-08-10
            └── html
                ├── _images
                │   ├── cilium-example.png
                │   └── marshmallow-example.png
                ├── _static
                │   ├── _sphinx_javascript_frameworks_compat.js
                │   ├── basic.css
                │   ├── css
                │   │   ├── badge_only.css
                │   │   ├── fonts
                │   │   │   ├── Roboto-Slab-Bold.woff
                │   │   │   ├── Roboto-Slab-Bold.woff2
                │   │   │   ├── Roboto-Slab-Regular.woff
                │   │   │   ├── Roboto-Slab-Regular.woff2
                │   │   │   ├── fontawesome-webfont.eot
                │   │   │   ├── fontawesome-webfont.svg
                │   │   │   ├── fontawesome-webfont.ttf
                │   │   │   ├── fontawesome-webfont.woff
                │   │   │   ├── fontawesome-webfont.woff2
                │   │   │   ├── lato-bold-italic.woff
                │   │   │   ├── lato-bold-italic.woff2
                │   │   │   ├── lato-bold.woff
                │   │   │   ├── lato-bold.woff2
                │   │   │   ├── lato-normal-italic.woff
                │   │   │   ├── lato-normal-italic.woff2
                │   │   │   ├── lato-normal.woff
                │   │   │   └── lato-normal.woff2
                │   │   └── theme.css
                │   ├── data
                │   │   └── versionwarning-data.json
                │   ├── doctools.js
                │   ├── documentation_options.js
                │   ├── file.png
                │   ├── fonts
                │   │   ├── Lato
                │   │   │   ├── lato-bold.eot
                │   │   │   ├── lato-bold.ttf
                │   │   │   ├── lato-bold.woff
                │   │   │   ├── lato-bold.woff2
                │   │   │   ├── lato-bolditalic.eot
                │   │   │   ├── lato-bolditalic.ttf
                │   │   │   ├── lato-bolditalic.woff
                │   │   │   ├── lato-bolditalic.woff2
                │   │   │   ├── lato-italic.eot
                │   │   │   ├── lato-italic.ttf
                │   │   │   ├── lato-italic.woff
                │   │   │   ├── lato-italic.woff2
                │   │   │   ├── lato-regular.eot
                │   │   │   ├── lato-regular.ttf
                │   │   │   ├── lato-regular.woff
                │   │   │   └── lato-regular.woff2
                │   │   └── RobotoSlab
                │   │       ├── roboto-slab-v7-bold.eot
                │   │       ├── roboto-slab-v7-bold.ttf
                │   │       ├── roboto-slab-v7-bold.woff
                │   │       ├── roboto-slab-v7-bold.woff2
                │   │       ├── roboto-slab-v7-regular.eot
                │   │       ├── roboto-slab-v7-regular.ttf
                │   │       ├── roboto-slab-v7-regular.woff
                │   │       └── roboto-slab-v7-regular.woff2
                │   ├── graphviz.css
                │   ├── jquery.js
                │   ├── js
                │   │   ├── badge_only.js
                │   │   ├── theme.js
                │   │   ├── versions.js
                │   │   └── versionwarning.js
                │   ├── language_data.js
                │   ├── minus.png
                │   ├── plus.png
                │   ├── pygments.css
                │   ├── searchtools.js
                │   ├── sphinx_highlight.js
                │   ├── tabs.css
                │   ├── tabs.js
                │   ├── twemoji.css
                │   └── twemoji.js
                ├── autoapi
                │   └── versionwarning
                │       ├── extension
                │       │   └── index.html
                │       ├── index.html
                │       └── signals
                │           └── index.html
                ├── configuration.html
                ├── genindex.html
                ├── get-involved.html
                ├── index.html
                ├── installation.html
                ├── objects.inv
                ├── py-modindex.html
                ├── releasing.html
                ├── search.html
                ├── searchindex.js
                └── who-is-using-it.html

18 directories, 81 files
```
</details>

<details><summary>content of python3.pkgs.sphinx-version-warning.out</summary>

```
/nix/store/yprg4xr40c88x4wzqdkcp2bj2fd6sjvw-python3.13-sphinx-version-warning-unstable-2019-08-10
├── lib
│   └── python3.13
│       └── site-packages
│           ├── sphinx_version_warning-1.1.2.dev0.dist-info
│           │   ├── METADATA
│           │   ├── RECORD
│           │   ├── WHEEL
│           │   ├── licenses
│           │   │   └── LICENSE
│           │   └── top_level.txt
│           └── versionwarning
│               ├── __init__.py
│               ├── __pycache__
│               │   ├── __init__.cpython-313.opt-1.pyc
│               │   ├── __init__.cpython-313.pyc
│               │   ├── extension.cpython-313.opt-1.pyc
│               │   ├── extension.cpython-313.pyc
│               │   ├── signals.cpython-313.opt-1.pyc
│               │   └── signals.cpython-313.pyc
│               ├── _static
│               │   ├── data
│               │   │   └── versionwarning-data.json
│               │   └── js
│               │       └── versionwarning.js
│               ├── extension.py
│               └── signals.py
└── nix-support
    └── propagated-build-inputs

12 directories, 17 files
```
</details>

<details><summary>build log of python3.pkgs.sphinx-version-warning</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing sphinx-hook
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/5is45d7c5hdip41nrdw2kimyhjipp38i-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/webpack.config.js"
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
applying patch /nix/store/kdzh1nff2rclaqny52m8s9ikxx7sz3p3-cb1b47becf2a0d3b2570ca9929f42f7d7e472b6f.patch
patching file versionwarning/signals.py
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing pypaBuildPhase
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
Warning: 'classifiers' should be a list, got type 'tuple'
/nix/store/r0m9k353nk3jvjhjzbr3rzrw80cgj9mn-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running egg_info
creating sphinx_version_warning.egg-info
writing sphinx_version_warning.egg-info/PKG-INFO
writing dependency_links to sphinx_version_warning.egg-info/dependency_links.txt
writing requirements to sphinx_version_warning.egg-info/requires.txt
writing top-level names to sphinx_version_warning.egg-info/top_level.txt
writing manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
reading manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
* Building wheel...
Warning: 'classifiers' should be a list, got type 'tuple'
/nix/store/r0m9k353nk3jvjhjzbr3rzrw80cgj9mn-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running bdist_wheel
running build
running build_py
creating build/lib/versionwarning
copying versionwarning/signals.py -> build/lib/versionwarning
copying versionwarning/extension.py -> build/lib/versionwarning
copying versionwarning/__init__.py -> build/lib/versionwarning
running egg_info
writing sphinx_version_warning.egg-info/PKG-INFO
writing dependency_links to sphinx_version_warning.egg-info/dependency_links.txt
writing requirements to sphinx_version_warning.egg-info/requires.txt
writing top-level names to sphinx_version_warning.egg-info/top_level.txt
reading manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
/nix/store/r0m9k353nk3jvjhjzbr3rzrw80cgj9mn-python3.13-setuptools-80.7.1/lib/python3.13/site-packages/setuptools/command/build_py.py:212: _Warning: Package 'versionwarning._static.js' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'versionwarning._static.js' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'versionwarning._static.js' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'versionwarning._static.js' to be distributed and are
        already explicitly excluding 'versionwarning._static.js' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
  check.warn(importable)
creating build/lib/versionwarning/_static/js
copying versionwarning/_static/js/versionwarning.js -> build/lib/versionwarning/_static/js
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/versionwarning
creating build/bdist.linux-x86_64/wheel/versionwarning/_static
creating build/bdist.linux-x86_64/wheel/versionwarning/_static/js
copying build/lib/versionwarning/_static/js/versionwarning.js -> build/bdist.linux-x86_64/wheel/./versionwarning/_static/js
copying build/lib/versionwarning/__init__.py -> build/bdist.linux-x86_64/wheel/./versionwarning
copying build/lib/versionwarning/extension.py -> build/bdist.linux-x86_64/wheel/./versionwarning
copying build/lib/versionwarning/signals.py -> build/bdist.linux-x86_64/wheel/./versionwarning
running install_egg_info
Copying sphinx_version_warning.egg-info to build/bdist.linux-x86_64/wheel/./sphinx_version_warning-1.1.2.dev0-py3.13.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/sphinx_version_warning-1.1.2.dev0.dist-info/WHEEL
creating '/build/source/dist/.tmp-tg8zelfj/sphinx_version_warning-1.1.2.dev0-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/licenses/LICENSE'
adding 'versionwarning/__init__.py'
adding 'versionwarning/extension.py'
adding 'versionwarning/signals.py'
adding 'versionwarning/_static/js/versionwarning.js'
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/METADATA'
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/WHEEL'
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/top_level.txt'
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built sphinx_version_warning-1.1.2.dev0-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for sphinx_version_warning-1.1.2.dev0-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Executing pypaInstallPhase
Successfully installed sphinx_version_warning-1.1.2.dev0-py3-none-any.whl
Finished executing pypaInstallPhase
Running phase: pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
Running phase: buildSphinxPhase
@nix { "action": "setPhase", "phase": "buildSphinxPhase" }
Executing buildSphinxPhase
Sphinx documentation found in docs
Executing sphinx-build with html builder
Running Sphinx v8.2.3
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
loading translations [en]... locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
done
WARNING: html_static_path entry '_static' does not exist
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
[AutoAPI] Reading files... [ 33%] /build/source/versionwarning/signals.py
[AutoAPI] Reading files... [ 67%] /build/source/versionwarning/extension.py
[AutoAPI] Reading files... [100%] /build/source/versionwarning/__init__.py
[AutoAPI] Mapping Data... [ 33%] /build/source/versionwarning/signals.py
[AutoAPI] Mapping Data... [ 67%] /build/source/versionwarning/extension.py
[AutoAPI] Mapping Data... [100%] /build/source/versionwarning/__init__.py
[AutoAPI] Rendering Data... [ 33%] versionwarning
Rendering versionwarning
Rendering versionwarning.name
Rendering versionwarning.version
[AutoAPI] Rendering Data... [ 67%] versionwarning.signals
Rendering versionwarning.signals
Rendering versionwarning.signals.STATIC_PATH
Rendering versionwarning.signals.JSON_DATA_FILENAME
Rendering versionwarning.signals.generate_versionwarning_data_json
[AutoAPI] Rendering Data... [100%] versionwarning.extension
Rendering versionwarning.extension
Rendering versionwarning.extension.setup

[autosummary] generating autosummary for: configuration.rst, get-involved.rst, index.rst, installation.rst, releasing.rst, who-is-using-it.rst
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 6 source files that are out of date
updating environment: locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
[new config] 9 added, 0 changed, 0 removed
reading sources... [ 11%] autoapi/versionwarning/extension/index
reading sources... [ 22%] autoapi/versionwarning/index
reading sources... [ 33%] autoapi/versionwarning/signals/index
reading sources... [ 44%] configuration
reading sources... [ 56%] get-involved
reading sources... [ 67%] index
reading sources... [ 78%] installation
reading sources... [ 89%] releasing
reading sources... [100%] who-is-using-it

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying static files... 
Writing evaluated template result to /build/source/.sphinx/html/html/_static/language_data.js
Writing evaluated template result to /build/source/.sphinx/html/html/_static/basic.css
Writing evaluated template result to /build/source/.sphinx/html/html/_static/documentation_options.js
Writing evaluated template result to /build/source/.sphinx/html/html/_static/js/versions.js
copying static files: done
copying extra files... 
copying extra files: done
copying assets: done
writing output... [ 11%] autoapi/versionwarning/extension/index
writing output... [ 22%] autoapi/versionwarning/index
writing output... [ 33%] autoapi/versionwarning/signals/index
writing output... [ 44%] configuration
writing output... [ 56%] get-involved
writing output... [ 67%] index
writing output... [ 78%] installation
writing output... [ 89%] releasing
writing output... [100%] who-is-using-it

generating indices... genindex py-modindex done
writing additional pages... search done
copying images... [ 50%] marshmallow-example.png
copying images... [100%] cilium-example.png

dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 2 warnings.

The HTML pages are in .sphinx/html/html.
Running phase: installSphinxPhase
@nix { "action": "setPhase", "phase": "installSphinxPhase" }
Executing installSphinxPhase
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/yprg4xr40c88x4wzqdkcp2bj2fd6sjvw-python3.13-sphinx-version-warning-unstable-2019-08-10
checking for references to /build/ in /nix/store/yprg4xr40c88x4wzqdkcp2bj2fd6sjvw-python3.13-sphinx-version-warning-unstable-2019-08-10...
patching script interpreter paths in /nix/store/yprg4xr40c88x4wzqdkcp2bj2fd6sjvw-python3.13-sphinx-version-warning-unstable-2019-08-10
stripping (with command strip and flags -S -p) in  /nix/store/yprg4xr40c88x4wzqdkcp2bj2fd6sjvw-python3.13-sphinx-version-warning-unstable-2019-08-10/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/8hlpjzys2m0vswhhpz74pmwhyia0wqvk-python3.13-sphinx-version-warning-unstable-2019-08-10-doc
checking for references to /build/ in /nix/store/8hlpjzys2m0vswhhpz74pmwhyia0wqvk-python3.13-sphinx-version-warning-unstable-2019-08-10-doc...
patching script interpreter paths in /nix/store/8hlpjzys2m0vswhhpz74pmwhyia0wqvk-python3.13-sphinx-version-warning-unstable-2019-08-10-doc
shrinking RPATHs of ELF executables and libraries in /nix/store/snqfq2wxcir0z30d8nbi86npq4pzgf8h-python3.13-sphinx-version-warning-unstable-2019-08-10-dist
checking for references to /build/ in /nix/store/snqfq2wxcir0z30d8nbi86npq4pzgf8h-python3.13-sphinx-version-warning-unstable-2019-08-10-dist...
patching script interpreter paths in /nix/store/snqfq2wxcir0z30d8nbi86npq4pzgf8h-python3.13-sphinx-version-warning-unstable-2019-08-10-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
Running phase: installCheckPhase
@nix { "action": "setPhase", "phase": "installCheckPhase" }
no Makefile or custom installCheckPhase, doing nothing
Running phase: pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
Running phase: pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
Running phase: pythonImportsCheckPhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: versionwarning
```
</details>
