### PR TITLE
do-agent: remove yvt from maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27996,12 +27996,6 @@
     githubId = 65394961;
     name = "Yves Straten";
   };
-  yvt = {
-    email = "i@yvt.jp";
-    github = "yvt";
-    githubId = 5253988;
-    name = "yvt";
-  };
   yzx9 = {
     email = "yuan.zx@outlook.com";
     github = "yzx9";

--- a/pkgs/by-name/do/do-agent/package.nix
+++ b/pkgs/by-name/do/do-agent/package.nix
@@ -37,7 +37,7 @@ buildGoModule rec {
     '';
     homepage = "https://github.com/digitalocean/do-agent";
     license = licenses.asl20;
-    maintainers = with maintainers; [ yvt ];
+    maintainers = [ ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
I'm migrating from DigitalOcean, so I won't be able to test do-agent (DigitalOcean droplet system metrics agent).