### PR TITLE
maintainers: drop arjix

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2059,12 +2059,6 @@
     githubId = 10400299;
     name = "Arjan Schrijver";
   };
-  arjix = {
-    email = "arjix@protonmail.com";
-    github = "arjix";
-    githubId = 62168569;
-    name = "arjix";
-  };
   arkivm = {
     email = "vikram186@gmail.com";
     github = "arkivm";

--- a/pkgs/by-name/ne/nengo-gui/package.nix
+++ b/pkgs/by-name/ne/nengo-gui/package.nix
@@ -26,6 +26,6 @@ python3Packages.buildPythonPackage rec {
     description = "Nengo interactive visualizer";
     homepage = "https://nengo.ai/";
     license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ arjix ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/nengo/default.nix
+++ b/pkgs/development/python-modules/nengo/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     description = "Python library for creating and simulating large-scale brain models";
     homepage = "https://nengo.ai/";
     license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ arjix ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
Last activity on GitHub was 2021. Not a member of the NixOS org, so can't be requested for reviews.

Per [maintainers/README.md], this can be merged in one week. @arjix: please speak up if you'd like to remain a maintainer.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
