### PR TITLE
cider-2: migrate from AppImage to deb; add update script

### DIFF
--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfree;
     mainProgram = "cider-2";
     maintainers = with lib.maintainers; [
+      amadejkastelic
       itsvic-dev
       l0r3v
     ];

--- a/pkgs/by-name/ci/cider-2/package.nix
+++ b/pkgs/by-name/ci/cider-2/package.nix
@@ -68,6 +68,8 @@ stdenv.mkDerivation rec {
       $out/share/icons/hicolor/256x256/apps/cider.png
   '';
 
+  passthru.updateScript = ./updater.sh;
+
   meta = {
     description = "Powerful music player that allows you listen to your favorite tracks with style";
     homepage = "https://cider.sh";

--- a/pkgs/by-name/ci/cider-2/updater.sh
+++ b/pkgs/by-name/ci/cider-2/updater.sh
@@ -1,0 +1,35 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -I nixpkgs=./. -i bash -p coreutils gnused curl common-updater-scripts nix-prefetch jq
+# shellcheck shell=bash
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+LATEST_DEB=$(curl -s https://repo.cider.sh/apt/pool/main/ | \
+    grep -oP 'cider-v(\d+\.\d+\.\d+)-linux-x64\.deb' | \
+    sort -rV | head -n 1)
+
+if [[ -z "$LATEST_DEB" ]]; then
+  echo "Could not find latest Cider .deb!" >&2
+  exit 1
+fi
+
+NEW_VERSION=$(echo "$LATEST_DEB" | sed -E 's|cider-v([0-9.]+)-linux-x64\.deb|\1|')
+DEB_URL="https://repo.cider.sh/apt/pool/main/${LATEST_DEB}"
+
+OLD_VERSION="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./package.nix)"
+
+echo "comparing versions $OLD_VERSION -> $NEW_VERSION"
+if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
+    echo "Already up to date!"
+    if [[ "${1-default}" != "--deps-only" ]]; then
+      exit 0
+    fi
+fi
+
+cd ../../../..
+
+if [[ "${1-default}" != "--deps-only" ]]; then
+    SHA="$(nix-prefetch-url --quiet --unpack --type sha256 $DEB_URL)"
+    SRI=$(nix --experimental-features nix-command hash to-sri "sha256:$SHA")
+    update-source-version cider-2 "$NEW_VERSION" "$SRI"
+fi


### PR DESCRIPTION
Available repositories: https://repo.cider.sh/

Can't seem to find any changelogs for 3.0.2 version - it seems to only be available as an AppImage. I have tested the app and it seems to work as expected.

Why: It's a pain having to manually download the AppImage binary and add it to nix store on each host.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
