### PR TITLE
mkwebfont: init at 0.2.0-alpha10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14725,6 +14725,12 @@
     name = "Loïs Postula";
     keys = [ { fingerprint = "0B4A E7C7 D3B7 53F5 3B3D  774C 3819 3C6A 09C3 9ED1"; } ];
   };
+  lpulley = {
+    email = "loganpulley@pm.me";
+    github = "lpulley";
+    githubId = 7193187;
+    name = "Logan Pulley";
+  };
   lrewega = {
     email = "lrewega@c32.ca";
     github = "lrewega";

--- a/pkgs/by-name/mk/mkwebfont/package.nix
+++ b/pkgs/by-name/mk/mkwebfont/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mkwebfont";
+  version = "0.2.0-alpha10";
+
+  src = fetchFromGitHub {
+    owner = "Lymia";
+    repo = "mkwebfont";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-EN2p8B5bU28p9lRT3uQlwp9DDIskVRvuIFA+M6qPCPY=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-hc1oD3JS4ZJM78SpnRQL65MdG3/y5cByDW0Xa3XXojc=";
+
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+
+  meta = {
+    description = "Simple tool for turning .ttf/.otf files into webfonts";
+    mainProgram = "mkwebfont";
+    homepage = "https://github.com/Lymia/mkwebfont";
+    changelog = "https://github.com/Lymia/mkwebfont/blob/${finalAttrs.src.rev}/RELEASES.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      lpulley
+    ];
+  };
+})


### PR DESCRIPTION
This adds mkwebfont as a package: https://github.com/Lymia/mkwebfont

It is a CLI utility that uses HarfBuzz to subset font files for web hosting. As the README puts it:

> mkwebfont is a simple tool for turning .ttf/.otf files into webfonts for self-hosting, without the complication or lack of flexibility that prepackaged webfonts or hosted webfonts have. It's designed to be an easy one-command solution that doesn't require complicated scripts or specific understanding of .woff2 or fonts to make work.
>
> Like Google Fonts, it splits the fonts into subsets that allows only part of the font to be loaded as needed, usually based on the languages used.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
