### PR TITLE
cppman: init at 0.5.9

### DIFF
--- a/pkgs/by-name/cp/cppman/package.nix
+++ b/pkgs/by-name/cp/cppman/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  groff,
+  nix-update-script,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "cppman";
+  version = "0.5.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aitjcize";
+    repo = "cppman";
+    tag = version;
+    hash = "sha256-iPJR4XAjNrBhFHZVOATPi3WwTC1/Y6HK3qmKLqbaK98=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    distutils
+  ];
+
+  dependencies = [
+    python3Packages.beautifulsoup4
+    python3Packages.html5lib
+    python3Packages.lxml
+    python3Packages.six
+    python3Packages.soupsieve
+    python3Packages.typing-extensions
+    python3Packages.webencodings
+    groff
+  ];
+
+  # cppman pins all dependency versions via requirements.txt as install_requires
+  pythonRelaxDeps = true;
+
+  # bs4 is merely a dummy package and can be safely removed
+  # Ideally, its version would also stay fixed.
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace-fail "bs4==0.0.2" ""
+  '';
+
+  pythonImportsCheck = [
+    "cppman"
+  ];
+
+  nativeCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  # Writable $HOME is required for `cppman --version` to work
+  versionCheckKeepEnvironment = "HOME";
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal viewer for C++ 98/11/14 manual pages";
+    homepage = "https://github.com/aitjcize/cppman";
+    changelog = "https://github.com/aitjcize/cppman/blob/${src.tag}/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ryan4yin ];
+    mainProgram = "cppman";
+  };
+}


### PR DESCRIPTION
This pull request supersedes #311178 and introduces cppman into nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
