### PR TITLE
vscode-solidity-server: init at 0.0.185

### DIFF
--- a/pkgs/by-name/vs/vscode-solidity-server/package.nix
+++ b/pkgs/by-name/vs/vscode-solidity-server/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  libsecret,
+}:
+
+buildNpmPackage {
+  pname = "solidity-language-server";
+  version = "0.0.185";
+
+  src = fetchFromGitHub {
+    owner = "juanfranblanco";
+    repo = "vscode-solidity";
+    rev = "5198201a23874e79248e6b09558ca30e5bf5cdcf";
+    hash = "sha256-GHa2VbMyYn0FXEhd1my0851rbtoWtlOGmsAF6JDzLkc=";
+  };
+
+  npmDepsHash = "sha256-zXhWtPuiu+CRk712KskuHP4vglogJmFoCak6qWczPFM=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libsecret ];
+
+  npmBuildScript = "build:cli";
+
+  meta = {
+    description = "Language Server for solidity code";
+    homepage = "https://github.com/juanfranblanco/vscode-solidity";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rookeur ];
+    mainProgram = "solidity-language-server";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
