### PR TITLE
python3Packages.pytestCheckHook: reduce parentheses for -m and -k options

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -11,11 +11,14 @@ function _pytestIncludeExcludeExpr() {
     local includeString excludeString
     if [[ -n "${includeListRef[*]-}" ]]; then
         # ((element1) or (element2))
-        includeString="(($(concatStringsSep ") or (" "$includeListName")))"
+        includeString="$(concatStringsSep " or " "$includeListName")"
+        if [[ "$includeString" =~ " or " ]]; then
+            includeString="($includeString)"
+        fi
     fi
     if [[ -n "${excludeListRef[*]-}" ]]; then
         # and not (element1) and not (element2)
-        excludeString="${includeString:+ and }not ($(concatStringsSep ") and not (" "$excludeListName"))"
+        excludeString="${includeString:+ and }not $(concatStringsSep " and not " "$excludeListName")"
     fi
     echo "$includeString$excludeString"
 }


### PR DESCRIPTION
The `-k` and `-m` options take expressions which can be constructed with `and`, `or`, `not` and - parentheses. However, an expression like `not (mark)` seems to be interpreted as the parentheses belonging to the mark and not to the expression.

Thus, this commit reduces the parentheses used in expression building. The only case left is when both enabled and disabled items are joined. Example:

```
(a or b) and not c and not d
```

This fixes https://github.com/NixOS/nixpkgs/pull/424782#issuecomment-3085694971.

~~I *think* it's not complete, yet, though: If passing a single `enableTestMarks`, this would still end up as `(a)` so potentially still fail.~~

## Things done

Not tested, yet.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
