### PR TITLE
pythonPackages.pylucidio: init at 2.4.0

### DIFF
--- a/pkgs/development/python-modules/pylucidio/default.nix
+++ b/pkgs/development/python-modules/pylucidio/default.nix
@@ -6,25 +6,25 @@
   pyserial,
 }:
 
+let
+  version = "2.4.0";
+  majorMinor = lib.versions.majorMinor version;
+in
 buildPythonPackage rec {
   pname = "pylucidio";
-  version = "2.4";
+  inherit version;
   pyproject = true;
 
   src = fetchzip {
-    url = "https://www.lucid-control.com/wp-content/uploads/Software/LucidControlAPI/PyLucidIo/${version}/pyLucidIo-${version}.zip";
-    hash = "sha256-uIG5f26oXPSpWkqZSq5Voq7hZwUkQ1oQQutpxDYW834=";
+    url = "https://www.lucid-control.com/wp-content/uploads/Software/LucidControlAPI/PyLucidIo/${majorMinor}/pyLucidIo-${majorMinor}.zip";
+    hash = "sha256-//TkFhHQorTRCF1ucLGf0/1B/6thmXWhnB7pwXpw1QE=";
     stripRoot = false;
+    postFetch = ''
+      cd $out
+      tar -xf pylucidio-${version}.tar.gz --strip-components=1
+      rm pylucidio-${version}.tar.gz *.whl
+    '';
   };
-
-  unpackPhase = ''
-    runHook preUnpack
-
-    tar xf $src/pylucidio-${version}*.tar.gz
-    sourceRoot=$(echo pylucidio-${version}*)
-
-    runHook postUnpack
-  '';
 
   build-system = [ pdm-backend ];
 

--- a/pkgs/development/python-modules/pylucidio/default.nix
+++ b/pkgs/development/python-modules/pylucidio/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchzip,
+  pdm-backend,
+  pyserial,
+}:
+
+buildPythonPackage rec {
+  pname = "pylucidio";
+  version = "2.4";
+  pyproject = true;
+
+  src = fetchzip {
+    url = "https://www.lucid-control.com/wp-content/uploads/Software/LucidControlAPI/PyLucidIo/${version}/pyLucidIo-${version}.zip";
+    hash = "sha256-uIG5f26oXPSpWkqZSq5Voq7hZwUkQ1oQQutpxDYW834=";
+    stripRoot = false;
+  };
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    tar xf $src/pylucidio-${version}*.tar.gz
+    sourceRoot=$(echo pylucidio-${version}*)
+
+    runHook postUnpack
+  '';
+
+  build-system = [ pdm-backend ];
+
+  dependencies = [ pyserial ];
+
+  pythonImportsCheck = [ "lucidIo" ];
+
+  meta = {
+    description = "LucidControl USB IO Module Package";
+    homepage = "https://www.lucid-control.com";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kvik ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13137,6 +13137,8 @@ self: super: with self; {
 
   pylsqpack = callPackage ../development/python-modules/pylsqpack { };
 
+  pylucidio = callPackage ../development/python-modules/pylucidio { };
+
   pylutron = callPackage ../development/python-modules/pylutron { };
 
   pylutron-caseta = callPackage ../development/python-modules/pylutron-caseta { };


### PR DESCRIPTION
This module provides a high level interface to the LucidControl USB IO Modules for Python 2.7 and Python 3.x.

WWW: https://www.lucid-control.com

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
