### PR TITLE
bcu: init at 1.1.119

### DIFF
--- a/pkgs/by-name/bc/bcu/darwin-install.patch
+++ b/pkgs/by-name/bc/bcu/darwin-install.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0d6b915..0a004f7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,4 +32,5 @@ elseif (MACOS)
+         link_directories(${LIBUSB_LIBRARY_DIRS} ${LIBFTDI_LIBRARY_DIRS} ${LIBYAML_LIBRARY_DIRS})
+         target_link_libraries (bcu_mac ${LIBUSB_LIBDIR}/lib${LIBUSB_LIBRARIES}.dylib ${LIBFTDI_LIBDIR}/${LIBFTDI_MODULE_NAME}.dylib ${LIBYAML_LIBDIR}/lib${LIBYAML_LIBRARIES}.dylib -lpthread -lm)
+         execute_process( COMMAND sh ${PROJECT_SOURCE_DIR}/create_version_h.sh ${PROJECT_SOURCE_DIR} )
++        install(TARGETS bcu_mac DESTINATION bin)
+ endif ()

--- a/pkgs/by-name/bc/bcu/package.nix
+++ b/pkgs/by-name/bc/bcu/package.nix
@@ -1,0 +1,63 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  libftdi1,
+  libusb1,
+  libyaml,
+  ncurses,
+  nix-update-script,
+  pkg-config,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bcu";
+  version = "1.1.119";
+
+  src = fetchFromGitHub {
+    owner = "nxp-imx";
+    repo = "bcu";
+    tag = "bcu_${finalAttrs.version}";
+    hash = "sha256-GVnUkIoqHED/9c3Tr4M29DB+t6Q8OPDcxVWKNn/lU/8=";
+  };
+
+  patches = [ ./darwin-install.patch ];
+
+  postPatch = ''
+    substituteInPlace create_version_h.sh \
+      --replace-fail "version=\`git describe --tags --long\`" "version=${finalAttrs.src.tag}"
+  '';
+
+  enableParallelBuilding = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libftdi1
+    libusb1
+    libyaml
+    ncurses
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-pointer-sign -Wno-deprecated-declarations -Wno-switch";
+
+  preFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    ln -sf $out/bin/bcu_mac $out/bin/bcu
+  '';
+
+  meta = {
+    description = "NXP i.MX remote control and power measurement tools";
+    homepage = "https://github.com/nxp-imx/bcu";
+    license = lib.licenses.bsd3;
+    mainProgram = "bcu";
+    maintainers = [ lib.maintainers.jmbaur ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/li/libftdi1/package.nix
+++ b/pkgs/by-name/li/libftdi1/package.nix
@@ -87,6 +87,11 @@ stdenv.mkDerivation {
     cp -r doc/html "$out/share/doc/libftdi1/"
   '';
 
+  preFixup = ''
+    substituteInPlace $out/lib/pkgconfig/libftdi1.pc --replace-fail "libdir=$out/$out/lib" "libdir=$out/lib"
+    substituteInPlace $out/lib/pkgconfig/libftdipp1.pc --replace-fail "libdir=$out/$out/lib" "libdir=$out/lib"
+  '';
+
   meta = with lib; {
     description = "Library to talk to FTDI chips using libusb";
     homepage = "https://www.intra2net.com/en/developer/libftdi/";


### PR DESCRIPTION
bcu is a remote control tool for NXP i.MX boards


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
