### PR TITLE
vscode-extensions.redhat.vscode-xml: remove manual throw

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/redhat.vscode-xml/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/redhat.vscode-xml/default.nix
@@ -28,8 +28,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
       name = "vscode-xml";
       version = "0.29.0";
     }
-    // sources.${stdenvNoCC.hostPlatform.system}
-      or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");
+    // sources.${stdenvNoCC.hostPlatform.system} or { };
 
   passthru.updateScript = vscode-extension-update-script {
     extraArgs = [


### PR DESCRIPTION
This can be handled via `meta.platforms` easily. Avoids throwing during attrpath generation in CI.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
