### PR TITLE
arrow-cpp: 20.0.0 -> 22.0.0, python3Packages.pyarrow: 20.0.0 -> 22.0.0

### DIFF
--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -37,7 +37,7 @@
   openssl,
   perl,
   pkg-config,
-  protobuf_31,
+  protobuf,
   python3,
   rapidjson,
   re2,
@@ -66,19 +66,19 @@ let
     name = "arrow-testing";
     owner = "apache";
     repo = "arrow-testing";
-    rev = "d2a13712303498963395318a4eb42872e66aead7";
-    hash = "sha256-c8FL37kG0uo7o0Zp71WjCl7FD5BnVgqUCCXXX9gI0lg=";
+    rev = "9a02925d1ba80bd493b6d4da6e8a777588d57ac4";
+    hash = "sha256-dEFCkeQpQrU61uCwJp/XB2umbQHjXtzado36BGChoc0=";
   };
 
   parquet-testing = fetchFromGitHub {
     name = "parquet-testing";
     owner = "apache";
     repo = "parquet-testing";
-    rev = "18d17540097fca7c40be3d42c167e6bfad90763c";
-    hash = "sha256-gKEQc2RKpVp39RmuZbIeIXAwiAXDHGnLXF6VQuJtnRA=";
+    rev = "a3d96a65e11e2bbca7d22a894e8313ede90a33a3";
+    hash = "sha256-Xd6o3RT6Q0tPutV77J0P1x3F6U3RHdCBOKGUKtkQCKk=";
   };
 
-  version = "20.0.0";
+  version = "22.0.0";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "arrow-cpp";
@@ -88,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "apache";
     repo = "arrow";
     rev = "apache-arrow-${version}";
-    hash = "sha256-JFPdKraCU+xRkBTAHyY4QGnBVlOjQ1P5+gq9uxyqJtk=";
+    hash = "sha256-i4Smt43oi4sddUt3qH7ePjensBSfPW+w/ExLVcVNKic=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/cpp";
@@ -107,21 +107,21 @@ stdenv.mkDerivation (finalAttrs: {
   ARROW_MIMALLOC_URL = fetchFromGitHub {
     owner = "microsoft";
     repo = "mimalloc";
-    rev = "v2.0.6";
-    hash = "sha256-u2ITXABBN/dwU+mCIbL3tN1f4c17aBuSdNTV+Adtohc=";
+    tag = "v3.1.5";
+    hash = "sha256-fk6nfyBFS1G0sJwUJVgTC1+aKd0We/JjsIYTO+IOfyg=";
   };
 
   ARROW_XSIMD_URL = fetchFromGitHub {
     owner = "xtensor-stack";
     repo = "xsimd";
-    rev = "13.0.0";
+    tag = "13.0.0";
     hash = "sha256-qElJYW5QDj3s59L3NgZj5zkhnUMzIP2mBa1sPks3/CE=";
   };
 
   ARROW_SUBSTRAIT_URL = fetchFromGitHub {
     owner = "substrait-io";
     repo = "substrait";
-    rev = "v0.44.0";
+    tag = "v0.44.0";
     hash = "sha256-V739IFTGPtbGPlxcOi8sAaYSDhNUEpITvN9IqdPReug=";
   };
 
@@ -138,6 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     brotli
     bzip2
+    curl
     flatbuffers
     gflags
     glog
@@ -145,7 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
     libbacktrace
     lz4
     nlohmann_json # alternative JSON parser to rapidjson
-    protobuf_31 # substrait requires protobuf
+    protobuf # substrait requires protobuf
     rapidjson
     re2
     snappy
@@ -157,7 +158,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals enableFlight [
     grpc
     openssl
-    protobuf_31
+    protobuf
     sqlite
   ]
   ++ lib.optionals enableS3 [
@@ -166,7 +167,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals enableGcs [
     crc32c
-    curl
     google-cloud-cpp
     grpc
     nlohmann_json

--- a/pkgs/development/python-modules/streamlit/default.nix
+++ b/pkgs/development/python-modules/streamlit/default.nix
@@ -7,6 +7,7 @@
   cachetools,
   click,
   fetchPypi,
+  fetchpatch2,
   gitpython,
   numpy,
   packaging,
@@ -37,6 +38,16 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-HnQqnAtpj0Zsb1v1jTM77aWh++jeZgdDl2eRtcFEbvY=";
   };
+
+  patches = [
+    # Allow pyarrow 22
+    (fetchpatch2 {
+      url = "https://github.com/streamlit/streamlit/commit/b9e1b875a948a0aa6e972edc6e86a4f89706e08c.diff?full_index=1";
+      stripLen = 1;
+      excludes = [ "tests/streamlit/data_test_cases.py" ];
+      hash = "sha256-qZau1XlP8Kf2hPtyFphJN4UEjbp0ZZYngFdRwXTVt3g=";
+    })
+  ];
 
   build-system = [
     setuptools


### PR DESCRIPTION
https://arrow.apache.org/release/21.0.0.html
https://arrow.apache.org/release/22.0.0.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
