### PR TITLE
nsncd: Skip some tests on big-endian

### DIFF
--- a/pkgs/by-name/ns/nsncd/package.nix
+++ b/pkgs/by-name/ns/nsncd/package.nix
@@ -25,19 +25,27 @@ rustPlatform.buildRustPackage {
   useFetchCargoVendor = true;
   cargoHash = "sha256-9M8Y0WwXFlrpRleSQPYDpnjNnxKGvrtO6Istl9qM30M=";
 
-  checkFlags = [
-    # Relies on the test environment to be able to resolve "localhost"
-    # on IPv4. That's not the case in the Nix sandbox somehow. Works
-    # when running cargo test impurely on a (NixOS|Debian) machine.
-    "--skip=ffi::test_gethostbyname2_r"
+  checkFlags =
+    [
+      # Relies on the test environment to be able to resolve "localhost"
+      # on IPv4. That's not the case in the Nix sandbox somehow. Works
+      # when running cargo test impurely on a (NixOS|Debian) machine.
+      "--skip=ffi::test_gethostbyname2_r"
 
-    # Relies on /etc/services to be present?
-    "--skip=handlers::test::test_handle_getservbyname_name"
-    "--skip=handlers::test::test_handle_getservbyname_name_proto"
-    "--skip=handlers::test::test_handle_getservbyport_port"
-    "--skip=handlers::test::test_handle_getservbyport_port_proto"
-    "--skip=handlers::test::test_handle_getservbyport_port_proto_aliases"
-  ];
+      # Relies on /etc/services to be present?
+      "--skip=handlers::test::test_handle_getservbyname_name"
+      "--skip=handlers::test::test_handle_getservbyname_name_proto"
+      "--skip=handlers::test::test_handle_getservbyport_port"
+      "--skip=handlers::test::test_handle_getservbyport_port_proto"
+      "--skip=handlers::test::test_handle_getservbyport_port_proto_aliases"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isBigEndian [
+      # Expected serialisation output in tests doesn't account for endianness differences
+      # https://github.com/twosigma/nsncd/issues/160
+      "--skip=handlers::test::test_hostent_serialization"
+      "--skip=handlers::test::test_innetgroup_serialization_in_group"
+      "--skip=handlers::test::test_netgroup_serialization"
+    ];
 
   meta = with lib; {
     description = "Name service non-caching daemon";


### PR DESCRIPTION
https://github.com/twosigma/nsncd/issues/160

Only causes rebuilds on big-endian, so automation won't see any rebuilds and won't auto-ping maintainers. Hence, CC @flokli @picnoir

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
