### PR TITLE
[25.05] nix-tree: 0.6.1 -> 0.6.3

### DIFF
--- a/pkgs/development/haskell-modules/replacements-by-name/nix-tree.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/nix-tree.nix
@@ -1,0 +1,76 @@
+{
+  mkDerivation,
+  aeson,
+  async,
+  base,
+  brick,
+  bytestring,
+  clock,
+  containers,
+  directory,
+  dot,
+  filepath,
+  hedgehog,
+  hrfsize,
+  lib,
+  microlens,
+  optparse-applicative,
+  relude,
+  terminal-progress-bar,
+  text,
+  typed-process,
+  unordered-containers,
+  vty,
+}:
+mkDerivation {
+  pname = "nix-tree";
+  version = "0.6.3";
+  sha256 = "06dzf87vckd11yiq2ng6l80rd17p920lajykn1vy2azyhivkp59j";
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    aeson
+    async
+    base
+    brick
+    bytestring
+    clock
+    containers
+    directory
+    dot
+    filepath
+    hrfsize
+    microlens
+    optparse-applicative
+    relude
+    terminal-progress-bar
+    text
+    typed-process
+    unordered-containers
+    vty
+  ];
+  testHaskellDepends = [
+    aeson
+    base
+    brick
+    bytestring
+    clock
+    containers
+    directory
+    dot
+    filepath
+    hedgehog
+    hrfsize
+    microlens
+    optparse-applicative
+    relude
+    text
+    typed-process
+    unordered-containers
+    vty
+  ];
+  description = "Interactively browse a Nix store paths dependencies";
+  license = lib.licenses.bsd3;
+  mainProgram = "nix-tree";
+  maintainers = [ lib.maintainers.utdemir ];
+}


### PR DESCRIPTION
selective manual backport of version bump

hand picked new version/hash from haskell package update in https://github.com/NixOS/nixpkgs/pull/413046


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
