### PR TITLE
POC: automated linting of nixpkgs with rules files

### DIFF
--- a/maintainers/lint/README.md
+++ b/maintainers/lint/README.md
@@ -1,0 +1,120 @@
+# Nixpkgs Tree-Sitter Linting
+
+This directory contains tree-sitter based linting rules for nixpkgs, powered by [ast-grep](https://ast-grep.github.io/).
+
+## Directory Structure
+
+```
+lint/
+├── sgconfig.yml       # ast-grep project configuration
+├── rules/            # Linting rules by category
+│   ├── pkgs/         # Rules for packages
+│   ├── general/      # General Nix/nixpkgs rules
+│   ├── nixos/        # Rules for NixOS modules
+│   └── experimental/ # Rules under development
+├── tests/            # Test cases for rules
+│   └── <category>/   # Mirrors rules structure
+├── utils/            # Reusable YAML rule snippets
+└── README.md         # This file
+```
+
+## Running the Linter
+
+### Locally
+```bash
+# Run ast-grep directly on specific files
+./maintainers/lint/ast-grep scan <files>
+
+# Run with auto-fix
+./maintainers/lint/ast-grep scan --fix <files>
+
+# Run specific rule
+./maintainers/lint/ast-grep scan --rule maintainers/lint/rules/pkgs/meta-description-required.yaml <files>
+```
+
+### In CI
+
+TODO
+
+## Writing New Rules
+
+### Quick Start
+```bash
+# Create a new rule using ast-grep's built-in command
+./ast-grep new
+
+# Test your rule
+./ast-grep test tests/<category>/<rule-name>-test.yaml
+```
+
+### Rule Format
+Rules are written in YAML using ast-grep's pattern syntax:
+
+```yaml
+id: rule-name
+language: nix
+message: Brief description of the issue
+severity: error  # or warning, info
+rule:
+  pattern: |
+    # Tree-sitter pattern to match
+note: |
+  Detailed explanation and how to fix
+metadata:
+  category: correctness  # or style, performance, security
+```
+
+### Debugging Rules
+To understand the AST structure of Nix code, use ast-grep's debug feature:
+
+```bash
+# Show the AST structure for a code snippet
+ast-grep -p "buildInputs = [ pkg-config ]" -l nix --debug-query=sexp
+
+# Example output:
+# (source_code expression: (apply_expression function: (variable_expression name: (identifier)) ...))
+```
+
+This helps you write accurate patterns by showing the exact tree-sitter node types and structure.
+
+### Using Utility Rules
+Common patterns can be defined in `utils/` and referenced:
+
+```yaml
+rule:
+  pattern: |
+    buildInputs = $LIST
+  has:
+    metavariable: LIST
+    has:
+      matches: is-native-build-tool  # References utils/common-patterns.yml
+```
+
+### Testing Rules
+Create a test file in `tests/<category>/<rule-name>-test.yaml`:
+
+```yaml
+id: rule-name
+valid:
+  - |
+    # Code that should NOT trigger the rule
+    { }
+invalid:
+  - |
+    # Code that SHOULD trigger the rule
+    { }
+```
+
+## Contributing
+
+1. Create a new rule in the appropriate category
+2. Add comprehensive tests
+3. Run `ast-grep test` to verify
+4. Submit PR with clear rationale
+5. Rules typically start in experimental and graduate after review
+
+## Resources
+
+- [ast-grep documentation](https://ast-grep.github.io/)
+- [tree-sitter-nix grammar](https://github.com/nix-community/tree-sitter-nix)
+- [Nixpkgs manual](https://nixos.org/manual/nixpkgs/stable/)

--- a/maintainers/lint/ast-grep
+++ b/maintainers/lint/ast-grep
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo="$(git rev-parse --show-toplevel)"
+ast_grep=$(nix-build "$repo" --no-out-link -A ast-grep)/bin/ast-grep
+exec $ast_grep --config "$(dirname "${BASH_SOURCE[0]}")/sgconfig.yml" "$@"

--- a/maintainers/lint/rules/pkgs/native-build-tools-in-build-inputs.yaml
+++ b/maintainers/lint/rules/pkgs/native-build-tools-in-build-inputs.yaml
@@ -1,0 +1,184 @@
+id: native-build-tools-in-build-inputs
+language: nix
+message: Build tools (pkg-config, cmake, meson, etc.) must be in nativeBuildInputs, not buildInputs
+severity: error
+rule:
+  kind: binding
+  all:
+    - has:
+        field: attrpath
+        has:
+          kind: identifier
+          pattern: buildInputs
+    - has:
+        field: expression
+        kind: list_expression
+        has:
+          kind: variable_expression
+          has:
+            field: name
+            any:
+              # Package configuration tools
+              - pattern: pkg-config
+              - pattern: pkgconfig
+              - pattern: pkgconf
+
+              # Build systems
+              - pattern: cmake
+              - pattern: cmakeMinimal
+              - pattern: meson
+              - pattern: ninja
+              - pattern: scons
+              - pattern: bazel
+              - pattern: gnumake
+              - pattern: bmake
+              - pattern: jam
+              - pattern: qmake
+              - pattern: bear
+
+              # Autotools and related
+              - pattern: autoreconfHook
+              - pattern: autoreconfHook269
+              - pattern: autoreconfHook213
+              - pattern: autoconf
+              - pattern: autoconf269
+              - pattern: autoconf213
+              - pattern: automake
+              - pattern: libtool
+              - pattern: intltool
+              - pattern: autoPatchelfHook
+
+              # Compiler toolchains
+              - pattern: cargo
+              - pattern: rustc
+              - pattern: rustPlatform.buildRustPackage
+              - pattern: go
+              - pattern: buildGoModule
+              - pattern: buildGoPackage
+              - pattern: ghc
+              - pattern: cabal-install
+              - pattern: stack
+              - pattern: dotnet-sdk
+              - pattern: dotnet-sdk_7
+              - pattern: dotnet-sdk_8
+              - pattern: mono
+              - pattern: fsharp
+              - pattern: javac
+              - pattern: ant
+              - pattern: maven
+              - pattern: gradle
+
+              # Wrappers and hooks
+              - pattern: makeWrapper
+              - pattern: makeBinaryWrapper
+              - pattern: wrapGAppsHook
+              - pattern: wrapGAppsHook3
+              - pattern: wrapGAppsHook4
+              - pattern: wrapQtAppsHook
+              - pattern: wrapProgram
+
+              # Desktop and icon tools
+              - pattern: desktop-file-utils
+              - pattern: copyDesktopItems
+              - pattern: makeDesktopItem
+              - pattern: icoutils
+              - pattern: imagemagick
+              - pattern: inkscape # when used for icon generation
+
+              # Localization and internationalization
+              - pattern: po4a
+              - pattern: msgfmt
+              # Note: gettext is excluded as it provides runtime libraries too
+
+              # Documentation generators
+              - pattern: doxygen
+              - pattern: gtk-doc
+              - pattern: gi-docgen
+              - pattern: sphinx
+              - pattern: help2man
+              - pattern: texinfo
+              - pattern: groff
+              - pattern: mandoc
+              - pattern: ronn
+              - pattern: scdoc
+              - pattern: asciidoc
+              - pattern: asciidoctor
+              - pattern: pandoc
+              - pattern: docbook_xsl
+              - pattern: docbook_xml_dtd_42
+              - pattern: docbook_xml_dtd_43
+              - pattern: docbook_xml_dtd_44
+              - pattern: docbook_xml_dtd_45
+              - pattern: docbook5
+              - pattern: xmlto
+
+              # Parser and lexer generators
+              - pattern: bison
+              - pattern: flex
+              - pattern: yacc
+              - pattern: antlr
+              - pattern: ragel
+              - pattern: re2c
+              - pattern: lemon
+
+              # File manipulation and analysis tools
+              - pattern: patchelf
+              - pattern: fixDarwinDylibNames
+              - pattern: nukeReferences
+              - pattern: removeReferencesTo
+              - pattern: installShellFiles
+              - pattern: substituteAll
+              - pattern: substituteAllFiles
+              - pattern: install_name_tool
+              - pattern: dos2unix
+              - pattern: unix2dos
+
+              # Code and protocol generators
+              - pattern: m4
+              - pattern: gnum4
+              - pattern: protobuf
+              - pattern: protoc-gen-go
+              - pattern: protoc-gen-grpc
+              - pattern: qt5.qttools
+              - pattern: qt6.qttools
+              - pattern: moc
+              - pattern: uic
+              - pattern: rcc
+              - pattern: sass
+              - pattern: sassc
+              - pattern: less
+              - pattern: lessc
+              - pattern: wayland-scanner
+              - pattern: glib-compile-schemas
+              - pattern: glib-compile-resources
+
+              # Testing frameworks (when used for build-time tests)
+              - pattern: check
+              - pattern: dejagnu
+              - pattern: cppunit
+              - pattern: gtest
+              - pattern: catch2
+              - pattern: cmocka
+
+              # Build utilities
+              - pattern: file
+              - pattern: bintools
+              - pattern: binutils
+              - pattern: elfutils
+              - pattern: patchutils
+              - pattern: chrpath
+              - pattern: cpio
+              - pattern: rpm
+              - pattern: dpkg
+              - pattern: fakeroot
+              - pattern: fakechroot
+files:
+  - pkgs/**/*.nix
+note: |
+  Move build tools from buildInputs to nativeBuildInputs for cross-compilation.
+
+    nativeBuildInputs = [ cmake pkg-config ];  # ← Build tools here
+    buildInputs = [ libfoo gtk3 ];             # ← Runtime deps here
+metadata:
+  category: correctness
+  documentation: https://nixos.org/manual/nixpkgs/stable/#ssec-stdenv-dependencies

--- a/maintainers/lint/sgconfig.yml
+++ b/maintainers/lint/sgconfig.yml
@@ -1,0 +1,10 @@
+# ast-grep configuration for nixpkgs linting
+# Documentation: https://ast-grep.github.io/reference/sgconfig.html
+ruleDirs:
+  - rules/pkgs
+  - rules/general
+  - rules/nixos
+  - rules/experimental
+
+testConfigs:
+  - testDir: tests

--- a/maintainers/lint/tests/__snapshots__/native-build-tools-in-build-inputs-snapshot.yml
+++ b/maintainers/lint/tests/__snapshots__/native-build-tools-in-build-inputs-snapshot.yml
@@ -1,0 +1,299 @@
+id: native-build-tools-in-build-inputs
+snapshots:
+  ? |
+    # Wrong: Go compiler in buildInputs
+    {
+      buildInputs = [ go libfoo ];
+    }
+  : labels:
+      - source: buildInputs = [ go libfoo ];
+        style: primary
+        start: 40
+        end: 68
+      - source: buildInputs
+        style: secondary
+        start: 40
+        end: 51
+      - source: buildInputs
+        style: secondary
+        start: 40
+        end: 51
+      - source: go
+        style: secondary
+        start: 56
+        end: 58
+      - source: go
+        style: secondary
+        start: 56
+        end: 58
+      - source: '[ go libfoo ]'
+        style: secondary
+        start: 54
+        end: 67
+  ? |
+    # Wrong: Go compiler in buildInputs
+    {
+      nativeBuildInputs = [ cmake ];
+      buildInputs = [ go libfoo ];
+    }
+  : labels:
+      - source: buildInputs = [ go libfoo ];
+        style: primary
+        start: 73
+        end: 101
+      - source: buildInputs
+        style: secondary
+        start: 73
+        end: 84
+      - source: buildInputs
+        style: secondary
+        start: 73
+        end: 84
+      - source: go
+        style: secondary
+        start: 89
+        end: 91
+      - source: go
+        style: secondary
+        start: 89
+        end: 91
+      - source: '[ go libfoo ]'
+        style: secondary
+        start: 87
+        end: 100
+  ? |
+    # Wrong: Rust toolchain in buildInputs
+    {
+      buildInputs = [ cargo rustc ];
+    }
+  : labels:
+      - source: buildInputs = [ cargo rustc ];
+        style: primary
+        start: 43
+        end: 73
+      - source: buildInputs
+        style: secondary
+        start: 43
+        end: 54
+      - source: buildInputs
+        style: secondary
+        start: 43
+        end: 54
+      - source: cargo
+        style: secondary
+        start: 59
+        end: 64
+      - source: cargo
+        style: secondary
+        start: 59
+        end: 64
+      - source: '[ cargo rustc ]'
+        style: secondary
+        start: 57
+        end: 72
+  ? |
+    # Wrong: autoreconfHook in buildInputs
+    {
+      buildInputs = [ autoreconfHook automake libtool ];
+    }
+  : labels:
+      - source: buildInputs = [ autoreconfHook automake libtool ];
+        style: primary
+        start: 43
+        end: 93
+      - source: buildInputs
+        style: secondary
+        start: 43
+        end: 54
+      - source: buildInputs
+        style: secondary
+        start: 43
+        end: 54
+      - source: autoreconfHook
+        style: secondary
+        start: 59
+        end: 73
+      - source: autoreconfHook
+        style: secondary
+        start: 59
+        end: 73
+      - source: '[ autoreconfHook automake libtool ]'
+        style: secondary
+        start: 57
+        end: 92
+  ? |
+    # Wrong: cmake in buildInputs
+    {
+      buildInputs = [ cmake libfoo ];
+    }
+  : labels:
+      - source: buildInputs = [ cmake libfoo ];
+        style: primary
+        start: 34
+        end: 65
+      - source: buildInputs
+        style: secondary
+        start: 34
+        end: 45
+      - source: buildInputs
+        style: secondary
+        start: 34
+        end: 45
+      - source: cmake
+        style: secondary
+        start: 50
+        end: 55
+      - source: cmake
+        style: secondary
+        start: 50
+        end: 55
+      - source: '[ cmake libfoo ]'
+        style: secondary
+        start: 48
+        end: 64
+  ? |
+    # Wrong: documentation tools in buildInputs
+    {
+      buildInputs = [ doxygen help2man pandoc ];
+    }
+  : labels:
+      - source: buildInputs = [ doxygen help2man pandoc ];
+        style: primary
+        start: 48
+        end: 90
+      - source: buildInputs
+        style: secondary
+        start: 48
+        end: 59
+      - source: buildInputs
+        style: secondary
+        start: 48
+        end: 59
+      - source: doxygen
+        style: secondary
+        start: 64
+        end: 71
+      - source: doxygen
+        style: secondary
+        start: 64
+        end: 71
+      - source: '[ doxygen help2man pandoc ]'
+        style: secondary
+        start: 62
+        end: 89
+  ? |
+    # Wrong: makeWrapper in buildInputs
+    {
+      buildInputs = [ makeWrapper gtk3 ];
+    }
+  : labels:
+      - source: buildInputs = [ makeWrapper gtk3 ];
+        style: primary
+        start: 40
+        end: 75
+      - source: buildInputs
+        style: secondary
+        start: 40
+        end: 51
+      - source: buildInputs
+        style: secondary
+        start: 40
+        end: 51
+      - source: makeWrapper
+        style: secondary
+        start: 56
+        end: 67
+      - source: makeWrapper
+        style: secondary
+        start: 56
+        end: 67
+      - source: '[ makeWrapper gtk3 ]'
+        style: secondary
+        start: 54
+        end: 74
+  ? "# Wrong: multiple build tools in buildInputs\n{\n  buildInputs = [ \n    meson\n    ninja\n    pkg-config\n    libfoo \n  ];\n}\n"
+  : labels:
+      - source: "buildInputs = [ \n    meson\n    ninja\n    pkg-config\n    libfoo \n  ];"
+        style: primary
+        start: 49
+        end: 117
+      - source: buildInputs
+        style: secondary
+        start: 49
+        end: 60
+      - source: buildInputs
+        style: secondary
+        start: 49
+        end: 60
+      - source: meson
+        style: secondary
+        start: 70
+        end: 75
+      - source: meson
+        style: secondary
+        start: 70
+        end: 75
+      - source: "[ \n    meson\n    ninja\n    pkg-config\n    libfoo \n  ]"
+        style: secondary
+        start: 63
+        end: 116
+  ? |
+    # Wrong: pkg-config in buildInputs
+    {
+      buildInputs = [ pkg-config ];
+    }
+  : labels:
+      - source: buildInputs = [ pkg-config ];
+        style: primary
+        start: 39
+        end: 68
+      - source: buildInputs
+        style: secondary
+        start: 39
+        end: 50
+      - source: buildInputs
+        style: secondary
+        start: 39
+        end: 50
+      - source: pkg-config
+        style: secondary
+        start: 55
+        end: 65
+      - source: pkg-config
+        style: secondary
+        start: 55
+        end: 65
+      - source: '[ pkg-config ]'
+        style: secondary
+        start: 53
+        end: 67
+  ? |-
+    # Wrong: wrappers in buildInputs
+    {
+      buildInputs = [ wrapGAppsHook wrapQtAppsHook libgtk ];
+    }
+  : labels:
+      - source: buildInputs = [ wrapGAppsHook wrapQtAppsHook libgtk ];
+        style: primary
+        start: 37
+        end: 91
+      - source: buildInputs
+        style: secondary
+        start: 37
+        end: 48
+      - source: buildInputs
+        style: secondary
+        start: 37
+        end: 48
+      - source: wrapGAppsHook
+        style: secondary
+        start: 53
+        end: 66
+      - source: wrapGAppsHook
+        style: secondary
+        start: 53
+        end: 66
+      - source: '[ wrapGAppsHook wrapQtAppsHook libgtk ]'
+        style: secondary
+        start: 51
+        end: 90

--- a/maintainers/lint/tests/pkgs/native-build-tools-in-build-inputs-test.yaml
+++ b/maintainers/lint/tests/pkgs/native-build-tools-in-build-inputs-test.yaml
@@ -1,0 +1,87 @@
+id: native-build-tools-in-build-inputs
+valid:
+  - |
+    # Correct: build tools in nativeBuildInputs
+    {
+      nativeBuildInputs = [ pkg-config cmake meson ];
+      buildInputs = [ libfoo libbar ];
+    }
+  - |
+    # Correct: empty buildInputs
+    {
+      buildInputs = [ ];
+    }
+  - |
+    # Correct: buildInputs with only runtime dependencies
+    {
+      buildInputs = [ gtk3 qt5 libxml2 ];
+    }
+  - |
+    # Correct: various build tools in nativeBuildInputs
+    {
+      nativeBuildInputs = [
+        autoreconfHook
+        makeWrapper
+        desktop-file-utils
+        cargo
+      ];
+      buildInputs = [ boost python3 ];  # python3 is OK in buildInputs now
+    }
+
+invalid:
+  - |
+    # Wrong: pkg-config in buildInputs
+    {
+      buildInputs = [ pkg-config ];
+    }
+  - |
+    # Wrong: cmake in buildInputs
+    {
+      buildInputs = [ cmake libfoo ];
+    }
+  - |
+    # Wrong: multiple build tools in buildInputs
+    {
+      buildInputs = [
+        meson
+        ninja
+        pkg-config
+        libfoo
+      ];
+    }
+  - |
+    # Wrong: Go compiler in buildInputs
+    {
+      nativeBuildInputs = [ cmake ];
+      buildInputs = [ go libfoo ];
+    }
+  - |
+    # Wrong: makeWrapper in buildInputs
+    {
+      buildInputs = [ makeWrapper gtk3 ];
+    }
+  - |
+    # Wrong: autoreconfHook in buildInputs
+    {
+      buildInputs = [ autoreconfHook automake libtool ];
+    }
+  - |
+    # Wrong: Go compiler in buildInputs
+    {
+      buildInputs = [ go libfoo ];
+    }
+  - |
+    # Wrong: Rust toolchain in buildInputs
+    {
+      buildInputs = [ cargo rustc ];
+    }
+  - |
+    # Wrong: documentation tools in buildInputs
+    {
+      buildInputs = [ doxygen help2man pandoc ];
+    }
+  - |
+    # Wrong: wrappers in buildInputs
+    {
+      buildInputs = [ wrapGAppsHook wrapQtAppsHook libgtk ];
+    }

--- a/pkgs/by-name/as/ast-grep/package.nix
+++ b/pkgs/by-name/as/ast-grep/package.nix
@@ -11,13 +11,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ast-grep";
-  version = "0.38.6";
+  version = "0.39.1";
 
   src = fetchFromGitHub {
     owner = "ast-grep";
     repo = "ast-grep";
     tag = finalAttrs.version;
-    hash = "sha256-bgJzu7n/Qy0JAJ19VRXCvMtZBM/wZkQKT9AAXvIg5Ms=";
+    hash = "sha256-LZ83PlIEC1Is5Fo7GMglLgYg0+acJcFc1yeaF2Yrs1I=";
   };
 
   # error: linker `aarch64-linux-gnu-gcc` not found
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-TVPI3394elxDzn/8S4hDkVounWI6bo6vpZeYJJzDOr4=";
+  cargoHash = "sha256-HXuU+B25+Cy8cLM2cNhwqcm/Wt3JS3aGKIKgGpttek8=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
## Motivation

In this POC I'm exploring how we could convert linting rules from documentation to code.

There is prior art such as nixpkgs-vet, nixpkgs-hammer, etc... The difference here is that the rules would live in rule files, sitting in nixpkgs. By having them here, it makes it easy to understand, discuss and evolve them alongside the code.

[ast-grep](https://ast-grep.github.io/) is a tool that allows doing just that for any language that can be parsed with tree-sitter. That means we can also use it to set rules for accompanying Bash and Python scripts. Another nice thing is the support for auto-fixing rules, if the rule author can express the fix automatically.

In this POC I just put down the base structure to demonstrate the capabilities. Something production-ready would also integrate with the CI, linting only the changed files, and post comments for errors it encounters.

Before moving further, I'd like to get some feedback. I am not aware of all the ongoing plans and how this would fit in the big picture. /cc @NixOS/nixpkgs-ci team and also @SuperSandro2000 that cares about linting a lot.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
