### PR TITLE
strawberry: move to pkgs/by-name

### DIFF
--- a/pkgs/by-name/st/strawberry/package.nix
+++ b/pkgs/by-name/st/strawberry/package.nix
@@ -24,32 +24,30 @@
   nix-update-script,
   p11-kit,
   pkg-config,
-  qtbase,
-  qttools,
+  qt6,
   sqlite,
   stdenv,
   taglib,
   util-linux,
-  wrapQtAppsHook,
   sparsehash,
   rapidjson,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "strawberry";
   version = "1.2.11";
 
   src = fetchFromGitHub {
     owner = "jonaski";
-    repo = pname;
-    rev = version;
+    repo = "strawberry";
+    rev = finalAttrs.finalPackage.version;
     hash = "sha256-AhNx2CdfE7ff3+L47X6lYPD8GA7imkDIJD5ESndn/cc=";
   };
 
   # the big strawberry shown in the context menu is *very* much in your face, so use the grey version instead
   postPatch = ''
     substituteInPlace src/context/contextalbum.cpp \
-      --replace pictures/strawberry.png pictures/strawberry-grey.png
+      --replace-fail pictures/strawberry.png pictures/strawberry-grey.png
   '';
 
   buildInputs =
@@ -67,7 +65,7 @@ stdenv.mkDerivation rec {
       libmtp
       libpthreadstubs
       libtasn1
-      qtbase
+      qt6.qtbase
       sqlite
       taglib
       sparsehash
@@ -94,8 +92,8 @@ stdenv.mkDerivation rec {
       cmake
       ninja
       pkg-config
-      qttools
-      wrapQtAppsHook
+      qt6.qttools
+      qt6.wrapQtAppsHook
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       util-linux
@@ -115,11 +113,11 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Music player and music collection organizer";
     homepage = "https://www.strawberrymusicplayer.org/";
-    changelog = "https://raw.githubusercontent.com/jonaski/strawberry/${version}/Changelog";
+    changelog = "https://raw.githubusercontent.com/jonaski/strawberry/${finalAttrs.finalPackage.version}/Changelog";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ peterhoeg ];
     # upstream says darwin should work but they lack maintainers as of 0.6.6
     platforms = lib.platforms.linux;
     mainProgram = "strawberry";
   };
-}
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1897,7 +1897,8 @@ mapAliases {
   steam-small = steam; # Added 2024-09-12
   steam-run-native = steam-run; # added 2022-02-21
   StormLib = stormlib; # Added 2024-01-21
-  strawberry-qt5 = throw "strawberry-qt5 has been replaced by strawberry-qt6"; # Added 2024-11-22
+  strawberry-qt5 = throw "strawberry-qt5 has been replaced by strawberry"; # Added 2024-11-22 and updated 2025-07-19
+  strawberry-qt6 = throw "strawberry-qt6 has been replaced by strawberry"; # Added 2025-07-19
   strelka = throw "strelka depends on Python 2.6+, and does not support Python 3."; # Added 2025-03-17
   subberthehut = throw "'subberthehut' has been removed as it was unmaintained upstream"; # Added 2025-05-17
   substituteAll = throw "`substituteAll` has been removed. Use `replaceVars` instead."; # Added 2025-05-23

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2820,10 +2820,6 @@ with pkgs;
 
   sonobuoy = callPackage ../applications/networking/cluster/sonobuoy { };
 
-  strawberry-qt6 = qt6Packages.callPackage ../applications/audio/strawberry { };
-
-  strawberry = strawberry-qt6;
-
   schleuder = callPackage ../tools/security/schleuder { };
 
   schleuder-cli = callPackage ../tools/security/schleuder/cli { };


### PR DESCRIPTION
Cleanups. Nothing earth shattering.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
