### PR TITLE
linux: use generic installation script on loongarch64

### DIFF
--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -216,6 +216,21 @@ lib.makeOverridable (
       # Required for deterministic builds along with some postPatch magic.
       ++ optional (lib.versionOlder version "5.19") ./randstruct-provide-seed.patch
       ++ optional (lib.versionAtLeast version "5.19") ./randstruct-provide-seed-5.19.patch
+      # Starting with Linux 6.16, LoongArch uses the generic script/install.sh
+      # to perform the make install operation.
+      # We backport the relevant commit to earlier versions so that
+      # we don't have to maintain some postInstall logic for LoongArch.
+      ++
+        optional
+          (
+            lib.versionAtLeast version "5.19"
+            && lib.versionOlder version "6.16"
+            && stdenv.hostPlatform.isLoongArch64
+          )
+          (fetchpatch {
+            url = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=75cffd392bfabc30ee88836887ea5439ec3b8089";
+            hash = "sha256-CtalygmqI9yk4JnXdSTqUBjA//7vTgKTHQ/64Ylb1RQ=";
+          })
       # Linux 5.12 marked certain PowerPC-only symbols as GPL, which breaks
       # OpenZFS; this was fixed in Linux 5.19 so we backport the fix
       # https://github.com/openzfs/zfs/pull/13367

--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -197,6 +197,21 @@ lib.makeOverridable (
       # Required for deterministic builds along with some postPatch magic.
       ++ optional (lib.versionOlder version "5.19") ./randstruct-provide-seed.patch
       ++ optional (lib.versionAtLeast version "5.19") ./randstruct-provide-seed-5.19.patch
+      # Starting with Linux 6.16, LoongArch uses the generic script/install.sh
+      # to perform the make install operation.
+      # We backport the relevant commit to earlier versions so that
+      # we don't have to maintain some postInstall logic for LoongArch.
+      ++
+        optional
+          (
+            lib.versionAtLeast version "5.19"
+            && lib.versionOlder version "6.16"
+            && stdenv.hostPlatform.isLoongArch64
+          )
+          (fetchpatch {
+            url = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=75cffd392bfabc30ee88836887ea5439ec3b8089";
+            hash = "sha256-CtalygmqI9yk4JnXdSTqUBjA//7vTgKTHQ/64Ylb1RQ=";
+          })
       # Linux 5.12 marked certain PowerPC-only symbols as GPL, which breaks
       # OpenZFS; this was fixed in Linux 5.19 so we backport the fix
       # https://github.com/openzfs/zfs/pull/13367


### PR DESCRIPTION
This PR backports https://github.com/torvalds/linux/commit/75cffd392bfabc30ee88836887ea5439ec3b8089, so we won't have to carry ugly patches like [this](https://github.com/loongson-community/nixpkgs/blob/c862c7bfb91375f3433bbcd666eb9d670ab444d0/pkgs/os-specific/linux/kernel/manual-config.nix#L508-L512).

Tested with Linux 6.12.39, 6.15.7 and 6.16-rc6.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
