### PR TITLE
phpactor: include the `tokenizer` extension

### DIFF
--- a/pkgs/by-name/ph/phpactor/package.nix
+++ b/pkgs/by-name/ph/phpactor/package.nix
@@ -21,7 +21,14 @@ php.buildComposerProject2 (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  php = php.withExtensions ({ all, ... }: with all; [ mbstring ]);
+  php = php.withExtensions (
+    { all, ... }:
+    with all;
+    [
+      mbstring
+      tokenizer
+    ]
+  );
 
   postInstall = ''
     installShellCompletion --cmd phpactor \


### PR DESCRIPTION
Follow up for https://github.com/NixOS/nixpkgs/pull/423274, phpactor depends on the `tokenizer` php extension but it is not explicitely defined in the `phpactor/tolerant-php-parser` package. It is required to define the [`T_*` constants](https://www.php.net/manual/en/tokens.php) that are used in this package.

Trying to run phpactor currently on unstable channel for more than a simple `--version` check results in the following error (I can reproduce with a `nix run nixpkgs-unstable#phpactor -- index:build`)

```
Fatal error: Uncaught Error: Undefined constant "Microsoft\PhpParser\T_CLASS_C" in /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/vendor/phpactor/tolerant-php-parser/src/PhpTokenizer.php:227
Stack trace:
#0 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/vendor/phpactor/tolerant-php-parser/src/TokenStreamProviderFactory.php(12): [constant expression]()
#1 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/vendor/phpactor/tolerant-php-parser/src/Parser.php(170): Microsoft\PhpParser\TokenStreamProviderFactory::GetTokenStreamProvider('<?php\n\ndeclare(...')
#2 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/vendor/phpactor/tolerant-php-parser/src/Parser.php(181): Microsoft\PhpParser\Parser->makeLexer('<?php\n\ndeclare(...')
#3 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/lib/Indexer/Adapter/Tolerant/TolerantIndexBuilder.php(68): Microsoft\PhpParser\Parser->parseSourceFile('<?php\n\ndeclare(...', 'file:///Users/Y...')
#4 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/lib/Indexer/Model/IndexJob.php(32): Phpactor\Indexer\Adapter\Tolerant\TolerantIndexBuilder->index(Object(Phpactor\TextDocument\StandardTextDocument))
#5 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/lib/Indexer/Extension/Command/IndexBuildCommand.php(85): Phpactor\Indexer\Model\IndexJob->generator()
#6 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/lib/Indexer/Extension/Command/IndexBuildCommand.php(56): Phpactor\Indexer\Extension\Command\IndexBuildCommand->buildIndex(Object(Symfony\Component\Console\Output\ConsoleOutput), NULL)
#7 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/vendor/symfony/console/Command/Command.php(326): Phpactor\Indexer\Extension\Command\IndexBuildCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/vendor/symfony/console/Application.php(1078): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(Phpactor\Indexer\Extension\Command\IndexBuildCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/lib/Application.php(48): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/vendor/symfony/console/Application.php(175): Phpactor\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/bin/phpactor(46): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 {main}
  thrown in /nix/store/wz0a2h6r6xms8l9xgjfw7wnm89z55h4f-phpactor-2025.04.17.0/share/php/phpactor/vendor/phpactor/tolerant-php-parser/src/PhpTokenizer.php on line 227
```

With the changes the language server works as expected 👍 

```
$: phpactor index:build
Building job...done
Building index:

  1208/43337 [>---------------------------]   2% 3 secs/1 min, 48 secs 131/1,611 mb
```

## Things done

Added the `tokenizer` extension on top of `mbstring` :+1:

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
