### PR TITLE
python3Packages.nengo: 4.0.0 -> 4.1.0, fix build; nengo-gui: 0.4.9 -> 0.6.0, use pyproject = true

### DIFF
--- a/pkgs/by-name/ne/nengo-gui/package.nix
+++ b/pkgs/by-name/ne/nengo-gui/package.nix
@@ -6,20 +6,21 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "nengo-gui";
-  version = "0.4.9";
-  format = "setuptools";
+  version = "0.6.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nengo";
     repo = "nengo-gui";
     tag = "v${version}";
-    sha256 = "sha256-aBi4roe9pqPmpbW5zrbDoIvyH5mTKgIzL2O5j1+VBMY=";
+    hash = "sha256-nm5rHXKTzVxrhEJ/ajEFC7yMzYicn+5ubeB2fHhoLys=";
   };
 
-  propagatedBuildInputs = with python3Packages; [ nengo ];
+  build-system = with python3Packages; [ setuptools ];
 
-  # checks req missing:
-  #   pyimgur
+  dependencies = with python3Packages; [ nengo ];
+
+  # selenium based tests don't seem to be working
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/development/python-modules/nengo/default.nix
+++ b/pkgs/development/python-modules/nengo/default.nix
@@ -12,19 +12,19 @@
 
 buildPythonPackage rec {
   pname = "nengo";
-  version = "4.0.0";
+  version = "4.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nengo";
     repo = "nengo";
     tag = "v${version}";
-    sha256 = "sha256-b9mPjKdewIqIeRrddV1/M3bghSyox7Lz6VbfSLCHZjA=";
+    hash = "sha256-yZDnttXU5qMmQwFESkhQb06BXcqPEiPYl54azS5b284=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs =
+  dependencies =
     [
       numpy
     ]
@@ -33,7 +33,6 @@ buildPythonPackage rec {
 
   # checks req missing:
   #   pytest-allclose
-  #   pytest-plt
   #   pytest-rng
   doCheck = false;
 


### PR DESCRIPTION
Note: I do not use this software, I'm just doing some cleanup.

The `nengo` python package had a upper version bound set for setuptools, which has already been reached and thus the `python3Packages.nengo` package was actually failing to build.

In the latest version that version bound was removed, so I just updated the package.
https://github.com/nengo/nengo/blob/main/CHANGES.rst

I also updated the related gui app
https://github.com/nengo/nengo-gui/blob/master/CHANGES.rst

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
