### PR TITLE
espanso-wayland: fix eval on darwin

### DIFF
--- a/pkgs/by-name/es/espanso/package.nix
+++ b/pkgs/by-name/es/espanso/package.nix
@@ -23,13 +23,12 @@
   waylandSupport ? false,
   x11Support ? stdenv.hostPlatform.isLinux,
   testers,
-  espanso,
 }:
 # espanso does not support building with both X11 and Wayland support at the same time
 assert stdenv.hostPlatform.isLinux -> x11Support != waylandSupport;
 assert stdenv.hostPlatform.isDarwin -> !x11Support;
 assert stdenv.hostPlatform.isDarwin -> !waylandSupport;
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "espanso";
   version = "2.2-unstable-2024-05-14";
 
@@ -130,7 +129,7 @@ rustPlatform.buildRustPackage {
       '';
 
   passthru.tests.version = testers.testVersion {
-    package = espanso;
+    package = finalAttrs.finalPackage;
     # remove when updating to a release version
     version = "2.2.1";
   };
@@ -151,4 +150,4 @@ rustPlatform.buildRustPackage {
       Espanso detects when you type a keyword and replaces it while you're typing.
     '';
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2129,7 +2129,6 @@ with pkgs;
   espanso-wayland = espanso.override {
     x11Support = false;
     waylandSupport = true;
-    espanso = espanso-wayland;
   };
 
   f3d_egl = f3d.override { vtk_9 = vtk_9_egl; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2128,7 +2128,7 @@ with pkgs;
 
   espanso-wayland = espanso.override {
     x11Support = false;
-    waylandSupport = true;
+    waylandSupport = !stdenv.hostPlatform.isDarwin;
   };
 
   f3d_egl = f3d.override { vtk_9 = vtk_9_egl; };


### PR DESCRIPTION
Since there is no support for wayland on darwin, just make `espanso-wayland` the same as `espanso` on that platform.

That's better than throwing an assertion error, which breaks CI (or requires ugly workarounds, which we want to get rid of).

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
