### PR TITLE
[Backport release-25.05] forgejo: 11.0.3 -> 12.0.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -416,6 +416,9 @@ Alongside many enhancements to NixOS modules and general system improvements, th
   As a result, all sections previously defined under `services.rsyncd.settings` must now be put in `services.rsyncd.settings.sections`.
   Global settings must now be placed in `services.rsyncd.settings.globalSection` instead of `services.rsyncd.settings.global`.
 
+- The non-LTS Forgejo package (`forgejo`) has been updated to 12.0.0. This release contains breaking changes, see the [release blog post](https://forgejo.org/2025-07-release-v12-0/)
+  for all the details and how to ensure smooth upgrades.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Other Notable Changes {#sec-release-25.05-notable-changes}

--- a/pkgs/by-name/fo/forgejo/package.nix
+++ b/pkgs/by-name/fo/forgejo/package.nix
@@ -1,1 +1,11 @@
-{ forgejo-lts }: forgejo-lts
+import ./generic.nix {
+  version = "12.0.0";
+  hash = "sha256-8cokjK9fbxd9lm+5oDoMll9f7ejiVzMNuDgC0Pk1pbM=";
+  npmDepsHash = "sha256-kq2AV1D0xA4Csm8XUTU5D0iCmyuajcnwlLdPjJ/mj1g=";
+  vendorHash = "sha256-B9menPCDUOYHPCS0B5KpxuE03FdFXmA8XqkiYEAxs5Y=";
+  lts = false;
+  nixUpdateExtraArgs = [
+    "--override-filename"
+    "pkgs/by-name/fo/forgejo/package.nix"
+  ];
+}


### PR DESCRIPTION
Manual backport of #426131 to `release-25.05`. See https://github.com/NixOS/nixpkgs/pull/426131#issuecomment-3085765869 for why this is acceptable for backport.