### PR TITLE
nixos/mautrix-discord: update the default config

### DIFF
--- a/nixos/modules/services/matrix/mautrix-discord.nix
+++ b/nixos/modules/services/matrix/mautrix-discord.nix
@@ -372,18 +372,6 @@ in
           The option `services.mautrix-discord.settings.bridge.permissions` has to be set.
         '';
       }
-      {
-        assertion = cfg.settings.appservice.id != "";
-        message = ''
-          The option `services.mautrix-discord.settings.appservice.id` has to be set.
-        '';
-      }
-      {
-        assertion = cfg.settings.appservice.bot.username != "";
-        message = ''
-          The option `services.mautrix-discord.settings.appservice.bot.username` has to be set.
-        '';
-      }
     ];
 
     users.users.mautrix-discord = {

--- a/nixos/modules/services/matrix/mautrix-discord.nix
+++ b/nixos/modules/services/matrix/mautrix-discord.nix
@@ -57,37 +57,51 @@ in
             appservice = lib.mkOption {
               type = lib.types.attrs;
               default = {
-                address = "http://localhost:8009";
-                port = 8009;
+                address = "http://localhost:29334";
+                hostname = "0.0.0.0";
+                port = 29334;
+                database = {
+                  type = "sqlite3";
+                  uri = "file:/var/lib/mautrix-discord/mautrix-discord.db?_txlock=immediate";
+                  max_open_conns = 20;
+                  max_idle_conns = 2;
+                  max_conn_idle_time = null;
+                  max_conn_lifetime = null;
+                };
                 id = "discord";
                 bot = {
                   username = "discordbot";
                   displayname = "Discord bridge bot";
                   avatar = "mxc://maunium.net/nIdEykemnwdisvHbpxflpDlC";
                 };
-                as_token = "generate";
-                hs_token = "generate";
-                database = {
-                  type = "sqlite3";
-                  uri = "file:/var/lib/mautrix-discord/mautrix-discord.db?_txlock=immediate";
-                };
+                ephemeral_events = true;
+                async_transactions = false;
+                as_token = "This value is generated when generating the registration";
+                hs_token = "This value is generated when generating the registration";
               };
               defaultText = lib.literalExpression ''
                 {
-                  address = "http://localhost:8009";
-                  port = 8009;
+                  address = "http://localhost:29334";
+                  hostname = "0.0.0.0";
+                  port = 29334;
+                  database = {
+                    type = "sqlite3";
+                    uri = "file:''${config.services.mautrix-discord.dataDir}/mautrix-discord.db?_txlock=immediate";
+                    max_open_conns = 20;
+                    max_idle_conns = 2;
+                    max_conn_idle_time = null;
+                    max_conn_lifetime = null;
+                  };
                   id = "discord";
                   bot = {
                     username = "discordbot";
                     displayname = "Discord bridge bot";
                     avatar = "mxc://maunium.net/nIdEykemnwdisvHbpxflpDlC";
                   };
-                  as_token = "generate";
-                  hs_token = "generate";
-                  database = {
-                    type = "sqlite3";
-                    uri = "file:''${config.services.mautrix-discord.dataDir}/mautrix-discord.db?_txlock=immediate";
-                  };
+                  ephemeral_events = true;
+                  async_transactions = false;
+                  as_token = "This value is generated when generating the registration";
+                  hs_token = "This value is generated when generating the registration";
                 }
               '';
               description = ''
@@ -125,10 +139,12 @@ in
                 prefix_webhook_messages = true;
                 enable_webhook_avatars = false;
                 use_discord_cdn_upload = true;
+                #proxy =
                 cache_media = "unencrypted";
                 direct_media = {
                   enabled = false;
-                  server_name = "discord-media.example.com";
+                  #server_name = "discord-media.example.com";
+                  #well_known_response =
                   allow_proxy = true;
                   server_key = "generate";
                 };
@@ -139,6 +155,13 @@ in
                     height = 320;
                     fps = 25;
                   };
+                };
+                double_puppet_server_map = {
+                  #"example.com" = "https://example.com";
+                };
+                double_puppet_allow_discovery = false;
+                login_shared_secret_map = {
+                  #"example.com" = "foobar";
                 };
                 command_prefix = "!discord";
                 management_room_text = {
@@ -199,12 +222,28 @@ in
                 };
                 permissions = {
                   "*" = "relay";
-                  # "example.com" = "user";
-                  # "@admin:example.com": "admin";
+                  #"example.com" = "user";
+                  #"@admin:example.com": "admin";
                 };
               };
               description = ''
                 Bridge configuration.
+                See [example-config.yaml](https://github.com/mautrix/discord/blob/main/example-config.yaml)
+                for more information.
+              '';
+            };
+            logging = lib.mkOption {
+              type = lib.types.attrs;
+              default = {
+                min_level = "info";
+                writers = lib.singleton {
+                  type = "stdout";
+                  format = "pretty-colored";
+                  time_format = " ";
+                };
+              };
+              description = ''
+                Logging configuration.
                 See [example-config.yaml](https://github.com/mautrix/discord/blob/main/example-config.yaml)
                 for more information.
               '';
@@ -225,7 +264,7 @@ in
             };
 
             bridge.permissions = {
-              "example.com" = "full";
+              "example.com" = "user";
               "@admin:example.com" = "admin";
             };
           }

--- a/nixos/modules/services/matrix/mautrix-discord.nix
+++ b/nixos/modules/services/matrix/mautrix-discord.nix
@@ -101,7 +101,7 @@ in
               type = lib.types.attrs;
               default = {
                 username_template = "discord_{{.}}";
-                displayname_template = "{{or .GlobalName .Username}}{{if .Bot}} (bot){{end}}";
+                displayname_template = "{{if .Webhook}}Webhook{{else}}{{or .GlobalName .Username}}{{if .Bot}} (bot){{end}}{{end}}";
                 channel_name_template = "{{if or (eq .Type 3) (eq .Type 4)}}{{.Name}}{{else}}#{{.Name}}{{end}}";
                 guild_name_template = "{{.Name}}";
                 private_chat_portal_meta = "default";
@@ -122,8 +122,8 @@ in
                 delete_portal_on_channel_delete = false;
                 delete_guild_on_leave = true;
                 federate_rooms = true;
-                prefix_webhook_messages = false;
-                enable_webhook_avatars = true;
+                prefix_webhook_messages = true;
+                enable_webhook_avatars = false;
                 use_discord_cdn_upload = true;
                 cache_media = "unencrypted";
                 direct_media = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As requested in #425765, I've updated the discord module to match the new mautrix-discord version.
I couldn't test the module yet, so I would appreciate if someone could do it.

The first commit is the actual update, based on the diff between the versions: https://github.com/mautrix/discord/compare/v0.7.4...v0.7.5#diff-8b9ef9c277ec2256b84aab2ff2c3b778753ac96389c892c95847057365b66016

The other commits are other things I found that may be changed too.
Please review those and tell me if those are good changes or if I should remove all commits except the first one.

I don't know why, but this module seems to be way too complicated in comparision to the other mautrix modules.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
