### PR TITLE
maintainers: drop bartsch

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2852,12 +2852,6 @@
     githubId = 75235;
     name = "Michael Walker";
   };
-  bartsch = {
-    email = "consume.noise@gmail.com";
-    github = "bartsch";
-    githubId = 3390885;
-    name = "Daniel Martin";
-  };
   bartuka = {
     email = "wand@hey.com";
     github = "wandersoncferreira";

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -146,7 +146,6 @@ let
             description = "Boot loader for embedded systems";
             license = licenses.gpl2Plus;
             maintainers = with maintainers; [
-              bartsch
               dezgeg
               lopsided98
             ];


### PR DESCRIPTION
Became maintainer of uboot in 2022, never joined the NixOS org, never reacted to any maintainer pings since. No other PRs, reviews or comments.

In accordance with https://github.com/NixOS/nixpkgs/tree/master/maintainers#how-to-lose-maintainer-status, I will wait a week before merging. @bartsch if you'd like to stay a maintainer, please speak up.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
