### PR TITLE
treewide: migrate big consumers of git in check inputs to gitMinimal

### DIFF
--- a/pkgs/development/python-modules/hatch-vcs/default.nix
+++ b/pkgs/development/python-modules/hatch-vcs/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   pytestCheckHook,
   pythonOlder,
-  git,
+  gitMinimal,
   hatchling,
   setuptools-scm,
 }:
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    git
+    gitMinimal
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/meson-python/default.nix
+++ b/pkgs/development/python-modules/meson-python/default.nix
@@ -14,7 +14,7 @@
 
   # tests
   cython,
-  git,
+  gitMinimal,
   pytestCheckHook,
   pytest-mock,
 }:
@@ -52,7 +52,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     cython
-    git
+    gitMinimal
     pytestCheckHook
     pytest-mock
   ];

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   pythonOlder,
   build,
-  git,
+  gitMinimal,
   pytest-cov-stub,
   pytest-mock,
   pytestCheckHook,
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     build
-    git
+    gitMinimal
     pytest-mock
     pytest-cov-stub
     pytestCheckHook

--- a/pkgs/development/python-modules/pytest-benchmark/default.nix
+++ b/pkgs/development/python-modules/pytest-benchmark/default.nix
@@ -5,7 +5,7 @@
   elasticsearch,
   fetchFromGitHub,
   freezegun,
-  git,
+  gitMinimal,
   mercurial,
   nbmake,
   py-cpuinfo,
@@ -52,7 +52,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     freezegun
-    git
+    gitMinimal
     mercurial
     nbmake
     pytestCheckHook

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -33,7 +33,7 @@
 
   # tests
   cython-test-exception-raiser,
-  git,
+  gitMinimal,
   glibcLocales,
   pyhamcrest,
   hypothesis,
@@ -196,7 +196,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs =
     [
-      git
+      gitMinimal
       glibcLocales
     ]
     ++ optional-dependencies.test

--- a/pkgs/development/python-modules/versioningit/default.nix
+++ b/pkgs/development/python-modules/versioningit/default.nix
@@ -13,7 +13,7 @@
   pytest-cov-stub,
   pytest-mock,
   setuptools,
-  git,
+  gitMinimal,
   mercurial,
 }:
 
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytest-mock
     setuptools
-    git
+    gitMinimal
     mercurial
   ];
 


### PR DESCRIPTION
Recently, `git` had a serious CVE. We considered patching `git`/`gitFull` on master to get a fix out faster, but rejected the idea because `git` caused almost 30k rebuilds.

Many of the packages using git use it solely as a check input. In those cases, it is safe to migrate to `gitMinimal` if the checks still pass. This makes it easier to fix CVEs conditionally in `git`/`gitFull` directly on master while sending `gitMinimal` to staging for a proper fix. `gitMinimal` being slower to update is fine: the check runs are basically trusted input.

Note: Even after this, `git` is still a mass-rebuild at ~6k reverse dependencies, most of which because of `python3Packages.setuptools-git`. That package uses `git` in `propagatedBuildInputs`, which makes testing the impact of replacing that with `gitMinimal` significantly more complex. If anyone wants to look into that, go ahead - but i skipped that one for this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
