### PR TITLE
Revert "hdr10plus: decouple the src from hdr10plus_tool"

### DIFF
--- a/pkgs/by-name/hd/hdr10plus/package.nix
+++ b/pkgs/by-name/hd/hdr10plus/package.nix
@@ -16,6 +16,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "hdr10plus";
+  # Version of the library, not the tool
+  # See https://github.com/quietvoid/hdr10plus_tool/blob/main/hdr10plus/Cargo.toml
   version = "2.1.4";
 
   outputs = [

--- a/pkgs/by-name/hd/hdr10plus/package.nix
+++ b/pkgs/by-name/hd/hdr10plus/package.nix
@@ -4,7 +4,6 @@
   rust,
   rustPlatform,
   hdr10plus_tool,
-  fetchFromGitHub,
   cargo-c,
   fontconfig,
 }:
@@ -17,25 +16,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "hdr10plus";
-  # Version of the library, not the tool
-  # See https://github.com/quietvoid/hdr10plus_tool/blob/main/hdr10plus/Cargo.toml
-  version = "2.1.3";
-
-  src = fetchFromGitHub {
-    owner = "quietvoid";
-    repo = "hdr10plus_tool";
-    # repo release snapshots are versioned per the tool
-    # https://github.com/quietvoid/hdr10plus_tool/releases/latest
-    tag = "1.7.0";
-    hash = "sha256-eueB+ZrOrnySEwUpCTvC4qARCsDcHJhm088XepLTlOE=";
-  };
-
-  cargoHash = "sha256-3D0HjDtKwYoi9bpQnosC/TPNBjfiWi5m1CH1eGQpGg0=";
+  version = "2.1.4";
 
   outputs = [
     "out"
     "dev"
   ];
+
+  inherit (hdr10plus_tool) src cargoDeps cargoHash;
 
   nativeBuildInputs = [ cargo-c ];
   buildInputs = [ fontconfig ];


### PR DESCRIPTION
This reverts commit 7f75ff0da259ffaa91c2864bbcdbcdc08cef5663.

This is no longer needed, as staging has cargo-c 0.10.14. The workaround was for https://github.com/NixOS/nixpkgs/pull/426181#issuecomment-3092161469

Verified that it builds with the latest cargo-c. https://github.com/NixOS/nixpkgs/pull/413726

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
