### PR TITLE
Fix build failures across Lomiri ecosystem

### DIFF
--- a/pkgs/by-name/li/librda/1001-configure-GLib-gettext-is-deprecated-use-regular-get.patch
+++ b/pkgs/by-name/li/librda/1001-configure-GLib-gettext-is-deprecated-use-regular-get.patch
@@ -1,0 +1,26 @@
+From 08208a1193d10903bd291c4993bdcd4203c20780 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Wed, 16 Jul 2025 20:34:38 +0200
+Subject: [PATCH] configure: GLib gettext is deprecated, use regular gettext
+
+---
+ configure.ac | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 0a50ed8..8e30d7b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -90,7 +90,8 @@ GETTEXT_PACKAGE=librda
+ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE",
+ 		   [The gettext translation domain])
+ AC_SUBST(GETTEXT_PACKAGE)
+-AM_GLIB_GNU_GETTEXT
++AM_GNU_GETTEXT([external])
++AM_GNU_GETTEXT_VERSION([0.21])
+ 
+ AC_CONFIG_FILES([
+ Makefile
+-- 
+2.49.0
+

--- a/pkgs/by-name/li/librda/package.nix
+++ b/pkgs/by-name/li/librda/package.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation (finalAttrs: {
     "bin"
   ];
 
+  patches = [
+    # Use proper gettext instead of GLib macros
+    # Remove when https://github.com/ArcticaProject/librda/pull/10 merged & in release
+    ./1001-configure-GLib-gettext-is-deprecated-use-regular-get.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pe/persistent-cache-cpp/package.nix
+++ b/pkgs/by-name/pe/persistent-cache-cpp/package.nix
@@ -54,6 +54,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch =
     ''
+      # GTest needs C++17
+      # Remove when https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/merge_requests/19 merged & in release
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'std=c++14' 'std=c++17'
+
       # Wrong concatenation
       substituteInPlace data/libpersistent-cache-cpp.pc.in \
         --replace "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" "\''${prefix}/lib"

--- a/pkgs/by-name/pr/properties-cpp/package.nix
+++ b/pkgs/by-name/pr/properties-cpp/package.nix
@@ -23,9 +23,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-C/BDEuKNMQHOjATO5aWBptjIlgfv6ykzjFAsHb6uP3Q=";
   };
 
-  postPatch = lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
-    sed -i "/add_subdirectory(tests)/d" CMakeLists.txt
-  '';
+  postPatch =
+    ''
+      # GTest needs C++17
+      # Remove when https://gitlab.com/ubports/development/core/lib-cpp/properties-cpp/-/merge_requests/3 merged & in release
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'std=c++14' 'std=c++17'
+    ''
+    + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
+      sed -i "/add_subdirectory(tests)/d" CMakeLists.txt
+    '';
 
   strictDeps = true;
 

--- a/pkgs/desktops/lomiri/development/gmenuharness/default.nix
+++ b/pkgs/desktops/lomiri/development/gmenuharness/default.nix
@@ -37,6 +37,13 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  postPatch = ''
+    # GTest needs C++17
+    # Remove when https://gitlab.com/ubports/development/core/gmenuharness/-/merge_requests/5 merged & in release
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'std=c++14' 'std=c++17'
+  '';
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -40,6 +40,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch =
     ''
+      # GTest needs C++17
+      # Remove when https://gitlab.com/ubports/development/core/biometryd/-/merge_requests/39 merged & in release
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'std=c++14' 'std=c++17'
+
       # Substitute systemd's prefix in pkg-config call
       substituteInPlace data/CMakeLists.txt \
         --replace-fail 'pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir)' 'pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemdsystemunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})'

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -49,6 +49,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
+    # GTest needs C++17
+    # std::multimap in C++17 is not happy with this not being const
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-indicator-network/-/merge_requests/134 merged & in release
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'CMAKE_CXX_STANDARD 14' 'CMAKE_CXX_STANDARD 17'
+    substituteInPlace src/indicator/nmofono/wwan/wwan-link.h \
+      --replace-fail 'bool operator()(int lhs, int rhs)' 'bool operator()(int lhs, int rhs) const'
+
     # Override original prefixes
     substituteInPlace data/CMakeLists.txt \
       --replace-fail 'pkg_get_variable(DBUS_SESSION_BUS_SERVICES_DIR dbus-1 session_bus_services_dir)' 'pkg_get_variable(DBUS_SESSION_BUS_SERVICES_DIR dbus-1 session_bus_services_dir DEFINE_VARIABLES datadir=''${CMAKE_INSTALL_FULL_SYSCONFDIR})' \

--- a/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
@@ -29,6 +29,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
+  postPatch = ''
+    # GTest needs C++17
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/merge_requests/15 merged & in release
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'std=c++14' 'std=c++17'
+  '';
+
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -79,6 +79,18 @@ in
         ];
         hash = "sha256-jVhVR7wZZZGRS40z+HPNoGBLHulvE1nHRKgYhQ6/g9M=";
       })
+
+      # Fix compat with newer GTest
+      # Remove when version > 2.21.1
+      (fetchpatch {
+        name = "0201-Fix-gtest-nodiscard-error.patch";
+        url = "https://github.com/canonical/mir/commit/60dab2b197deb159087e44865e7314ad2865b79d.patch";
+        includes = [
+          "tests/integration-tests/input/test_single_seat_setup.cpp"
+          "tests/unit-tests/input/test_default_input_device_hub.cpp"
+        ];
+        hash = "sha256-gzLVQW9Z6y+s2D7pKtp0ondQrjkzZ5iUYhGDPqFXD5M=";
+      })
     ];
   };
 }


### PR DESCRIPTION
Mostly fallout from GTest bump requiring C++17, and one leftover glib gettext macro issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
