### PR TITLE
xfce.*: Fix build with gettext 0.25

### DIFF
--- a/pkgs/desktops/xfce/applications/xfdashboard/default.nix
+++ b/pkgs/desktops/xfce/applications/xfdashboard/default.nix
@@ -2,6 +2,7 @@
   lib,
   mkXfceDerivation,
   clutter,
+  gettext,
   libXcomposite,
   libXinerama,
   libXdamage,
@@ -19,10 +20,16 @@
 mkXfceDerivation {
   category = "apps";
   pname = "xfdashboard";
-  version = "1.0.0";
+  version = "1.0.0-unstable-2025-07-18";
+  # Fix build with gettext 0.25
+  rev = "93255940950ef5bc89cab729c8b977a706f98e0c";
   rev-prefix = "";
 
-  sha256 = "sha256-iC41I0u9id9irUNyjuvRRzSldF3dzRYkaxb/fgptnq4=";
+  sha256 = "sha256-Qv0ASuJF0FzPoeLx2D6/kXkxnOJV7mdAFD6PCk+CMac=";
+
+  nativeBuildInputs = [
+    gettext
+  ];
 
   buildInputs = [
     clutter

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-i3-workspaces-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-i3-workspaces-plugin/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  gettext,
   pkg-config,
   intltool,
   gtk3,
@@ -24,6 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext
     pkg-config
     intltool
     xfce4-dev-tools
@@ -35,6 +37,13 @@ stdenv.mkDerivation rec {
     libxfce4util
     xfce4-panel
     i3ipc-glib
+  ];
+
+  patches = [
+    # Fix build with gettext 0.25
+    # https://hydra.nixos.org/build/302762031/nixlog/2
+    # FIXME: remove when gettext is fixed
+    ./gettext-0.25.patch
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-i3-workspaces-plugin/gettext-0.25.patch
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-i3-workspaces-plugin/gettext-0.25.patch
@@ -1,0 +1,21 @@
+diff --git a/configure.ac.in b/configure.ac.in
+index 7932c16..1778d38 100644
+--- a/configure.ac.in
++++ b/configure.ac.in
+@@ -24,6 +24,7 @@ AC_COPYRIGHT([Copyright (C) 2014
+ AC_INIT([xfce4-i3-workspaces-plugin], [plugin_version], [https://github.com/denesb/xfce4-i3-workspaces-plugin/issues], [xfce4-i3-workspaces-plugin])
+ AC_PREREQ([2.50])
+ AC_REVISION([xfce4_panel_version_build])
++AC_CONFIG_MACRO_DIRS([m4])
+ 
+ dnl ***************************
+ dnl *** Initialize automake ***
+@@ -31,6 +32,8 @@ dnl ***************************
+ AM_INIT_AUTOMAKE([1.8 no-dist-gzip dist-bzip2 tar-ustar])
+ AM_CONFIG_HEADER([config.h])
+ AM_MAINTAINER_MODE()
++AM_GNU_GETTEXT_VERSION([0.21])
++AM_GNU_GETTEXT([external])
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+ 
+ dnl **************************


### PR DESCRIPTION



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

