### PR TITLE
icecream-sundae: init at v1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27100,6 +27100,12 @@
     githubId = 3992240;
     name = "Elijah Rum";
   };
+  x-zvf = {
+    email = "peter@bohner.me";
+    github = "x-zvf";
+    githubId = 37499690;
+    name = "Peter Bohner";
+  };
   x0ba = {
     name = "x0ba";
     email = "dax@omg.lol";

--- a/pkgs/by-name/ic/icecream-sundae/package.nix
+++ b/pkgs/by-name/ic/icecream-sundae/package.nix
@@ -1,0 +1,57 @@
+{
+  fetchFromGitHub,
+  glib,
+  icecream,
+  lib,
+  libcap_ng,
+  libnl,
+  lzo,
+  meson,
+  ncurses,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  stdenv,
+  zstd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "icecream-sundae";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "JPEWdev";
+    repo = "icecream-sundae";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XFDVkPRwjbJa79lLMeMN78uuHGQRJ8rH10dKipCDjM8=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  buildInputs = [
+    ncurses
+    glib
+    libnl
+    icecream
+    lzo
+    libcap_ng
+    zstd
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  meta = {
+    description = "TUI for monitoring icecream clusters";
+    homepage = "https://github.com/JPEWdev/icecream-sundae/";
+    changelog = "https://github.com/JPEWdev/icecream-sundae/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "icecream-sundae";
+    maintainers = with lib.maintainers; [
+      x-zvf
+    ];
+  };
+})


### PR DESCRIPTION
This PR packages [icecream-sundae](https://github.com/JPEWdev/icecream-sundae), a TUI frontend for monitoring icc/icecream clusters.


## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
