### PR TITLE
pulumi: 3.162.0 -> 3.185.0

### DIFF
--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -17,18 +17,18 @@
 }:
 buildGoModule rec {
   pname = "pulumi";
-  version = "3.162.0";
+  version = "3.185.0";
 
   src = fetchFromGitHub {
     owner = "pulumi";
     repo = "pulumi";
     tag = "v${version}";
-    hash = "sha256-avtqURmj3PL82j89kLmVsBWqJJHnOFqR1huoUESt4L4=";
+    hash = "sha256-/7VaFeEQXVqF7g+CR2oTSmOWgWjw/LS9s0+VZcSlFvU=";
     # Some tests rely on checkout directory name
     name = "pulumi";
   };
 
-  vendorHash = "sha256-fJFpwhbRkxSI2iQfNJ9qdL9oYM1SVVMJ30VIymoZBmg=";
+  vendorHash = "sha256-aAxBVMLL7JRSJSVIR9/gNTNj8sZHg39ftv+ZAO8PS54=";
 
   sourceRoot = "${src.name}/pkg";
 
@@ -81,6 +81,11 @@ buildGoModule rec {
         "TestPulumiNewWithOrgTemplates"
         "TestPulumiNewWithoutPulumiAccessToken"
         "TestPulumiNewWithoutTemplateSupport"
+        "TestGeneratingProjectWithAIPromptSucceeds"
+        "TestPulumiNewWithRegistryTemplates"
+
+        # Connects to https://api.pulumi.com/…
+        "TestGetLatestPluginIncludedVersion"
 
         # Connects to https://pulumi-testing.vault.azure.net/…
         "TestAzureCloudManager"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-3I9Kh3Zqpu0gT0pQNzg2mMwxQUdhEpjITZOrO7Yt50A=";
+  vendorHash = "sha256-FSkFZhuwbTxCQgES+rFoVeSJHtepZiHEtnfShZ+eSMU=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-UvfSmHWRFRZkmcgzUrLkqktQAt8ZlVDEzP6y+pxUOGc=";
+  vendorHash = "sha256-q/NKPB5U7z3gPXIV2wCZXBN6QfJ4nMVdLUMcwXJ800Q=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-5tr3mQ5x6jMOa9meHK6gaoRjNgLoHkWiTiaYXXqmUDo=";
+  vendorHash = "sha256-oWEl/IeoMya40D62QaYoGiyKcKQZZ008RxR9m/pJ7VU=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Bump pulumi to 3.184.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
