### PR TITLE
gcl: remove asserts

### DIFF
--- a/pkgs/development/compilers/gcl/default.nix
+++ b/pkgs/development/compilers/gcl/default.nix
@@ -19,11 +19,6 @@
   libXmu,
 }:
 
-assert stdenv ? cc;
-assert stdenv.cc.isGNU;
-assert stdenv.cc ? libc;
-assert stdenv.cc.libc != null;
-
 stdenv.mkDerivation rec {
   pname = "gcl";
   version = "2.6.14";


### PR DESCRIPTION
These asserts throw on darwin, before `meta.platforms` is checked. This, among many others, makes CI require ugly workarounds.

Upstream says its build requirements are "gcc/clang, ..." - so it seems like these asserts are not required in principle. Also, they are 10 years old.

Wanted to test whether it maybe even builds on darwin, but the packge is marked as broken entirely. Tried updating to latest 2.7.1, but the build didn't succeed for linux either.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
