### PR TITLE
contact: init at 1.3.16

### DIFF
--- a/pkgs/by-name/co/contact/package.nix
+++ b/pkgs/by-name/co/contact/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "contact";
+  version = "1.3.16";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pdxlocations";
+    repo = "contact";
+    tag = version;
+    hash = "sha256-buT3c8mcDgzUF9FP/nkvSijaqnyQgD87vQGU73qn3K4=";
+  };
+
+  dependencies = [ python3Packages.meshtastic ];
+
+  build-system = [ python3Packages.poetry-core ];
+
+  meta = {
+    homepage = "https://github.com/pdxlocations/contact";
+    changelog = "https://github.com/pdxlocations/contact/releases/tag/${src.tag}";
+    description = "Console UI for Meshtastic";
+    mainProgram = "contact";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      sarcasticadmin
+    ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

These changes were tested using `SenseCAP Indicator (2.7.0.705515a)` meshtastic hardware over a serial connection.

Additional context around the upstream issue can be found here: https://github.com/pdxlocations/contact/issues/203

~~Utilizing unstable to include fix for writing user config to $HOME instead of scripts parent dir (/nix/store/ in our case): https://github.com/pdxlocations/contact/pull/208~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
