### PR TITLE
ci/github-script/commits: fix formatting of diffs

### DIFF
--- a/ci/github-script/commits.js
+++ b/ci/github-script/commits.js
@@ -220,9 +220,9 @@ module.exports = async function ({ github, context, core, dry }) {
         }
 
         core.summary.addRaw('<details><summary>Show diff</summary>')
-        core.summary.addRaw('\n\n```diff', true)
+        core.summary.addRaw('\n\n``````````diff', true)
         core.summary.addRaw(truncated.join('\n'), true)
-        core.summary.addRaw('```', true)
+        core.summary.addRaw('``````````', true)
         core.summary.addRaw('</details>')
       }
 

--- a/ci/github-script/commits.js
+++ b/ci/github-script/commits.js
@@ -220,14 +220,9 @@ module.exports = async function ({ github, context, core, dry }) {
         }
 
         core.summary.addRaw('<details><summary>Show diff</summary>')
-        core.summary.addCodeBlock(
-          truncated
-            .join('\n')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;'),
-          'diff',
-        )
+        core.summary.addRaw('\n\n```diff', true)
+        core.summary.addRaw(truncated.join('\n'), true)
+        core.summary.addRaw('```', true)
         core.summary.addRaw('</details>')
       }
 


### PR DESCRIPTION
In #425789 I "fixed" the code block for diffs in the automated review. Unfortunately, it leads to really strange rendering, for example in https://github.com/NixOS/nixpkgs/pull/426224#pullrequestreview-3031174844.

Should have listened to @MattSturgeon in https://github.com/NixOS/nixpkgs/pull/425789#discussion_r2211299173 - so went with his suggestion now.

## Things done

- [x] Tested in markdown editor preview.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
