### PR TITLE
ci/eval: fail on asserts when generating attrpaths

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -64,8 +64,7 @@ let
             -I "$src" \
             --option restrict-eval true \
             --option allow-import-from-derivation false \
-            --option eval-system "${evalSystem}" \
-            --arg enableWarnings false > $out/paths.json
+            --option eval-system "${evalSystem}" > $out/paths.json
       '';
 
   singleSystem =

--- a/pkgs/by-name/bm/bmake/package.nix
+++ b/pkgs/by-name/bm/bmake/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   getopt,
   ksh,
-  pkgsMusl,
+  pkgsMusl ? { },
   stdenv,
   tzdata,
 }:
@@ -107,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
-      bmakeMusl = pkgsMusl.bmake;
+      bmakeMusl = pkgsMusl.bmake or null;
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -113,12 +113,10 @@ with pkgs;
 
   stringsWithDeps = lib.stringsWithDeps;
 
-  ### Evaluating the entire Nixpkgs naively will fail, make failure fast
+  ### Evaluating the entire Nixpkgs naively will likely fail, make failure fast
   AAAAAASomeThingsFailToEvaluate = throw ''
-    Please be informed that this pseudo-package is not the only part
-    of Nixpkgs that fails to evaluate. You should not evaluate
-    entire Nixpkgs without some special measures to handle failing
-    packages, like using pkgs/top-level/release-attrpaths-superset.nix.
+    This pseudo-package is likely not the only part of Nixpkgs that fails to evaluate.
+    You should not evaluate entire Nixpkgs without measures to handle failing packages.
   '';
 
   tests = callPackages ../test { };

--- a/pkgs/top-level/release-attrpaths-superset.nix
+++ b/pkgs/top-level/release-attrpaths-superset.nix
@@ -24,7 +24,6 @@
 {
   lib ? import (path + "/lib"),
   trace ? false,
-  enableWarnings ? true,
   checkMeta ? true,
   path ? ./../..,
 }:
@@ -62,8 +61,10 @@ let
   justAttrNames =
     path: value:
     let
-      attempt =
-        if
+      result =
+        if path == [ "AAAAAASomeThingsFailToEvaluate" ] then
+          [ ]
+        else if
           lib.isDerivation value
           &&
             # in some places we have *derivations* with jobsets as subattributes, ugh
@@ -94,17 +95,6 @@ let
             builtins.attrValues
             builtins.concatLists
           ];
-
-      seq = builtins.deepSeq attempt attempt;
-      tried = builtins.tryEval seq;
-
-      result =
-        if tried.success then
-          tried.value
-        else if enableWarnings && path != [ "AAAAAASomeThingsFailToEvaluate" ] then
-          lib.warn "tryEval failed at: ${lib.concatStringsSep "." path}" [ ]
-        else
-          [ ];
     in
     if !trace then result else lib.trace "** ${lib.concatStringsSep "." path}" result;
 

--- a/pkgs/top-level/release-outpaths.nix
+++ b/pkgs/top-level/release-outpaths.nix
@@ -29,6 +29,7 @@ let
             allowBroken = includeBroken;
             allowUnfree = true;
             allowInsecurePredicate = x: true;
+            allowVariants = !attrNamesOnly;
             checkMeta = checkMeta;
 
             handleEvalIssue =

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -280,28 +280,6 @@ let
       else
         throw "i686 Linux package set can only be used with the x86 family.";
 
-    # x86_64-darwin packages for aarch64-darwin users to use with Rosetta for incompatible packages
-    pkgsx86_64Darwin =
-      if stdenv.hostPlatform.isDarwin then
-        nixpkgsFun {
-          overlays = [
-            (self': super': {
-              pkgsx86_64Darwin = super';
-            })
-          ]
-          ++ overlays;
-          localSystem = {
-            config = lib.systems.parse.tripleFromSystem (
-              stdenv.hostPlatform.parsed
-              // {
-                cpu = lib.systems.parse.cpuTypes.x86_64;
-              }
-            );
-          };
-        }
-      else
-        throw "x86_64 Darwin package set can only be used on Darwin systems.";
-
     # If already linux: the same package set unaltered
     # Otherwise, return a natively built linux package set for the current cpu architecture string.
     # (ABI and other details will be set to the default for the cpu/os pair)

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -90,6 +90,28 @@ self: super: {
     else
       throw "Musl libc only supports 64-bit Linux systems.";
 
+  # x86_64-darwin packages for aarch64-darwin users to use with Rosetta for incompatible packages
+  pkgsx86_64Darwin =
+    if stdenv.hostPlatform.isDarwin then
+      nixpkgsFun {
+        overlays = [
+          (self': super': {
+            pkgsx86_64Darwin = super';
+          })
+        ]
+        ++ overlays;
+        localSystem = {
+          config = lib.systems.parse.tripleFromSystem (
+            stdenv.hostPlatform.parsed
+            // {
+              cpu = lib.systems.parse.cpuTypes.x86_64;
+            }
+          );
+        };
+      }
+    else
+      throw "x86_64 Darwin package set can only be used on Darwin systems.";
+
   # Full package set with rocm on cuda off
   # Mostly useful for asserting pkgs.pkgsRocm.torchWithRocm == pkgs.torchWithRocm and similar
   pkgsRocm = nixpkgsFun ({


### PR DESCRIPTION
Work towards #397184.

TLDR of that issue: In the attrpaths generation step for Eval, we catch and ignore evaluation errors here:
https://github.com/NixOS/nixpkgs/blob/ab8897625aa037442f1b312763ca7165e514cdca/pkgs/top-level/release-attrpaths-superset.nix#L99-L107
We do this because a lot of asserts/throws are used to give feedback about invalid combinations of things for the current system, throw errors for non-accepted licenses etc. But that also means we silently ignore asserts/throws where they point at a real problem, for example when `mkDerivation` triggers an assert.

We can show these eval failures by turning on `enableWarnings` for `release-attrpaths-superset.nix`. This will give us:
- 48 attributes with warning for x86_64-linux
- 110 attributes with warning for aarch64-linux
- 6040 attributes with warning for x86_64-darwin
- 6041 attributes with warning for aarch64-darwin
- (5898 of these darwin warnings are about the linux kernels)

~~This PR fixes only the warnings for x86_64-linux, and then disables the `tryEval` logic *only on that platform*. Arguably this gives us a lot already, because most attributes are evaluated on x86_64-linux, too, and most real eval failures will surface this way. Eventually,~~ it would be good to get rid of all the warnings, though... :white_check_mark: 

We need to do the following things first:
- [x] Some `throw`s about removals are just made aliases, which they should have been anyway. #426639
- [x] Use `meta.broken` for some lua packages, instead of rolling their own `disabled` + `throw`. #426640
- [x] Fix an actual eval failure for `flutterPackages.beta` which tries to call `lib.last` on an empty list. #426641
- [x] Move certain license related check "behind" eval of meta. For these, the generic "unfree" error will now be thrown first, and CI will already filter them out because of that. This has a nice side-effect: These packages should also show up in the package search now, where they didn't before, because they'd fail evaluation. #426642
- [x] Move some top-level attributes to different versions of the underlying package set (ocaml, elixir), so that they build again. #426643
- [x] Move some "incompatibility asserts" behind a check on `config.allowAliases` as mentioned in https://github.com/NixOS/nixpkgs/issues/397184#issuecomment-3089535542. #426645

In here we also do:
- Avoid generating attrpaths for "variants", here `pkgsx86_64Darwin`, which doesn't eval on Linux.

## Things done

- Built `ci -A eval.attrpathsSuperset` on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
