### PR TITLE
tor: add tor.proxyHook

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -163,6 +163,8 @@ Nixpkgs fetchers can make use of a http(s) proxy. Each fetcher will automaticall
 
 The environment variable `NIX_SSL_CERT_FILE` is also inherited in fetchers, and can be used to provide a custom certificate bundle to fetchers. This is usually required for a https proxy to work without certificate validation errors.
 
+To use a temporary Tor instance as a proxy for fetching from `.onion` addresses, add `nativeBuildInputs = [ tor.proxyHook ];` to the fetcher parameters.
+
 []{#fetchurl}
 ## `fetchurl` {#sec-pkgs-fetchers-fetchurl}
 

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -158,6 +158,19 @@ lib.makeOverridable (
             "GIT_PROXY_COMMAND"
             "NIX_GIT_SSL_CAINFO"
             "SOCKS_SERVER"
+
+            # This is a parameter intended to be set by setup hooks or preFetch
+            # scripts that want per-URL control over HTTP proxies used by Git
+            # (if per-URL control isn't needed, `http_proxy` etc. will
+            # suffice). It must be a whitespace-separated (with backslash as an
+            # escape character) list of pairs like this:
+            #
+            #   http://domain1/path1 proxy1 https://domain2/path2 proxy2
+            #
+            # where the URLs are as documented in the `git-config` manual page
+            # under `http.<url>.*`, and the proxies are as documented on the
+            # same page under `http.proxy`.
+            "FETCHGIT_HTTP_PROXIES"
           ];
 
         inherit preferLocalBuild meta allowedRequisites;

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -126,6 +126,11 @@ init_remote(){
         echo "$sparseCheckout" | git sparse-checkout set --stdin ${nonConeMode:+--no-cone}
     fi
     ( [ -n "$http_proxy" ] && clean_git config --global http.proxy "$http_proxy" ) || true
+    local proxy_pairs i
+    read -a proxy_pairs <<< "${FETCHGIT_HTTP_PROXIES:-}"
+    for ((i = 1; i < ${#proxy_pairs[@]}; i += 2)); do
+        clean_git config --global "http.${proxy_pairs[$i - 1]}.proxy" "${proxy_pairs[$i]}"
+    done
 }
 
 # Return the reference of an hash if it exists on the remote repository.

--- a/pkgs/by-name/to/tor/package.nix
+++ b/pkgs/by-name/to/tor/package.nix
@@ -19,6 +19,7 @@
   nixosTests,
   writeShellScript,
   versionCheckHook,
+  makeSetupHook,
 }:
 
 let
@@ -112,8 +113,21 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgramArg = "--version";
 
   passthru = {
-    tests.tor = nixosTests.tor;
+    tests = {
+      inherit (nixosTests) tor;
+      proxyHook = callPackage ./proxy-hook-tests.nix {
+        tor = finalAttrs.finalPackage;
+      };
+    };
     updateScript = callPackage ./update.nix { };
+    proxyHook = makeSetupHook {
+      name = "tor-proxy-hook";
+      substitutions = {
+        grep = lib.getExe gnugrep;
+        tee = lib.getExe' coreutils "tee";
+        tor = lib.getExe finalAttrs.finalPackage;
+      };
+    } ./proxy-hook.sh;
   };
 
   meta = {

--- a/pkgs/by-name/to/tor/proxy-hook-tests.nix
+++ b/pkgs/by-name/to/tor/proxy-hook-tests.nix
@@ -1,0 +1,45 @@
+{
+  testers,
+  fetchFromGitLab,
+  fetchgit,
+  fetchurl,
+  fetchzip,
+  linkFarm,
+  tor,
+}:
+let
+  domain = "eweiibe6tdjsdprb4px6rqrzzcsi22m4koia44kc5pcjr7nec2rlxyad.onion";
+  rev = "933c5491db00c703d5d8264fdabd5a5b10aff96f";
+  hash = "sha256-o6Wpso8GSlQH39GpH3IXZyrVhdP8pEYFxLDq9a7yHX0=";
+in
+linkFarm "tor-proxy-hook-tests" {
+  fetchgit = testers.invalidateFetcherByDrvHash fetchgit {
+    name = "fetchgit-tor-source";
+    url = "http://${domain}/tpo/core/tor";
+    inherit rev hash;
+    nativeBuildInputs = [ tor.proxyHook ];
+  };
+
+  fetchzip = testers.invalidateFetcherByDrvHash fetchzip {
+    name = "fetchzip-tor-source";
+    url = "http://${domain}/tpo/core/tor/-/archive/${rev}/tor-${rev}.zip";
+    inherit hash;
+    nativeBuildInputs = [ tor.proxyHook ];
+  };
+
+  fetchurl = testers.invalidateFetcherByDrvHash fetchurl {
+    name = "fetchurl-tor-source";
+    url = "http://${domain}/tpo/core/tor/-/raw/${rev}/Cargo.lock";
+    hash = "sha256-oX4WbsscLADgJ5o+czpueyAih7ic0u4lZQs7y1vMA3A=";
+    nativeBuildInputs = [ tor.proxyHook ];
+  };
+
+  fetchFromGitLab = testers.invalidateFetcherByDrvHash fetchFromGitLab {
+    name = "gitlab-tor-source";
+    protocol = "http";
+    owner = "tpo/core";
+    repo = "tor";
+    inherit domain rev hash;
+    nativeBuildInputs = [ tor.proxyHook ];
+  };
+}

--- a/pkgs/by-name/to/tor/proxy-hook.sh
+++ b/pkgs/by-name/to/tor/proxy-hook.sh
@@ -1,0 +1,19 @@
+_setupTorProxy(){
+    local torSocket=$NIX_BUILD_TOP/.tor.sock
+    local torPort=unix:$torSocket
+
+    exec {tor_fd}< <(@tor@ --DataDirectory "$NIX_BUILD_TOP/.tor" --SocksPort "$torPort")
+    exitHooks+=("kill '$!'")
+
+    # Wait for Tor to start
+    read < <(<&$tor_fd- @tee@ /dev/fd/2 | @grep@ -m 1 -F 'Bootstrapped 100% (done): Done')
+
+    export ALL_PROXY="socks5h://localhost$torSocket"
+
+    # A Git repository may have submodules that fetch from clearnet URLs, so
+    # for better performance, use Tor only for onion addresses. (fetchgit
+    # doesn't respect ALL_PROXY, so this doesn't conflict.)
+    export FETCHGIT_HTTP_PROXIES="http://*.onion $ALL_PROXY ${FETCHGIT_HTTP_PROXIES-}"
+}
+
+postHooks+=(_setupTorProxy)


### PR DESCRIPTION
tor.proxyHook is a setup hook intended for use with HTTP-based fetchers, enabling them to download from .onion addresses using Tor as a proxy.

Motivated by @philiptaron's suggestion in #414912.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
