### PR TITLE
ropr: init at 0.2.26-unstable-2025-07-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8292,6 +8292,12 @@
     githubId = 92429150;
     name = "Paul Meinhold";
   };
+  feyorsh = {
+    email = "george@feyor.sh";
+    github = "Feyorsh";
+    githubId = 44840644;
+    name = "George Huebner";
+  };
   ffinkdevs = {
     email = "fink@h0st.space";
     github = "ffinkdevs";

--- a/pkgs/by-name/ro/ropr/package.nix
+++ b/pkgs/by-name/ro/ropr/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ropr";
+  version = "0.2.26-unstable-2025-07-20";
+
+  src = fetchFromGitHub {
+    owner = "Ben-Lichtman";
+    repo = "ropr";
+    rev = "ec3eb2d91d9b4a940a8013a079ead47d7eab6dac";
+    hash = "sha256-iN6CSivyBe6Ibbl+oQ2wThbSyHTKne14XsilkMntnfE=";
+  };
+
+  cargoHash = "sha256-4YEriANTAt1dx9bXhlHFN+kNLde+8BLocuhXdFG24xo=";
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  preVersionCheck = ''
+    version=${builtins.head (lib.splitString "-" finalAttrs.version)}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Multithreaded ROP gadget finder for x86(_64)";
+    homepage = "https://github.com/Ben-Lichtman/ropr";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    mainProgram = "ropr";
+    maintainers = with lib.maintainers; [ feyorsh ];
+  };
+})


### PR DESCRIPTION
ropr is a faster alternative to tools like ROPGadget or ropper (although it only works on x86):
```
$ hyperfine -r 1 --output=pipe "ropr vmlinux" "ROPGadget --binary vmlinux"
Benchmark 1: ropr vmlinux
  Time (abs ≡):         1.693 s               [User: 1.843 s, System: 0.309 s]
 
Benchmark 2: ROPGadget --binary vmlinux
  Time (abs ≡):        627.583 s               [User: 468.720 s, System: 153.585 s]
 
Summary
  ropr vmlinux ran
  370.66 times faster than ROPGadget --binary vmlinux
```

I have intentionally omitted `passthru.updateScript` until upstream adds a Git tag for the latest version, at which point `rev` will point to a tag instead of a commit SHA-1.

Also, add myself as a maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
