### PR TITLE
sigil: 2.5.2 -> 2.6.0 and wrap qt app

### DIFF
--- a/pkgs/by-name/si/sigil/package.nix
+++ b/pkgs/by-name/si/sigil/package.nix
@@ -57,9 +57,27 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  dontWrapQtApps = true;
+
   preFixup = ''
     qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
   '';
+
+  fixupPhase =
+    let
+      sigil =
+        if stdenv.hostPlatform.isDarwin then
+          "$out/Applications/Sigil.app/Contents/MacOS/Sigil"
+        else
+          "$out/bin/sigil";
+    in
+    ''
+      runHook preFixup
+
+      wrapQtApp "${sigil}"
+
+      runHook postFixup
+    '';
 
   meta = {
     description = "Free, open source, multi-platform ebook (ePub) editor";

--- a/pkgs/by-name/si/sigil/package.nix
+++ b/pkgs/by-name/si/sigil/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sigil";
-  version = "2.5.2";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     repo = "Sigil";
     owner = "Sigil-Ebook";
     tag = version;
-    hash = "sha256-nMPBkAAah4qbatvtfkCJqdo6BVL0NuxFZEHhSiB4uXY=";
+    hash = "sha256-orOuY+gCh7X24jfnGgCbqRWDbtQqrlopYx9sWN2VawA=";
   };
 
   pythonPath = with python3Packages; [ lxml ];


### PR DESCRIPTION
$out/bin/sigil is a shell script, not an ELF file, so it will not be wrapped automatically.

Reference: https://nixos.org/manual/nixpkgs/unstable/#qt-runtime-dependencies

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
