### PR TITLE
karakeep: 0.25.0 -> 0.26.0

### DIFF
--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -17,13 +17,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "karakeep";
-  version = "0.25.0";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "karakeep-app";
     repo = "karakeep";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eAiRvesUZIwTaj7CSxtI4rkGlTkgVjbzzwjYaXlhSuo=";
+    hash = "sha256-t5mQmrBrXc1wl5PRCdEHZvIEMxeCokrd0x4YhZU+qE0=";
   };
 
   patches = [
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     };
 
     fetcherVersion = 1;
-    hash = "sha256-yf8A0oZ0Y4A5k7gfinIU02Lbqp/ygyvIBlldS0pv5+0=";
+    hash = "sha256-8NdYEcslo9dxSyJbNWzO81/MrDLO+QyrhQN1hwM0/j4=";
   };
   buildPhase = ''
     runHook preBuild
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
         package = finalAttrs.finalPackage;
         # remove hardcoded version if upstream syncs general version with cli
         # version
-        version = "0.23.0";
+        version = "0.25.0";
       };
     };
     updateScript = nix-update-script { };

--- a/pkgs/by-name/ka/karakeep/patches/dont-lock-pnpm-version.patch
+++ b/pkgs/by-name/ka/karakeep/patches/dont-lock-pnpm-version.patch
@@ -1,6 +1,6 @@
-The Hoarder project uses a very specific version of pnpm (9.0.0-alpha.8) and
-will fail to build with other pnpm versions. Instead of adding this pnpm
-version to nixpkgs, we override this requirement and use the latest v9 release.
+Karakeep uses a specific version of pnpm and will fail to build with other pnpm
+versions. Instead of adding this pnpm version to nixpkgs, we override this
+requirement.
 
 ---
 --- a/package.json
@@ -9,16 +9,8 @@ version to nixpkgs, we override this requirement and use the latest v9 release.
      "turbo": "^2.1.2"
    },
    "prettier": "@karakeep/prettier-config",
--  "packageManager": "pnpm@9.0.0-alpha.8+sha256.a433a59569b00389a951352956faf25d1fdf43b568213fbde591c36274d4bc30",
+-  "packageManager": "pnpm@9.15.9",
 +  "packageManager": "pnpm",
    "pnpm": {
      "patchedDependencies": {
        "xcode@3.0.1": "patches/xcode@3.0.1.patch"
---- a/pnpm-lock.yaml
-+++ b/pnpm-lock.yaml
-@@ -1,4 +1,4 @@
--lockfileVersion: '7.0'
-+lockfileVersion: '9.0'
- 
- settings:
-   autoInstallPeers: true


### PR DESCRIPTION
Upgrade Karakeep to 0.26.0

Release Notes: https://github.com/karakeep-app/karakeep/releases/tag/v0.26.0

I tested this on my homelab with the karkaeep module and it's functional

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
