### PR TITLE
python3Packages.httpx-aiohttp: init at 0.1.8

### DIFF
--- a/pkgs/development/python-modules/httpx-aiohttp/default.nix
+++ b/pkgs/development/python-modules/httpx-aiohttp/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  aiohttp,
+  httpx,
+}:
+
+buildPythonPackage rec {
+  pname = "httpx-aiohttp";
+  version = "0.1.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "karpetrosyan";
+    repo = "httpx-aiohttp";
+    tag = version;
+    hash = "sha256-Fdu8aKsXWggRkc/512OBEiEwWNAajrhjfG/+v4+cows=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "requires = [\"hatchling\", \"hatch-fancy-pypi-readme\"]" \
+      "requires = [\"hatchling\"]"
+  '';
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    aiohttp
+    httpx
+  ];
+
+  pythonImportsCheck = [
+    "httpx_aiohttp"
+  ];
+
+  meta = {
+    description = "Transports for httpx to work atop aiohttp";
+    homepage = "https://github.com/karpetrosyan/httpx-aiohttp/";
+    changelog = "https://github.com/karpetrosyan/httpx-aiohttp/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6701,6 +6701,8 @@ self: super: with self; {
 
   httpx = callPackage ../development/python-modules/httpx { };
 
+  httpx-aiohttp = callPackage ../development/python-modules/httpx-aiohttp { };
+
   httpx-auth = callPackage ../development/python-modules/httpx-auth { };
 
   httpx-ntlm = callPackage ../development/python-modules/httpx-ntlm { };


### PR DESCRIPTION
Used by `python3Packages.groq`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
