### PR TITLE
nixos/tests/stalwart: split config into separate file

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1331,7 +1331,7 @@ in
   ssh-audit = runTest ./ssh-audit.nix;
   sssd = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd.nix { };
   sssd-ldap = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./sssd-ldap.nix { };
-  stalwart-mail = runTest ./stalwart-mail.nix;
+  stalwart-mail = runTest ./stalwart/stalwart-mail.nix;
   stargazer = runTest ./web-servers/stargazer.nix;
   starship = runTest ./starship.nix;
   stash = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./stash.nix { };

--- a/nixos/tests/stalwart/stalwart-mail-config.nix
+++ b/nixos/tests/stalwart/stalwart-mail-config.nix
@@ -1,0 +1,81 @@
+{ pkgs, lib, ... }:
+
+let
+  certs = import ../common/acme/server/snakeoil-certs.nix;
+  domain = certs.domain;
+in
+{
+  security.pki.certificateFiles = [ certs.ca.cert ];
+
+  services.stalwart-mail = {
+    enable = true;
+    settings = {
+      server.hostname = domain;
+
+      certificate."snakeoil" = {
+        cert = "%{file:${certs.${domain}.cert}}%";
+        private-key = "%{file:${certs.${domain}.key}}%";
+      };
+
+      server.tls = {
+        certificate = "snakeoil";
+        enable = true;
+        implicit = false;
+      };
+
+      server.listener = {
+        "smtp-submission" = {
+          bind = [ "[::]:587" ];
+          protocol = "smtp";
+        };
+
+        "imap" = {
+          bind = [ "[::]:143" ];
+          protocol = "imap";
+        };
+
+        "http" = {
+          bind = [ "[::]:80" ];
+          protocol = "http";
+        };
+      };
+
+      session.auth.mechanisms = "[plain]";
+      session.auth.directory = "'in-memory'";
+      storage.directory = "in-memory";
+
+      storage.data = "rocksdb";
+      storage.fts = "rocksdb";
+      storage.blob = "rocksdb";
+      storage.lookup = "rocksdb";
+
+      session.rcpt.directory = "'in-memory'";
+      queue.outbound.next-hop = "'local'";
+
+      store."rocksdb" = {
+        type = "rocksdb";
+        path = "/var/lib/stalwart-mail/data";
+        compression = "lz4";
+      };
+
+      directory."in-memory" = {
+        type = "memory";
+        principals = [
+          {
+            class = "individual";
+            name = "alice";
+            secret = "foobar";
+            email = [ "alice@${domain}" ];
+          }
+          {
+            class = "individual";
+            name = "bob";
+            secret = "foobar";
+            email = [ "bob@${domain}" ];
+          }
+        ];
+      };
+    };
+  };
+
+}

--- a/nixos/tests/stalwart/stalwart-mail.nix
+++ b/nixos/tests/stalwart/stalwart-mail.nix
@@ -3,9 +3,8 @@
 # - serve this message through IMAP.
 
 let
-  certs = import ./common/acme/server/snakeoil-certs.nix;
+  certs = import ../common/acme/server/snakeoil-certs.nix;
   domain = certs.domain;
-
 in
 { lib, ... }:
 {
@@ -14,78 +13,9 @@ in
   nodes.main =
     { pkgs, ... }:
     {
-      security.pki.certificateFiles = [ certs.ca.cert ];
-
-      services.stalwart-mail = {
-        enable = true;
-        settings = {
-          server.hostname = domain;
-
-          certificate."snakeoil" = {
-            cert = "%{file:${certs.${domain}.cert}}%";
-            private-key = "%{file:${certs.${domain}.key}}%";
-          };
-
-          server.tls = {
-            certificate = "snakeoil";
-            enable = true;
-            implicit = false;
-          };
-
-          server.listener = {
-            "smtp-submission" = {
-              bind = [ "[::]:587" ];
-              protocol = "smtp";
-            };
-
-            "imap" = {
-              bind = [ "[::]:143" ];
-              protocol = "imap";
-            };
-
-            "http" = {
-              bind = [ "[::]:80" ];
-              protocol = "http";
-            };
-          };
-
-          session.auth.mechanisms = "[plain]";
-          session.auth.directory = "'in-memory'";
-          storage.directory = "in-memory";
-
-          storage.data = "rocksdb";
-          storage.fts = "rocksdb";
-          storage.blob = "rocksdb";
-          storage.lookup = "rocksdb";
-
-          session.rcpt.directory = "'in-memory'";
-          queue.outbound.next-hop = "'local'";
-
-          store."rocksdb" = {
-            type = "rocksdb";
-            path = "/var/lib/stalwart-mail/data";
-            compression = "lz4";
-          };
-
-          directory."in-memory" = {
-            type = "memory";
-            principals = [
-              {
-                class = "individual";
-                name = "alice";
-                secret = "foobar";
-                email = [ "alice@${domain}" ];
-              }
-              {
-                class = "individual";
-                name = "bob";
-                secret = "foobar";
-                email = [ "bob@${domain}" ];
-              }
-            ];
-          };
-        };
-      };
+      imports = [
+        ./stalwart-mail-config.nix
+      ];
 
       environment.systemPackages = [
         (pkgs.writers.writePython3Bin "test-smtp-submission" { } ''


### PR DESCRIPTION
NGIpkgs (ngi-nix) is interested in reusing some of the stalwart test's config. Split it into a separate file.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
