### PR TITLE
vagrant: Fix dangling symlinks build failure

### DIFF
--- a/pkgs/by-name/va/vagrant/package.nix
+++ b/pkgs/by-name/va/vagrant/package.nix
@@ -36,6 +36,7 @@ let
             inherit url hash;
           };
           inherit version;
+          dontCheckForBrokenSymlinks = true;
         };
       }
       // lib.optionalAttrs withLibvirt (import ./gemset_libvirt.nix)


### PR DESCRIPTION
`vagrant` fails to build as of

- #411775

```
ruby3.3-vagrant> Running phase: fixupPhase
ruby3.3-vagrant> shrinking RPATHs of ELF executables and libraries in /nix/store/3dk342zzl3s5v5jgaj4xh0abxq5mabdc-ruby3.3-vagrant-2.4.3
ruby3.3-vagrant> checking for references to /build/ in /nix/store/3dk342zzl3s5v5jgaj4xh0abxq5mabdc-ruby3.3-vagrant-2.4.3...
ruby3.3-vagrant> patching script interpreter paths in /nix/store/3dk342zzl3s5v5jgaj4xh0abxq5mabdc-ruby3.3-vagrant-2.4.3
ruby3.3-vagrant> stripping (with command strip and flags -S -p) in  /nix/store/3dk342zzl3s5v5jgaj4xh0abxq5mabdc-ruby3.3-vagrant-2.4.3/lib /nix/store/3dk342zzl3s5v5jgaj4xh0abxq5mabdc-ruby3.3-vagrant-2.4.3/bin
ruby3.3-vagrant> ERROR: noBrokenSymlinks: the symlink /nix/store/3dk342zzl3s5v5jgaj4xh0abxq5mabdc-ruby3.3-vagrant-2.4.3/nix-support/gem-meta/spec points to /build directory: /build/vagrant-2.4.3/vagrant.gemspec
ruby3.3-vagrant> ERROR: noBrokenSymlinks: found 1 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
```

Fix it by setting `dontCheckForBrokenSymlinks`.

- Fixes #427785.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
