### PR TITLE
cargo: unset HOST_PKG_CONFIG_PATH

### DIFF
--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -15,99 +15,91 @@
   rustc,
   auditable ? !cargo-auditable.meta.broken,
   cargo-auditable,
-  pkgsBuildBuild,
 }:
 
 rustPlatform.buildRustPackage.override
   {
     cargo-auditable = cargo-auditable.bootstrap;
   }
-  (
-    {
-      pname = "cargo";
-      inherit (rustc.unwrapped) version src;
+  {
+    pname = "cargo";
+    inherit (rustc.unwrapped) version src;
 
-      # the rust source tarball already has all the dependencies vendored, no need to fetch them again
-      cargoVendorDir = "vendor";
-      buildAndTestSubdir = "src/tools/cargo";
+    # the rust source tarball already has all the dependencies vendored, no need to fetch them again
+    cargoVendorDir = "vendor";
+    buildAndTestSubdir = "src/tools/cargo";
 
-      inherit auditable;
+    inherit auditable;
 
-      passthru = {
-        rustc = rustc;
-        inherit (rustc.unwrapped) tests;
-      };
+    passthru = {
+      rustc = rustc;
+      inherit (rustc.unwrapped) tests;
+    };
 
-      # changes hash of vendor directory otherwise
-      dontUpdateAutotoolsGnuConfigScripts = true;
+    # changes hash of vendor directory otherwise
+    dontUpdateAutotoolsGnuConfigScripts = true;
 
-      nativeBuildInputs = [
-        pkg-config
-        cmake
-        installShellFiles
-        makeWrapper
-        (lib.getDev pkgsHostHost.curl)
-        zlib
+    nativeBuildInputs = [
+      pkg-config
+      cmake
+      installShellFiles
+      makeWrapper
+      (lib.getDev pkgsHostHost.curl)
+      zlib
+    ];
+    buildInputs = [
+      file
+      curl
+      python3
+      openssl
+      zlib
+    ];
+
+    # cargo uses git-rs which is made for a version of libgit2 from recent master that
+    # is not compatible with the current version in nixpkgs.
+    #LIBGIT2_SYS_USE_PKG_CONFIG = 1;
+
+    # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
+    RUSTC_BOOTSTRAP = 1;
+
+    postInstall = ''
+      wrapProgram "$out/bin/cargo" --suffix PATH : "${rustc}/bin"
+
+      installManPage src/tools/cargo/src/etc/man/*
+
+      installShellCompletion --bash --name cargo \
+        src/tools/cargo/src/etc/cargo.bashcomp.sh
+
+      installShellCompletion --zsh src/tools/cargo/src/etc/_cargo
+    '';
+
+    checkPhase = ''
+      # Disable cross compilation tests
+      export CFG_DISABLE_CROSS_TESTS=1
+      cargo test
+    '';
+
+    # Disable check phase as there are failures (4 tests fail)
+    doCheck = false;
+
+    doInstallCheck = !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isElf;
+    installCheckPhase = ''
+      runHook preInstallCheck
+      ${stdenv.cc.targetPrefix}readelf -a $out/bin/.cargo-wrapped | grep -F 'Shared library: [libcurl.so'
+      runHook postInstallCheck
+    '';
+
+    meta = with lib; {
+      homepage = "https://crates.io";
+      description = "Downloads your Rust project's dependencies and builds your project";
+      mainProgram = "cargo";
+      teams = [ teams.rust ];
+      license = [
+        licenses.mit
+        licenses.asl20
       ];
-      buildInputs = [
-        file
-        curl
-        python3
-        openssl
-        zlib
-      ];
-
-      # cargo uses git-rs which is made for a version of libgit2 from recent master that
-      # is not compatible with the current version in nixpkgs.
-      #LIBGIT2_SYS_USE_PKG_CONFIG = 1;
-
-      # fixes: the cargo feature `edition` requires a nightly version of Cargo, but this is the `stable` channel
-      RUSTC_BOOTSTRAP = 1;
-
-      postInstall = ''
-        wrapProgram "$out/bin/cargo" --suffix PATH : "${rustc}/bin"
-
-        installManPage src/tools/cargo/src/etc/man/*
-
-        installShellCompletion --bash --name cargo \
-          src/tools/cargo/src/etc/cargo.bashcomp.sh
-
-        installShellCompletion --zsh src/tools/cargo/src/etc/_cargo
-      '';
-
-      checkPhase = ''
-        # Disable cross compilation tests
-        export CFG_DISABLE_CROSS_TESTS=1
-        cargo test
-      '';
-
-      # Disable check phase as there are failures (4 tests fail)
-      doCheck = false;
-
-      doInstallCheck = !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isElf;
-      installCheckPhase = ''
-        runHook preInstallCheck
-        ${stdenv.cc.targetPrefix}readelf -a $out/bin/.cargo-wrapped | grep -F 'Shared library: [libcurl.so'
-        runHook postInstallCheck
-      '';
-
-      meta = with lib; {
-        homepage = "https://crates.io";
-        description = "Downloads your Rust project's dependencies and builds your project";
-        mainProgram = "cargo";
-        teams = [ teams.rust ];
-        license = [
-          licenses.mit
-          licenses.asl20
-        ];
-        platforms = platforms.unix;
-        # https://github.com/alexcrichton/nghttp2-rs/issues/2
-        broken = stdenv.hostPlatform.isx86 && stdenv.buildPlatform != stdenv.hostPlatform;
-      };
-    }
-    //
-      lib.optionalAttrs (stdenv.buildPlatform.rust.rustcTarget != stdenv.hostPlatform.rust.rustcTarget)
-        {
-          HOST_PKG_CONFIG_PATH = "${pkgsBuildBuild.pkg-config}/bin/pkg-config";
-        }
-  )
+      platforms = platforms.unix;
+      # https://github.com/alexcrichton/nghttp2-rs/issues/2
+      broken = stdenv.hostPlatform.isx86 && stdenv.buildPlatform != stdenv.hostPlatform;
+    };
+  }


### PR DESCRIPTION
This is no longer required for the original use case since 83aaf6183611 ("cargo,clippy,rustc,rustfmt: 1.78.0 -> 1.79.0").

Extracted from https://github.com/NixOS/nixpkgs/pull/196333, since it no longer depends on any other changes in that PR.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
