### PR TITLE
nginx-ui: init at 2.1.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10573,6 +10573,13 @@
     name = "Hugo Reeves";
     keys = [ { fingerprint = "78C2 E81C 828A 420B 269A  EBC1 49FA 39F8 A7F7 35F9"; } ];
   };
+  huizengek = {
+    email = "25huizengek1@gmail.com";
+    github = "25huizengek1";
+    githubId = 50515369;
+    name = "Bart Oostveen";
+    keys = [ { fingerprint = "EE8C 31D4 55D8 EAA5 3730  395B 3180 5D46 50DE 1EC8"; } ];
+  };
   hulr = {
     github = "hulr";
     githubId = 17255815;

--- a/pkgs/by-name/ng/nginx-ui/package.nix
+++ b/pkgs/by-name/ng/nginx-ui/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nodejs,
+  pnpm_10,
+}:
+
+let
+  pnpm = pnpm_10;
+in
+buildGoModule (finalAttrs: {
+  pname = "nginx-ui";
+  version = "2.1.17";
+
+  src = fetchFromGitHub {
+    owner = "0xJacky";
+    repo = "nginx-ui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jFxklALQqrwDchjTYRTbuexJnQH/cAAMJCEzERKGtZs=";
+  };
+
+  vendorHash = "sha256-ThRV7Z6CM22iYE1uAjVoiDnlCI1+oqyA4t4gyGQEzjk=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X 'github.com/0xJacky/Nginx-UI/settings.buildTime=0'"
+  ];
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 2;
+    hash = "sha256-ozJw9MOJSnNRSKqHBIBsuY9GmbbJm4DGeWOrax3UkmU=";
+    sourceRoot = "${finalAttrs.src.name}/app";
+  };
+
+  pnpmRoot = "app";
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm.configHook
+  ];
+
+  overrideModAttrs = _finalModAttrs: _prevModAttrs: {
+    inherit (finalAttrs) pnpmDeps pnpmRoot;
+  };
+
+  preBuild = ''
+    pushd app
+    pnpm build
+    popd
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Yet another WebUI for Nginx";
+    homepage = "https://github.com/0xJacky/nginx-ui";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ huizengek ];
+    mainProgram = "Nginx-UI";
+  };
+})


### PR DESCRIPTION
- **maintainers: add huizengek**
- **nginx-ui: init at 2.1.17**

Add [nginx-ui](https://github.com/0xJacky/nginx-ui) (closes #426969), and add myself as a maintainer.
Some stuff in this package are a bit hacky, so please do correct me if there is a better way. Let me at least explain the hacks at first:
- `pnpm.configHook` also gets used in the `goModules` derivation after adding it to `nativeBuildInputs`, so I added the `overrideModAttrs` so the build wouldn't error. Since the pnpm dependencies resolve to the same derivation, this shouldn't vendor the pnpm dependencies twice
- According to https://nginxui.com/guide/build.html it is required to specify a `settings.buildTime` in ldflags, so I set that to 0 for reproducibility
- I set `doCheck` to false since tests fail without network access. I'll look into this, because setting `-skip=^TestSonyFlake$` doesn't work.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
