### PR TITLE
postgresql_18: turn off NUMA support in 18beta2 as well

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -102,11 +102,11 @@ let
       numaSupport ?
         lib.versionAtLeast version "18"
         && lib.meta.availableOn stdenv.hostPlatform numactl
-        # NUMA can fail in 18beta1 on some hardware with:
+        # NUMA can fail in 18beta2 on some hardware with:
         # ERROR:  invalid NUMA node id outside of allowed range [0, 0]: 1
         # https://github.com/NixOS/nixpkgs/pull/411958#issuecomment-3031680123
         # https://www.postgresql.org/message-id/flat/E1u1tr8-003BbN-2E%40gemulon.postgresql.org
-        && version != "18beta1",
+        && version != "18beta2",
       numactl,
 
       # PAM


### PR DESCRIPTION
Follows up on #426118

Still produces a broken test:

    diff -U3 /build/source/src/test/regress/expected/numa.out /build/source/src/test/regress/results/numa.out
    --- /build/source/src/test/regress/expected/numa.out	1970-01-01 00:00:01.000000000 +0000
    +++ /build/source/src/test/regress/results/numa.out	2025-07-19 08:44:02.793368816 +0000
    @@ -6,8 +6,4 @@
     -- switch to superuser
     \c -
     SELECT COUNT(*) >= 0 AS ok FROM pg_shmem_allocations_numa;
    - ok -----
    - t -(1 row) - +ERROR:  invalid NUMA node id outside of allowed range [0, 0]: 1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
