### PR TITLE
python313Packages.dbus-deviation: remove unused setuptools_git dep, m…

### DIFF
--- a/pkgs/development/python-modules/dbus-deviation/default.nix
+++ b/pkgs/development/python-modules/dbus-deviation/default.nix
@@ -4,7 +4,6 @@
   fetchPypi,
   lxml,
   setuptools,
-  setuptools-git,
 }:
 
 buildPythonPackage rec {
@@ -18,15 +17,13 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    sed -i "/'sphinx',/d" setup.py
+    substituteInPlace setup.py \
+      --replace-fail "'setuptools_git >= 0.3'," "" \
+      --replace-fail "'sphinx'," ""
   '';
 
-  nativeBuildInputs = [
-    setuptools
-    setuptools-git
-  ];
-
-  propagatedBuildInputs = [ lxml ];
+  build-system = [ setuptools ];
+  dependencies = [ lxml ];
 
   pythonImportsCheck = [ "dbusdeviation" ];
 


### PR DESCRIPTION
…odernize

This (via hotdoc) drops git's reverse closure by another 3.7k builds per Linux.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
