### PR TITLE
vscode-extension-update: Fix usage of experimental Nix features

### DIFF
--- a/pkgs/by-name/vs/vscode-extension-update/vscode_extension_update.py
+++ b/pkgs/by-name/vs/vscode-extension-update/vscode_extension_update.py
@@ -89,16 +89,31 @@ class VSCodeExtensionUpdater:
         """
         Retrieves a raw Nix attribute value.
         """
-        return self.execute_command(["nix", "eval", "--raw", "-f", ".", attribute_path])
+        return self.execute_command([
+            "nix",
+            "--extra-experimental-features",
+            "nix-command",
+            "eval",
+            "--raw",
+            "-f",
+            ".",
+            attribute_path
+        ])
 
     def get_nix_system(self) -> str:
         """
         Retrieves system from Nix.
         """
-        return self._get_nix_attribute("system")
+        return self._get_nix_attribute("stdenv.hostPlatform.system")
 
     def get_supported_nix_systems(self) -> list[str]:
-        nix_config = self.execute_command(["nix", "config", "show"])
+        nix_config = self.execute_command([
+            "nix",
+            "--extra-experimental-features",
+            "nix-command",
+            "config",
+            "show"
+        ])
         system = None
         extra_platforms = []
         for line in nix_config.splitlines():
@@ -120,6 +135,8 @@ class VSCodeExtensionUpdater:
     def _get_nix_vscode_extension_src_hash(self, system: str) -> str:
         url = self.execute_command([
             "nix",
+            "--extra-experimental-features",
+            "nix-command",
             "eval",
             "--raw",
             "-f",
@@ -131,6 +148,8 @@ class VSCodeExtensionUpdater:
         sha256 = self.execute_command(["nix-prefetch-url", url])
         return self.execute_command([
             "nix",
+            "--extra-experimental-features",
+            "nix-command",
             "hash",
             "convert",
             "--to",
@@ -183,6 +202,8 @@ class VSCodeExtensionUpdater:
             return json.loads(
                 self.execute_command([
                     "nix",
+                    "--extra-experimental-features",
+                    "nix-command",
                     "eval",
                     "--json",
                     "-f",


### PR DESCRIPTION
Make sure to consistently use `--extra-experimental-features nix-command` for `nix` calls that use the new Nix CLI throughout the file, so running the updateScript for an extension actually works without enabling this feature system-wide.

Also, the call in `get_nix_system()` was giving me:

```
↪ nix --extra-experimental-features 'nix-command flakes' eval --raw -f . system
error: attribute 'system' in selection path 'system' not found
       Did you mean one of mystem, systemc, systemd, syntex or systemfd?
```

…so I changed it to `stdenv.hostPlatform.system`.

With these changes, `nix-shell maintainers/scripts/update.nix --argstr package vscode-extensions.ethersync.ethersync` works on my system.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
