### PR TITLE
libtiff: Apply patch to fix test_directory test on big-endian

### DIFF
--- a/pkgs/by-name/li/libtiff/package.nix
+++ b/pkgs/by-name/li/libtiff/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  fetchpatch,
   nix-update-script,
 
   cmake,
@@ -50,6 +51,14 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # Fix test_directory test on big-endian
+    # https://gitlab.com/libtiff/libtiff/-/issues/652
+    (fetchpatch {
+      name = "0001-Update-test_directory-not-to-fail-on-big-endian-machines";
+      url = "https://gitlab.com/libtiff/libtiff/-/commit/e8233c42f2e0a0ea7260c3cc7ebbaec8e5cb5e07.patch";
+      hash = "sha256-z5odG66j4U+WoUjTUuBIhcVUCGK1GYdvW/cVucawNZI=";
+    })
+
     # libc++abi 11 has an `#include <version>`, this picks up files name
     # `version` in the project's include paths
     ./rename-version.patch


### PR DESCRIPTION
Fixes:
```
        Start  12: test_directory
 12/155 Test  #12: test_directory .......................................................................***Failed    0.14 sec
-- Running  /build/source/build/test/test_directory

[...]

--- Test for test_current_dirnum_incrementing non-BigTIFF and BE testcase 0. ---
TIFFRewriteDirectory: Error fetching directory link.
----- Expect some error messages about 'scanline size is zero' -----
TIFFScanlineSize64: Computed scanline size is zero.
TIFFScanlineSize64: Computed scanline size is zero.
TIFFReadDirectory: Cannot handle zero scanline size.
TIFFScanlineSize64: Computed scanline size is zero.
TIFFReadDirectory: Cannot handle zero scanline size.
TIFFScanlineSize64: Computed scanline size is zero.
TIFFReadDirectory: Cannot handle zero scanline size.
----- Expect error messages about 'Sanity check AND Failed to read directory' -----
TIFFFetchDirectory: Sanity check on directory count failed, this is probably not a valid IFD offset.
TIFFReadDirectory: Failed to read directory at offset 10.
----- Expect error messages about 'Error fetching directory link.' -----
TIFFAdvanceDirectory: /build/source/libtiff/tif_dir.c:1953: test_current_dirnum_incrementing_wb.tif: Error fetching directory count.
----- Expect error messages about 'Cannot read TIFF directory.' -----
test_current_dirnum_incrementing_wb.tif: Failed to allocate memory for to read TIFF directory (0 elements of 12 bytes each).
TIFFReadDirectory: Failed to read directory at offset 458.
----- Expect error messages about 'Error fetching directory link.' -----
TIFFAdvanceDirectory: /build/source/libtiff/tif_dir.c:1953: test_current_dirnum_incrementing_wb.tif: Error fetching directory count.
----- Expect error messages about 'Failed to allocate memory for to read TIFF directory.' AND 'Failed to read directory ..' -----
TIFFReadDirectory: Warning, Unknown field with tag 1 (0x1) encountered.
MissingRequired: TIFF directory is missing required "ImageLength" field.
Error: curdir 3 is different to expected one -1 at line 2048
Failed during Current Directory Number Incrementing test #0 in non-BigTIFF and BE.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
