### PR TITLE
python3Packages.rustworkx: properly add numpy as a dependency

### DIFF
--- a/pkgs/development/python-modules/rustworkx/default.nix
+++ b/pkgs/development/python-modules/rustworkx/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   fetchFromGitHub,
   buildPythonPackage,
   cargo,
@@ -10,9 +11,6 @@
   fixtures,
   networkx,
   testtools,
-  libiconv,
-  stdenv,
-  lib,
   pytestCheckHook,
 }:
 
@@ -44,7 +42,7 @@ buildPythonPackage rec {
     setuptools-rust
   ];
 
-  buildInputs = [ numpy ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [
     fixtures


### PR DESCRIPTION
So that you can actually use functions that use numpy stuff.

Putting python dependencies into `buildInputs` will only make them available during build-time: it will not be propagated.

e.g this now properly outputs a numpy array without having to manually install numpy:
```
from rustworkx import *
graph_adjacency_matrix(PyGraph())
```

---

Also: I removed the `libiconv` dependency, since it is propagated by the darwin SDK.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
