### PR TITLE
x11_ssh_askpass: replace xmkmf with autoconf

### DIFF
--- a/pkgs/by-name/x1/x11_ssh_askpass/package.nix
+++ b/pkgs/by-name/x1/x11_ssh_askpass/package.nix
@@ -2,9 +2,10 @@
   lib,
   stdenv,
   fetchurl,
+  fetchDebianPatch,
+  autoreconfHook,
+  pkg-config,
   xorg,
-  imake,
-  gccmakedep,
 }:
 
 stdenv.mkDerivation rec {
@@ -21,29 +22,26 @@ stdenv.mkDerivation rec {
     sha256 = "620de3c32ae72185a2c9aeaec03af24242b9621964e38eb625afb6cdb30b8c88";
   };
 
-  nativeBuildInputs = [
-    imake
-    gccmakedep
+  patches = [
+    (fetchDebianPatch {
+      pname = "ssh-askpass";
+      version = "1:1.2.4.1";
+      debianRevision = "16";
+      patch = "autotools.patch";
+      hash = "sha256-S2tl0GeDia/ZuyXetPOsiu79kS9yLId7gUj3siw7pH4=";
+    })
   ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
   buildInputs = [
     xorg.libX11
     xorg.libXt
     xorg.libICE
     xorg.libSM
-  ];
-
-  configureFlags = [
-    "--with-app-defaults-dir=$out/etc/X11/app-defaults"
-  ];
-
-  dontUseImakeConfigure = true;
-  postConfigure = ''
-    xmkmf -a
-  '';
-
-  installTargets = [
-    "install"
-    "install.man"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
This PR replaces imake with autotools in `x11_ssh_askpass` so that it builds on more platforms. This is due to a recent discovery https://github.com/loongson-community/nixpkgs/commit/7abca2d21a6bdd0ac8d0f35244dda3bf36ba1b50 showing that imake is surprisingly platform-dependent.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
