### PR TITLE
poetry: skip sandbox-violating test on darwin

### DIFF
--- a/pkgs/by-name/po/poetry/unwrapped.nix
+++ b/pkgs/by-name/po/poetry/unwrapped.nix
@@ -128,24 +128,30 @@ buildPythonPackage rec {
     unset no_proxy
   '';
 
-  disabledTests = [
-    "test_builder_should_execute_build_scripts"
-    "test_env_system_packages_are_relative_to_lib"
-    "test_install_warning_corrupt_root"
-    "test_no_additional_output_in_verbose_mode"
-    "test_project_plugins_are_installed_in_project_folder"
-    "test_application_command_not_found_messages"
-    # PermissionError: [Errno 13] Permission denied: '/build/pytest-of-nixbld/pytest-0/popen-gw3/test_find_poetry_managed_pytho1/.local/share/pypoetry/python/pypy@3.10.8/bin/python'
-    "test_list_poetry_managed"
-    "test_list_poetry_managed"
-    "test_find_all_with_poetry_managed"
-    "test_find_poetry_managed_pythons"
-    # Flaky
-    "test_threading_property_types"
-    "test_threading_single_thread_safe"
-    "test_threading_property_caching"
-    "test_threading_atomic_cached_property_different_instances"
-  ];
+  disabledTests =
+    [
+      "test_builder_should_execute_build_scripts"
+      "test_env_system_packages_are_relative_to_lib"
+      "test_install_warning_corrupt_root"
+      "test_no_additional_output_in_verbose_mode"
+      "test_project_plugins_are_installed_in_project_folder"
+      "test_application_command_not_found_messages"
+      # PermissionError: [Errno 13] Permission denied: '/build/pytest-of-nixbld/pytest-0/popen-gw3/test_find_poetry_managed_pytho1/.local/share/pypoetry/python/pypy@3.10.8/bin/python'
+      "test_list_poetry_managed"
+      "test_list_poetry_managed"
+      "test_find_all_with_poetry_managed"
+      "test_find_poetry_managed_pythons"
+      # Flaky
+      "test_threading_property_types"
+      "test_threading_single_thread_safe"
+      "test_threading_property_caching"
+      "test_threading_atomic_cached_property_different_instances"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Sandbox violation:
+      # PermissionError: [Errno 1] Operation not permitted: '/Library/Frameworks/Python.framework/Versions'
+      "test_find_all"
+    ];
 
   pytestFlagsArray = [
     "-m 'not network'"


### PR DESCRIPTION
This test tries to access the system Python at `/Library/Frameworks/Python.framework`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
