### PR TITLE
jitsi-meet: 1.0.8043 -> 1.0.8792, from GitHub

### DIFF
--- a/pkgs/by-name/el/element-web-unwrapped/package.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (
       runHook preInstall
 
       cp -R webapp $out
-      tar --extract --to-stdout --file ${jitsi-meet.src} jitsi-meet/libs/external_api.min.js > $out/jitsi_external_api.min.js
+      cp ${jitsi-meet}/libs/external_api.min.js $out/jitsi_external_api.min.js
       echo "${finalAttrs.version}" > "$out/version"
       jq -s '.[0] * $conf' "config.sample.json" --argjson "conf" '${builtins.toJSON noPhoningHome}' > "$out/config.json"
 

--- a/pkgs/by-name/ji/jitsi-meet/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet/package.nix
@@ -55,16 +55,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = ./update.sh;
 
-  meta = with lib; {
+  meta = {
     description = "Secure, Simple and Scalable Video Conferences";
     longDescription = ''
       Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge
       to provide high quality, secure and scalable video conferences.
     '';
     homepage = "https://github.com/jitsi/jitsi-meet";
-    license = licenses.asl20;
-    teams = [ teams.jitsi ];
-    platforms = platforms.all;
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.jitsi ];
+    inherit (nodejs.meta) platforms;
     inherit (olm.meta) knownVulnerabilities;
   };
 })

--- a/pkgs/by-name/ji/jitsi-meet/update.sh
+++ b/pkgs/by-name/ji/jitsi-meet/update.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl pup common-updater-scripts
+#!nix-shell -i bash -p curl pup nix-update
 
 set -eu -o pipefail
 
-version="$(curl https://download.jitsi.org/stable/ | \
-    pup 'a[href] text{}' | \
-    awk -F'[_-]' '/jitsi-meet-web_/ {printf $4"\n"}' | \
-    sort -Vu | \
-    tail -n 1)"
+version="$(curl https://download.jitsi.org/jitsi-meet/src/ |
+  pup 'a[href] text{}' |
+  awk -F'-|.tar.bz2' '/jitsi-meet-/ {printf $3"\n"}' |
+  sort -Vu |
+  tail -n 1)"
 
-update-source-version jitsi-meet "$version"
+nix-update --version="$version" jitsi-meet


### PR DESCRIPTION
Closes #426514

Couldn't use the GitHub API for the update script, because of the large amount of tags the endpoint would 504.

Weird quirk (might be my laptop being slow) is that the nixos test only passes when I run the interactive driver, otherwise I get [caddy.service is inactive](https://github.com/NixOS/nixpkgs/blob/dbd993a88c3b7c12e7ebe5f456320c91bd879533/nixos/lib/test-driver/src/test_driver/machine/__init__.py#L346)

~~Also I had to change the versioning scheme because that's how the tags work upsteam. I could instead maybe do `tag = lib.last (lib.splitVersion finalAttrs.version);` and `version = "1.0.8726";`?~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
