### PR TITLE
josm: add update script

### DIFF
--- a/pkgs/by-name/jo/josm/package.nix
+++ b/pkgs/by-name/jo/josm/package.nix
@@ -63,6 +63,11 @@ stdenv.mkDerivation {
           --prefix _JAVA_OPTIONS : "-Dawt.useSystemAAFontSettings=on"
       '';
 
+  passthru = {
+    inherit srcs;
+    updateScript = ./update.sh;
+  };
+
   meta = {
     description = "Extensible editor for OpenStreetMap";
     homepage = "https://josm.openstreetmap.de/";

--- a/pkgs/by-name/jo/josm/update.sh
+++ b/pkgs/by-name/jo/josm/update.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl nurl pup common-updater-scripts
+
+# partially taken from jitsi-meet/update.sh, as they both scrape an apt repo.
+
+set -euo pipefail
+
+version="$(curl https://josm.openstreetmap.de/apt/pool/universe/j/josm/ |
+  pup 'a[href] text{}' |
+  sed -nr 's/josm_[0-9]+.[0-9]+.svn([0-9]+)_all.deb/\1/p' |
+  sort -n |
+  tail -n1)"
+
+pkgHash="$(nurl -H https://github.com/JOSM/josm "$version-tested")"
+
+update-source-version josm "$version" --source-key=srcs.jar
+update-source-version josm "$version" --ignore-same-version --source-key=srcs.macosx
+update-source-version josm "$version" "$pkgHash" --ignore-same-version --source-key=srcs.pkg


### PR DESCRIPTION
Hi, I noticed JOSM was outdated on my system, which turned out to be caused by an outdated channel, but I thought this could aid further updatage of the package.

Tested by reverting 7e2e65497cb15c473e8bc07d545a3f5f108ed24a temporarily and running the script. I got the same diff, and the output was cached, so I'm pretty sure this works.

I guess we'll see if r-ryantm is going to successfully make PRs with this or not.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
