### PR TITLE
readest: 0.9.64 -> 0.9.66

### DIFF
--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -20,13 +20,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "readest";
-  version = "0.9.65";
+  version = "0.9.66";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zXAlptPYHXE5XgAi4lZZnrtIf6YMBo3S5CdK8jfoeYI=";
+    hash = "sha256-0KIqPB41sS0rX5IBao+0ThPz4EttpZxSb5mL4Spuoho=";
     fetchSubmodules = true;
   };
 
@@ -40,14 +40,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-nWDMtQZE+96gnvEwtp84iOcbfMAjnqKZK0cgQuh4+k8=";
+    hash = "sha256-o0R5b+cE680RgdBT+4uiCtec3y3dGxYkBmnKzT/7JOg=";
   };
 
   pnpmRoot = "../..";
 
   useFetchCargoVendor = true;
 
-  cargoHash = "sha256-35REIeZy/D9UWzSI6yQZc1MRYwlAnjzsk5T7KOAhWVw=";
+  cargoHash = "sha256-ReRCzKbdmjPr9rQwCI7mLEs/MjV2yCp7FFZAlib1xIs=";
 
   cargoRoot = "../..";
 

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -20,13 +20,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "readest";
-  version = "0.9.64";
+  version = "0.9.65";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-J3AqZIbpf/B0KMFjjNRq97E5OWPt7wJvIlDdfb4sbvU=";
+    hash = "sha256-zXAlptPYHXE5XgAi4lZZnrtIf6YMBo3S5CdK8jfoeYI=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Changelog: https://github.com/readest/readest/releases/tag/v0.9.66
Diff: https://github.com/readest/readest/compare/v0.9.64...v0.9.66

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
