### PR TITLE
python313Packages.lmfit: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/development/python-modules/lmfit/default.nix
+++ b/pkgs/development/python-modules/lmfit/default.nix
@@ -1,19 +1,25 @@
 {
   lib,
   buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
   asteval,
   dill,
-  fetchPypi,
-  matplotlib,
   numpy,
-  pandas,
-  pytest-cov-stub,
-  pytestCheckHook,
-  pythonOlder,
   scipy,
-  setuptools-scm,
-  setuptools,
   uncertainties,
+
+  # tests
+  pytestCheckHook,
+  pytest-cov-stub,
+  matplotlib,
+  pandas,
 }:
 
 buildPythonPackage rec {
@@ -42,10 +48,10 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
     matplotlib
     pandas
-    pytest-cov-stub
-    pytestCheckHook
   ];
 
   pythonImportsCheck = [ "lmfit" ];

--- a/pkgs/development/python-modules/lmfit/default.nix
+++ b/pkgs/development/python-modules/lmfit/default.nix
@@ -58,11 +58,11 @@ buildPythonPackage rec {
 
   disabledTests = [ "test_check_ast_errors" ];
 
-  meta = with lib; {
+  meta = {
     description = "Least-Squares Minimization with Bounds and Constraints";
     homepage = "https://lmfit.github.io/lmfit-py/";
     changelog = "https://github.com/lmfit/lmfit-py/releases/tag/${version}";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ nomeata ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nomeata ];
   };
 }

--- a/pkgs/development/python-modules/lmfit/default.nix
+++ b/pkgs/development/python-modules/lmfit/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  fetchpatch,
   asteval,
   dill,
   fetchPypi,
@@ -19,22 +18,15 @@
 
 buildPythonPackage rec {
   pname = "lmfit";
-  version = "1.3.3";
+  version = "1.3.4";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-czIea4gfL2hiNXIaffwCr2uw8DCiXv62Zjj2KxxgU6E=";
+    hash = "sha256-PCLCjEP3F/bFtKO9geiTohSXOcJqWSwEby4zwjz75Jc=";
   };
-  patches = [
-    # https://github.com/lmfit/lmfit-py/issues/999
-    (fetchpatch {
-      url = "https://github.com/lmfit/lmfit-py/commit/d4f4e3755d50cb9720c616fcff2cd7b58fbabba5.patch";
-      hash = "sha256-h1WK3ajnoX3pOZOduFBKpPz3exfoKzkbO/QNgROLT7c=";
-    })
-  ];
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/lmfit/default.nix
+++ b/pkgs/development/python-modules/lmfit/default.nix
@@ -63,6 +63,6 @@ buildPythonPackage rec {
     homepage = "https://lmfit.github.io/lmfit-py/";
     changelog = "https://github.com/lmfit/lmfit-py/releases/tag/${version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ nomeata ];
+    maintainers = with lib.maintainers; [ doronbehar ];
   };
 }


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
