### PR TITLE
zoom-us: avoid manual throw

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -55,7 +55,6 @@
 
 let
   inherit (stdenv.hostPlatform) system;
-  throwSystem = throw "Unsupported system: ${system}";
 
   # Zoom versions are released at different times for each platform
   # and often with different versions. We write them on three lines
@@ -83,9 +82,9 @@ let
 
   unpacked = stdenv.mkDerivation {
     pname = "zoom";
-    version = versions.${system} or throwSystem;
+    version = versions.${system} or "";
 
-    src = srcs.${system} or throwSystem;
+    src = srcs.${system};
 
     dontUnpack = stdenv.hostPlatform.isLinux;
     unpackPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -129,7 +128,7 @@ let
             mv $out/usr/* $out/
           '';
         }
-        .${system} or throwSystem
+        .${system}
       }
       runHook postInstall
     '';
@@ -159,8 +158,6 @@ let
       mainProgram = "zoom";
     };
   };
-  packages.aarch64-darwin = unpacked;
-  packages.x86_64-darwin = unpacked;
 
   # linux definitions
 
@@ -237,13 +234,17 @@ let
     ++ targetPkgs pkgs
     ++ targetPkgsFixed;
 
+in
+if !stdenv.hostPlatform.isLinux then
+  unpacked
+else
   # We add the `unpacked` zoom archive to the FHS env
   # and also bind-mount its `/opt` directory.
   # This should assist Zoom in finding all its
   # files in the places where it expects them to be.
-  packages.x86_64-linux = buildFHSEnv {
+  buildFHSEnv {
     pname = "zoom"; # Will also be the program's name!
-    version = versions.${system} or throwSystem;
+    version = versions.${system} or "";
 
     targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
     extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
@@ -263,8 +264,4 @@ let
       inherit unpacked;
     };
     inherit (unpacked) meta;
-  };
-
-in
-
-packages.${system} or throwSystem
+  }


### PR DESCRIPTION
Relying on `meta.platforms` to throw errors on unsupported platforms (here: aarch64-linux) allows CI to filter out these attrpaths without hitting an error on evaluation.

Related #426629.

Closes #293422.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
