### PR TITLE
go: Mark powerpc64-linux as badPlatform

### DIFF
--- a/pkgs/development/compilers/go/1.23.nix
+++ b/pkgs/development/compilers/go/1.23.nix
@@ -163,6 +163,13 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.bsd3;
     teams = [ teams.golang ];
     platforms = platforms.darwin ++ platforms.linux ++ platforms.wasi ++ platforms.freebsd;
+    badPlatforms = [
+      # Support for big-endian POWER < 8 was dropped in 1.9, but POWER8 users have less of a reason to run in big-endian mode than pre-POWER8 ones
+      # So non-LE ppc64 is effectively unsupported, and Go SIGILLs on affordable ppc64 hardware
+      # https://github.com/golang/go/issues/19074 - Dropped support for big-endian POWER < 8, with community pushback
+      # https://github.com/golang/go/issues/73349 - upstream will not accept submissions to fix this
+      "powerpc64-linux"
+    ];
     mainProgram = "go";
   };
 })

--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -163,6 +163,13 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.bsd3;
     teams = [ teams.golang ];
     platforms = platforms.darwin ++ platforms.linux ++ platforms.wasi ++ platforms.freebsd;
+    badPlatforms = [
+      # Support for big-endian POWER < 8 was dropped in 1.9, but POWER8 users have less of a reason to run in big-endian mode than pre-POWER8 ones
+      # So non-LE ppc64 is effectively unsupported, and Go SIGILLs on affordable ppc64 hardware
+      # https://github.com/golang/go/issues/19074 - Dropped support for big-endian POWER < 8, with community pushback
+      # https://github.com/golang/go/issues/73349 - upstream will not accept submissions to fix this
+      "powerpc64-linux"
+    ];
     mainProgram = "go";
   };
 })

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -168,6 +168,13 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.bsd3;
     teams = [ teams.golang ];
     platforms = platforms.darwin ++ platforms.linux ++ platforms.wasi ++ platforms.freebsd;
+    badPlatforms = [
+      # Support for big-endian POWER < 8 was dropped in 1.9, but POWER8 users have less of a reason to run in big-endian mode than pre-POWER8 ones
+      # So non-LE ppc64 is effectively unsupported, and Go SIGILLs on affordable ppc64 hardware
+      # https://github.com/golang/go/issues/19074 - Dropped support for big-endian POWER < 8, with community pushback
+      # https://github.com/golang/go/issues/73349 - upstream will not accept submissions to fix this
+      "powerpc64-linux"
+    ];
     mainProgram = "go";
   };
 })

--- a/pkgs/development/compilers/go/binary.nix
+++ b/pkgs/development/compilers/go/binary.nix
@@ -35,5 +35,12 @@ stdenv.mkDerivation {
     license = lib.licenses.bsd3;
     teams = [ lib.teams.golang ];
     platforms = lib.platforms.darwin ++ lib.platforms.linux;
+    badPlatforms = [
+      # Support for big-endian POWER < 8 was dropped in 1.9, but POWER8 users have less of a reason to run in big-endian mode than pre-POWER8 ones
+      # So non-LE ppc64 is effectively unsupported, and Go SIGILLs on affordable ppc64 hardware
+      # https://github.com/golang/go/issues/19074 - Dropped support for big-endian POWER < 8, with community pushback
+      # https://github.com/golang/go/issues/73349 - upstream will not accept submissions to fix this
+      "powerpc64-linux"
+    ];
   };
 }


### PR DESCRIPTION
Since 1.9, there is no support for POWER < 8, and no interest upstream in supporting it again.

On the hardware that I have available, `go` SIGILLs due to POWER8 instructions. So at least for me, this is an unsupported platform for these packages.

To still allow the use of Go on it, I will be making follow-up PRs that

- add some attributes to the cc-wrapper, to make `gccgo` compatible with some expectations that other code has of a Go compiler derivation, and
- conditionally point the top-level `go` and `buildGoModule` attributes at `gccgo` and a corresponding `buildGccgoModule` when normal `go` is unavailable on the requested platform, to at least have *a* Go compiler available. It won't handle everything, but I'd still consider it better than nothing. At least for the few Go packages that I had to build along the way to bigger packages and an installer ISO, it worked Good Enough :tm:.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
