### PR TITLE
liquibase: disable analytics/telemetry which is on by default since `v4.30` (since NixOS 25.05)

### DIFF
--- a/pkgs/by-name/li/liquibase/package.nix
+++ b/pkgs/by-name/li/liquibase/package.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       # there’s a lot of escaping, but I’m not sure how to improve that
       cat > $out/bin/liquibase <<EOF
       #!/usr/bin/env bash
+      export LIQUIBASE_ANALYTICS_ENABLED="\''${LIQUIBASE_ANALYTICS_ENABLED:-false}"
       # taken from the executable script in the source
       CP=""
       ${addJars "$out/internal/lib"}


### PR DESCRIPTION
liquibase introduced analytics activated on by default.

- https://www.liquibase.com/blog/product-update-liquibase-now-collects-anonymous-usage-analytics
- https://github.com/liquibase/liquibase/issues/6503 

As per the discussion of https://discourse.nixos.org/t/update-on-telemetry/60777 and others there should either be a meta tag added or it disabled by default. I don't think it's collecting "sensitive" information, but I do think it's not good practice for a low-level component sending analytics. This may introduce issues running liquibase in (Nix) sandboxes etc otherwise.

Users who may continue contributing can set `export LIQUIBASE_ANALYTICS_ENABLED=true` (as outlined by the blog).

 ```bash
$ export LIQUIBASE_ANALYTICS_ENABLED=true; bash -x ./result/bin/liquibase --help |& grep -i LIQUIBASE_ANALYTICS
+ export LIQUIBASE_ANALYTICS_ENABLED=true
+ LIQUIBASE_ANALYTICS_ENABLED=true
                               'LIQUIBASE_ANALYTICS_ENABLED')
$ export LIQUIBASE_ANALYTICS_ENABLED=; bash -x ./result/bin/liquibase --help |& grep -i LIQUIBASE_ANALYTICS
+ export LIQUIBASE_ANALYTICS_ENABLED=false
+ LIQUIBASE_ANALYTICS_ENABLED=false
                               'LIQUIBASE_ANALYTICS_ENABLED')
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

cc @jsoo1 