### PR TITLE
obs-studio-plugins.obs-aitum-multistream: fix build

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-aitum-multistream.diff
+++ b/pkgs/applications/video/obs-studio/plugins/obs-aitum-multistream.diff
@@ -1,0 +1,14 @@
+diff --color -urpN obs-aitum-multistream.bak/file-updater.c obs-aitum-multistream/file-updater.c
+--- obs-aitum-multistream.bak/file-updater.c	2025-07-18 17:41:35.605779462 -0400
++++ obs-aitum-multistream/file-updater.c	2025-07-18 17:45:29.485046420 -0400
+@@ -83,8 +83,8 @@ static bool do_http_request(struct updat
+ 	curl_easy_setopt(info->curl, CURLOPT_ERRORBUFFER, info->error);
+ 	curl_easy_setopt(info->curl, CURLOPT_WRITEFUNCTION, http_write);
+ 	curl_easy_setopt(info->curl, CURLOPT_WRITEDATA, info);
+-	curl_easy_setopt(info->curl, CURLOPT_FAILONERROR, true);
+-	curl_easy_setopt(info->curl, CURLOPT_NOSIGNAL, 1);
++	curl_easy_setopt(info->curl, CURLOPT_FAILONERROR, 1L);
++	curl_easy_setopt(info->curl, CURLOPT_NOSIGNAL, 1L);
+ 	curl_easy_setopt(info->curl, CURLOPT_ACCEPT_ENCODING, "");
+ 	curl_obs_set_revoke_setting(info->curl);
+ 

--- a/pkgs/applications/video/obs-studio/plugins/obs-aitum-multistream.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-aitum-multistream.nix
@@ -19,6 +19,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-TqddyTBRWLyfwYi9I0nQE8Z19YL2RwkZqUwi7F9XpwQ=";
   };
 
+  # Remove after https://github.com/Aitum/obs-aitum-multistream/pull/15 is released :)
+  patches = [ ./obs-aitum-multistream.diff ];
+
   # Fix FTBFS with Qt >= 6.8
   prePatch = ''
     substituteInPlace CMakeLists.txt \


### PR DESCRIPTION
Fix a build failure introduced by -Werror=attribute-warning in CFLAGS

https://hydra.nixos.org/build/302612625

https://github.com/Aitum/obs-aitum-multistream/pull/15

See also: #426516

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
