### PR TITLE
libavif: fix cmake include path

### DIFF
--- a/pkgs/by-name/li/libavif/libavif-cmake-installdir.patch
+++ b/pkgs/by-name/li/libavif/libavif-cmake-installdir.patch
@@ -1,0 +1,49 @@
+From 83425cef38eb7053cbb1780b82ba7c9f1a01e9c7 Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Sat, 19 Jul 2025 16:45:57 +0200
+Subject: [PATCH] Don't hardcode 'include' as includedir
+
+GNUInstallDirs defines CMAKE_INSTALL_INCLUDEDIR as a location
+to install headers. This is important for distributions that
+want to install development files under a different prefix, see
+https://github.com/NixOS/nixpkgs/pull/424658.
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ CMakeLists.txt | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 558761e6bc..859860fb16 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,6 +37,7 @@ include(ExternalProject)
+ include(FetchContent)
+ include(FindPkgConfig)
+ include(AvifExternalProjectUtils)
++include(GNUInstallDirs)
+ 
+ option(AVIF_ENABLE_NODISCARD "Add [[nodiscard]] to some functions. CMake must be at least 3.21 to force C23." OFF)
+ 
+@@ -591,7 +592,9 @@ endif()
+ # Main avif library.
+ set_target_properties(avif PROPERTIES VERSION ${LIBRARY_VERSION} SOVERSION ${LIBRARY_SOVERSION})
+ target_link_libraries(avif PRIVATE avif_obj)
+-target_include_directories(avif PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
++target_include_directories(
++    avif PUBLIC $<BUILD_INTERFACE:${libavif_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++)
+ if(BUILD_SHARED_LIBS)
+     target_compile_definitions(avif INTERFACE AVIF_DLL)
+     if(AVIF_LIB_USE_CXX)
+@@ -636,10 +639,6 @@ if(CMAKE_SKIP_INSTALL_RULES)
+     set(SKIP_INSTALL_ALL TRUE)
+ endif()
+ 
+-if(NOT SKIP_INSTALL_ALL)
+-    include(GNUInstallDirs)
+-endif()
+-
+ if(AVIF_BUILD_APPS OR (AVIF_BUILD_TESTS AND (AVIF_FUZZTEST OR AVIF_GTEST)))
+     if(AVIF_ZLIBPNG STREQUAL "OFF")
+         message(FATAL_ERROR "libavif: AVIF_ZLIBPNG cannot be OFF when AVIF_BUILD_APPS or AVIF_BUILD_TESTS is ON")

--- a/pkgs/by-name/li/libavif/package.nix
+++ b/pkgs/by-name/li/libavif/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   libaom,
   cmake,
   pkg-config,
@@ -44,6 +45,13 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-0J56wpXa2AVh9JUp5UY2kzWijNE3i253RKhpG5oDFJE=";
   };
+
+  patches = [
+    # Correct include directory path in CMake files, cf.
+    # <https://github.com/AOMediaCodec/libavif/pull/2848>.
+    # Remove this once merged upstream.
+    ./libavif-cmake-installdir.patch
+  ];
 
   postPatch = ''
     substituteInPlace contrib/gdk-pixbuf/avif.thumbnailer.in \
@@ -105,11 +113,6 @@ stdenv.mkDerivation rec {
       makeWrapper ${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer "$out/libexec/gdk-pixbuf-thumbnailer-avif" \
         --set GDK_PIXBUF_MODULE_FILE ${gdkPixbufModuleFile}
     '';
-
-  postFixup = ''
-    substituteInPlace $dev/lib/cmake/libavif/libavif-config.cmake \
-      --replace-fail "_IMPORT_PREFIX \"$out\"" "_IMPORT_PREFIX \"$dev\""
-  '';
 
   meta = {
     description = "C implementation of the AV1 Image File Format";


### PR DESCRIPTION
fixes #425306 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
