### PR TITLE
odoo{17,18,}: use pyproject = true, update dependency list

### DIFF
--- a/pkgs/by-name/od/odoo/package.nix
+++ b/pkgs/by-name/od/odoo/package.nix
@@ -17,8 +17,7 @@ in
 python.pkgs.buildPythonApplication rec {
   pname = "odoo";
   version = "${odoo_version}.${odoo_release}";
-
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchzip {
     # find latest version on https://nightly.odoo.com/${odoo_version}/nightly/src
@@ -28,22 +27,25 @@ python.pkgs.buildPythonApplication rec {
   };
 
   makeWrapperArgs = [
-    "--prefix"
-    "PATH"
-    ":"
-    "${lib.makeBinPath [
-      wkhtmltopdf
-      rtlcss
-    ]}"
+    "--prefix PATH : ${
+      lib.makeBinPath [
+        wkhtmltopdf
+        rtlcss
+      ]
+    }"
   ];
 
-  propagatedBuildInputs = with python.pkgs; [
+  build-system = with python.pkgs; [
+    setuptools
+    distutils
+  ];
+
+  dependencies = with python.pkgs; [
     asn1crypto
     babel
     cbor2
     chardet
     cryptography
-    distutils
     docutils
     freezegun
     geoip2
@@ -57,6 +59,7 @@ python.pkgs.buildPythonApplication rec {
     markupsafe
     num2words
     ofxparse
+    openpyxl
     passlib
     pillow
     polib

--- a/pkgs/by-name/od/odoo17/package.nix
+++ b/pkgs/by-name/od/odoo17/package.nix
@@ -31,8 +31,7 @@ in
 python.pkgs.buildPythonApplication rec {
   pname = "odoo";
   version = "${odoo_version}.${odoo_release}";
-
-  format = "setuptools";
+  pyproject = true;
 
   # latest release is at https://github.com/odoo/docker/blob/master/17.0/Dockerfile
   src = fetchzip {
@@ -48,23 +47,24 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   makeWrapperArgs = [
-    "--prefix"
-    "PATH"
-    ":"
-    "${lib.makeBinPath [
-      wkhtmltopdf
-      rtlcss
-    ]}"
+    "--prefix PATH : ${
+      lib.makeBinPath [
+        wkhtmltopdf
+        rtlcss
+      ]
+    }"
   ];
 
-  propagatedBuildInputs = with python.pkgs; [
+  build-system = with python.pkgs; [
+    setuptools
+  ];
+
+  dependencies = with python.pkgs; [
     babel
     chardet
     cryptography
     decorator
     docutils-0_17 # sphinx has a docutils requirement >= 18
-    ebaysdk
-    freezegun
     geoip2
     gevent
     greenlet
@@ -102,8 +102,7 @@ python.pkgs.buildPythonApplication rec {
     xlwt
     zeep
 
-    setuptools
-    mock
+    setuptools # pkg_resources is imported during runtime
   ];
 
   # takes 5+ minutes and there are not files to strip

--- a/pkgs/by-name/od/odoo18/package.nix
+++ b/pkgs/by-name/od/odoo18/package.nix
@@ -17,8 +17,7 @@ in
 python.pkgs.buildPythonApplication rec {
   pname = "odoo";
   version = "${odoo_version}.${odoo_release}";
-
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchzip {
     # find latest version on https://nightly.odoo.com/${odoo_version}/nightly/src
@@ -28,22 +27,27 @@ python.pkgs.buildPythonApplication rec {
   };
 
   makeWrapperArgs = [
-    "--prefix"
-    "PATH"
-    ":"
-    "${lib.makeBinPath [
-      wkhtmltopdf
-      rtlcss
-    ]}"
+    "--prefix PATH : ${
+      lib.makeBinPath [
+        wkhtmltopdf
+        rtlcss
+      ]
+    }"
   ];
 
-  propagatedBuildInputs = with python.pkgs; [
+  build-system = with python.pkgs; [
+    setuptools
+    distutils
+  ];
+
+  dependencies = with python.pkgs; [
+    asn1crypto
     babel
+    cbor2
     chardet
     cryptography
     decorator
     docutils
-    distutils
     ebaysdk
     freezegun
     geoip2
@@ -53,10 +57,10 @@ python.pkgs.buildPythonApplication rec {
     jinja2
     libsass
     lxml
-    lxml-html-clean
     markupsafe
     num2words
     ofxparse
+    openpyxl
     passlib
     pillow
     polib
@@ -82,9 +86,6 @@ python.pkgs.buildPythonApplication rec {
     xlsxwriter
     xlwt
     zeep
-
-    setuptools
-    mock
   ];
 
   # takes 5+ minutes and there are not files to strip


### PR DESCRIPTION
This PR migrates the `odoo` packages to using `pyproject = true` instead of the old `format = "setuptools"` functionality.

I updated the dependency list, mainly using the dependency list inside `setup.py`.

`freezegun` was removed: it's only in `tests_require` and we don't run tests
`distutils` was moved to `build-system`
`ebaysdk` was removed: it doesn't seem to be used and it's not listed in `setup.py`
`mock` was removed: it doesn't seem to be used and it's not listed in `setup.py`

I added a comment for `setuptools` about it being required for `pkg_resources`

---

Please do note that I don't use this software, so I can't really tell if I've broken it:
I ran the nixos tests, though.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
