### PR TITLE
Revert "high-tide: fix stream error"

### DIFF
--- a/pkgs/by-name/hi/high-tide/package.nix
+++ b/pkgs/by-name/hi/high-tide/package.nix
@@ -14,7 +14,6 @@
   libsecret,
   libportal,
   nix-update-script,
-  glib-networking,
 }:
 
 python313Packages.buildPythonApplication rec {
@@ -43,7 +42,6 @@ python313Packages.buildPythonApplication rec {
       glib-networking
       libadwaita
       libportal
-      glib-networking
     ]
     ++ (with gst_all_1; [
       gstreamer


### PR DESCRIPTION
Reverts NixOS/nixpkgs#426412

Duplicate of #426459.