### PR TITLE
mochi: 1.18.11 -> 1.19.0

### DIFF
--- a/pkgs/by-name/mo/mochi/package.nix
+++ b/pkgs/by-name/mo/mochi/package.nix
@@ -2,7 +2,6 @@
   _7zz,
   appimageTools,
   fetchurl,
-  fetchzip,
   lib,
   stdenvNoCC,
   xorg,
@@ -35,21 +34,28 @@ let
   darwin = stdenvNoCC.mkDerivation {
     inherit pname version meta;
 
-    src = fetchzip {
+    src = fetchurl {
       url = "https://mochi.cards/releases/Mochi-${version}.dmg";
-      hash = "sha256-5RM4eqHQoYfO5JiUH9ol+3XxOk4VX4ocE3Yia82sovI=";
-      stripRoot = false;
-      nativeBuildInputs = [ _7zz ];
+      hash = "sha256-Bv0EFBZVZMxHCvdDHfBdL267cwyeciBqZhrKgppxtm4=";
     };
+
+    sourceRoot = "Mochi.app";
+    nativeBuildInputs = [
+      _7zz
+    ];
 
     installPhase = ''
       runHook preInstall
 
-      mkdir -p $out/Applications
-      cp -r *.app $out/Applications
+      mkdir -p $out/Applications/Mochi.app
+      cp -r . $out/Applications/Mochi.app
 
       runHook postInstall
     '';
+
+    dontUpdateAutotoolsGnuConfigScripts = true;
+    dontConfigure = true;
+    dontFixup = true;
   };
 
   meta = {

--- a/pkgs/by-name/mo/mochi/package.nix
+++ b/pkgs/by-name/mo/mochi/package.nix
@@ -10,7 +10,7 @@
 
 let
   pname = "mochi";
-  version = "1.18.11";
+  version = "1.19.0";
   appName = "Mochi";
 
   linux = appimageTools.wrapType2 rec {
@@ -18,7 +18,7 @@ let
 
     src = fetchurl {
       url = "https://mochi.cards/releases/Mochi-${version}.AppImage";
-      hash = "sha256-NQ591KtWQz8hlXPhV83JEwGm+Au26PIop5KVzsyZKp4=";
+      hash = "";
     };
 
     appimageContents = appimageTools.extractType2 { inherit pname version src; };
@@ -43,7 +43,7 @@ let
 
     src = fetchurl {
       url = "https://mochi.cards/releases/Mochi-${version}.dmg";
-      hash = "sha256-Bv0EFBZVZMxHCvdDHfBdL267cwyeciBqZhrKgppxtm4=";
+      hash = "sha256-2y9gwO+l2Hs5+Le87vROYb7Nq2G/gYu0DUHJFfQ+Imw=";
     };
 
     sourceRoot = "${appName}.app";

--- a/pkgs/by-name/mo/mochi/package.nix
+++ b/pkgs/by-name/mo/mochi/package.nix
@@ -2,16 +2,15 @@
   _7zz,
   appimageTools,
   fetchurl,
+  fetchzip,
   lib,
   stdenvNoCC,
   xorg,
-  makeWrapper,
 }:
 
 let
   pname = "mochi";
   version = "1.19.0";
-  appName = "Mochi";
 
   linux = appimageTools.wrapType2 rec {
     inherit pname version meta;
@@ -34,46 +33,29 @@ let
   };
 
   darwin = stdenvNoCC.mkDerivation {
-    inherit
-      pname
-      version
-      meta
-      appName
-      ;
+    inherit pname version meta;
 
-    src = fetchurl {
+    src = fetchzip {
       url = "https://mochi.cards/releases/Mochi-${version}.dmg";
-      hash = "sha256-2y9gwO+l2Hs5+Le87vROYb7Nq2G/gYu0DUHJFfQ+Imw=";
+      hash = "sha256-q7kdrNVRsgbnG5IxWHq5ArS5BH4ieTAmlzixfxxdbEg=";
+      stripRoot = false;
+      nativeBuildInputs = [ _7zz ];
     };
-
-    sourceRoot = "${appName}.app";
-    nativeBuildInputs = [
-      _7zz
-      makeWrapper
-    ];
 
     installPhase = ''
       runHook preInstall
 
-      # 7zz extracts all the entitlements, which trips the signature
-      find . -name '*com.apple.cs*' -exec rm {} \;
-      mkdir -p $out/{Applications/${appName}.app,bin}
-      cp -r . $out/Applications/${appName}.app
-      makeWrapper $out/Applications/${appName}.app/Contents/MacOS/${appName} $out/bin/${pname}
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications
 
       runHook postInstall
     '';
-
-    dontUpdateAutotoolsGnuConfigScripts = true;
-    dontConfigure = true;
-    dontFixup = true;
   };
 
   meta = {
     description = "Simple markdown-powered SRS app";
     homepage = "https://mochi.cards/";
     changelog = "https://mochi.cards/changelog.html";
-    mainProgram = "mochi";
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [ poopsicles ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Updated to 1.19.0. See [changelog](https://mochi.cards/changelog.html).
- Changed to `fetchurl` since `fetchzip` was extracting the `.dmg` which influenced the hash, see [lix-project/lix#904](https://git.lix.systems/lix-project/lix/issues/904).
- Added `meta.mainProgram` attribute.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
