### PR TITLE
home-assistant-custom-components.volvo_cars: 1.5.4 -> 1.5.6, add maintainer, with lib; cleanup

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/volvo_cars/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/volvo_cars/package.nix
@@ -16,14 +16,14 @@ buildHomeAssistantComponent rec {
     hash = "sha256-2eTUIbwAadJsOp1ETDY6+cEPVMOzhj1otEyzobysqaY=";
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/thomasddn/ha-volvo-cars/releases/tag/${src.tag}";
     homepage = "https://github.com/thomasddn/ha-volvo-cars";
     description = "Volvo Cars Home Assistant integration";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       matteopacini
       seberm
     ];
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
   };
 }

--- a/pkgs/servers/home-assistant/custom-components/volvo_cars/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/volvo_cars/package.nix
@@ -20,7 +20,10 @@ buildHomeAssistantComponent rec {
     changelog = "https://github.com/thomasddn/ha-volvo-cars/releases/tag/${src.tag}";
     homepage = "https://github.com/thomasddn/ha-volvo-cars";
     description = "Volvo Cars Home Assistant integration";
-    maintainers = with maintainers; [ seberm ];
+    maintainers = with maintainers; [
+      matteopacini
+      seberm
+    ];
     license = licenses.gpl3Only;
   };
 }

--- a/pkgs/servers/home-assistant/custom-components/volvo_cars/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/volvo_cars/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "thomasddn";
   domain = "volvo_cars";
-  version = "1.5.4";
+  version = "1.5.6";
 
   src = fetchFromGitHub {
     owner = "thomasddn";
     repo = "ha-volvo-cars";
     tag = "v${version}";
-    hash = "sha256-oAGUa8KxLbzZs7xw/P9kwwG/ija03HXJ4jACluUd048=";
+    hash = "sha256-2eTUIbwAadJsOp1ETDY6+cEPVMOzhj1otEyzobysqaY=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
- Upgraded the package to `v.1.5.6` (https://github.com/thomasddn/ha-volvo-cars/releases/tag/v1.5.6)
- Added myself as maintainer, happy to collaborate as I use this daily on my HASS instance
- Cleaned up `with lib;` usage

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
