### PR TITLE
bumblebee: unpin autotools

### DIFF
--- a/pkgs/by-name/bu/bumblebee/package.nix
+++ b/pkgs/by-name/bu/bumblebee/package.nix
@@ -35,8 +35,7 @@
   pkgsi686Linux,
   virtualgl,
   libglvnd,
-  automake111x,
-  autoconf,
+  autoreconfHook,
   # The below should only be non-null in a x86_64 system. On a i686
   # system the above nvidia_x11 and virtualgl will be the i686 packages.
   # TODO: Confusing. Perhaps use "SubArch" instead of i686?
@@ -124,10 +123,6 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    # Don't use a special group, just reuse wheel.
-    substituteInPlace configure \
-      --replace 'CONF_GID="bumblebee"' 'CONF_GID="wheel"'
-
     # Apply configuration options
     substituteInPlace conf/xorg.conf.nvidia \
       --subst-var nvidiaDeviceOptions
@@ -148,8 +143,7 @@ stdenv.mkDerivation rec {
     makeWrapper
     pkg-config
     help2man
-    automake111x
-    autoconf
+    autoreconfHook
   ];
 
   # The order of LDPATH is very specific: First X11 then the host
@@ -162,6 +156,8 @@ stdenv.mkDerivation rec {
   configureFlags =
     [
       "--with-udev-rules=$out/lib/udev/rules.d"
+      # Don't use a special group, just reuse wheel.
+      "CONF_GID=wheel"
       # see #10282
       #"CONF_PRIMUS_LD_PATH=${primusLibs}"
     ]


### PR DESCRIPTION
This PR drops the last reference to `automake111x` in Nixpkgs. Checked that the output is the same modulo Nix path names.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
