### PR TITLE
fw-fanctrl: set default strategies

### DIFF
--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -48,51 +48,49 @@ in
           };
 
           strategies = lib.mkOption {
-            default = null;
+            default = { };
             description = ''
               Additional strategies which can be used by fw-fanctrl
             '';
-            type = lib.types.nullOr (
-              lib.types.attrsOf (
-                lib.types.submodule {
-                  options = {
-                    fanSpeedUpdateFrequency = lib.mkOption {
-                      type = lib.types.ints.unsigned;
-                      default = 5;
-                      description = "How often the fan speed should be updated in seconds";
-                    };
-
-                    movingAverageInterval = lib.mkOption {
-                      type = lib.types.ints.unsigned;
-                      default = 25;
-                      description = "Interval (seconds) of the last temperatures to use to calculate the average temperature";
-                    };
-
-                    speedCurve = lib.mkOption {
-                      default = [ ];
-                      description = "How should the speed curve look like";
-                      type = lib.types.listOf (
-                        lib.types.submodule {
-                          options = {
-                            temp = lib.mkOption {
-                              type = lib.types.int;
-                              default = 0;
-                              description = "Temperature in °C at which the fan speed should be changed";
-                            };
-
-                            speed = lib.mkOption {
-                              type = lib.types.ints.between 0 100;
-                              default = 0;
-                              description = "Percent how fast the fan should run at";
-                            };
-
-                          };
-                        }
-                      );
-                    };
+            type = lib.types.attrsOf (
+              lib.types.submodule {
+                options = {
+                  fanSpeedUpdateFrequency = lib.mkOption {
+                    type = lib.types.ints.unsigned;
+                    default = 5;
+                    description = "How often the fan speed should be updated in seconds";
                   };
-                }
-              )
+
+                  movingAverageInterval = lib.mkOption {
+                    type = lib.types.ints.unsigned;
+                    default = 25;
+                    description = "Interval (seconds) of the last temperatures to use to calculate the average temperature";
+                  };
+
+                  speedCurve = lib.mkOption {
+                    default = [ ];
+                    description = "How should the speed curve look like";
+                    type = lib.types.listOf (
+                      lib.types.submodule {
+                        options = {
+                          temp = lib.mkOption {
+                            type = lib.types.int;
+                            default = 0;
+                            description = "Temperature in °C at which the fan speed should be changed";
+                          };
+
+                          speed = lib.mkOption {
+                            type = lib.types.ints.between 0 100;
+                            default = 0;
+                            description = "Percent how fast the fan should run at";
+                          };
+
+                        };
+                      }
+                    );
+                  };
+                };
+              }
             );
           };
         };


### PR DESCRIPTION
- fixes #426282

- current implementation breaks generation of strategies, when strategies are not defined by user.

- minimal working config with `strategies.default = null`:
```nix
  hardware.fw-fanctrl = {
    enable = true;
    config.strategies = { };
  };
```

- User should be able to start the service, when only `hardware.fw-fanctrl.enable` is enabled.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
