### PR TITLE
nixos/systemd: convert extraConfig to rfc 42

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -141,6 +141,13 @@
 
 - `libvirt` now supports using `nftables` backend.
 
+- `systemd.extraConfig` and `boot.initrd.systemd.extraConfig` was converted to RFC42-style `systemd.settings.Manager` and `boot.initrd.systemd.settings.Manager` respectively.
+  - `systemd.watchdog.runtimeTime` was renamed to `systemd.settings.Manager.RuntimeWatchdogSec`
+  - `systemd.watchdog.device` was renamed to `systemd.settings.Manager.WatchdogDevice`
+  - `systemd.watchdog.rebootTime` was renamed to `systemd.settings.Manager.RebootWatchdogSec`
+  - `systemd.watchdog.kexecTime` was renamed to `systemd.settings.Manager.KExecWatchdogSec`
+  - `systemd.enableCgroupAccounting` was removed. Cgroup accounting now needs to be disabled directly using `systemd.settings.Manager.*Accounting`.
+
 - `services.ntpd-rs` now performs configuration validation.
 
 - `services.postsrsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.postsrsd.configurePostfix](#opt-services.postsrsd.configurePostfix) option.

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1663,7 +1663,7 @@ in
         must be that described in {manpage}`limits.conf(5)`.
 
         Note that these limits do not apply to systemd services,
-        whose limits can be changed via {option}`systemd.extraConfig`
+        whose limits can be changed via {option}`systemd.settings.Manager`
         instead.
       '';
     };

--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -412,8 +412,6 @@ in
       });
     };
 
-    systemd.enableCgroupAccounting = true;
-
     security.wrappers = {
       "apps.plugin" = {
         source = "${cfg.package}/libexec/netdata/plugins.d/apps.plugin.org";

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -424,6 +424,38 @@ in
       '';
       type = lib.types.submodule {
         freeformType = types.attrsOf unitOption;
+        options = {
+          DefaultCPUAccounting = mkOption {
+            type = types.bool;
+            default = cfg.enableCgroupAccounting;
+            defaultText = lib.literalExpression "config.systemd.enableCgroupAccounting";
+            description = "Turn on CPU usage accounting";
+          };
+
+          DefaultIOAccounting = mkOption {
+            type = types.bool;
+            default = cfg.enableCgroupAccounting;
+            defaultText = lib.literalExpression "config.systemd.enableCgroupAccounting";
+            description = "Turn on Block I/O accounting.";
+          };
+
+          DefaultBlockIOAccounting = mkOption {
+            type = types.bool;
+            default = cfg.enableCgroupAccounting;
+            defaultText = lib.literalExpression "config.systemd.enableCgroupAccounting";
+            description = "(Deprecated since systemd 252).";
+          };
+
+          DefaultIPAccounting = mkOption {
+            type = types.bool;
+            default = cfg.enableCgroupAccounting;
+            defaultText = lib.literalExpression "config.systemd.enableCgroupAccounting";
+            description = ''
+              If true, turns on IPv4 and IPv6 network traffic accounting for packets sent or received by the unit. When
+              this option is turned on, all IPv4 and IPv6 sockets created by any process are accounted for.
+            '';
+          };
+        };
       };
       example = {
         WatchdogDevice = "/dev/watchdog";
@@ -599,12 +631,6 @@ in
 
         "systemd/system.conf".text = ''
           [Manager]
-          ${optionalString cfg.enableCgroupAccounting ''
-            DefaultCPUAccounting=yes
-            DefaultIOAccounting=yes
-            DefaultBlockIOAccounting=yes
-            DefaultIPAccounting=yes
-          ''}
           ${attrsToSection cfg.settings.Manager}
         '';
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -424,6 +424,15 @@ in
       '';
       type = lib.types.submodule {
         freeformType = types.attrsOf unitOption;
+        options = {
+          DefaultLimitCORE = mkOption {
+            type = types.nullOr types.str;
+            default = "infinity";
+            description = ''
+              Default for the maximum size of core files created by services.
+            '';
+          };
+        };
       };
       example = {
         WatchdogDevice = "/dev/watchdog";
@@ -605,7 +614,6 @@ in
             DefaultBlockIOAccounting=yes
             DefaultIPAccounting=yes
           ''}
-          DefaultLimitCORE=infinity
           ${attrsToSection cfg.settings.Manager}
         '';
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -425,13 +425,6 @@ in
       type = lib.types.submodule {
         freeformType = types.attrsOf unitOption;
         options = {
-          DefaultCPUAccounting = mkOption {
-            type = types.bool;
-            default = cfg.enableCgroupAccounting;
-            defaultText = lib.literalExpression "config.systemd.enableCgroupAccounting";
-            description = "Turn on CPU usage accounting";
-          };
-
           DefaultIOAccounting = mkOption {
             type = types.bool;
             default = cfg.enableCgroupAccounting;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -424,60 +424,6 @@ in
       '';
       type = lib.types.submodule {
         freeformType = types.attrsOf unitOption;
-        options = {
-          WatchdogDevice = mkOption {
-            type = types.nullOr types.path;
-            default = null;
-            example = "/dev/watchdog";
-            description = ''
-              The path to a hardware watchdog device which will be managed by systemd.
-              If not specified, systemd will default to `/dev/watchdog`.
-            '';
-          };
-
-          RuntimeWatchdogSec = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            example = "30s";
-            description = ''
-              The amount of time which can elapse before a watchdog hardware device
-              will automatically reboot the system.
-
-              Valid time units include "ms", "s", "min", "h", "d", and "w";
-              see {manpage}`systemd.time(7)`.
-            '';
-          };
-
-          RebootWatchdogSec = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            example = "10m";
-            description = ''
-              The amount of time which can elapse after a reboot has been triggered
-              before a watchdog hardware device will automatically reboot the system.
-              If left `null`, systemd will use its default of 10 minutes;
-              see {manpage}`systemd-system.conf(5)`.
-
-              Valid time units include "ms", "s", "min", "h", "d", and "w";
-              see also {manpage}`systemd.time(7)`.
-            '';
-          };
-
-          KExecWatchdogSec = mkOption {
-            type = types.nullOr types.str;
-            default = null;
-            example = "10m";
-            description = ''
-              The amount of time which can elapse when `kexec` is being executed before
-              a watchdog hardware device will automatically reboot the system. This
-              option should only be enabled if `reloadTime` is also enabled;
-              see {manpage}`kexec(8)`.
-
-              Valid time units include "ms", "s", "min", "h", "d", and "w";
-              see also {manpage}`systemd.time(7)`.
-            '';
-          };
-        };
       };
       example = {
         WatchdogDevice = "/dev/watchdog";

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -439,13 +439,6 @@ in
             description = "Turn on Block I/O accounting.";
           };
 
-          DefaultBlockIOAccounting = mkOption {
-            type = types.bool;
-            default = cfg.enableCgroupAccounting;
-            defaultText = lib.literalExpression "config.systemd.enableCgroupAccounting";
-            description = "(Deprecated since systemd 252).";
-          };
-
           DefaultIPAccounting = mkOption {
             type = types.bool;
             default = cfg.enableCgroupAccounting;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -424,15 +424,6 @@ in
       '';
       type = lib.types.submodule {
         freeformType = types.attrsOf unitOption;
-        options = {
-          DefaultLimitCORE = mkOption {
-            type = types.nullOr types.str;
-            default = "infinity";
-            description = ''
-              Default for the maximum size of core files created by services.
-            '';
-          };
-        };
       };
       example = {
         WatchdogDevice = "/dev/watchdog";

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -386,26 +386,6 @@ in
       '';
     };
 
-    managerEnvironment = mkOption {
-      type =
-        with types;
-        attrsOf (
-          nullOr (oneOf [
-            str
-            path
-            package
-          ])
-        );
-      default = { };
-      example = {
-        SYSTEMD_LOG_LEVEL = "debug";
-      };
-      description = ''
-        Environment variables of PID 1. These variables are
-        *not* passed to started units.
-      '';
-    };
-
     enableCgroupAccounting = mkOption {
       default = true;
       type = types.bool;
@@ -424,6 +404,29 @@ in
       '';
       type = lib.types.submodule {
         freeformType = types.attrsOf unitOption;
+        options = {
+          ManagerEnvironment = mkOption {
+            type =
+              with types;
+              attrsOf (
+                nullOr (oneOf [
+                  str
+                  path
+                  package
+                ])
+              );
+            default = { };
+            example = {
+              SYSTEMD_LOG_LEVEL = "debug";
+            };
+            description = ''
+              Environment variables of PID 1. These variables are
+              *not* passed to started units.
+            '';
+            apply =
+              env: lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") env);
+          };
+        };
       };
       example = {
         WatchdogDevice = "/dev/watchdog";
@@ -652,11 +655,6 @@ in
 
         "systemd/system.conf".text = ''
           [Manager]
-          ManagerEnvironment=${
-            lib.concatStringsSep " " (
-              lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment
-            )
-          }
           ${optionalString cfg.enableCgroupAccounting ''
             DefaultCPUAccounting=yes
             DefaultIOAccounting=yes
@@ -747,7 +745,7 @@ in
       // listToAttrs (map (withName automountToUnit) cfg.automounts);
 
     # Environment of PID 1
-    systemd.managerEnvironment = {
+    systemd.settings.Manager.ManagerEnvironment = {
       # Doesn't contain systemd itself - everything works so it seems to use the compiled-in value for its tools
       # util-linux is needed for the main fsck utility wrapping the fs-specific ones
       PATH = lib.makeBinPath (
@@ -873,5 +871,9 @@ in
       NixOS does not officially support this configuration and might cause your system to be unbootable in future versions. You are on your own.
     '')
     (mkRemovedOptionModule [ "systemd" "extraConfig" ] "Use systemd.settings.Manager instead.")
+    (lib.mkRenamedOptionModule
+      [ "systemd" "managerEnvironment" ]
+      [ "systemd" "settings.Manager" "ManagerEnvironment" ]
+    )
   ];
 }

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -24,6 +24,7 @@ let
     mountToUnit
     automountToUnit
     sliceToUnit
+    attrsToSection
     ;
 
   upstreamSystemUnits = [
@@ -423,6 +424,29 @@ in
       '';
     };
 
+    settings.Manager = mkOption {
+      default = { };
+      defaultText = lib.literalExpression ''
+        {
+          DefaultIOAccounting = true;
+          DefaultIPAccounting = true;
+        }
+      '';
+      type = lib.types.submodule {
+        freeformType = types.attrsOf unitOption;
+      };
+      example = {
+        WatchdogDevice = "/dev/watchdog";
+        RuntimeWatchdogSec = "30s";
+        RebootWatchdogSec = "10min";
+        KExecWatchdogSec = "5min";
+      };
+      description = ''
+        Options for the global systemd service manager. See {manpage}`systemd-system.conf(5)` man page
+        for available options.
+      '';
+    };
+
     sleep.extraConfig = mkOption {
       default = "";
       type = types.lines;
@@ -664,6 +688,7 @@ in
           ''}
 
           ${cfg.extraConfig}
+          ${attrsToSection cfg.settings.Manager}
         '';
 
         "systemd/sleep.conf".text = ''

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -414,16 +414,6 @@ in
       '';
     };
 
-    extraConfig = mkOption {
-      default = "";
-      type = types.lines;
-      example = "DefaultLimitCORE=infinity";
-      description = ''
-        Extra config options for systemd. See {manpage}`systemd-system.conf(5)` man page
-        for available options.
-      '';
-    };
-
     settings.Manager = mkOption {
       default = { };
       defaultText = lib.literalExpression ''
@@ -687,7 +677,6 @@ in
             KExecWatchdogSec=${cfg.watchdog.kexecTime}
           ''}
 
-          ${cfg.extraConfig}
           ${attrsToSection cfg.settings.Manager}
         '';
 
@@ -883,5 +872,6 @@ in
       To forcibly reenable cgroup v1 support, you can set boot.kernelParams = [ "systemd.unified_cgroup_hierarchy=0" "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1" ].
       NixOS does not officially support this configuration and might cause your system to be unbootable in future versions. You are on your own.
     '')
+    (mkRemovedOptionModule [ "systemd" "extraConfig" ] "Use systemd.settings.Manager instead.")
   ];
 }

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -424,6 +424,60 @@ in
       '';
       type = lib.types.submodule {
         freeformType = types.attrsOf unitOption;
+        options = {
+          WatchdogDevice = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            example = "/dev/watchdog";
+            description = ''
+              The path to a hardware watchdog device which will be managed by systemd.
+              If not specified, systemd will default to `/dev/watchdog`.
+            '';
+          };
+
+          RuntimeWatchdogSec = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = "30s";
+            description = ''
+              The amount of time which can elapse before a watchdog hardware device
+              will automatically reboot the system.
+
+              Valid time units include "ms", "s", "min", "h", "d", and "w";
+              see {manpage}`systemd.time(7)`.
+            '';
+          };
+
+          RebootWatchdogSec = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = "10m";
+            description = ''
+              The amount of time which can elapse after a reboot has been triggered
+              before a watchdog hardware device will automatically reboot the system.
+              If left `null`, systemd will use its default of 10 minutes;
+              see {manpage}`systemd-system.conf(5)`.
+
+              Valid time units include "ms", "s", "min", "h", "d", and "w";
+              see also {manpage}`systemd.time(7)`.
+            '';
+          };
+
+          KExecWatchdogSec = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = "10m";
+            description = ''
+              The amount of time which can elapse when `kexec` is being executed before
+              a watchdog hardware device will automatically reboot the system. This
+              option should only be enabled if `reloadTime` is also enabled;
+              see {manpage}`kexec(8)`.
+
+              Valid time units include "ms", "s", "min", "h", "d", and "w";
+              see also {manpage}`systemd.time(7)`.
+            '';
+          };
+        };
       };
       example = {
         WatchdogDevice = "/dev/watchdog";
@@ -469,59 +523,6 @@ in
         {option}`systemd.additionalUpstreamSystemUnits`. The main purpose of this is to
         prevent a upstream systemd unit from being added to the initrd with any modifications made to it
         by other NixOS modules.
-      '';
-    };
-
-    watchdog.device = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      example = "/dev/watchdog";
-      description = ''
-        The path to a hardware watchdog device which will be managed by systemd.
-        If not specified, systemd will default to `/dev/watchdog`.
-      '';
-    };
-
-    watchdog.runtimeTime = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "30s";
-      description = ''
-        The amount of time which can elapse before a watchdog hardware device
-        will automatically reboot the system.
-
-        Valid time units include "ms", "s", "min", "h", "d", and "w";
-        see {manpage}`systemd.time(7)`.
-      '';
-    };
-
-    watchdog.rebootTime = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "10m";
-      description = ''
-        The amount of time which can elapse after a reboot has been triggered
-        before a watchdog hardware device will automatically reboot the system.
-        If left `null`, systemd will use its default of 10 minutes;
-        see {manpage}`systemd-system.conf(5)`.
-
-        Valid time units include "ms", "s", "min", "h", "d", and "w";
-        see also {manpage}`systemd.time(7)`.
-      '';
-    };
-
-    watchdog.kexecTime = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "10m";
-      description = ''
-        The amount of time which can elapse when `kexec` is being executed before
-        a watchdog hardware device will automatically reboot the system. This
-        option should only be enabled if `reloadTime` is also enabled;
-        see {manpage}`kexec(8)`.
-
-        Valid time units include "ms", "s", "min", "h", "d", and "w";
-        see also {manpage}`systemd.time(7)`.
       '';
     };
   };
@@ -659,19 +660,6 @@ in
             DefaultIPAccounting=yes
           ''}
           DefaultLimitCORE=infinity
-          ${optionalString (cfg.watchdog.device != null) ''
-            WatchdogDevice=${cfg.watchdog.device}
-          ''}
-          ${optionalString (cfg.watchdog.runtimeTime != null) ''
-            RuntimeWatchdogSec=${cfg.watchdog.runtimeTime}
-          ''}
-          ${optionalString (cfg.watchdog.rebootTime != null) ''
-            RebootWatchdogSec=${cfg.watchdog.rebootTime}
-          ''}
-          ${optionalString (cfg.watchdog.kexecTime != null) ''
-            KExecWatchdogSec=${cfg.watchdog.kexecTime}
-          ''}
-
           ${attrsToSection cfg.settings.Manager}
         '';
 
@@ -871,5 +859,21 @@ in
       NixOS does not officially support this configuration and might cause your system to be unbootable in future versions. You are on your own.
     '')
     (mkRemovedOptionModule [ "systemd" "extraConfig" ] "Use systemd.settings.Manager instead.")
+    (lib.mkRenamedOptionModule
+      [ "systemd" "watchdog" "device" ]
+      [ "systemd" "settings" "Manager" "WatchdogDevice" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "systemd" "watchdog" "runtimeTime" ]
+      [ "systemd" "settings" "Manager" "RuntimeWatchdogSec" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "systemd" "watchdog" "rebootTime" ]
+      [ "systemd" "settings" "Manager" "RebootWatchdogSec" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "systemd" "watchdog" "kexecTime" ]
+      [ "systemd" "settings" "Manager" "KExecWatchdogSec" ]
+    )
   ];
 }

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -141,6 +141,12 @@ in
       It only saved ~1MiB of initramfs size, but caused a few issues
       like unloadable kernel modules.
     '')
+    (lib.mkRemovedOptionModule [
+      "boot"
+      "initrd"
+      "systemd"
+      "extraConfig"
+    ] "Use boot.initrd.systemd.settings.Manager instead.")
   ];
 
   options.boot.initrd.systemd = {
@@ -160,16 +166,6 @@ in
       defaultText = lib.literalExpression "config.systemd.package";
       description = ''
         The systemd package to use.
-      '';
-    };
-
-    extraConfig = mkOption {
-      default = "";
-      type = types.lines;
-      example = "DefaultLimitCORE=infinity";
-      description = ''
-        Extra config options for systemd. See {manpage}`systemd-system.conf(5)` man page
-        for available options.
       '';
     };
 
@@ -488,7 +484,6 @@ in
         "/etc/systemd/system.conf".text = ''
           [Manager]
           DefaultEnvironment=PATH=/bin:/sbin
-          ${cfg.extraConfig}
           ${attrsToSection cfg.settings.Manager}
           ManagerEnvironment=${
             lib.concatStringsSep " " (

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -475,6 +475,10 @@ in
       };
 
       managerEnvironment.PATH = "/bin:/sbin";
+      settings.Manager.ManagerEnvironment = lib.concatStringsSep " " (
+        lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment
+      );
+      settings.Manager.DefaultEnvironment = "PATH=/bin:/sbin";
 
       contents = {
         "/tmp/.keep".text = "systemd requires the /tmp mount point in the initrd cpio archive";
@@ -483,13 +487,7 @@ in
 
         "/etc/systemd/system.conf".text = ''
           [Manager]
-          DefaultEnvironment=PATH=/bin:/sbin
           ${attrsToSection cfg.settings.Manager}
-          ManagerEnvironment=${
-            lib.concatStringsSep " " (
-              lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment
-            )
-          }
         '';
 
         "/lib".source = "${config.system.build.modulesClosure}/lib";

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -11,6 +11,7 @@ with lib;
 
 let
   inherit (utils) systemdUtils escapeSystemdPath;
+  inherit (systemdUtils.unitOptions) unitOption;
   inherit (systemdUtils.lib)
     generateUnits
     pathToUnit
@@ -21,6 +22,7 @@ let
     timerToUnit
     mountToUnit
     automountToUnit
+    attrsToSection
     ;
 
   cfg = config.boot.initrd.systemd;
@@ -171,6 +173,28 @@ in
       '';
     };
 
+    settings.Manager = mkOption {
+      default = { };
+      defaultText = lib.literalExpression ''
+        {
+          DefaultEnvironment = "PATH=/bin:/sbin";
+        }
+      '';
+      type = lib.types.submodule {
+        freeformType = types.attrsOf unitOption;
+      };
+      example = {
+        WatchdogDevice = "/dev/watchdog";
+        RuntimeWatchdogSec = "30s";
+        RebootWatchdogSec = "10min";
+        KExecWatchdogSec = "5min";
+      };
+      description = ''
+        Options for the global systemd service manager used in initrd. See {manpage}`systemd-system.conf(5)` man page
+        for available options.
+      '';
+    };
+
     managerEnvironment = mkOption {
       type =
         with types;
@@ -182,6 +206,11 @@ in
           ])
         );
       default = { };
+      defaultText = ''
+        {
+          PATH = "/bin:/sbin";
+        }
+      '';
       example = {
         SYSTEMD_LOG_LEVEL = "debug";
       };
@@ -460,6 +489,7 @@ in
           [Manager]
           DefaultEnvironment=PATH=/bin:/sbin
           ${cfg.extraConfig}
+          ${attrsToSection cfg.settings.Manager}
           ManagerEnvironment=${
             lib.concatStringsSep " " (
               lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -115,7 +115,7 @@ in
           MaxLevelConsole=debug
         '';
 
-        extraConfig = config.systemd.extraConfig;
+        settings.Manager = config.systemd.settings.Manager;
       }
 
       (lib.mkIf cfg.initrdBackdoor {
@@ -210,13 +210,13 @@ in
       MaxLevelConsole=debug
     '';
 
-    systemd.extraConfig = ''
+    systemd.settings.Manager = {
       # Don't clobber the console with duplicate systemd messages.
-      ShowStatus=no
+      ShowStatus = false;
       # Allow very slow start
-      DefaultTimeoutStartSec=300
-      DefaultDeviceTimeoutSec=300
-    '';
+      DefaultTimeoutStartSec = 300;
+      DefaultDeviceTimeoutSec = 300;
+    };
     systemd.user.extraConfig = ''
       # Allow very slow start
       DefaultTimeoutStartSec=300

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -68,9 +68,9 @@ in
             echo "systemd 0" > $out/init-interface-version
           '';
 
-          modifiedSystemConf.configuration.systemd.extraConfig = ''
-            # Hello world!
-          '';
+          modifiedSystemConf.configuration.systemd.settings.Manager = {
+            DefaultEnvironment = "XXX_SYSTEM=foo";
+          };
 
           addedMount.configuration.virtualisation.fileSystems."/test" = {
             device = "tmpfs";

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -27,7 +27,9 @@
         };
       };
 
-      systemd.extraConfig = "DefaultEnvironment=\"XXX_SYSTEM=foo\"";
+      systemd.settings.Manager = {
+        DefaultEnvironment = "XXX_SYSTEM=foo";
+      };
       systemd.user.extraConfig = "DefaultEnvironment=\"XXX_USER=bar\"";
       services.journald.extraConfig = "Storage=volatile";
       test-support.displayManager.auto.user = "alice";

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -29,6 +29,10 @@
 
       systemd.settings.Manager = {
         DefaultEnvironment = "XXX_SYSTEM=foo";
+        WatchdogDevice = "/dev/watchdog";
+        RuntimeWatchdogSec = "30s";
+        RebootWatchdogSec = "10min";
+        KExecWatchdogSec = "5min";
       };
       systemd.user.extraConfig = "DefaultEnvironment=\"XXX_USER=bar\"";
       services.journald.extraConfig = "Storage=volatile";
@@ -86,13 +90,6 @@
             touch "$HOME/user_conf_read"
           fi
         '';
-      };
-
-      systemd.watchdog = {
-        device = "/dev/watchdog";
-        runtimeTime = "30s";
-        rebootTime = "10min";
-        kexecTime = "5min";
       };
 
       environment.etc."systemd/system-preset/10-testservice.preset".text = ''


### PR DESCRIPTION
Converted `systemd.extraConfig`and `boot.initrd.systemd.extraConfig` to rfc-42-style `systemd.settings`.
Moved explicit definitions for `system.conf` to set settings instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
