### PR TITLE
fakeroot: add patch to fix crashing on darwin

### DIFF
--- a/pkgs/by-name/fa/fakeroot/package.nix
+++ b/pkgs/by-name/fa/fakeroot/package.nix
@@ -25,17 +25,27 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-2ihdvYRnv2wpZrEikP4hCdshY8Eqarqnw3s9HPb+xKU=";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isLinux [
-    ./einval.patch
+  patches =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      ./einval.patch
 
-    # patches needed for musl libc, borrowed from alpine packaging.
-    # it is applied regardless of the environment to prevent patchrot
-    (fetchpatch {
-      name = "fakeroot-no64.patch";
-      url = "https://git.alpinelinux.org/aports/plain/main/fakeroot/fakeroot-no64.patch?id=f68c541324ad07cc5b7f5228501b5f2ce4b36158";
-      sha256 = "sha256-NCDaB4nK71gvz8iQxlfaQTazsG0SBUQ/RAnN+FqwKkY=";
-    })
-  ];
+      # patches needed for musl libc, borrowed from alpine packaging.
+      # it is applied regardless of the environment to prevent patchrot
+      (fetchpatch {
+        name = "fakeroot-no64.patch";
+        url = "https://git.alpinelinux.org/aports/plain/main/fakeroot/fakeroot-no64.patch?id=f68c541324ad07cc5b7f5228501b5f2ce4b36158";
+        sha256 = "sha256-NCDaB4nK71gvz8iQxlfaQTazsG0SBUQ/RAnN+FqwKkY=";
+      })
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # patch needed to fix execution on macos
+      # TODO: remove when the next release comes out: https://salsa.debian.org/clint/fakeroot/-/merge_requests/34
+      (fetchpatch {
+        name = "fakeroot-fix-macos.patch";
+        url = "https://salsa.debian.org/clint/fakeroot/-/merge_requests/34.diff";
+        hash = "sha256-D5f1bXUaN2YMD/NTx/WIrqDBx/qNHpfLRcPhbdHYLl8=";
+      })
+    ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This adds a [patch](https://salsa.debian.org/clint/fakeroot/-/merge_requests/34/commits) that fixes crashing on macOS.

Essentially https://github.com/Homebrew/homebrew-core/pull/230109 but Nix. Fixes #327311.

```sh
$ nix-shell -p

[nix-shell:~]$ nix run nixpkgs#fakeroot id
dyld[7364]: symbol not found in flat namespace '_fstat$INODE64'
/nix/store/ffk3dds0mjxqj1zb3j7jqmfdh269v8sq-fakeroot-1.37.1.2/bin/fakeroot: line 178:  7364 Abort trap: 6           FAKEROOTKEY=$FAKEROOTKEY DYLD_INSERT_LIBRARIES="$FAKEROOT_LIB" "$@"

[nix-shell:~]$ nix run github:poopsicles/nixpkgs/push-zwxyxtwoxktl#fakeroot id
uid=0(root) gid=0(wheel) groups=0(wheel)
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
