### PR TITLE
akkoma: Use magick command from ImageMagick

### DIFF
--- a/pkgs/by-name/ak/akkoma/akkoma-imagemagick.patch
+++ b/pkgs/by-name/ak/akkoma/akkoma-imagemagick.patch
@@ -1,0 +1,60 @@
+From c48f5d57b6e57f42b668c0c6b8744e4620c77320 Mon Sep 17 00:00:00 2001
+From: Mikael Voss <mvs@nyantec.com>
+Date: Tue, 19 Nov 2024 20:47:27 +0100
+Subject: [PATCH] Use magick command from ImageMagick
+
+With ImageMagick version 7 the convert command has been deprecated in
+favour of magick. Calling convert instead results in the logs being
+spammed with warning messages.
+
+The mogrify Elixir wrapper also runs magick with the mogrify argument
+in current releases.
+---
+ lib/pleroma/application_requirements.ex | 8 ++++----
+ lib/pleroma/helpers/media_helper.ex     | 4 ++--
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/lib/pleroma/application_requirements.ex b/lib/pleroma/application_requirements.ex
+index c3777d8f1..55ee674a2 100644
+--- a/lib/pleroma/application_requirements.ex
++++ b/lib/pleroma/application_requirements.ex
+@@ -166,10 +166,10 @@ defp check_system_commands!(:ok) do
+     filter_commands_statuses = [
+       check_filter(Pleroma.Upload.Filter.Exiftool.StripMetadata, "exiftool"),
+       check_filter(Pleroma.Upload.Filter.Exiftool.ReadDescription, "exiftool"),
+-      check_filter(Pleroma.Upload.Filter.Mogrify, "mogrify"),
+-      check_filter(Pleroma.Upload.Filter.Mogrifun, "mogrify"),
+-      check_filter(Pleroma.Upload.Filter.AnalyzeMetadata, "mogrify"),
+-      check_filter(Pleroma.Upload.Filter.AnalyzeMetadata, "convert"),
++      check_filter(Pleroma.Upload.Filter.Mogrify, "magick"),
++      check_filter(Pleroma.Upload.Filter.Mogrifun, "magick"),
++      check_filter(Pleroma.Upload.Filter.AnalyzeMetadata, "magick"),
++      check_filter(Pleroma.Upload.Filter.AnalyzeMetadata, "magick"),
+       check_filter(Pleroma.Upload.Filter.AnalyzeMetadata, "ffprobe")
+     ]
+ 
+diff --git a/lib/pleroma/helpers/media_helper.ex b/lib/pleroma/helpers/media_helper.ex
+index cb95d0e68..17cd9629d 100644
+--- a/lib/pleroma/helpers/media_helper.ex
++++ b/lib/pleroma/helpers/media_helper.ex
+@@ -12,7 +12,7 @@ defmodule Pleroma.Helpers.MediaHelper do
+   require Logger
+ 
+   def missing_dependencies do
+-    Enum.reduce([imagemagick: "convert", ffmpeg: "ffmpeg"], [], fn {sym, executable}, acc ->
++    Enum.reduce([imagemagick: "magick", ffmpeg: "ffmpeg"], [], fn {sym, executable}, acc ->
+       if Pleroma.Utils.command_available?(executable) do
+         acc
+       else
+@@ -22,7 +22,7 @@ def missing_dependencies do
+   end
+ 
+   def image_resize(url, options) do
+-    with executable when is_binary(executable) <- System.find_executable("convert"),
++    with executable when is_binary(executable) <- System.find_executable("magick"),
+          {:ok, args} <- prepare_image_resize_args(options),
+          {:ok, env} <- HTTP.get(url, [], []),
+          {:ok, fifo_path} <- mkfifo() do
+-- 
+2.43.0
+

--- a/pkgs/by-name/ak/akkoma/package.nix
+++ b/pkgs/by-name/ak/akkoma/package.nix
@@ -23,6 +23,16 @@ beamPackages.mixRelease rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ file ];
 
+  patches = [
+    # See <https://akkoma.dev/AkkomaGang/akkoma/pulls/854>
+    # Akkoma uses the deprecated “convert” command instead of “magick”, which
+    # results in the logs being spammed with warning messages. Upstream is
+    # reluctant to change this, to ensure compatibility with Debian stable,
+    # which does not yet provide ImageMagick 7.
+    # Remove this patch once merged upstream.
+    ./akkoma-imagemagick.patch
+  ];
+
   mixFodDeps = beamPackages.fetchMixDeps {
     pname = "mix-deps-${pname}";
     inherit src version;


### PR DESCRIPTION
Akkoma uses the deprecated `convert` command instead of `magick`, which results in the logs being spammed with warning messages.

Upstream is reluctant to change this, to ensure compatibility with Debian stable, which does not yet provide ImageMagick 7.

See <https://akkoma.dev/AkkomaGang/akkoma/pulls/854>.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
