### PR TITLE
deco: fix build

### DIFF
--- a/pkgs/by-name/de/deco/package.nix
+++ b/pkgs/by-name/de/deco/package.nix
@@ -5,17 +5,18 @@
   scsh,
   feh,
   xorg,
+  xdg-user-dirs,
 }:
 
 stdenv.mkDerivation {
   pname = "deco";
-  version = "unstable-2019-04-03";
+  version = "0-unstable-2025-07-07";
 
   src = fetchFromGitHub {
-    owner = "ebzzry";
+    owner = "vedatechnologiesinc";
     repo = "deco";
-    rev = "dd8ec7905bc85d085eb2ee3bddabea451054288c";
-    sha256 = "sha256-/3GeNvWOCRPOYTUbodXDUxR5QVDEyx6x2Jt5PxsPdvk=";
+    rev = "2fd28241ed28c07b9d641061d4e1bf3cacfcc7a0";
+    sha256 = "sha256-kjXEvgYO1p/dX9nXQ3HHcXmJdtxDM6xzKqDQu3yM4Tw=";
   };
 
   installPhase = ''
@@ -28,10 +29,11 @@ stdenv.mkDerivation {
     substituteInPlace $out/bin/deco --replace "/usr/bin/env scsh" "${scsh}/bin/scsh"
     substituteInPlace $out/bin/deco --replace "feh" "${feh}/bin/feh"
     substituteInPlace $out/bin/deco --replace "xdpyinfo" "${xorg.xdpyinfo}/bin/xdpyinfo"
+    substituteInPlace $out/bin/deco --replace "xdg-user-dir" "${xdg-user-dirs}/bin/xdg-user-dir"
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/ebzzry/deco";
+    homepage = "https://github.com/vedatechnologiesinc/deco";
     description = "Simple root image setter";
     license = licenses.mit;
     maintainers = [ maintainers.ebzzry ];

--- a/pkgs/by-name/de/deco/package.nix
+++ b/pkgs/by-name/de/deco/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     owner = "vedatechnologiesinc";
     repo = "deco";
     rev = "2fd28241ed28c07b9d641061d4e1bf3cacfcc7a0";
-    sha256 = "sha256-kjXEvgYO1p/dX9nXQ3HHcXmJdtxDM6xzKqDQu3yM4Tw=";
+    hash = "sha256-kjXEvgYO1p/dX9nXQ3HHcXmJdtxDM6xzKqDQu3yM4Tw=";
   };
 
   installPhase = ''
@@ -26,18 +26,18 @@ stdenv.mkDerivation {
   '';
 
   postFixup = ''
-    substituteInPlace $out/bin/deco --replace "/usr/bin/env scsh" "${scsh}/bin/scsh"
-    substituteInPlace $out/bin/deco --replace "feh" "${feh}/bin/feh"
-    substituteInPlace $out/bin/deco --replace "xdpyinfo" "${xorg.xdpyinfo}/bin/xdpyinfo"
-    substituteInPlace $out/bin/deco --replace "xdg-user-dir" "${xdg-user-dirs}/bin/xdg-user-dir"
+    substituteInPlace $out/bin/deco --replace-fail "/usr/bin/env scsh" "${scsh}/bin/scsh"
+    substituteInPlace $out/bin/deco --replace-fail "feh" "${feh}/bin/feh"
+    substituteInPlace $out/bin/deco --replace-fail "xdpyinfo" "${xorg.xdpyinfo}/bin/xdpyinfo"
+    substituteInPlace $out/bin/deco --replace-fail "xdg-user-dir" "${xdg-user-dirs}/bin/xdg-user-dir"
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/vedatechnologiesinc/deco";
     description = "Simple root image setter";
-    license = licenses.mit;
-    maintainers = [ maintainers.ebzzry ];
-    platforms = platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ebzzry ];
+    platforms = lib.platforms.unix;
     mainProgram = "deco";
   };
 

--- a/pkgs/by-name/sc/scsh/package.nix
+++ b/pkgs/by-name/sc/scsh/package.nix
@@ -31,6 +31,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ scheme48 ];
   configureFlags = [ "--with-scheme48=${scheme48}" ];
+  makeFlags = [
+    "SCHEME48VERSION=${scheme48.version}"
+  ];
 
   passthru.updateScript = unstableGitUpdater { };
 


### PR DESCRIPTION
## Things done
- adjust owner of source
  https://github.com/vedainc/deco/commit/2fd28241ed28c07b9d641061d4e1bf3cacfcc7a0 is committed by the original repo owner.
- update to latest commit at 2025-07-07
- remove `with lib;` pattern.

Resolves #370880

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
