### PR TITLE
lua{54,Jit}Packages.lua-pam: mark as broken

### DIFF
--- a/pkgs/development/lua-modules/generic/default.nix
+++ b/pkgs/development/lua-modules/generic/default.nix
@@ -5,31 +5,27 @@
 }:
 
 {
-  disabled ? false,
   propagatedBuildInputs ? [ ],
   makeFlags ? [ ],
   ...
 }@attrs:
 
-if disabled then
-  throw "${attrs.name} not supported by interpreter lua-${lua.luaversion}"
-else
-  toLuaModule (
-    lua.stdenv.mkDerivation (
-      attrs
-      // {
-        name = "lua${lua.luaversion}-" + attrs.pname + "-" + attrs.version;
+toLuaModule (
+  lua.stdenv.mkDerivation (
+    attrs
+    // {
+      name = "lua${lua.luaversion}-" + attrs.pname + "-" + attrs.version;
 
-        makeFlags = [
-          "PREFIX=$(out)"
-          "LUA_INC=-I${lua}/include"
-          "LUA_LIBDIR=$(out)/lib/lua/${lua.luaversion}"
-          "LUA_VERSION=${lua.luaversion}"
-        ] ++ makeFlags;
+      makeFlags = [
+        "PREFIX=$(out)"
+        "LUA_INC=-I${lua}/include"
+        "LUA_LIBDIR=$(out)/lib/lua/${lua.luaversion}"
+        "LUA_VERSION=${lua.luaversion}"
+      ] ++ makeFlags;
 
-        propagatedBuildInputs = propagatedBuildInputs ++ [
-          lua # propagate it for its setup-hook
-        ];
-      }
-    )
+      propagatedBuildInputs = propagatedBuildInputs ++ [
+        lua # propagate it for its setup-hook
+      ];
+    }
   )
+)

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -121,8 +121,6 @@ rec {
     buildLuaPackage rec {
       pname = "lua-pam";
       version = "unstable-2015-07-03";
-      # Needed for `disabled`, overridden in buildLuaPackage
-      name = "${pname}-${version}";
 
       src = fetchFromGitHub {
         owner = "devurandom";
@@ -147,10 +145,9 @@ rec {
         runHook postInstall
       '';
 
-      # The package does not build with lua 5.4 or luaJIT
-      disabled = luaAtLeast "5.4" || isLuaJIT;
-
       meta = with lib; {
+        # The package does not build with lua 5.4 or luaJIT
+        broken = luaAtLeast "5.4" || isLuaJIT;
         description = "Lua module for PAM authentication";
         homepage = "https://github.com/devurandom/lua-pam";
         license = licenses.mit;


### PR DESCRIPTION
Removes the roll-your-own-broken-attribute that `disabled` was. The advantage of `meta.broken`: It can be caught and properly handled by CI, while the custom `throw` can not.

Part of https://github.com/NixOS/nixpkgs/pull/426629, ultimately targeting https://github.com/NixOS/nixpkgs/issues/397184.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
