### PR TITLE
ocamlPackages.ocsipersist: 1.1.0 → 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocsipersist/default.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/default.nix
@@ -1,23 +1,15 @@
 {
   buildDunePackage,
   ocsipersist-lib,
-  ocsipersist-pgsql,
-  ocsipersist-sqlite,
 }:
 
 buildDunePackage {
   pname = "ocsipersist";
   inherit (ocsipersist-lib) src version;
-  duneVersion = "3";
-
-  buildInputs = [
-    ocsipersist-pgsql
-    ocsipersist-sqlite
-  ];
 
   propagatedBuildInputs = [ ocsipersist-lib ];
 
   meta = ocsipersist-lib.meta // {
-    description = "Persistent key/value storage (for Ocsigen) using multiple backends";
+    description = "Persistent key/value storage for OCaml using multiple backends";
   };
 }

--- a/pkgs/development/ocaml-modules/ocsipersist/lib.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/lib.nix
@@ -8,15 +8,13 @@
 
 buildDunePackage rec {
   pname = "ocsipersist-lib";
-  version = "1.1.0";
-
-  duneVersion = "3";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "ocsipersist";
-    rev = version;
-    sha256 = "sha256:1d6kdcfjvrz0dl764mnyxc477aa57rvmzkg154qc915w2y1nbz9a";
+    tag = version;
+    hash = "sha256-7CKKwJxqxUpCMNs4xGbsMZ6Qud9AnczBStTXS+N21DU=";
   };
 
   buildInputs = [ lwt_ppx ];
@@ -26,6 +24,6 @@ buildDunePackage rec {
     description = "Persistent key/value storage (for Ocsigen) - support library";
     license = lib.licenses.lgpl21Only;
     maintainers = [ lib.maintainers.vbgl ];
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/ocsigen/ocsipersist/";
   };
 }

--- a/pkgs/development/ocaml-modules/ocsipersist/pgsql-config.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/pgsql-config.nix
@@ -1,0 +1,23 @@
+{
+  buildDunePackage,
+  findlib,
+  ocsipersist-pgsql,
+  ocsigen_server,
+  xml-light,
+}:
+
+buildDunePackage {
+  pname = "ocsipersist-pgsql-config";
+  inherit (ocsipersist-pgsql) version src;
+
+  propagatedBuildInputs = [
+    findlib
+    ocsipersist-pgsql
+    ocsigen_server
+    xml-light
+  ];
+
+  meta = ocsipersist-pgsql.meta // {
+    description = "Ocsigen Server configuration file extension for ocsipersist-pgsql";
+  };
+}

--- a/pkgs/development/ocaml-modules/ocsipersist/pgsql.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/pgsql.nix
@@ -1,26 +1,22 @@
 {
   buildDunePackage,
-  ocsipersist-lib,
+  ocsipersist,
   lwt_log,
-  ocsigen_server,
   pgocaml,
   xml-light,
 }:
 
 buildDunePackage {
   pname = "ocsipersist-pgsql";
-  inherit (ocsipersist-lib) version src;
-  duneVersion = "3";
+  inherit (ocsipersist) version src;
 
   propagatedBuildInputs = [
     lwt_log
-    ocsigen_server
-    ocsipersist-lib
+    ocsipersist
     pgocaml
-    xml-light
   ];
 
-  meta = ocsipersist-lib.meta // {
-    description = "Persistent key/value storage (for Ocsigen) using PostgreSQL";
+  meta = ocsipersist.meta // {
+    description = "Persistent key/value storage for OCaml using PostgreSQL";
   };
 }

--- a/pkgs/development/ocaml-modules/ocsipersist/sqlite-config.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/sqlite-config.nix
@@ -1,0 +1,23 @@
+{
+  buildDunePackage,
+  findlib,
+  ocsipersist-sqlite,
+  ocsigen_server,
+  xml-light,
+}:
+
+buildDunePackage {
+  pname = "ocsipersist-sqlite-config";
+  inherit (ocsipersist-sqlite) version src;
+
+  propagatedBuildInputs = [
+    findlib
+    ocsipersist-sqlite
+    ocsigen_server
+    xml-light
+  ];
+
+  meta = ocsipersist-sqlite.meta // {
+    description = "Ocsigen Server configuration file extension for ocsipersist-sqlite";
+  };
+}

--- a/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
@@ -1,26 +1,22 @@
 {
   buildDunePackage,
-  ocsipersist-lib,
+  ocsipersist,
   lwt_log,
   ocaml_sqlite3,
   ocsigen_server,
-  xml-light,
 }:
 
 buildDunePackage {
   pname = "ocsipersist-sqlite";
-  inherit (ocsipersist-lib) version src;
-  duneVersion = "3";
+  inherit (ocsipersist) version src;
 
   propagatedBuildInputs = [
     lwt_log
     ocaml_sqlite3
-    ocsigen_server
-    ocsipersist-lib
-    xml-light
+    ocsipersist
   ];
 
-  meta = ocsipersist-lib.meta // {
-    description = "Persistent key/value storage (for Ocsigen) using SQLite";
+  meta = ocsipersist.meta // {
+    description = "Persistent key/value storage for OCaml using SQLite";
   };
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1514,7 +1514,15 @@ let
 
         ocsipersist-pgsql = callPackage ../development/ocaml-modules/ocsipersist/pgsql.nix { };
 
+        ocsipersist-pgsql-config =
+          callPackage ../development/ocaml-modules/ocsipersist/pgsql-config.nix
+            { };
+
         ocsipersist-sqlite = callPackage ../development/ocaml-modules/ocsipersist/sqlite.nix { };
+
+        ocsipersist-sqlite-config =
+          callPackage ../development/ocaml-modules/ocsipersist/sqlite-config.nix
+            { };
 
         octavius = callPackage ../development/ocaml-modules/octavius { };
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
