### PR TITLE
opkssh: init service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5859,6 +5859,12 @@
       { fingerprint = "E8F9 0B80 908E 723D 0EDF  0916 5803 CDA5 9C26 A96A"; }
     ];
   };
+  datosh = {
+    email = "fabian@kammel.dev";
+    github = "datosh";
+    githubId = 6423339;
+    name = "Fabian Kammel";
+  };
   dav-wolff = {
     email = "nixpkgs@dav.dev";
     github = "dav-wolff";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1296,6 +1296,7 @@
   ./services/networking/openconnect.nix
   ./services/networking/opengfw.nix
   ./services/networking/openvpn.nix
+  ./services/networking/opkssh/opkssh.nix
   ./services/networking/ostinato.nix
   ./services/networking/owamp.nix
   ./services/networking/pangolin.nix

--- a/nixos/modules/services/networking/opkssh/opkssh.nix
+++ b/nixos/modules/services/networking/opkssh/opkssh.nix
@@ -1,0 +1,170 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.opkssh;
+
+  providerFile = pkgs.writeText "opkssh-providers" (
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (
+        name: provider: "${provider.issuer} ${provider.clientId} ${provider.lifetime}"
+      ) cfg.providers
+    )
+  );
+
+  authIdFile = pkgs.writeText "opkssh-auth-id" (
+    lib.concatStringsSep "\n" (
+      lib.map (auth: "${auth.user} ${auth.principal} ${auth.issuer}") cfg.authorizations
+    )
+  );
+in
+{
+  options.services.opkssh = {
+    enable = lib.mkEnableOption "OpenID Connect SSH authentication";
+
+    package = lib.mkPackageOption pkgs "opkssh" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "opksshuser";
+      description = "System user for running opkssh";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "opksshuser";
+      description = "System group for opkssh";
+    };
+
+    providers = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            issuer = lib.mkOption {
+              type = lib.types.str;
+              description = "Issuer URI";
+              example = "https://accounts.google.com";
+            };
+
+            clientId = lib.mkOption {
+              type = lib.types.str;
+              description = "OAuth client ID";
+            };
+
+            lifetime = lib.mkOption {
+              type = lib.types.enum [
+                "12h"
+                "24h"
+                "48h"
+                "1week"
+                "oidc"
+                "oidc-refreshed"
+              ];
+              default = "24h";
+              description = "Token lifetime";
+            };
+          };
+        }
+      );
+      default = {
+        google = {
+          issuer = "https://accounts.google.com";
+          clientId = "206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com";
+          lifetime = "24h";
+        };
+        microsoft = {
+          issuer = "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0";
+          clientId = "096ce0a3-5e72-4da8-9c86-12924b294a01";
+          lifetime = "24h";
+        };
+        github = {
+          issuer = "https://token.actions.githubusercontent.com";
+          clientId = "github";
+          lifetime = "oidc";
+        };
+      };
+      description = "OpenID Connect providers configuration";
+    };
+
+    authorizations = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            user = lib.mkOption {
+              type = lib.types.str;
+              description = "Linux user to authorize";
+            };
+
+            principal = lib.mkOption {
+              type = lib.types.str;
+              description = "Principal identifier (email, repo, etc.)";
+            };
+
+            issuer = lib.mkOption {
+              type = lib.types.str;
+              description = "Issuer URI";
+            };
+          };
+        }
+      );
+      default = [ ];
+      description = "User authorization mappings";
+      example = lib.literalExpression ''
+        # This example refers to values in the providers example
+        # adjust your expressions as necessary
+        [
+          {
+            user = "alice";
+            principal = "alice@gmail.com";
+            inherit (config.services.opkssh.providers.google) issuer;
+          }
+          {
+            user = "bob";
+            principal = "repo:NixOs/nixpkgs:environment:production";
+            inherit (config.services.opkssh.providers.github) issuer;
+          }
+        ];
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.groups.${cfg.group} = { };
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      description = "OpenPubkey OpenID Connect SSH User";
+      group = cfg.group;
+    };
+
+    services.openssh = {
+      authorizedKeysCommand = "/run/wrappers/bin/opkssh verify %u %k %t";
+      authorizedKeysCommandUser = cfg.user;
+    };
+
+    security.wrappers."opkssh" = {
+      source = "${cfg.package}/bin/opkssh";
+      owner = "root";
+      group = "root";
+    };
+
+    environment.etc."opk/providers" = {
+      mode = "0640";
+      user = cfg.user;
+      group = cfg.group;
+      source = providerFile;
+    };
+
+    environment.etc."opk/auth_id" = {
+      mode = "0640";
+      user = cfg.user;
+      group = cfg.group;
+      source = authIdFile;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ datosh ];
+}


### PR DESCRIPTION
[opkssh](https://github.com/openpubkey/opkssh) is a tool which enables ssh to be used with OpenID Connect allowing SSH access to be managed via identities like alice@example.com instead of long-lived SSH keys.

A [package for opkssh](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/op/opkssh/package.nix) is already available in nixpkgs. This provides the binary which needs to be used on the client to generate a keypair, and on the server to verify the key. 

The package can be used as is for client, but this service adds the required configuration files which servers need to make authorization decision decisions. 

I have tested this, by creating a NixOS VM and connecting to it using `opkssh login` and then simply `ssh test@VM_IP`

```nix
{
  inputs.nixpkgs.url = "path:/home/datosh/code/nixpkgs";

  outputs = { self, nixpkgs }: {
    nixosConfigurations = {
      opkssh-test = nixpkgs.lib.nixosSystem {
        system = "x86_64-linux";
        modules = [
          ({ pkgs, ... }: {
            services.openssh = {
              enable = true;
              settings = {
                PermitRootLogin = "no";
                PasswordAuthentication = true;
              };
            };

            services.opkssh = {
              enable = true;

              providers = {
                google = {
                  issuer = "https://accounts.google.com";
                  clientId = "206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com";
                  lifetime = "24h";
                };
              };

              authorizations = [
                {
                  user = "test";
                  principal = "datosh18@gmail.com";
                  issuer = "https://accounts.google.com";
                }
              ];
            };

            users.users.test = {
              isNormalUser = true;
              extraGroups = [ "wheel" ];
              initialPassword = "test";
            };

            system.stateVersion = "25.11";
          })
        ];
      };
    };
  };
}
```

Link to issue in opkssh repository: https://github.com/openpubkey/opkssh/issues/220

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
