### PR TITLE
Add meta attribute set to cups-browsed and libppd

### DIFF
--- a/pkgs/by-name/cu/cups-browsed/package.nix
+++ b/pkgs/by-name/cu/cups-browsed/package.nix
@@ -46,4 +46,12 @@ stdenv.mkDerivation rec {
     "CUPS_DATADIR=$(out)/share/cups"
     "CUPS_SERVERROOT=$(out)/etc/cups"
   ];
+
+  meta = {
+    description = "Daemon for browsing the Bonjour broadcasts of shared, remote CUPS printers";
+    homepage = "https://github.com/OpenPrinting/cups-browsed";
+    license = lib.licenses.asl20;
+    mainProgram = "cups-browsed";
+    platforms = lib.platforms.linux;
+  };
 }

--- a/pkgs/by-name/li/libppd/package.nix
+++ b/pkgs/by-name/li/libppd/package.nix
@@ -3,6 +3,7 @@
   cups,
   fetchFromGitHub,
   ghostscript,
+  lib,
   libcupsfilters,
   libz,
   mupdf,
@@ -46,4 +47,11 @@ stdenv.mkDerivation rec {
     "CUPS_DATADIR=$(out)/share/cups"
     "CUPS_SERVERROOT=$(out)/etc/cups"
   ];
+
+  meta = {
+    description = "Library designed to support legacy printer drivers by handling PostScript Printer Description (PPD) file";
+    homepage = "https://github.com/OpenPrinting/libppd";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+  };
 }


### PR DESCRIPTION
- **cups-browsed: add meta attribute set**
- **libppd: add meta attribute set**

I wanted to add `mainProgram` to cups-browsed, but was surprised to see `meta` missing as a whole. So I did both.

Since https://github.com/NixOS/nixpkgs/pull/358724 introduced 3 new packages and 1 of them has `meta`, I added the 2 missing ones.

For cups-browsed description I used line from name section in man pages, for libppd I just LLM-generated it, because its README file doesn't have an explicit description, and I barely know what this package is.

@raboof, I'm not sure, but you probably have to add yourself as a maintainer as per `pkgs/README.md`:

https://github.com/NixOS/nixpkgs/blob/da98619ee04e2c41dd1427eeda428e605c8faa52/pkgs/README.md?plain=1#L489

The https://github.com/NixOS/nixpkgs/pull/358724 _was_ marked with `8.has: packagae (new)` label.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
