### PR TITLE
libheif: use absolute binary path in thumbnailer file

### DIFF
--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
   # add support for more image formats
   env.GDK_PIXBUF_MODULE_FILE = gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
     extraLoaders = [
-      libheif.out
+      libheif.lib
       libjxl
       librsvg
       webp-pixbuf-loader

--- a/pkgs/by-name/eo/eog/package.nix
+++ b/pkgs/by-name/eo/eog/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
           libjxl
           librsvg
           webp-pixbuf-loader
-          libheif.out
+          libheif.lib
         ];
       }
     }"

--- a/pkgs/by-name/li/libheif/package.nix
+++ b/pkgs/by-name/li/libheif/package.nix
@@ -60,6 +60,12 @@ stdenv.mkDerivation rec {
   # Fix installation path for gdk-pixbuf module
   PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = "${placeholder "lib"}/${gdk-pixbuf.moduleDir}";
 
+  postInstall = ''
+    substituteInPlace $out/share/thumbnailers/heif.thumbnailer \
+      --replace-fail "TryExec=heif-thumbnailer" "TryExec=$bin/bin/heif-thumbnailer" \
+      --replace-fail "Exec=heif-thumbnailer" "Exec=$bin/bin/heif-thumbnailer"
+  '';
+
   # Wrong include path in .cmake.  It's a bit difficult to patch because of special characters.
   postFixup = ''
     sed '/^  INTERFACE_INCLUDE_DIRECTORIES/s|"[^"]*/include"|"${placeholder "dev"}/include"|' \

--- a/pkgs/by-name/li/libheif/package.nix
+++ b/pkgs/by-name/li/libheif/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     "out"
     "dev"
     "man"
+    "lib"
   ];
 
   src = fetchFromGitHub {
@@ -57,7 +58,7 @@ stdenv.mkDerivation rec {
   ];
 
   # Fix installation path for gdk-pixbuf module
-  PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = "${placeholder "out"}/${gdk-pixbuf.moduleDir}";
+  PKG_CONFIG_GDK_PIXBUF_2_0_GDK_PIXBUF_MODULEDIR = "${placeholder "lib"}/${gdk-pixbuf.moduleDir}";
 
   # Wrong include path in .cmake.  It's a bit difficult to patch because of special characters.
   postFixup = ''

--- a/pkgs/by-name/sh/shotwell/package.nix
+++ b/pkgs/by-name/sh/shotwell/package.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     export GDK_PIXBUF_MODULE_FILE="${
       gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
         extraLoaders = [
-          libheif.out
+          libheif.lib
         ];
       }
     }"

--- a/pkgs/desktops/xfce/applications/ristretto/default.nix
+++ b/pkgs/desktops/xfce/applications/ristretto/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     export GDK_PIXBUF_MODULE_FILE="${
       gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
         extraLoaders = [
-          libheif.out
+          libheif.lib
           libjxl
           librsvg
           webp-pixbuf-loader


### PR DESCRIPTION
Fixes #377661

Requires adding a `lib` output to enable referencing the `bin` output from `out` without creating a circular dependency between the outputs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
