### PR TITLE
tuatara: init at 1631040452-unstable-2025-04-29

### DIFF
--- a/pkgs/by-name/tu/tuatara/package.nix
+++ b/pkgs/by-name/tu/tuatara/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  zig_0_13,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tuatara";
+  version = "1631040452-unstable-2025-04-29";
+
+  src = fetchFromGitHub {
+    owner = "q60";
+    repo = "tuatara";
+    rev = "bc093e5fe1cb8dec667806f1b41c8e4e913368e8";
+    hash = "sha256-GLOb2vqDlcCQ3bPXC50t1j+DJFhl8JK117t7uRLrBbk=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ zig_0_13.hook ];
+
+  preBuild = ''
+    export ZIG_LOCAL_CACHE_DIR=$TMPDIR/zig-cache
+    export ZIG_GLOBAL_CACHE_DIR=$TMPDIR/zig-global-cache
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Ziggidy *nix system info fetcher";
+    longDescription = ''
+      tuatara is a ziggidy *nix system info fetcher. WIP. It is
+      descendant of disfetch. Although sharing some common concepts
+      and principles, they are different.
+
+      The main difference of tuatara from disfetch is that tuatara
+      will be highly customizable, while disfetch won't, because it
+      covers minimalism and simplicity. Though, they will share some
+      other principles regarding showing only needed information,
+      being fast and reliable and sharing the same handmade logos with
+      the principle of not-more-or-less-than 8 rows.
+    '';
+    homepage = "https://github.com/q60/tuatara";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "tuatara";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
[tuatara](https://github.com/q60/tuatara) is [ziggidy](https://github.com/ziglang/zig) *nix system info fetcher. WIP. it is descendant of [disfetch](https://github.com/q60/disfetch), although sharing some common concepts and principles, they are different.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- ~~Nixpkgs Release Notes~~
  - [ ] ~~Package update: when the change is major or breaking.~~
- ~~NixOS Release Notes~~
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
