### PR TITLE
the-dark-aid: init at 15

### DIFF
--- a/pkgs/by-name/th/the-dark-aid/package.nix
+++ b/pkgs/by-name/th/the-dark-aid/package.nix
@@ -1,0 +1,64 @@
+{
+  autoPatchelfHook,
+  lib,
+  makeWrapper,
+  pcre2,
+  qt5,
+  requireFile,
+  stdenv,
+}:
+let
+  qtVersion = lib.versions.majorMinor qt5.qtbase.version;
+in
+stdenv.mkDerivation rec {
+  name = "the-dark-aid";
+  version = "15";
+
+  src = requireFile rec {
+    name = "419450-thedarkaid_${version}_linux_qt${qtVersion}.tar.gz";
+    hash = "sha256-r+2GP3JcUM6DISGyCk+p8izxfwbZpL5nTpLwgwHMLuo=";
+
+    message = ''
+      Unfortunately, we cannot download file ${name} automatically, as it is not redistributable.
+      Please go to ${meta.downloadPage} to download it yourself, and add it to the Nix store
+      using
+
+        nix-prefetch-url --type sha256 file:///path/to/${name}
+
+      Then re-run the installation.
+    '';
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    qt5.wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    qt5.qtbase
+  ];
+
+  preferLocalBuild = true; # Because of having to manually download the sources
+
+  installPhase = ''
+    mkdir --parents "$out/opt/thedarkaid"
+    cp --recursive . "$out/opt/thedarkaid"
+  '';
+
+  postFixup = ''
+    makeWrapper "$out/opt/thedarkaid/thedarkaid" "$out/bin/thedarkaid" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath propagatedBuildInputs}:$out/opt/thedarkaid" \
+  '';
+
+  meta = {
+    description = "Character generator for The Dark Eye 5th Edition";
+    homepage = "https://www.ulisses-ebooks.de/product/309175";
+    downloadPage = "https://www.ulisses-ebooks.de/product/309175";
+    mainProgram = "thedarkaid";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ l0b0 ];
+  };
+}


### PR DESCRIPTION
## Todo

- [ ] Figure out why it just silently fails to run.
   - `strace --follow-forks ./result/bin/thedarkaid` seems to indicate that it starts looking for the `thedarkaid` executable in all the wrong places, ending up trying to `execve("", [""], …`. Not sure what to do about that.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
