### PR TITLE
rustc: Fix cross-compilation for the targets with dot in name

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -118,9 +118,9 @@ stdenv.mkDerivation (finalAttrs: {
         stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang" else "cc"}";
       cxxPrefixForStdenv =
         stdenv: "${prefixForStdenv stdenv}${if (stdenv.cc.isClang or false) then "clang++" else "c++"}";
-      setBuild = "--set=target.${stdenv.buildPlatform.rust.rustcTarget}";
-      setHost = "--set=target.${stdenv.hostPlatform.rust.rustcTarget}";
-      setTarget = "--set=target.${stdenv.targetPlatform.rust.rustcTarget}";
+      setBuild = "--set=target.\"${stdenv.buildPlatform.rust.rustcTarget}\"";
+      setHost = "--set=target.\"${stdenv.hostPlatform.rust.rustcTarget}\"";
+      setTarget = "--set=target.\"${stdenv.targetPlatform.rust.rustcTarget}\"";
       ccForBuild = ccPrefixForStdenv pkgsBuildBuild.targetPackages.stdenv;
       cxxForBuild = cxxPrefixForStdenv pkgsBuildBuild.targetPackages.stdenv;
       ccForHost = ccPrefixForStdenv pkgsBuildHost.targetPackages.stdenv;


### PR DESCRIPTION
When you are trying to cross-compile rustc to the target platform with the dot in name, e.g. "thumb8vm.main-none-eabi", rustc compilation fails with this error during configuration:

    armv8m-unknown-none-eabi-rustc> Running phase: configurePhase
    armv8m-unknown-none-eabi-rustc> patching script interpreter paths in ./configure
    armv8m-unknown-none-eabi-rustc> ./configure: interpreter directive changed from "#!/bin/sh" to "/nix/store/ih68ar79msmj0496pgld4r3vqfr7bbin-bash-5.2p37/bin/sh"
    armv8m-unknown-none-eabi-rustc> configure flags: --prefix=/nix/store/wscr78z0s5v2hxx3p1n4qjgjnds8dm0g-armv8m-unknown-none-eabi-rustc-1.86.0 --sysconfdir=/nix/store/wscr78z0s5v2hxx3p1n4qjgjnds8dm0g-armv8m-unknown-none-eabi-rustc-1.86.0/etc --release-channel=stable --set=build.rustc=/nix/store/f9zdz15l2zd408yq7a3bgrj593kpwjqx-rustc-wrapper-1.86.0/bin/rustc --set=build.cargo=/nix/store/ygri5mmqmril5ll9lhawa01faa2qhdvd-cargo-1.86.0/bin/cargo --tools=rustc\,rustdoc\,rust-analyzer-proc-macro-srv --enable-rpath --enable-vendor --disable-lld --build=x86_64-unknown-linux-gnu --host=x86_64-unknown-linux-gnu --target=thumbv8m.main-none-eabi --set=target.x86_64-unknown-linux-gnu.cc=/nix/store/a0d7m3zn9p2dfa1h7ag9h2wzzr2w25sn-gcc-wrapper-14.2.1.20250322/bin/cc --set=target.x86_64-unknown-linux-gnu.cc=/nix/store/a0d7m3zn9p2dfa1h7ag9h2wzzr2w25sn-gcc-wrapper-14.2.1.20250322/bin/cc --set=target.thumbv8m.main-none-eabi.cc=/nix/store/wnnwk5vknch7d8jy3cdykbsnn5qrmjj3-armv8m-unknown-none-eabi-gcc-wrapper-14.2.1.20250322/bin/armv8m-unknown-none-eabi-cc --set=target.thumbv8m.main-none-eabi.linker=/nix/store/wnnwk5vknch7d8jy3cdykbsnn5qrmjj3-armv8m-unknown-none-eabi-gcc-wrapper-14.2.1.20250322/bin/armv8m-unknown-none-eabi-cc --set=target.x86_64-unknown-linux-gnu.linker=/nix/store/a0d7m3zn9p2dfa1h7ag9h2wzzr2w25sn-gcc-wrapper-14.2.1.20250322/bin/cc --set=target.x86_64-unknown-linux-gnu.linker=/nix/store/a0d7m3zn9p2dfa1h7ag9h2wzzr2w25sn-gcc-wrapper-14.2.1.20250322/bin/cc --set=target.x86_64-unknown-linux-gnu.cxx=/nix/store/a0d7m3zn9p2dfa1h7ag9h2wzzr2w25sn-gcc-wrapper-14.2.1.20250322/bin/c++ --set=target.x86_64-unknown-linux-gnu.cxx=/nix/store/a0d7m3zn9p2dfa1h7ag9h2wzzr2w25sn-gcc-wrapper-14.2.1.20250322/bin/c++ --set=target.thumbv8m.main-none-eabi.cxx=/nix/store/wnnwk5vknch7d8jy3cdykbsnn5qrmjj3-armv8m-unknown-none-eabi-gcc-wrapper-14.2.1.20250322/bin/armv8m-unknown-none-eabi-c++ --set=target.x86_64-unknown-linux-gnu.crt-static=false --set=target.x86_64-unknown-linux-gnu.crt-static=false --set=target.thumbv8m.main-none-eabi.crt-static=false --enable-llvm-link-shared --set=target.x86_64-unknown-linux-gnu.llvm-config=/nix/store/bw1i8r1ilp79xyybr2n633aq3jj1wrrd-llvm-19.1.7-dev/bin/llvm-config --set=target.x86_64-unknown-linux-gnu.llvm-config=/nix/store/bw1i8r1ilp79xyybr2n633aq3jj1wrrd-llvm-19.1.7-dev/bin/llvm-config --set=target.thumbv8m.main-none-eabi.llvm-config=/nix/store/bw1i8r1ilp79xyybr2n633aq3jj1wrrd-llvm-19.1.7-dev/bin/llvm-config --disable-llvm-bitcode-linker --disable-docs
    armv8m-unknown-none-eabi-rustc> configure: processing command line
    armv8m-unknown-none-eabi-rustc> configure:
    armv8m-unknown-none-eabi-rustc> configure: build.configure-args := ['--prefix=/nix/store/wscr78z0s5v2hxx3p1n4qjgj ...
    armv8m-unknown-none-eabi-rustc> configure: install.prefix       := /nix/store/wscr78z0s5v2hxx3p1n4qjgjnds8dm0g-ar ...
    armv8m-unknown-none-eabi-rustc> configure: install.sysconfdir   := /nix/store/wscr78z0s5v2hxx3p1n4qjgjnds8dm0g-ar ...
    armv8m-unknown-none-eabi-rustc> configure: rust.channel         := stable
    armv8m-unknown-none-eabi-rustc> configure: build.rustc          := /nix/store/f9zdz15l2zd408yq7a3bgrj593kpwjqx-ru ...
    armv8m-unknown-none-eabi-rustc> configure: build.cargo          := /nix/store/ygri5mmqmril5ll9lhawa01faa2qhdvd-ca ...
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.cc := /nix/store/a0d7m3zn9p2dfa1h7ag9h ...
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.cc := /nix/store/a0d7m3zn9p2dfa1h7ag9h ...
    armv8m-unknown-none-eabi-rustc> configure: target.thumbv8m.main-none-eabi.cc := /nix/store/wnnwk5vknch7d8jy3cdykb ...
    armv8m-unknown-none-eabi-rustc> configure: target.thumbv8m.main-none-eabi.linker := /nix/store/wnnwk5vknch7d8jy3c ...
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.linker := /nix/store/a0d7m3zn9p2dfa1h7 ...
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.linker := /nix/store/a0d7m3zn9p2dfa1h7 ...
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.cxx := /nix/store/a0d7m3zn9p2dfa1h7ag9 ...
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.cxx := /nix/store/a0d7m3zn9p2dfa1h7ag9 ...
    armv8m-unknown-none-eabi-rustc> configure: target.thumbv8m.main-none-eabi.cxx := /nix/store/wnnwk5vknch7d8jy3cdyk ...
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.crt-static := False
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.crt-static := False
    armv8m-unknown-none-eabi-rustc> configure: target.thumbv8m.main-none-eabi.crt-static := False
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.llvm-config := /nix/store/bw1i8r1ilp79 ...
    armv8m-unknown-none-eabi-rustc> configure: target.x86_64-unknown-linux-gnu.llvm-config := /nix/store/bw1i8r1ilp79 ...
    armv8m-unknown-none-eabi-rustc> configure: target.thumbv8m.main-none-eabi.llvm-config := /nix/store/bw1i8r1ilp79x ...
    armv8m-unknown-none-eabi-rustc> configure: build.tools          := ['rustc', 'rustdoc', 'rust-analyzer-proc-macro ...
    armv8m-unknown-none-eabi-rustc> configure: rust.rpath           := True
    armv8m-unknown-none-eabi-rustc> configure: build.vendor         := True
    armv8m-unknown-none-eabi-rustc> configure: rust.lld             := False
    armv8m-unknown-none-eabi-rustc> configure: build.build          := x86_64-unknown-linux-gnu
    armv8m-unknown-none-eabi-rustc> configure: build.host           := ['x86_64-unknown-linux-gnu']
    armv8m-unknown-none-eabi-rustc> configure: build.target         := ['thumbv8m.main-none-eabi']
    armv8m-unknown-none-eabi-rustc> configure: llvm.link-shared     := True
    armv8m-unknown-none-eabi-rustc> configure: rust.llvm-bitcode-linker := False
    armv8m-unknown-none-eabi-rustc> configure: build.docs           := False
    armv8m-unknown-none-eabi-rustc> configure: profile              := dist
    armv8m-unknown-none-eabi-rustc> Traceback (most recent call last):
    armv8m-unknown-none-eabi-rustc>   File "/build/rustc-1.86.0-src/./src/bootstrap/configure.py", line 762, in <module>
    armv8m-unknown-none-eabi-rustc>     section_order, sections, targets = parse_args(sys.argv[1:])
    armv8m-unknown-none-eabi-rustc>                                        ^^^^^^^^^^^^^^^^^^^^^^^^
    armv8m-unknown-none-eabi-rustc>   File "/build/rustc-1.86.0-src/./src/bootstrap/configure.py", line 446, in parse_args
    armv8m-unknown-none-eabi-rustc>     return parse_example_config(known_args, config)
    armv8m-unknown-none-eabi-rustc>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    armv8m-unknown-none-eabi-rustc>   File "/build/rustc-1.86.0-src/./src/bootstrap/configure.py", line 622, in parse_example_config
    armv8m-unknown-none-eabi-rustc>     configure_file(sections, top_level_keys, targets, config)
    armv8m-unknown-none-eabi-rustc>   File "/build/rustc-1.86.0-src/./src/bootstrap/configure.py", line 709, in configure_file
    armv8m-unknown-none-eabi-rustc>     configure_section(targets[target], section_config[target])
    armv8m-unknown-none-eabi-rustc>   File "/build/rustc-1.86.0-src/./src/bootstrap/configure.py", line 683, in configure_section
    armv8m-unknown-none-eabi-rustc>     raise RuntimeError("failed to find config line for {}".format(key))
    armv8m-unknown-none-eabi-rustc> RuntimeError: failed to find config line for main-none-eabi

This is probably related to
https://github.com/rust-lang/rust/issues/130602 and thus target string should be double-quotted so bootstrap/configure.py can parse it correctly.

Changes tested on x86_64-linux build machine with rustc built for "thumb8vm.main-none-eabi" target.

I did not run nixpkgs-review since it requires a lot of rebuilds:

    [kamil@laptop:~/code/nixpkgs]$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
    ...
    [0/93365 built, 14/630/67964 copied (6868.9/913105.5 MiB), 2214.5/414493.9 MiB DL] fetching Breitbandmessung-3.9.1-linux.deb from https://cache.nixos.org$ git worktree remove -f /home/kamil/.cache/nixpkgs-review/rev-c666dbb7d88a54fe8b709a0ed7459007822f3e63-1/nixpkgs


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and others READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
