### PR TITLE
wayback-x11: init at 0-unstable-2025-07-20

### DIFF
--- a/pkgs/by-name/wa/wayback-x11/package.nix
+++ b/pkgs/by-name/wa/wayback-x11/package.nix
@@ -1,0 +1,64 @@
+{
+  fetchFromGitLab,
+  lib,
+  libxkbcommon,
+  meson,
+  ninja,
+  pixman,
+  pkg-config,
+  scdoc,
+  stdenv,
+  unstableGitUpdater,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  wlroots_0_19,
+  xwayland,
+}:
+
+stdenv.mkDerivation {
+  pname = "wayback";
+  version = "0-unstable-2025-07-20";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "wayback";
+    repo = "wayback";
+    rev = "4b1b4c59f67a2639e960d6b19e1282cf03fc3660";
+    hash = "sha256-+4fPMVVPoUAYbt0jgfl+dmt0ZNyGGWF7xuF1UzZ2uiU=";
+  };
+
+  strictDeps = true;
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    libxkbcommon
+    pixman
+    wayland
+    wayland-protocols
+    wlroots_0_19
+    xwayland
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "X11 compatibility layer leveraging wlroots and Xwayland";
+    homepage = "https://wayback.freedesktop.org";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "wayback-session";
+    maintainers = with lib.maintainers; [ dramforever ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Attribute name is `wayback-x11` instead of `wayback` to avoid a collision, based on AUR `wayback-x11-git` precedent and GitHub org name [wayback-x11](https://github.com/wayback-x11) (no longer active, moved to gitlab.freedesktop.org)

"Just enough Wayland to make Xwayland work" (tagline on https://wayback.freedesktop.org/)

Still a work in progress, obviously, but the basic functionality is there. I believe this is good enough for user testing and can cover many basic use cases. I intend to switch to following tags instead of git when 0.1 is released.

If you want to give it a go, here are some things I've found:

Notable things that work:

- Running a full KDE X11 session (!)

Notable things that don't work:

- Multiple monitors (`WAYBACK_OUTPUT` can select a single monitor but it does not work very well)
- Detailed touchpad config (e.g. scroll direction, tap to click)
- Some setxkbmap options (e.g. caps lock as ctrl)
- On Intel graphics ("iris"), KDE crashes on start, but it should be fixed in mesa 25.2, earlier if they bother backporting the fix: <https://gitlab.freedesktop.org/mesa/mesa/-/issues/13564>. If you have this problem overlay mesa to add this patch: https://gitlab.freedesktop.org/mesa/mesa/-/commit/103a16e4fa36d52bb0dc6325848fbdd7b5c1372f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
