### PR TITLE
add jalbum 37.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2,18 +2,18 @@
   List of NixOS maintainers.
    ```nix
    handle = {
-     # Required
-     name = "Your name";
+   # Required
+   name = "Your name";
 
-     # Optional, but at least one of email, matrix or githubId must be given
-     email = "address@example.org";
-     matrix = "@user:example.org";
-     github = "GithubUsername";
-     githubId = your-github-id;
+   # Optional, but at least one of email, matrix or githubId must be given
+   email = "address@example.org";
+   matrix = "@user:example.org";
+   github = "GithubUsername";
+   githubId = your-github-id;
 
-     keys = [{
+   keys = [{
        fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
-     }];
+   }];
    };
    ```
 
@@ -30,14 +30,14 @@
    Specifying a GitHub account ensures that you automatically:
    - get invited to the @NixOS/nixpkgs-maintainers team ;
    - once you are part of the @NixOS org, OfBorg will request you review
-     pull requests that modify a package for which you are a maintainer.
+   pull requests that modify a package for which you are a maintainer.
 
    `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
 
    If `github` begins with a numeral, `handle` should be prefixed with an underscore.
    ```nix
    _1example = {
-     github = "1example";
+   github = "1example";
    };
    ```
 
@@ -23310,6 +23310,12 @@
     email = "noonsilk+nixpkgs@gmail.com";
     github = "silky";
     githubId = 129525;
+  };
+  silmaril = {
+    name = "silmaril";
+    email = "nix@silmaril.de";
+    github = "silmaril42";
+    githubId = 31900904;
   };
   sils = {
     name = "Silas Schöffel";

--- a/pkgs/by-name/ja/jalbum/package.nix
+++ b/pkgs/by-name/ja/jalbum/package.nix
@@ -62,14 +62,6 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = {
-    description = "Free Photo Gallery Software for Any Website";
-    homepage = "https://jalbum.net";
-    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
-    license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ silmaril ];
-  };
-
   passthru.updateScript = lib.getExe (writeShellApplication {
     name = "update-jalbum";
     runtimeInputs = [
@@ -82,4 +74,14 @@ stdenv.mkDerivation rec {
       update-source-version jalbum "$LATEST_VERSION"
     '';
   });
+
+  meta = {
+    description = "Free Photo Gallery Software for Any Website";
+    homepage = "https://jalbum.net";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ silmaril ];
+    mainProgram = "jalbum";
+    platforms = lib.platforms.unix;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
 }

--- a/pkgs/by-name/ja/jalbum/package.nix
+++ b/pkgs/by-name/ja/jalbum/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     url = "https://download.jalbum.net/download/${version}/jAlbum.zip";
-    sha256 = "QGy8agZ88Q0npcodnP6S/BF4lQEGbUMlQa8v7T2kNWU=";
+    hash = "sha256-kQTBd7WkR6cgUl4Gke9ZcHBtizNS4uYCFaqexpRjLZE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ja/jalbum/package.nix
+++ b/pkgs/by-name/ja/jalbum/package.nix
@@ -11,6 +11,7 @@
   curl,
   gnused,
 }:
+
 let
   openjdk = openjdk23.override { enableJavaFX = true; };
 in

--- a/pkgs/by-name/ja/jalbum/package.nix
+++ b/pkgs/by-name/ja/jalbum/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  fetchzip,
+  makeWrapper,
+  openjdk23,
+  stdenv,
+  copyDesktopItems,
+  makeDesktopItem,
+  writeShellApplication,
+  common-updater-scripts,
+  curl,
+  gnused,
+}:
+let
+  openjdk = openjdk23.override { enableJavaFX = true; };
+in
+stdenv.mkDerivation rec {
+  pname = "jalbum";
+  version = "37.7";
+
+  src = fetchzip {
+    url = "https://download.jalbum.net/download/${version}/jAlbum.zip";
+    sha256 = "QGy8agZ88Q0npcodnP6S/BF4lQEGbUMlQa8v7T2kNWU=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "jalbum";
+      exec = "jalbum";
+      icon = "jalbum";
+      comment = meta.description;
+      genericName = "jalbum";
+      desktopName = "JAlbum";
+      categories = [ "Graphics" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/jalbum
+    cp -r ./* $out/share/jalbum
+
+    mkdir -p $out/share/icons/hicolor/48x48/apps
+    ln -s $out/share/jalbum/icons/JalbumApp48.png \
+      $out/share/icons/hicolor/48x48/apps/jalbum.png
+
+    makeWrapper ${openjdk}/bin/java $out/bin/jalbum \
+      --add-flags "-Xmx8000m \
+      --add-exports=java.desktop/sun.awt.shell=ALL-UNNAMED \
+      -XX:+UseParallelGC \
+      -DmaxSubsampling=2 \
+      -DuseDesktop=true \
+      -jar $out/share/jalbum/JAlbum.jar"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Free Photo Gallery Software for Any Website";
+    homepage = "https://jalbum.net";
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ silmaril ];
+  };
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "update-jalbum";
+    runtimeInputs = [
+      curl
+      common-updater-scripts
+      gnused
+    ];
+    text = ''
+      LATEST_VERSION=$(curl -Lsf https://jalbum.net/en/downloadmirror | sed -n 's!^.*<h1>Download jAlbum \(.*\)</h1>!\1!p')
+      update-source-version jalbum "$LATEST_VERSION"
+    '';
+  });
+}


### PR DESCRIPTION
## Things done

Add new package `jalbum`.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.
