### PR TITLE
nixos/local-content-share: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -52,6 +52,8 @@
 
 - [boot.kernel.sysfs](options.html#opt-boot.kernel.sysfs) allows setting of sysfs attributes.
 
+- [local-content-share](https://github.com/Tanq16/local-content-share), a simple web-app for storing/sharing text snippets and files in your local network. Available as [services.local-content-share](#opt-services.local-content-share.enable).
+
 - Docker now defaults to 28.x, because version 27.x stopped receiving security updates and bug fixes after [May 2, 2025](https://github.com/moby/moby/pull/49910).
 
 - [Corteza](https://cortezaproject.org/), a low-code platform. Available as [services.corteza](#opt-services.corteza.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -863,6 +863,7 @@
   ./services/misc/lifecycled.nix
   ./services/misc/litellm.nix
   ./services/misc/llama-cpp.nix
+  ./services/misc/local-content-share.nix
   ./services/misc/logkeys.nix
   ./services/misc/mame.nix
   ./services/misc/mbpfan.nix

--- a/nixos/modules/services/misc/local-content-share.nix
+++ b/nixos/modules/services/misc/local-content-share.nix
@@ -1,0 +1,63 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.services.local-content-share;
+in
+{
+  options.services.local-content-share = {
+    enable = lib.mkEnableOption "Local-Content-Share";
+
+    package = lib.mkPackageOption pkgs "local-content-share" { };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      example = "127.0.0.1";
+      description = ''
+        Address on which the service will be available.
+
+        The service will listen on all interfaces if set to an empty string.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "Port on which the service will be available";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to automatically open the specified port in the firewall";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.local-content-share = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        DynamicUser = true;
+        User = "local-content-share";
+        StateDirectory = "local-content-share";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = "/var/lib/local-content-share";
+        ExecStart = "${lib.getExe' cfg.package "local-content-share"} -listen=${cfg.listenAddress}:${toString cfg.port}";
+        Restart = "on-failure";
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ e-v-o-l-v-e ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -849,6 +849,7 @@ in
   litestream = runTest ./litestream.nix;
   lk-jwt-service = runTest ./matrix/lk-jwt-service.nix;
   lldap = runTest ./lldap.nix;
+  local-content-share = runTest ./local-content-share.nix;
   localsend = runTest ./localsend.nix;
   locate = runTest ./locate.nix;
   login = runTest ./login.nix;

--- a/nixos/tests/local-content-share.nix
+++ b/nixos/tests/local-content-share.nix
@@ -1,0 +1,25 @@
+{ pkgs, lib, ... }:
+{
+  name = "local-content-share";
+  meta.maintainers = pkgs.local-content-share.meta.maintainers;
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.local-content-share = {
+        enable = true;
+        port = 8081;
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      cfg = nodes.machine.services.local-content-share;
+    in
+    ''
+      machine.wait_for_unit("local-content-share.service")
+      machine.wait_for_open_port(${toString cfg.port})
+      machine.wait_until_succeeds("curl -sS -f http://127.0.0.1:${toString cfg.port}/", timeout=300)
+    '';
+}

--- a/pkgs/by-name/lo/local-content-share/package.nix
+++ b/pkgs/by-name/lo/local-content-share/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 buildGoModule (finalAttrs: {
@@ -19,6 +20,8 @@ buildGoModule (finalAttrs: {
 
   # no test file in upstream
   doCheck = false;
+
+  passthru.tests.nixos = nixosTests.local-content-share;
 
   meta = {
     description = "Storing/sharing text/files in your local network with no setup on client devices";


### PR DESCRIPTION
Add a service module for [local-content-share](https://github.com/Tanq16/local-content-share), a simple self-hosted app for storing/sharing text snippets and files in your local network with no setup on client devices.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
