### PR TITLE
memos: 0.24.4 -> 0.25.0

### DIFF
--- a/pkgs/by-name/me/memos/package.nix
+++ b/pkgs/by-name/me/memos/package.nix
@@ -14,12 +14,12 @@
   protoc-gen-validate,
 }:
 let
-  version = "0.24.4";
+  version = "0.25.0";
   src = fetchFromGitHub {
     owner = "usememos";
     repo = "memos";
     rev = "v${version}";
-    hash = "sha256-Vimc9Z6X1+UBm2UnNnlsYqXEnOV3JcEPm9SD3obKkLc=";
+    hash = "sha256-M1o7orU4xw/t9PjSFXNj7tiYTarBv7kIIj8X0r3QD8s=";
   };
 
   memos-protobuf-gen = stdenvNoCC.mkDerivation {
@@ -52,7 +52,7 @@ let
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-cJK9wT5uj1MYjYZkzgMSL9nShCO2xPJOYZT+ebndwlY=";
+    outputHash = "sha256-lV92s/KLzWs/KSLbsb61FaA9+PEDMLshl/srDcjdRcU=";
   };
 
   memos-web = stdenvNoCC.mkDerivation (finalAttrs: {
@@ -62,7 +62,7 @@ let
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/web";
       fetcherVersion = 1;
-      hash = "sha256-AyQYY1vtBB6DTcieC7nw5aOOVuwESJSDs8qU6PGyaTw=";
+      hash = "sha256-TEWaFWFQ0sHdgfFFvolnwoa4hTaFkzqqyFep56Cevp4=";
     };
     pnpmRoot = "web";
     nativeBuildInputs = [
@@ -93,7 +93,7 @@ buildGoModule {
     memos-protobuf-gen
     ;
 
-  vendorHash = "sha256-EzVgQpWJJA7EUKdnnnCIvecaOXg856f/WQyfV/WuWFU=";
+  vendorHash = "sha256-xiBxnrjJsskRCcUBGKnrc5s5tuhMFSqRoELcr5ww/XU=";
 
   preBuild = ''
     rm -rf server/router/frontend/dist
@@ -113,6 +113,7 @@ buildGoModule {
   meta = {
     homepage = "https://usememos.com";
     description = "Lightweight, self-hosted memo hub";
+    changelog = "https://github.com/usememos/memos/releases/tag/${src.rev}";
     maintainers = with lib.maintainers; [
       indexyz
       kuflierl


### PR DESCRIPTION
Bumped memos from 0.24.4 to 0.25.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
