### PR TITLE
tal-noisemaker: init at 5.0.6

### DIFF
--- a/pkgs/by-name/ta/tal-noisemaker/package.nix
+++ b/pkgs/by-name/ta/tal-noisemaker/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  autoPatchelfHook,
+  freetype,
+  alsa-lib,
+  libatomic_ops,
+
+  installVST3 ? true,
+  installVST2 ? true,
+  installCLAP ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tal-noisemaker";
+  version = "5.0.6";
+
+  src = fetchzip {
+    url = "https://archive.org/download/tal-noise-maker-64-linux-${finalAttrs.version}/TAL-NoiseMaker_64_linux_${finalAttrs.version}.zip";
+    hash = "sha256-p6XUltjdpbCUvsqNmP6tRTIZ+uXC3rloAZoGo7nGrk8=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    freetype
+    alsa-lib
+    libatomic_ops
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd TAL-NoiseMaker
+      ${lib.optionalString installVST3 ''
+        mkdir -p $out/lib/vst3
+        cp TAL-NoiseMaker.vst3 $out/lib/vst3
+      ''}
+
+      ${lib.optionalString installVST2 ''
+        mkdir -p $out/lib/vst
+        cp libTAL-NoiseMaker.so $out/lib/vst
+      ''}
+
+      ${lib.optionalString installCLAP ''
+        mkdir -p $out/lib/clap
+        cp TAL-NoiseMaker.clap $out/lib/clap
+      ''}
+    popd
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Virtual analog synthesizer";
+    homepage = "https://tal-software.com/products/TAL-NoiseMaker";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ mrtnvgr ];
+  };
+})


### PR DESCRIPTION
[TAL-NoiseMaker](https://tal-software.com/products/TAL-NoiseMaker) is a synth audio plugin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
