### PR TITLE
nixos/memos: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -92,6 +92,9 @@ Alongside many enhancements to NixOS modules and general system improvements, th
 
 - [Traccar](https://www.traccar.org/), a modern GPS Tracking Platform. Available as [services.traccar](#opt-services.traccar.enable).
 
+- [Memos](https://www.usememos.com/), a privacy-first, lightweight note-taking solution that allows you to effortlessly capture and share your ideas.
+  Available as [services.memos](#opt-services.memos.enable).
+
 - [Schroot](https://codeberg.org/shelter/reschroot), a lightweight virtualisation tool. Securely enter a chroot and run a command or login shell. Available as [programs.schroot](#opt-programs.schroot.enable).
 
 - [Firezone](https://firezone.dev), an enterprise-ready zero-trust access platform built on WireGuard. This includes the server stack as [services.firezone.server.enable](#opt-services.firezone.server.enable), a TURN/STUN relay service as [services.firezone.relay.enable](#opt-services.firezone.relay.enable), a gateway service as [services.firezone.gateway.enable](#opt-services.firezone.gateway.enable), a headless client as [services.firezone.headless-client.enable](#opt-services.firezone.headless-client.enable) and a GUI client as [services.firezone.gui-client.enable](#opt-services.firezone.gui-client.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -865,6 +865,7 @@
   ./services/misc/mame.nix
   ./services/misc/mbpfan.nix
   ./services/misc/mediatomb.nix
+  ./services/misc/memos.nix
   ./services/misc/metabase.nix
   ./services/misc/mollysocket.nix
   ./services/misc/moonraker.nix

--- a/nixos/modules/services/misc/memos.nix
+++ b/nixos/modules/services/misc/memos.nix
@@ -1,0 +1,199 @@
+{
+  config,
+  options,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.memos;
+  opt = options.services.memos;
+  envFileFormat = pkgs.formats.keyValue { };
+in
+{
+  options.services.memos = {
+    enable = lib.mkEnableOption "Memos note-taking";
+    package = lib.mkPackageOption pkgs "Memos" {
+      default = "memos";
+    };
+
+    openFirewall = lib.mkEnableOption "opening the ports in the firewall";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        The user to run Memos as.
+
+        ::: {.note}
+        If changing the default value, **you** are responsible of creating the corresponding user with [{option}`users.users`](#opt-users.users).
+        :::
+      '';
+      default = "memos";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        The group to run Memos as.
+
+        ::: {.note}
+        If changing the default value, **you** are responsible of creating the corresponding group with [{option}`users.groups`](#opt-users.groups).
+        :::
+      '';
+      default = "memos";
+    };
+
+    dataDir = lib.mkOption {
+      default = "/var/lib/memos/";
+      type = lib.types.path;
+      description = ''
+        Specifies the directory where Memos will store its data.
+
+        ::: {.note}
+        It will be automatically created with the permissions of [{option}`services.memos.user`](#opt-services.memos.user) and [{option}`services.memos.group`](#opt-services.memos.group).
+        :::
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = envFileFormat.type;
+      description = ''
+        The environment variables to configure Memos.
+
+        ::: {.note}
+        At time of writing, there is no clear documentation about possible values.
+        It's possible to convert CLI flags into these variables.
+        Example : CLI flag "--unix-sock" converts to {env}`MEMOS_UNIX_SOCK`.
+        :::
+      '';
+      default = {
+        MEMOS_MODE = "prod";
+        MEMOS_ADDR = "127.0.0.1";
+        MEMOS_PORT = "5230";
+        MEMOS_DATA = cfg.dataDir;
+        MEMOS_DRIVER = "sqlite";
+        MEMOS_INSTANCE_URL = "http://localhost:5230";
+      };
+      defaultText = lib.literalExpression ''
+        {
+          MEMOS_MODE = "prod";
+          MEMOS_ADDR = "127.0.0.1";
+          MEMOS_PORT = "5230";
+          MEMOS_DATA = config.${opt.dataDir};
+          MEMOS_DRIVER = "sqlite";
+          MEMOS_INSTANCE_URL = "http://localhost:5230";
+        }
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        The environment file to use when starting Memos.
+
+        ::: {.note}
+        By default, generated from [](opt-${opt.settings}).
+        :::
+      '';
+      example = "/var/lib/memos/memos.env";
+      default = envFileFormat.generate "memos.env" cfg.settings;
+      defaultText = lib.literalMD ''
+        generated from {option}`${opt.settings}`
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users = lib.mkIf (cfg.user == "memos") {
+      ${cfg.user} = {
+        description = lib.mkDefault "Memos service user";
+        isSystemUser = true;
+        group = cfg.group;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "memos") {
+      ${cfg.group} = { };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
+      cfg.port
+    ];
+
+    systemd.tmpfiles.settings."10-memos" = {
+      "${cfg.dataDir}" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+    };
+
+    systemd.services.memos = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      description = "Memos, a privacy-first, lightweight note-taking solution";
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Type = "simple";
+        RestartSec = 60;
+        LimitNOFILE = 65536;
+        NoNewPrivileges = true;
+        LockPersonality = true;
+        RemoveIPC = true;
+        ReadWritePaths = [
+          cfg.dataDir
+        ];
+        ProtectSystem = "strict";
+        PrivateUsers = true;
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        UMask = "0077";
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        ProtectProc = "invisible";
+        SystemCallFilter = [
+          " " # This is needed to clear the SystemCallFilter existing definitions
+          "~@reboot"
+          "~@swap"
+          "~@obsolete"
+          "~@mount"
+          "~@module"
+          "~@debug"
+          "~@cpu-emulation"
+          "~@clock"
+          "~@raw-io"
+          "~@privileged"
+          "~@resources"
+        ];
+        CapabilityBoundingSet = [
+          " " # Reset all capabilities to an empty set
+        ];
+        RestrictAddressFamilies = [
+          " " # This is needed to clear the RestrictAddressFamilies existing definitions
+          "none" # Remove all addresses families
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        DevicePolicy = "closed";
+        ProtectKernelLogs = true;
+        SystemCallArchitectures = "native";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        EnvironmentFile = cfg.environmentFile;
+        ExecStart = lib.getExe cfg.package;
+      };
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.m0ustach3 ];
+}


### PR DESCRIPTION
Added NixOS module for memos

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
