### PR TITLE
phira{,-unwrapped,-free}: init at 0.6.7

### DIFF
--- a/pkgs/by-name/ph/phira-free/package.nix
+++ b/pkgs/by-name/ph/phira-free/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenvNoCC,
+  phira,
+  phira-unwrapped,
+  imagemagick,
+  ubuntu-classic,
+}:
+
+phira.override {
+  overrideAssets = stdenvNoCC.mkDerivation {
+    pname = "phira-assets";
+    version = phira.version;
+
+    nativeBuildInputs = [ imagemagick ];
+
+    dontUnpack = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r ${phira-unwrapped.src}/assets $out
+      chmod -R +w $out/assets
+
+      magick -size 4000x2000 canvas:'rgb(128,162,206)' $out/assets/background.jpg
+      cp ${ubuntu-classic}/share/fonts/truetype/ubuntu/Ubuntu-R.ttf $out/assets/font.ttf
+
+      runHook postInstall
+    '';
+  };
+}

--- a/pkgs/by-name/ph/phira-unwrapped/assets.patch
+++ b/pkgs/by-name/ph/phira-unwrapped/assets.patch
@@ -1,0 +1,19 @@
+diff --git a/prpr/src/core.rs b/prpr/src/core.rs
+index 7f9d4db..33c44bb 100644
+--- a/prpr/src/core.rs
++++ b/prpr/src/core.rs
+@@ -68,6 +68,14 @@ thread_local! {
+ }
+ 
+ pub fn init_assets() {
++    if let Ok(root_path) = std::env::var("PHIRA_ROOT") {
++        let path = std::path::Path::new(&root_path);
++        if path.exists() {
++            std::env::set_current_dir(path).unwrap();
++            set_pc_assets_folder("assets");
++            return;
++        }
++    }
+     if let Ok(mut exe) = std::env::current_exe() {
+         while exe.pop() {
+             if exe.join("assets").exists() {

--- a/pkgs/by-name/ph/phira-unwrapped/ffmpeg.patch
+++ b/pkgs/by-name/ph/phira-unwrapped/ffmpeg.patch
@@ -1,0 +1,119 @@
+diff --git a/prpr-avc/Cargo.toml b/prpr-avc/Cargo.toml
+index 257c575..bf35b10 100644
+--- a/prpr-avc/Cargo.toml
++++ b/prpr-avc/Cargo.toml
+@@ -9,3 +9,6 @@ edition = "2021"
+ sasa = { git = "https://github.com/Mivik/sasa", default-features = false }
+ thiserror = "1.0.56"
+ tracing = "0.1.37"
++
++[build-dependencies]
++pkg-config = "0.3"
+diff --git a/prpr-avc/build.rs b/prpr-avc/build.rs
+index 961b032..6d0b714 100644
+--- a/prpr-avc/build.rs
++++ b/prpr-avc/build.rs
+@@ -1,10 +1,7 @@
+ use std::path::Path;
+ 
+ fn main() {
+-    let libs_dir = std::env::var("PRPR_AVC_LIBS").unwrap_or_else(|_| format!("{}/static-lib", std::env::var("CARGO_MANIFEST_DIR").unwrap()));
+-    let libs_path = Path::new(&libs_dir).join(std::env::var("TARGET").unwrap());
+-    let libs_path = libs_path.display();
+-    println!("cargo:rustc-link-search={libs_path}");
+-    println!("cargo:rustc-link-lib=z");
+-    println!("cargo:rerun-if-changed={libs_path}");
++    for lib in ["libavformat", "libavcodec", "libavutil", "libswscale", "libswresample"] {
++        let _ = pkg_config::Config::new().statik(false).probe(lib);
++    }
+ }
+diff --git a/prpr-avc/src/ffi.rs b/prpr-avc/src/ffi.rs
+index 8218ef3..a2c7f6a 100644
+--- a/prpr-avc/src/ffi.rs
++++ b/prpr-avc/src/ffi.rs
+@@ -6,7 +6,6 @@ pub const AV_SAMPLE_FMT_FLT: AVSampleFormat = 3;
+ 
+ pub const AV_ROUND_UP: AVRounding = 0;
+ 
+-#[link(name = "avformat", kind = "static")]
+ extern "C" {
+     pub fn avformat_alloc_context() -> *mut AVFormatContext;
+     pub fn avformat_free_context(s: *mut AVFormatContext);
+@@ -20,7 +19,6 @@ extern "C" {
+     pub fn av_read_frame(s: *mut AVFormatContext, pkt: *mut AVPacket) -> ::std::os::raw::c_int;
+ }
+ 
+-#[link(name = "avutil", kind = "static")]
+ extern "C" {
+     pub fn av_strerror(errnum: ::std::os::raw::c_int, errbuf: *mut ::std::os::raw::c_char, errbuf_size: usize) -> ::std::os::raw::c_int;
+     pub fn av_frame_alloc() -> *mut AVFrame;
+@@ -29,7 +27,6 @@ extern "C" {
+     pub fn av_rescale_rnd(a: i64, b: i64, c: i64, r: AVRounding) -> i64;
+ }
+ 
+-#[link(name = "avcodec", kind = "static")]
+ extern "C" {
+     pub fn avcodec_find_decoder(id: AVCodecID) -> *mut AVCodec;
+     pub fn avcodec_alloc_context3(codec: *const AVCodec) -> *mut AVCodecContext;
+@@ -43,7 +40,6 @@ extern "C" {
+     pub fn avcodec_default_get_format(s: *mut AVCodecContext, fmt: *const AVPixelFormat) -> AVPixelFormat;
+ }
+ 
+-#[link(name = "swscale", kind = "static")]
+ extern "C" {
+     pub fn sws_getContext(
+         srcW: ::std::os::raw::c_int,
+@@ -68,10 +64,9 @@ extern "C" {
+     ) -> ::std::os::raw::c_int;
+ }
+ 
+-#[link(name = "swresample", kind = "static")]
+ extern "C" {
+-    pub fn swr_alloc_set_opts(
+-        s: *mut SwrContext,
++    pub fn swr_alloc_set_opts2(
++        ps: *mut *mut SwrContext,
+         out_ch_layout: i64,
+         out_sample_fmt: AVSampleFormat,
+         out_sample_rate: ::std::os::raw::c_int,
+@@ -80,7 +75,7 @@ extern "C" {
+         in_sample_rate: ::std::os::raw::c_int,
+         log_offset: ::std::os::raw::c_int,
+         log_ctx: *mut ::std::os::raw::c_void,
+-    ) -> *mut SwrContext;
++    ) -> ::std::os::raw::c_int;
+     pub fn swr_init(s: *mut SwrContext) -> ::std::os::raw::c_int;
+     pub fn swr_get_delay(s: *const SwrContext, base: ::std::os::raw::c_int) -> i64;
+     pub fn swr_convert(
+diff --git a/prpr-avc/src/swr.rs b/prpr-avc/src/swr.rs
+index 7288a51..c00b874 100644
+--- a/prpr-avc/src/swr.rs
++++ b/prpr-avc/src/swr.rs
+@@ -5,8 +5,9 @@ pub struct SwrContext(OwnedPtr<ffi::SwrContext>);
+ impl SwrContext {
+     pub fn new(in_format: &AudioStreamFormat, out_format: &AudioStreamFormat) -> Result<Self> {
+         unsafe {
+-            OwnedPtr::new(ffi::swr_alloc_set_opts(
+-                null_mut(),
++            let mut raw: *mut ffi::SwrContext = null_mut();
++            let ret = ffi::swr_alloc_set_opts2(
++                &mut raw,
+                 out_format.channel_layout as _,
+                 out_format.sample_fmt,
+                 out_format.sample_rate,
+@@ -15,9 +16,12 @@ impl SwrContext {
+                 in_format.sample_rate,
+                 0,
+                 null_mut(),
+-            ))
+-            .map(|ctx| Self(ctx))
+-            .ok_or(Error::AllocationFailed)
++            );
++            if ret < 0 || raw.is_null() {
++                Err(Error::AllocationFailed)
++            } else {
++                OwnedPtr::new(raw).map(|ctx| Self(ctx)).ok_or(Error::AllocationFailed)
++            }
+         }
+     }
+ 

--- a/pkgs/by-name/ph/phira-unwrapped/package.nix
+++ b/pkgs/by-name/ph/phira-unwrapped/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  rustPlatform,
+  pkg-config,
+  perl,
+  ffmpeg,
+  alsa-lib,
+  gtk3,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "phira-unwrapped";
+  version = "0.6.7";
+
+  src = fetchFromGitHub {
+    owner = "TeamFlos";
+    repo = "phira";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4WIvLfKeh+quu7dHKMlUKt+NQnui2/txlFYZoU3voPA=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    perl
+    copyDesktopItems
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    rustPlatform.bindgenHook # for crate coreaudio-sys
+  ];
+
+  buildInputs = [
+    ffmpeg
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib # for crate alsa-sys
+    gtk3 # for crate gtk-sys
+  ];
+
+  patches = [
+    # use dynamically linked ffmpeg instead of expecting static lib
+    ./ffmpeg.patch
+
+    # error[E0554]: `#![feature]` may not be used on the stable release channel
+    ./stable-features.patch
+
+    # missing macro from tracing crate
+    ./tracing.patch
+
+    # allow using env var to specify location of assets and data
+    ./assets.patch
+  ];
+
+  cargoHash = "sha256-6mRb3M56G20fA+px1cZyrGpel0v54qoVAQK2ZgTzkmI=";
+
+  # The developer put assets necessary for this test in gitignore, so it cannot run.
+  checkFlags = [ "--skip test_parse_chart" ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "phira";
+      desktopName = "Phira";
+      exec = "phira-main";
+      icon = "phira";
+      comment = finalAttrs.meta.description;
+      categories = [ "Game" ];
+    })
+  ];
+
+  postInstall = ''
+    install -Dm644 assets/icon.png $out/share/icons/hicolor/128x128/apps/phira.png
+  '';
+
+  meta = {
+    description = "Rhythm game with custom charts and multiplayer";
+    homepage = "https://github.com/TeamFlos/phira";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    changelog = "https://github.com/TeamFlos/phira/releases/tag/v${finalAttrs.version}";
+    platforms = lib.platforms.unix;
+    mainProgram = "phira-main";
+  };
+
+})

--- a/pkgs/by-name/ph/phira-unwrapped/stable-features.patch
+++ b/pkgs/by-name/ph/phira-unwrapped/stable-features.patch
@@ -1,0 +1,10 @@
+diff --git a/prpr/src/lib.rs b/prpr/src/lib.rs
+index 15a139f..6b4e469 100644
+--- a/prpr/src/lib.rs
++++ b/prpr/src/lib.rs
+@@ -1,5 +1,3 @@
+-#![feature(local_key_cell_methods)]
+-
+ pub mod bin;
+ pub mod config;
+ pub mod core;

--- a/pkgs/by-name/ph/phira-unwrapped/tracing.patch
+++ b/pkgs/by-name/ph/phira-unwrapped/tracing.patch
@@ -1,0 +1,24 @@
+diff --git a/phira-monitor/Cargo.toml b/phira-monitor/Cargo.toml
+index 722a022..899b7db 100644
+--- a/phira-monitor/Cargo.toml
++++ b/phira-monitor/Cargo.toml
+@@ -15,6 +15,7 @@ serde = { version = "*", features = ["derive"] }
+ serde_yaml = "*"
+ tokio = { workspace = true }
+ uuid = { version = "1.4.0", features = ["v4"] }
++tracing = "0.1"
+ 
+ phira-mp-client = { git = "https://github.com/TeamFlos/phira-mp" }
+ phira-mp-common = { git = "https://github.com/TeamFlos/phira-mp" }
+diff --git a/phira-monitor/src/main.rs b/phira-monitor/src/main.rs
+index 61bcfba..a4bf8af 100644
+--- a/phira-monitor/src/main.rs
++++ b/phira-monitor/src/main.rs
+@@ -14,6 +14,7 @@ use prpr::{
+ use scene::MainScene;
+ use serde::Deserialize;
+ use std::fs::File;
++use tracing::warn;
+ 
+ mod dir {
+     use anyhow::Result;

--- a/pkgs/by-name/ph/phira/package.nix
+++ b/pkgs/by-name/ph/phira/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  symlinkJoin,
+  fetchzip,
+  phira-unwrapped,
+  makeWrapper,
+  libGL,
+  # A derivation or a path that contains a dir `assets`.
+  overrideAssets ? fetchzip {
+    url = "https://github.com/TeamFlos/phira/releases/download/v${phira-unwrapped.version}/Phira-windows-v${phira-unwrapped.version}.zip";
+    hash = "sha256-kgmIIIzg+wxyspQTyW1GucW0RVPfBhIRlK5DEGXK1Qs=";
+    stripRoot = false;
+    meta.license = lib.licenses.unfree;
+  },
+}:
+
+symlinkJoin {
+  pname = "phira";
+  version = phira-unwrapped.version;
+
+  paths = [ phira-unwrapped ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    phira_root=$out/share/phira
+    mkdir -p $phira_root
+    cp -r ${overrideAssets}/assets $phira_root
+
+    wrapper_options=(
+      ${lib.optionalString stdenv.hostPlatform.isLinux "--suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libGL ]}"}
+      --run '
+        export PHIRA_ROOT=''${PHIRA_ROOT-"''${XDG_DATA_HOME-"$HOME/.local/share"}/phira"}
+        if [[ ! -d "$PHIRA_ROOT/assets" ]]; then
+          mkdir -p "$PHIRA_ROOT"
+          cp -r "'$phira_root/assets'" "$PHIRA_ROOT"
+          chmod -R +w "$PHIRA_ROOT/assets"
+        fi
+      '
+    )
+
+    wrapProgram $out/bin/phira-main "''${wrapper_options[@]}"
+    wrapProgram $out/bin/phira-monitor "''${wrapper_options[@]}"
+  '';
+
+  passthru.assets = overrideAssets;
+
+  meta = phira-unwrapped.meta;
+
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I wrote a patch to make the game load assets from and download data to `~/.local/share/phira` instead of the installation dir (among other patches to fix the build). Currently it seems to work without flaw on Linux.

The build on macOS cannot launch because the window creation with GL capabilities fails, but it can probably be due to I am testing in a VM (where I cannot seem to write some code myself to use GLFW to create a window, either). More testing is needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
