### PR TITLE
libunwind: fix dangling symlink errors

### DIFF
--- a/pkgs/development/compilers/llvm/common/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/common/libunwind/default.nix
@@ -107,9 +107,12 @@ stdenv.mkDerivation (
       + lib.optionalString (enableShared && stdenv.hostPlatform.isWindows) ''
         ln -s $out/lib/libunwind.dll.a $out/lib/libunwind_shared.dll.a
       ''
-      + lib.optionalString (doFakeLibgcc) ''
+      + lib.optionalString (doFakeLibgcc && !stdenv.hostPlatform.isWindows) ''
         ln -s $out/lib/libunwind.so $out/lib/libgcc_s.so
         ln -s $out/lib/libunwind.so $out/lib/libgcc_s.so.1
+      ''
+      + lib.optionalString (doFakeLibgcc && stdenv.hostPlatform.isWindows) ''
+        ln -s $out/lib/libunwind.dll.a $out/lib/libgcc_s.dll.a
       '';
 
     meta = llvm_meta // {


### PR DESCRIPTION
Windows ucrt for aarch64 crossPkgs fail building because of the dangling
symlinks this code introduces


`nix build "nixpkgs#pkgsCross.ucrtAarch64.stdenv.cc"` fails with the error

```
libunwind-aarch64-w64-mingw32> ERROR: noBrokenSymlinks: the symlink /nix/store/da98flhxpxlhbx435bairwr65kkss8bs-libunwind-aarch64-w64-mingw32-19.1.7/lib/libgcc_s.so points to a missing target: /nix/store/da98flhxpxlhbx435bairwr65kkss8bs-libunwind-aarch64-w64-mingw32-19.1.7/lib/libunwind.so
libunwind-aarch64-w64-mingw32> ERROR: noBrokenSymlinks: the symlink /nix/store/da98flhxpxlhbx435bairwr65kkss8bs-libunwind-aarch64-w64-mingw32-19.1.7/lib/libgcc_s.so.1 points to a missing target: /nix/store/da98flhxpxlhbx435bairwr65kkss8bs-libunwind-aarch64-w64-mingw32-19.1.7/lib/libunwind.so
libunwind-aarch64-w64-mingw32> ERROR: noBrokenSymlinks: found 2 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
```

This fixes it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
