### PR TITLE
postgresql.pg_config: make overrideable

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -58,10 +58,7 @@ buildPythonPackage rec {
     "psycopg-pool"
   ];
 
-  # Temporarily disabled until the following is solved:
-  # https://github.com/NixOS/nixpkgs/pull/425384
-  doCheck = false;
-  # doCheck = !(stdenvNoCC.hostPlatform.isDarwin);
+  doCheck = !(stdenvNoCC.hostPlatform.isDarwin);
 
   nativeCheckInputs = [
     pytest-asyncio

--- a/pkgs/development/python-modules/pgvector/default.nix
+++ b/pkgs/development/python-modules/pgvector/default.nix
@@ -42,10 +42,6 @@ buildPythonPackage rec {
 
   dependencies = [ numpy ];
 
-  # Temporarily disabled until the following is solved:
-  # https://github.com/NixOS/nixpkgs/pull/425384
-  doCheck = false;
-
   nativeCheckInputs = [
     asyncpg
     django

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -456,9 +456,12 @@ let
         "$out/bin/pg_config" > "$dev/nix-support/pg_config.expected"
       ''
       + ''
-        rm "$out/bin/pg_config"
-        make -C src/common pg_config.env
-        install -D src/common/pg_config.env "$dev/nix-support/pg_config.env"
+          rm "$out/bin/pg_config"
+          make -C src/common pg_config.env
+          substituteInPlace src/common/pg_config.env \
+            --replace-fail "$out" "@out@" \
+            --replace-fail "$man" "@man@"
+          install -D src/common/pg_config.env "$dev/nix-support/pg_config.env"
 
         # postgres exposes external symbols get_pkginclude_path and similar. Those
         # can't be stripped away by --gc-sections/LTO, because they could theoretically
@@ -585,7 +588,13 @@ let
             postgresql = this;
           };
 
-          pg_config = buildPackages.callPackage ./pg_config.nix { inherit (finalAttrs) finalPackage; };
+          pg_config = buildPackages.callPackage ./pg_config.nix {
+            inherit (finalAttrs) finalPackage;
+            outputs = {
+              out = lib.getOutput "out" finalAttrs.finalPackage;
+              man = lib.getOutput "man" finalAttrs.finalPackage;
+            };
+          };
 
           tests = {
             postgresql = nixosTests.postgresql.postgresql.passthru.override finalAttrs.finalPackage;
@@ -639,84 +648,76 @@ let
     f:
     let
       installedExtensions = f postgresql.pkgs;
-      finalPackage =
-        (buildEnv {
-          name = "${postgresql.pname}-and-plugins-${postgresql.version}";
-          paths = installedExtensions ++ [
-            # consider keeping in-sync with `postBuild` below
-            postgresql
-            postgresql.man # in case user installs this into environment
-          ];
+      finalPackage = buildEnv {
+        name = "${postgresql.pname}-and-plugins-${postgresql.version}";
+        paths = installedExtensions ++ [
+          # consider keeping in-sync with `postBuild` below
+          postgresql
+          postgresql.man # in case user installs this into environment
+        ];
 
-          pathsToLink = [
-            "/"
-            "/bin"
-            "/share/postgresql/extension"
-            # Unbreaks Omnigres' build system
-            "/share/postgresql/timezonesets"
-            "/share/postgresql/tsearch_data"
-          ];
+        pathsToLink = [
+          "/"
+          "/bin"
+          "/share/postgresql/extension"
+          # Unbreaks Omnigres' build system
+          "/share/postgresql/timezonesets"
+          "/share/postgresql/tsearch_data"
+        ];
 
-          nativeBuildInputs = [ makeBinaryWrapper ];
-          postBuild =
-            let
-              args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
-            in
-            ''
-              wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
+        nativeBuildInputs = [ makeBinaryWrapper ];
+        postBuild =
+          let
+            args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
+          in
+          ''
+            wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
+          '';
 
-              mkdir -p "$dev/nix-support"
-              substitute "${lib.getDev postgresql}/nix-support/pg_config.env" "$dev/nix-support/pg_config.env" \
-                --replace-fail "${postgresql}" "$out" \
-                --replace-fail "${postgresql.man}" "$out"
-            '';
+        passthru = {
+          inherit installedExtensions;
+          inherit (postgresql)
+            pkgs
+            psqlSchema
+            version
+            ;
 
-          passthru = {
-            inherit installedExtensions;
-            inherit (postgresql)
-              pkgs
-              psqlSchema
-              version
+          pg_config = postgresql.pg_config.override {
+            outputs = {
+              out = finalPackage;
+              man = finalPackage;
+            };
+          };
+
+          withJIT = postgresqlWithPackages {
+            inherit
+              buildEnv
+              lib
+              makeBinaryWrapper
+              postgresql
               ;
+          } (_: installedExtensions ++ [ postgresql.jit ]);
+          withoutJIT = postgresqlWithPackages {
+            inherit
+              buildEnv
+              lib
+              makeBinaryWrapper
+              postgresql
+              ;
+          } (_: lib.remove postgresql.jit installedExtensions);
 
-            pg_config = postgresql.pg_config.override { inherit finalPackage; };
-
-            withJIT = postgresqlWithPackages {
+          withPackages =
+            f':
+            postgresqlWithPackages {
               inherit
                 buildEnv
                 lib
                 makeBinaryWrapper
                 postgresql
                 ;
-            } (_: installedExtensions ++ [ postgresql.jit ]);
-            withoutJIT = postgresqlWithPackages {
-              inherit
-                buildEnv
-                lib
-                makeBinaryWrapper
-                postgresql
-                ;
-            } (_: lib.remove postgresql.jit installedExtensions);
-
-            withPackages =
-              f':
-              postgresqlWithPackages {
-                inherit
-                  buildEnv
-                  lib
-                  makeBinaryWrapper
-                  postgresql
-                  ;
-              } (ps: installedExtensions ++ f' ps);
-          };
-        }).overrideAttrs
-          {
-            # buildEnv doesn't support passing `outputs`, so going via overrideAttrs.
-            outputs = [
-              "out"
-              "dev"
-            ];
-          };
+            } (ps: installedExtensions ++ f' ps);
+        };
+      };
     in
     finalPackage;
 

--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -128,6 +128,9 @@ stdenv.mkDerivation (finalAttrs: {
     make -C src/interfaces/libpq install
     make -C src/port install
 
+    substituteInPlace src/common/pg_config.env \
+      --replace-fail "$out" "@out@"
+
     install -D src/common/pg_config.env "$dev/nix-support/pg_config.env"
     moveToOutput "lib/*.a" "$dev"
 
@@ -151,6 +154,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.pg_config = buildPackages.callPackage ./pg_config.nix {
     inherit (finalAttrs) finalPackage;
+    outputs = {
+      out = lib.getOutput "out" finalAttrs.finalPackage;
+    };
   };
 
   meta = {

--- a/pkgs/servers/sql/postgresql/pg_config.nix
+++ b/pkgs/servers/sql/postgresql/pg_config.nix
@@ -6,6 +6,8 @@
   stdenv,
   # PostgreSQL package
   finalPackage,
+  # PostgreSQL package's outputs
+  outputs,
 }:
 
 replaceVarsWith {
@@ -15,12 +17,17 @@ replaceVarsWith {
   isExecutable = true;
   replacements = {
     inherit runtimeShell;
-    postgresql-dev = lib.getDev finalPackage;
+    "pg_config.env" = replaceVarsWith {
+      name = "pg_config.env";
+      src = "${lib.getDev finalPackage}/nix-support/pg_config.env";
+      replacements = outputs;
+    };
   };
   nativeCheckInputs = [
     diffutils
   ];
-  postCheck = ''
+  # The expected output only matches when outputs have *not* been altered by postgresql.withPackages.
+  postCheck = lib.optionalString (outputs.out == lib.getOutput "out" finalPackage) ''
     if [ -e ${lib.getDev finalPackage}/nix-support/pg_config.expected ]; then
         diff ${lib.getDev finalPackage}/nix-support/pg_config.expected <($out/bin/pg_config)
     fi

--- a/pkgs/servers/sql/postgresql/pg_config.sh
+++ b/pkgs/servers/sql/postgresql/pg_config.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 #   https://github.com/postgres/postgres/blob/7510ac6203bc8e3c56eae95466feaeebfc1b4f31/src/bin/pg_config/pg_config.sh
 #   https://github.com/postgres/postgres/blob/master/src/bin/pg_config/pg_config.c
 
-source @postgresql-dev@/nix-support/pg_config.env
+source @pg_config.env@
 
 help="
 pg_config provides information about the installed version of PostgreSQL.


### PR DESCRIPTION
This allows `postgresql.withPackages` to easily override the paths to the default and man outputs for `pg_config`. It avoids all `buildEnv`-dev-output hackery, which it didn't properly support, and separates the logic cleanly.

Closes #425384, reverts #426048.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
