### PR TITLE
python3Packages.bugsnag: 4.7.1 -> 4.8.0; enable unit tests

### DIFF
--- a/pkgs/development/python-modules/bugsnag/default.nix
+++ b/pkgs/development/python-modules/bugsnag/default.nix
@@ -2,11 +2,12 @@
   lib,
   blinker,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   flask,
   pythonOlder,
   setuptools,
   webob,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -16,10 +17,17 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.10";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-m9YA/PauhWe20RZSJknqFzUXqpizc56bpzsf6ivIJEQ=";
+  src = fetchFromGitHub {
+    owner = "bugsnag";
+    repo = "bugsnag-python";
+    tag = "v${version}";
+    hash = "sha256-aN7/MpTdsRsAINPXOmSau4pG1+F8gmvjlx5czKpx7H8=";
   };
+
+  postPatch = ''
+    substituteInPlace tox.ini --replace-fail \
+      "--cov=bugsnag --cov-report html --cov-append --cov-report term" ""
+  '';
 
   build-system = [ setuptools ];
 
@@ -34,8 +42,22 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "bugsnag" ];
 
-  # Module ha no tests
-  doCheck = false;
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # Extra dependencies
+    "tests/integrations"
+    # Flaky due to timeout
+    "tests/test_client.py::ClientTest::test_flush_waits_for_outstanding_events_before_returning"
+    # Flaky due to timeout
+    "tests/test_client.py::ClientTest::test_flush_waits_for_outstanding_sessions_before_returning"
+    # Flaky failure due to AssertionError: assert 0 == 3
+    "tests/test_client.py::ClientTest::test_aws_lambda_handler_decorator_warns_of_potential_timeout"
+    # Flaky failure due to AssertionError: assert 0 == 1
+    "tests/test_client.py::ClientTest::test_exception_hook_does_not_leave_a_breadcrumb_if_errors_are_disabled"
+  ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Automatic error monitoring for Python applications";

--- a/pkgs/development/python-modules/bugsnag/default.nix
+++ b/pkgs/development/python-modules/bugsnag/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "bugsnag";
-  version = "4.7.1";
+  version = "4.8.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-mECP4X1KfzAKVlNUB6ZEi5hE2bUoxEUnkIho/DZG6HM=";
+    hash = "sha256-m9YA/PauhWe20RZSJknqFzUXqpizc56bpzsf6ivIJEQ=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Closes: #424737

meta.description for python3Packages.bugsnag is: Automatic error monitoring for Python applications

meta.homepage for python3Packages.bugsnag is: https://github.com/bugsnag/bugsnag-python

meta.changelog for python3Packages.bugsnag is: https://github.com/bugsnag/bugsnag-python/blob/v4.8.0/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
