### PR TITLE
various: move license check "behind" meta.unfree eval

### DIFF
--- a/pkgs/applications/science/machine-learning/sc2-headless/default.nix
+++ b/pkgs/applications/science/machine-learning/sc2-headless/default.nix
@@ -8,66 +8,67 @@
   licenseAccepted ? config.sc2-headless.accept_license or false,
 }:
 
-if !licenseAccepted then
-  throw ''
-    You must accept the Blizzard® Starcraft® II AI and Machine Learning License at
-    https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html
-    by setting nixpkgs config option 'sc2-headless.accept_license = true;'
-  ''
-else
-  assert licenseAccepted;
-  let
-    maps = callPackage ./maps.nix { };
-  in
-  stdenv.mkDerivation rec {
-    version = "4.7.1";
-    pname = "sc2-headless";
+let
+  maps = callPackage ./maps.nix { inherit licenseAccepted; };
+in
+stdenv.mkDerivation rec {
+  version = "4.7.1";
+  pname = "sc2-headless";
 
-    src = fetchurl {
-      url = "https://blzdistsc2-a.akamaihd.net/Linux/SC2.${version}.zip";
-      sha256 = "0q1ry9bd3dm8y4hvh57yfq7s05hl2k2sxi2wsl6h0r3w690v1kdd";
+  src = fetchurl {
+    url = "https://blzdistsc2-a.akamaihd.net/Linux/SC2.${version}.zip";
+    sha256 = "0q1ry9bd3dm8y4hvh57yfq7s05hl2k2sxi2wsl6h0r3w690v1kdd";
+  };
+
+  unpackCmd =
+    if !licenseAccepted then
+      throw ''
+        You must accept the Blizzard® Starcraft® II AI and Machine Learning License at
+        https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html
+        by setting nixpkgs config option 'sc2-headless.accept_license = true;'
+      ''
+    else
+      assert licenseAccepted;
+      ''
+        unzip -P 'iagreetotheeula' $curSrc
+      '';
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r . "$out"
+    rm -r $out/Libs
+
+    cp -ur "${maps.minigames}"/* "${maps.melee}"/* "${maps.ladder2017season1}"/* "${maps.ladder2017season2}"/* "${maps.ladder2017season3}"/* \
+      "${maps.ladder2017season4}"/* "${maps.ladder2018season1}"/* "${maps.ladder2018season2}"/* \
+      "${maps.ladder2018season3}"/*  "${maps.ladder2018season4}"/* "${maps.ladder2019season1}"/* "$out"/Maps/
+  '';
+
+  preFixup = ''
+    find $out -type f -print0 | while IFS=''' read -d ''' -r file; do
+      isELF "$file" || continue
+      patchelf \
+        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath ${
+          lib.makeLibraryPath [
+            stdenv.cc.cc
+            stdenv.cc.libc
+          ]
+        } \
+        "$file"
+    done
+  '';
+
+  meta = {
+    platforms = lib.platforms.linux;
+    description = "Starcraft II headless linux client for machine learning research";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = {
+      fullName = "BLIZZARD® STARCRAFT® II AI AND MACHINE LEARNING LICENSE";
+      url = "https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html";
+      free = false;
     };
-
-    unpackCmd = ''
-      unzip -P 'iagreetotheeula' $curSrc
-    '';
-
-    nativeBuildInputs = [ unzip ];
-
-    installPhase = ''
-      mkdir -p $out
-      cp -r . "$out"
-      rm -r $out/Libs
-
-      cp -ur "${maps.minigames}"/* "${maps.melee}"/* "${maps.ladder2017season1}"/* "${maps.ladder2017season2}"/* "${maps.ladder2017season3}"/* \
-        "${maps.ladder2017season4}"/* "${maps.ladder2018season1}"/* "${maps.ladder2018season2}"/* \
-        "${maps.ladder2018season3}"/*  "${maps.ladder2018season4}"/* "${maps.ladder2019season1}"/* "$out"/Maps/
-    '';
-
-    preFixup = ''
-      find $out -type f -print0 | while IFS=''' read -d ''' -r file; do
-        isELF "$file" || continue
-        patchelf \
-          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath ${
-            lib.makeLibraryPath [
-              stdenv.cc.cc
-              stdenv.cc.libc
-            ]
-          } \
-          "$file"
-      done
-    '';
-
-    meta = {
-      platforms = lib.platforms.linux;
-      description = "Starcraft II headless linux client for machine learning research";
-      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-      license = {
-        fullName = "BLIZZARD® STARCRAFT® II AI AND MACHINE LEARNING LICENSE";
-        url = "https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html";
-        free = false;
-      };
-      maintainers = [ ];
-    };
-  }
+    maintainers = [ ];
+  };
+}

--- a/pkgs/applications/science/machine-learning/sc2-headless/maps.nix
+++ b/pkgs/applications/science/machine-learning/sc2-headless/maps.nix
@@ -1,12 +1,21 @@
 {
   fetchzip,
+  licenseAccepted,
 }:
 let
   fetchzip' =
-    args:
-    (fetchzip args).overrideAttrs (old: {
-      UNZIP = "-j -P iagreetotheeula";
-    });
+    if !licenseAccepted then
+      throw ''
+        You must accept the Blizzard® Starcraft® II AI and Machine Learning License at
+        https://blzdistsc2-a.akamaihd.net/AI_AND_MACHINE_LEARNING_LICENSE.html
+        by setting nixpkgs config option 'sc2-headless.accept_license = true;'
+      ''
+    else
+      assert licenseAccepted;
+      args:
+      (fetchzip args).overrideAttrs (old: {
+        UNZIP = "-j -P iagreetotheeula";
+      });
 in
 {
   minigames = fetchzip {

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -631,32 +631,32 @@ lib.recurseIntoAttrs rec {
   # This derivation deploys the tools package and symlinks all the desired
   # plugins that we want to use. If the license isn't accepted, prints all the licenses
   # requested and throws.
-  androidsdk =
-    if !licenseAccepted then
-      throw ''
-        ${builtins.concatStringsSep "\n\n" (mkLicenseTexts licenseNames)}
+  androidsdk = callPackage ./cmdline-tools.nix {
+    inherit
+      deployAndroidPackage
+      os
+      arch
+      meta
+      ;
 
-        You must accept the following licenses:
-        ${lib.concatMapStringsSep "\n" (str: "  - ${str}") licenseNames}
+    package = cmdline-tools-package;
 
-        a)
-          by setting nixpkgs config option 'android_sdk.accept_license = true;'.
-        b)
-          by an environment variable for a single invocation of the nix tools.
-            $ export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
-      ''
-    else
-      callPackage ./cmdline-tools.nix {
-        inherit
-          deployAndroidPackage
-          os
-          arch
-          meta
-          ;
+    postInstall =
+      if !licenseAccepted then
+        throw ''
+          ${builtins.concatStringsSep "\n\n" (mkLicenseTexts licenseNames)}
 
-        package = cmdline-tools-package;
+          You must accept the following licenses:
+          ${lib.concatMapStringsSep "\n" (str: "  - ${str}") licenseNames}
 
-        postInstall = ''
+          a)
+            by setting nixpkgs config option 'android_sdk.accept_license = true;'.
+          b)
+            by an environment variable for a single invocation of the nix tools.
+              $ export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
+        ''
+      else
+        ''
           # Symlink all requested plugins
           ${linkPlugin {
             name = "platform-tools";
@@ -769,5 +769,5 @@ lib.recurseIntoAttrs rec {
             ''
           ) licenseNames}
         '';
-      };
+  };
 }

--- a/pkgs/tools/misc/gams/default.nix
+++ b/pkgs/tools/misc/gams/default.nix
@@ -8,8 +8,6 @@
   optgamsFile ? null,
 }:
 
-assert licenseFile != null;
-
 stdenv.mkDerivation rec {
   version = "25.0.2";
   pname = "gams";
@@ -23,6 +21,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   installPhase =
+    assert licenseFile != null;
     ''
       mkdir -p "$out/bin" "$out/share/gams"
       cp -a * "$out/share/gams"


### PR DESCRIPTION
Some packages require custom licenses to be accepted, but throw / assert before evaluating *anything* of the package. This means that not even their `meta` section can be evaluated. This has several drawbacks:
- These packages don't appear on https://search.nixos.org/packages
- These packages need ugly workarounds in CI during Eval

By moving the license check into an attribute of the derivation that is lazily evaluated, only when the full derivation is, we can eval meta separately - and fix these problems.

Part of https://github.com/NixOS/nixpkgs/pull/426629, ultimately targeting https://github.com/NixOS/nixpkgs/issues/397184.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
