### PR TITLE
ciscoPacketTracer{7,8}: use libxml2_13 that has patches for CVEs, fix desktop icons, refactor

### DIFF
--- a/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
@@ -91,12 +91,13 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ copyDesktopItems ];
 
-  meta = with lib; {
+  meta = {
     description = "Network simulation tool from Cisco";
     homepage = "https://www.netacad.com/courses/packet-tracer";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfree;
-    maintainers = with maintainers; [ ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+    ];
     platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
@@ -1,95 +1,139 @@
 {
-  stdenv,
   lib,
+  stdenvNoCC,
+  requireFile,
+  autoPatchelfHook,
+  dpkg,
+  makeWrapper,
+  alsa-lib,
+  dbus,
+  expat,
+  fontconfig,
+  glib,
+  libdrm,
+  libglvnd,
+  libpulseaudio,
+  libudev0-shim,
+  libxkbcommon,
+  libxml2_13,
+  libxslt,
+  nspr,
+  nss,
+  xorg,
   buildFHSEnv,
   copyDesktopItems,
-  dpkg,
-  libxml2_13,
-  lndir,
   makeDesktopItem,
-  makeWrapper,
-  requireFile,
+  packetTracerSource ? null,
 }:
 
 let
   version = "7.3.1";
 
-  ptFiles = stdenv.mkDerivation {
-    pname = "PacketTracer7drv";
+  unwrapped = stdenvNoCC.mkDerivation {
+    pname = "ciscoPacketTracer7-unwrapped";
     inherit version;
 
-    dontUnpack = true;
-    src = requireFile {
-      name = "PacketTracer_${builtins.replaceStrings [ "." ] [ "" ] version}_amd64.deb";
-      hash = "sha256-w5gC0V3WHQC6J/uMEW2kX9hWKrS0mZZVWtZriN6s4n8=";
-      url = "https://www.netacad.com";
-    };
+    src =
+      if (packetTracerSource != null) then
+        packetTracerSource
+      else
+        requireFile {
+          name = "PacketTracer_731_amd64.deb";
+          hash = "sha256-w5gC0V3WHQC6J/uMEW2kX9hWKrS0mZZVWtZriN6s4n8=";
+          url = "https://www.netacad.com";
+        };
 
     nativeBuildInputs = [
+      autoPatchelfHook
       dpkg
       makeWrapper
     ];
 
-    installPhase = ''
+    buildInputs = [
+      alsa-lib
+      dbus
+      expat
+      fontconfig
+      glib
+      libdrm
+      libglvnd
+      libpulseaudio
+      libudev0-shim
+      libxkbcommon
+      libxml2_13
+      libxslt
+      nspr
+      nss
+    ]
+    ++ (with xorg; [
+      libICE
+      libSM
+      libX11
+      libXScrnSaver
+    ]);
+
+    unpackPhase = ''
+      runHook preUnpack
+
       dpkg-deb -x $src $out
+      chmod 755 "$out"
+
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
       makeWrapper "$out/opt/pt/bin/PacketTracer7" "$out/bin/packettracer7" \
-          --prefix LD_LIBRARY_PATH : "$out/opt/pt/bin"
+        --prefix LD_LIBRARY_PATH : "$out/opt/pt/bin"
+
+      runHook postInstall
     '';
   };
 
-  desktopItem = makeDesktopItem {
-    name = "cisco-pt7.desktop";
-    desktopName = "Cisco Packet Tracer 7";
-    icon = "${ptFiles}/opt/pt/art/app.png";
-    exec = "packettracer7 %f";
-    mimeTypes = [
-      "application/x-pkt"
-      "application/x-pka"
-      "application/x-pkz"
-    ];
-  };
-
-  fhs = buildFHSEnv {
-    pname = "packettracer7";
-    inherit version;
-    runScript = "${ptFiles}/bin/packettracer7";
-
-    targetPkgs =
-      pkgs: with pkgs; [
-        alsa-lib
-        dbus
-        expat
-        fontconfig
-        glib
-        libglvnd
-        libpulseaudio
-        libudev0-shim
-        libxkbcommon
-        libxml2_13
-        libxslt
-        nspr
-        nss
-        xorg.libICE
-        xorg.libSM
-        xorg.libX11
-        xorg.libXScrnSaver
-      ];
+  fhs-env = buildFHSEnv {
+    name = "ciscoPacketTracer7-fhs-env";
+    runScript = lib.getExe' unwrapped "packettracer7";
+    targetPkgs = _: [ libudev0-shim ];
   };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "ciscoPacketTracer7";
   inherit version;
 
   dontUnpack = true;
 
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
   installPhase = ''
-    mkdir $out
-    ${lndir}/bin/lndir -silent ${fhs} $out
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ln -s ${fhs-env}/bin/${fhs-env.name} $out/bin/packettracer7
+
+    mkdir -p $out/share/icons/hicolor/48x48/apps
+    ln -s ${unwrapped}/opt/pt/art/app.png $out/share/icons/hicolor/48x48/apps/cisco-packet-tracer-7.png
+    ln -s ${unwrapped}/usr/share/icons/gnome/48x48/mimetypes $out/share/icons/hicolor/48x48/mimetypes
+    ln -s ${unwrapped}/usr/share/mime $out/share/mime
+
+    runHook postInstall
   '';
 
-  desktopItems = [ desktopItem ];
-
-  nativeBuildInputs = [ copyDesktopItems ];
+  desktopItems = [
+    (makeDesktopItem {
+      name = "cisco-pt7.desktop";
+      desktopName = "Cisco Packet Tracer 7";
+      icon = "cisco-packet-tracer-7";
+      exec = "packettracer7 %f";
+      mimeTypes = [
+        "application/x-pkt"
+        "application/x-pka"
+        "application/x-pkz"
+      ];
+    })
+  ];
 
   meta = {
     description = "Network simulation tool from Cisco";

--- a/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
@@ -95,6 +95,7 @@ stdenv.mkDerivation {
     description = "Network simulation tool from Cisco";
     homepage = "https://www.netacad.com/courses/packet-tracer";
     license = lib.licenses.unfree;
+    mainProgram = "packettracer7";
     maintainers = with lib.maintainers; [
       gepbird
     ];

--- a/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
@@ -96,6 +96,7 @@ stdenv.mkDerivation {
     homepage = "https://www.netacad.com/courses/packet-tracer";
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
+      gepbird
     ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer7/package.nix
@@ -4,8 +4,7 @@
   buildFHSEnv,
   copyDesktopItems,
   dpkg,
-  fetchurl,
-  libxml2,
+  libxml2_13,
   lndir,
   makeDesktopItem,
   makeWrapper,
@@ -50,19 +49,6 @@ let
     ];
   };
 
-  libxml2' = libxml2.overrideAttrs (oldAttrs: rec {
-    version = "2.13.8";
-    src = fetchurl {
-      url = "mirror://gnome/sources/libxml2/${lib.versions.majorMinor version}/libxml2-${version}.tar.xz";
-      hash = "sha256-J3KUyzMRmrcbK8gfL0Rem8lDW4k60VuyzSsOhZoO6Eo=";
-    };
-    meta = oldAttrs.meta // {
-      knownVulnerabilities = oldAttrs.meta.knownVulnerabilities or [ ] ++ [
-        "CVE-2025-6021"
-      ];
-    };
-  });
-
   fhs = buildFHSEnv {
     pname = "packettracer7";
     inherit version;
@@ -79,7 +65,7 @@ let
         libpulseaudio
         libudev0-shim
         libxkbcommon
-        libxml2'
+        libxml2_13
         libxslt
         nspr
         nss

--- a/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   requireFile,
   autoPatchelfHook,
+  dpkg,
   makeWrapper,
   alsa-lib,
   dbus,
@@ -17,10 +18,9 @@
   libxml2_13,
   libxslt,
   nspr,
-  wayland,
   nss,
+  wayland,
   xorg,
-  dpkg,
   buildFHSEnv,
   copyDesktopItems,
   makeDesktopItem,
@@ -54,9 +54,13 @@ let
           url = "https://www.netacad.com";
         };
 
-    buildInputs = [
+    nativeBuildInputs = [
       autoPatchelfHook
+      dpkg
       makeWrapper
+    ];
+
+    buildInputs = [
       alsa-lib
       dbus
       expat
@@ -97,7 +101,7 @@ let
     unpackPhase = ''
       runHook preUnpack
 
-      ${lib.getExe' dpkg "dpkg-deb"} -x $src $out
+      dpkg-deb -x $src $out
       chmod 755 "$out"
 
       runHook postUnpack
@@ -116,7 +120,7 @@ let
   fhs-env = buildFHSEnv {
     name = "ciscoPacketTracer8-fhs-env";
     runScript = lib.getExe' unwrapped "packettracer8";
-    targetPkgs = pkgs: [ libudev0-shim ];
+    targetPkgs = _: [ libudev0-shim ];
   };
 in
 
@@ -137,7 +141,7 @@ stdenvNoCC.mkDerivation {
     ln -s ${fhs-env}/bin/${fhs-env.name} $out/bin/packettracer8
 
     mkdir -p $out/share/icons/hicolor/48x48/apps
-    ln -s ${unwrapped}/opt/pt/art/app.png $out/share/icons/hicolor/48x48/apps/cisco-packet-tracer.png
+    ln -s ${unwrapped}/opt/pt/art/app.png $out/share/icons/hicolor/48x48/apps/cisco-packet-tracer-8.png
     ln -s ${unwrapped}/usr/share/icons/gnome/48x48/mimetypes $out/share/icons/hicolor/48x48/mimetypes
     ln -s ${unwrapped}/usr/share/mime $out/share/mime
 
@@ -148,7 +152,7 @@ stdenvNoCC.mkDerivation {
     (makeDesktopItem {
       name = "cisco-pt8.desktop";
       desktopName = "Cisco Packet Tracer 8";
-      icon = "cisco-packet-tracer";
+      icon = "cisco-packet-tracer-8";
       exec = "packettracer8 %f";
       mimeTypes = [
         "application/x-pkt"

--- a/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
+++ b/pkgs/by-name/ci/ciscoPacketTracer8/package.nix
@@ -7,7 +7,6 @@
   alsa-lib,
   dbus,
   expat,
-  fetchurl,
   fontconfig,
   glib,
   libdrm,
@@ -15,7 +14,7 @@
   libpulseaudio,
   libudev0-shim,
   libxkbcommon,
-  libxml2,
+  libxml2_13,
   libxslt,
   nspr,
   wayland,
@@ -40,19 +39,6 @@ let
     "8.2.1" = "CiscoPacketTracer_821_Ubuntu_64bit.deb";
     "8.2.2" = "CiscoPacketTracer822_amd64_signed.deb";
   };
-
-  libxml2' = libxml2.overrideAttrs (oldAttrs: rec {
-    version = "2.13.8";
-    src = fetchurl {
-      url = "mirror://gnome/sources/libxml2/${lib.versions.majorMinor version}/libxml2-${version}.tar.xz";
-      hash = "sha256-J3KUyzMRmrcbK8gfL0Rem8lDW4k60VuyzSsOhZoO6Eo=";
-    };
-    meta = oldAttrs.meta // {
-      knownVulnerabilities = oldAttrs.meta.knownVulnerabilities or [ ] ++ [
-        "CVE-2025-6021"
-      ];
-    };
-  });
 
   unwrapped = stdenvNoCC.mkDerivation {
     name = "ciscoPacketTracer8-unwrapped";
@@ -81,7 +67,7 @@ let
       libpulseaudio
       libudev0-shim
       libxkbcommon
-      libxml2'
+      libxml2_13
       libxslt
       nspr
       nss


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- [x] Depends on/follow up for: https://github.com/NixOS/nixpkgs/pull/421740 (this has hit staging-next)

This fixes the security warning, as `libxml2_13` includes CVE patches. I also made some other refactoring changes and smaller fixes.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
