### PR TITLE
[Backport release-25.05] solidtime-desktop: init at 0.0.39

### DIFF
--- a/pkgs/by-name/so/solidtime-desktop/package.nix
+++ b/pkgs/by-name/so/solidtime-desktop/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+  electron,
+}:
+
+buildNpmPackage rec {
+  pname = "solidtime-desktop";
+  version = "0.0.39";
+
+  src = fetchFromGitHub {
+    owner = "solidtime-io";
+    repo = "solidtime-desktop";
+    rev = "v${version}";
+    hash = "sha256-d3DPPVo3+NiZWCpk2NkHhlIpfl6JvMaGEdfh70XpkKA=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      copyDesktopItems
+    ];
+
+  npmDepsHash = "sha256-6Fmh4XIfVC+t3WOfKZy1QLRjzZV/Oe0q9LJ/2E34ATU=";
+
+  makeCacheWritable = true;
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+
+  postInstall = ''
+    mkdir -p $out/opt
+    cp -a . $out/opt/solidtime-desktop
+
+    makeWrapper ${lib.getExe electron} $out/bin/solidtime-desktop \
+      --add-flags $out/opt/solidtime-desktop
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "solidtime-desktop";
+      exec = "solidtime-desktop %U";
+      icon = "solidtime-desktop";
+      desktopName = "Solidtime Desktop";
+      comment = meta.description;
+      categories = [ "Utility" ];
+      mimeTypes = [ "x-scheme-handler/solidtime" ];
+      terminal = false;
+    })
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/solidtime-io/solidtime-desktop/releases/tag/${src.rev}";
+    description = "Solidtime Desktop application powered by Electron";
+    homepage = "https://github.com/solidtime-io/solidtime-desktop";
+    license = licenses.agpl3Only;
+    mainProgram = "solidtime-desktop";
+    maintainers = [ maintainers.hensoko ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Backport of #426985 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
