### PR TITLE
catppuccin-papirus-folders: 0-unstable-2023-08-02 -> 0-unstable-2024-08-06

### DIFF
--- a/pkgs/by-name/ca/catppuccin-papirus-folders/package.nix
+++ b/pkgs/by-name/ca/catppuccin-papirus-folders/package.nix
@@ -2,7 +2,9 @@
   stdenvNoCC,
   lib,
   fetchFromGitHub,
+  fetchurl,
   gtk3,
+  getent,
   papirus-icon-theme,
   flavor ? "mocha",
   accent ? "blue",
@@ -31,27 +33,42 @@ let
     "mocha"
   ];
   pname = "catppuccin-papirus-folders";
+
+  # Fetch the papirus-folders script from upstream
+  # Per instructions in the papirus-folders project.
+  papirus-folders-rev = "0f838ee5679229e3a3e97e3b333c222c9e9615b4";
+  papirus-folders-script = fetchurl {
+    url = "https://raw.githubusercontent.com/PapirusDevelopmentTeam/papirus-folders/${papirus-folders-rev}/papirus-folders";
+    sha256 = "sha256-NJpXdf1ymnvQzRwUl3OalLzs3sXWVFTp5jN2B3vtUk0=";
+    executable = true;
+  };
 in
 lib.checkListOfEnum "${pname}: accent colors" validAccents [ accent ] lib.checkListOfEnum
   "${pname}: flavors"
   validFlavors
   [ flavor ]
-
   stdenvNoCC.mkDerivation
   {
     inherit pname;
-    version = "0-unstable-2023-08-02";
+    version = "0-unstable-2024-08-06";
 
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "papirus-folders";
-      rev = "fcf96737fffc343a1bf129732c37d19f2d77fa5c";
-      sha256 = "sha256-3yjIGzN+/moP2OVGDIAy4zPqUroSjx3c2mJjdZGhTsY=";
+      rev = "f83671d17ea67e335b34f8028a7e6d78bca735d7";
+      sha256 = "sha256-FiZdwzsaMhS+5EYTcVU1LVax2H1FidQw97xZklNH2R4=";
     };
 
-    nativeBuildInputs = [ gtk3 ];
+    # This takes a horribly long time, and there's nothing to fixup in
+    # this package.
+    dontFixup = true;
+    nativeBuildInputs = [
+      gtk3
+      getent
+    ];
 
     postPatch = ''
+      cp ${papirus-folders-script} ./papirus-folders
       patchShebangs ./papirus-folders
     '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates `catppuccin-papirus-folders` from [fcf9673](https://github.com/catppuccin/papirus-folders/commit/fcf96737fffc343a1bf129732c37d19f2d77fa5c) to [f83671d](https://github.com/catppuccin/papirus-folders/commit/f83671d17ea67e335b34f8028a7e6d78bca735d7) (latest).

The most important change is the removal of the `papirus-folders` script from upstream.

Upstream now says `fetch it from papirus-folders`, so I'm doing an URL fetch on a specific commit (latest at time of writing) to ensure reproducability.

## Need Help

In this PR I had to set `dontFixup = true`, which is likely undesirable.

Help is requested here. To the best of my awareness [per nixpkgs docs](https://nixos.org/manual/nixpkgs/stable/#ssec-fixup-phase), there are no binaries, man pages, etc. in build output, yet the fixup step locks up. Removing fixup doesn't seem like good practice. So help is requested.

More details here:

- https://github.com/NixOS/nixpkgs/issues/426952

I'm not sure how to debug this, as I've only got 3 days experience with Nix(OS) ***(I haven't even set up my machine fully yet!!)***, so help would be appreciated.

Aside from that, works as expected, if fixup is skipped.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
