### PR TITLE
python3Packages.tensorflowWithCuda: move assert to meta.broken

### DIFF
--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -46,9 +46,6 @@
 # - the source build is currently brittle and not easy to maintain
 # - the source build doesn't work on NVIDIA Jetson platforms
 
-# unsupported combination
-assert !(stdenv.hostPlatform.isDarwin && cudaSupport);
-
 let
   packages = import ./binary-hashes.nix;
   inherit (cudaPackages) cudatoolkit cudnn;
@@ -233,5 +230,7 @@ buildPythonPackage rec {
       abbradar
     ];
     badPlatforms = [ "x86_64-darwin" ];
+    # unsupported combination
+    broken = stdenv.hostPlatform.isDarwin && cudaSupport;
   };
 }


### PR DESCRIPTION
`meta.broken` can be caught nicely by CI when running attrpath generation for Eval. `assert` can not and requires ugly workarounds.

They both do the same for the user, though. Thus using the former.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
