### PR TITLE
nixos/xserver: remove default enabling of LightDM and instead warn users

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -754,12 +754,10 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-    services.displayManager.enable = true;
-
-    services.xserver.displayManager.lightdm.enable =
+    services.displayManager.enable =
       let
         dmConf = cfg.displayManager;
-        default =
+        noDisplayManager =
           !(
             config.services.displayManager.gdm.enable
             || config.services.displayManager.sddm.enable
@@ -769,9 +767,22 @@ in
             || config.services.greetd.enable
             || config.services.displayManager.ly.enable
             || config.services.displayManager.lemurs.enable
+            || config.services.displayManager.cosmic-greeter.enable
           );
+        hasDesktopEnvironment = (
+          config.services.desktopManager.gnome.enable
+          || config.services.desktopManager.plasma6.enable
+          || config.services.xserver.desktopManager.plasma5.enable
+          || config.services.desktopManager.cosmic.enable
+          || config.services.xserver.desktopManager.xfce.enable
+        );
       in
-      mkIf (default) (mkDefault true);
+      lib.mkIf (noDisplayManager && hasDesktopEnvironment) (
+        lib.warn ''
+          Xserver and a desktop environment is configured but no diplay manager (aka login manager) is enabled.
+          This will boot into a TTY and all Desktop sessions will need to be manually launched.
+        '' true
+      );
 
     services.xserver.videoDrivers = mkIf (cfg.videoDriver != null) [ cfg.videoDriver ];
 


### PR DESCRIPTION
Changed behavior of this module to warn users with a Desktop Environment (but not a Window Manager) but no Display Manager.  This overrides the default behavior of silently installing LightDM when xserver and hardware graphics are enabled.

Additionally, added nixpkg's cosmic-greeter to the DM detection logic. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
