### PR TITLE
glab: 1.61.0 -> 1.62.0, cleanup

### DIFF
--- a/pkgs/by-name/gl/glab/package.nix
+++ b/pkgs/by-name/gl/glab/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitLab,
   installShellFiles,
+  makeBinaryWrapper,
   stdenv,
   nix-update-script,
   writableTmpDirAsHomeHook,
@@ -38,7 +39,7 @@ buildGoModule (finalAttrs: {
     ldflags+=" -X main.commit=$(cat COMMIT)"
   '';
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [ installShellFiles makeBinaryWrapper ];
 
   subPackages = [ "cmd/glab" ];
 
@@ -49,6 +50,10 @@ buildGoModule (finalAttrs: {
       --bash <($out/bin/glab completion -s bash) \
       --fish <($out/bin/glab completion -s fish) \
       --zsh <($out/bin/glab completion -s zsh)
+
+    wrapProgram $out/bin/glab \
+      --set-default GLAB_CHECK_UPDATE 0 \
+      --set-default GLAB_SEND_TELEMETRY 0
   '';
 
   nativeCheckInputs = [

--- a/pkgs/by-name/gl/glab/package.nix
+++ b/pkgs/by-name/gl/glab/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "glab";
-  version = "1.61.0";
+  version = "1.62.0";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LM1doLLVdY7gOwfYfjwT/aFzVkyXxoD4/WPXJGqoPmw=";
+    hash = "sha256-+dXMlNc54i/vEwYV0YRKXrdWejcgfXFW+tFq3tf8TZY=";
     leaveDotGit = true;
     postFetch = ''
       cd "$out"
@@ -27,7 +27,7 @@ buildGoModule (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-COp4RebkU36OChbZFeLALUppXqHLRbrm3D64Hb5RmI4=";
+  vendorHash = "sha256-sgph04zjHvvgL0QJm2//h8jyDg/5NY7dq50C0G0hYYM=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/gl/glab/package.nix
+++ b/pkgs/by-name/gl/glab/package.nix
@@ -6,6 +6,7 @@
   stdenv,
   nix-update-script,
   writableTmpDirAsHomeHook,
+  gitMinimal,
 }:
 
 buildGoModule (finalAttrs: {
@@ -37,10 +38,9 @@ buildGoModule (finalAttrs: {
     ldflags+=" -X main.commit=$(cat COMMIT)"
   '';
 
+  nativeBuildInputs = [ installShellFiles ];
 
   subPackages = [ "cmd/glab" ];
-
-  nativeBuildInputs = [ installShellFiles ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     make manpage
@@ -51,7 +51,14 @@ buildGoModule (finalAttrs: {
       --zsh <($out/bin/glab completion -s zsh)
   '';
 
-  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    git init
+  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/gl/glab/package.nix
+++ b/pkgs/by-name/gl/glab/package.nix
@@ -7,6 +7,7 @@
   stdenv,
   nix-update-script,
   writableTmpDirAsHomeHook,
+  versionCheckHook,
   gitMinimal,
 }:
 
@@ -39,7 +40,10 @@ buildGoModule (finalAttrs: {
     ldflags+=" -X main.commit=$(cat COMMIT)"
   '';
 
-  nativeBuildInputs = [ installShellFiles makeBinaryWrapper ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
 
   subPackages = [ "cmd/glab" ];
 
@@ -56,14 +60,20 @@ buildGoModule (finalAttrs: {
       --set-default GLAB_SEND_TELEMETRY 0
   '';
 
-  nativeCheckInputs = [
-    gitMinimal
-    writableTmpDirAsHomeHook
-  ];
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
   preCheck = ''
     git init
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    gitMinimal
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/gl/glab/package.nix
+++ b/pkgs/by-name/gl/glab/package.nix
@@ -16,7 +16,13 @@ buildGoModule (finalAttrs: {
     owner = "gitlab-org";
     repo = "cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pouFnmHCfRFDy+MMbRI82o73jO8hRewHeXgGnJ4hnww=";
+    hash = "sha256-LM1doLLVdY7gOwfYfjwT/aFzVkyXxoD4/WPXJGqoPmw=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse --short HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
   vendorHash = "sha256-COp4RebkU36OChbZFeLALUppXqHLRbrm3D64Hb5RmI4=";
@@ -27,7 +33,10 @@ buildGoModule (finalAttrs: {
     "-X main.version=${finalAttrs.version}"
   ];
 
-  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+  preBuild = ''
+    ldflags+=" -X main.commit=$(cat COMMIT)"
+  '';
+
 
   subPackages = [ "cmd/glab" ];
 
@@ -41,6 +50,8 @@ buildGoModule (finalAttrs: {
       --fish <($out/bin/glab completion -s fish) \
       --zsh <($out/bin/glab completion -s zsh)
   '';
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Current `glab` version is 1.63.0 and require Go 1.24.5 which is not yet in `master` but `staging`. I can't upgrade to it until https://github.com/NixOS/nixpkgs/pull/423655 ([staging PR](https://github.com/NixOS/nixpkgs/pull/425387)) gets merged into `master`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
