### PR TITLE
x2goserver: fix build

### DIFF
--- a/pkgs/by-name/x2/x2goserver/package.nix
+++ b/pkgs/by-name/x2/x2goserver/package.nix
@@ -117,6 +117,8 @@ stdenv.mkDerivation {
     do
       substituteInPlace $i --replace '/etc/x2go' '/var/lib/x2go/conf'
     done
+    substituteInPlace x2goserver/Makefile \
+      --replace-fail "\$(DESTDIR)/etc" "\$(DESTDIR)/\$(ETCDIR)"
     substituteInPlace x2goserver/sbin/x2gocleansessions \
       --replace '/var/run/x2goserver.pid' '/var/run/x2go/x2goserver.pid'
     substituteInPlace x2goserver/sbin/x2godbadmin --replace 'user="x2gouser"' 'user="x2go"'
@@ -126,16 +128,16 @@ stdenv.mkDerivation {
   '';
 
   makeFlags = [
-    "PREFIX=/"
-    "NXLIBDIR=${nx-libs}/lib/nx"
+    "PREFIX=${placeholder "out"}"
+    "ETCDIR=${placeholder "out"}/etc/x2go"
+    "NXLIBDIR=${placeholder "out"}"
   ];
-
-  installFlags = [ "DESTDIR=$(out)" ];
 
   postInstall = ''
     mv $out/etc/x2go/x2goserver.conf{,.example}
     mv $out/etc/x2go/x2goagent.options{,.example}
     ln -sf ${nx-libs}/bin/nxagent $out/bin/x2goagent
+    ln -sf ${nx-libs}/share/nx/VERSION.nxagent $out/share/x2go/versions/VERSION.x2goserver-x2goagent
     for i in $out/sbin/x2go* $(find $out/bin -type f) \
       $(ls $out/lib/x2go/x2go* | grep -v x2gocheckport)
     do


### PR DESCRIPTION
Closes #413544.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
