### PR TITLE
dropbox: avoid manual assert

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -6,15 +6,6 @@
   makeDesktopItem,
 }:
 
-let
-  platforms = [
-    "i686-linux"
-    "x86_64-linux"
-  ];
-in
-
-assert lib.elem stdenv.hostPlatform.system platforms;
-
 # Dropbox client to bootstrap installation.
 # The client is self-updating, so the actual version may be newer.
 let
@@ -23,7 +14,7 @@ let
       x86_64-linux = "217.4.4417";
       i686-linux = "206.3.6386";
     }
-    .${stdenv.hostPlatform.system};
+    .${stdenv.hostPlatform.system} or "";
 
   arch =
     {


### PR DESCRIPTION
This package already sets `meta.platforms` accordingly, so will fail to evaluate on other platforms anyway. Relying on `meta.platforms` has the advantage that CI doesn't need to work around these eval failures in hacky ways.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
