### PR TITLE
various: move throws to aliases

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   callPackage,
   pkg-config,
@@ -28,12 +29,12 @@ let
     { hypr-dynamic-cursors = import ./hypr-dynamic-cursors.nix; }
     { hyprfocus = import ./hyprfocus.nix; }
     { hyprgrass = import ./hyprgrass.nix; }
-    {
-      hyprscroller = throw "hyprlandPlugins.hyprscroller has been removed as the upstream project is deprecated. Consider using `hyprlandPlugins.hyprscrolling`.";
-    } # Added 2025-05-09
     { hyprspace = import ./hyprspace.nix; }
     { hyprsplit = import ./hyprsplit.nix; }
     (import ./hyprland-plugins.nix)
+    (lib.optionalAttrs config.allowAliases {
+      hyprscroller = throw "hyprlandPlugins.hyprscroller has been removed as the upstream project is deprecated. Consider using `hyprlandPlugins.hyprscrolling`."; # Added 2025-05-09
+    })
   ];
 in
 (lib.mapAttrs (name: plugin: callPackage plugin { inherit mkHyprlandPlugin; }) plugins)

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -1,4 +1,8 @@
-{ pkgs, haskellLib }:
+{
+  config,
+  pkgs,
+  haskellLib,
+}:
 
 with haskellLib;
 
@@ -108,7 +112,10 @@ self: super: {
 
   doctest = dontCheck super.doctest;
 
-  haskell-language-server = throw "haskell-language-server has dropped support for ghc 9.0 in version 2.4.0.0, please use a newer ghc version or an older nixpkgs version";
+  haskell-language-server =
+    lib.throwIf config.allowAliases
+      "haskell-language-server has dropped support for ghc 9.0 in version 2.4.0.0, please use a newer ghc version or an older nixpkgs version"
+      (markBroken super.haskell-language-server);
 
   # Needs to use ghc-lib due to incompatible GHC
   ghc-tags = doDistribute self.ghc-tags_1_5;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -1,4 +1,8 @@
-{ pkgs, haskellLib }:
+{
+  config,
+  pkgs,
+  haskellLib,
+}:
 
 with haskellLib;
 
@@ -74,7 +78,10 @@ self: super: {
     }
   );
 
-  haskell-language-server = throw "haskell-language-server has dropped support for ghc 9.2 in version 2.10.0.0, please use a newer ghc version or an older nixpkgs version";
+  haskell-language-server =
+    lib.throwIf config.allowAliases
+      "haskell-language-server has dropped support for ghc 9.2 in version 2.10.0.0, please use a newer ghc version or an older nixpkgs version"
+      (markBroken super.haskell-language-server);
 
   # For GHC < 9.4, some packages need data-array-byte as an extra dependency
   hashable = addBuildDepends [ self.data-array-byte ] super.hashable;

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -422,8 +422,6 @@ in
     } ./setuptools-build-hook.sh
   ) { };
 
-  setuptoolsCheckHook = throw "The setuptoolsCheckHook has been removed, since the test command has been removed in setuptools 72.0";
-
   setuptoolsRustBuildHook = callPackage (
     { makePythonHook, setuptools-rust }:
     makePythonHook {

--- a/pkgs/development/libraries/science/math/magma/releases.nix
+++ b/pkgs/development/libraries/science/math/magma/releases.nix
@@ -5,68 +5,6 @@
 #   CUDA works around magma's wrappers and uses FindCUDAToolkit directly
 [
   {
-    version = "2.6.2";
-    hash = "sha256-dbVU2rAJA+LRC5cskT5Q5/iMvGLzrkMrWghsfk7aCnE=";
-    supportedGpuTargets = [
-      "700"
-      "701"
-      "702"
-      "703"
-      "704"
-      "705"
-      "801"
-      "802"
-      "803"
-      "805"
-      "810"
-      "900"
-      "902"
-      "904"
-      "906"
-      "908"
-      "909"
-      "90c"
-      "1010"
-      "1011"
-      "1012"
-      "1030"
-      "1031"
-      "1032"
-      "1033"
-    ];
-  }
-  {
-    version = "2.7.2";
-    hash = "sha256-cpvBpw5RinQi/no6VFN6R0EDWne+M0n2bqxcNiV21WA=";
-    supportedGpuTargets = [
-      "700"
-      "701"
-      "702"
-      "703"
-      "704"
-      "705"
-      "801"
-      "802"
-      "803"
-      "805"
-      "810"
-      "900"
-      "902"
-      "904"
-      "906"
-      "908"
-      "909"
-      "90c"
-      "1010"
-      "1011"
-      "1012"
-      "1030"
-      "1031"
-      "1032"
-      "1033"
-    ];
-  }
-  {
     version = "2.9.0";
     hash = "sha256-/3f9Nyaz3+w7+1V5CwZICqXMOEOWwts1xW/a5KgsZBw=";
     supportedGpuTargets = [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1214,6 +1214,8 @@ mapAliases {
   ma1sd = throw "ma1sd was dropped as it is unmaintained"; # Added 2024-07-10
   mac = monkeysAudio; # Added 2024-11-30
   MACS2 = macs2; # Added 2023-06-12
+  magma_2_6_2 = throw "'magma_2_6_2' has been removed, use the latest 'magma' package instead."; # Added 2025-07-20
+  magma_2_7_2 = throw "'magma_2_7_2' has been removed, use the latest 'magma' package instead."; # Added 2025-07-20
   mailcore2 = throw "'mailcore2' has been removed due to lack of upstream maintenance."; # Added 2025-06-09
   mailctl = throw "mailctl has been renamed to oama"; # Added 2024-08-19
   mailman-rss = throw "The mailman-rss package was dropped since it was unmaintained."; # Added 2024-06-21

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15312,7 +15312,7 @@ with pkgs;
   # standard BLAS and LAPACK.
   openblasCompat = openblas.override { blas64 = false; };
 
-  inherit (callPackage ../development/libraries/science/math/magma { }) magma magma_2_7_2 magma_2_6_2;
+  inherit (callPackage ../development/libraries/science/math/magma { }) magma;
 
   magma-cuda = magma.override {
     cudaSupport = true;

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -727,6 +727,7 @@ mapAliases ({
   sequoia = throw "python3Packages.sequoia was replaced by pysequoia - built from a dedicated repository, with a new API."; # added 2023-06-24
   setuptools_dso = setuptools-dso; # added 2024-03-03
   setuptools_scm = setuptools-scm; # added 2021-06-03
+  setuptoolsCheckHook = throw "The setuptoolsCheckHook has been removed, since the test command has been removed in setuptools 72.0."; # added 2024-08-06
   setuptoolsTrial = setuptools-trial; # added 2023-11-11
   sharkiqpy = sharkiq; # added 2022-05-21
   shouldbe = throw "shouldbe was removed, because it was disabled on all python version since 3.8 and last updated in 2019."; # added 2024-05-12


### PR DESCRIPTION
In some cases we throw for already removed packages. These should only be there with aliases enabled. This helps when generating all attrpaths for evaluation in CI.

Part of #426629, ultimately targeting #397184.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
