### PR TITLE
darktable: fix build by using Saxon XSLT processor

### DIFF
--- a/pkgs/by-name/da/darktable/package.nix
+++ b/pkgs/by-name/da/darktable/package.nix
@@ -120,7 +120,7 @@ stdenv.mkDerivation rec {
       lensfun
       lerc
       libaom
-      libavif
+      #libavif # TODO re-enable once cmake files are fixed (#425306)
       libdatrie
       libepoxy
       libexif

--- a/pkgs/by-name/da/darktable/package.nix
+++ b/pkgs/by-name/da/darktable/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  runCommand,
 
   # nativeBuildInputs
   cmake,
@@ -12,6 +13,7 @@
   perl,
   pkg-config,
   wrapGAppsHook3,
+  saxon,
 
   # buildInputs
   SDL2,
@@ -52,7 +54,6 @@
   libtiff,
   libwebp,
   libxml2,
-  libxslt,
   lua,
   util-linux,
   openexr,
@@ -79,6 +80,17 @@
   gitUpdater,
 }:
 
+let
+  # Create a wrapper for saxon to provide saxon-xslt command
+  saxon-xslt = runCommand "saxon-xslt" { } ''
+    mkdir -p $out/bin
+    cat > $out/bin/saxon-xslt << 'EOF'
+    #!/bin/sh
+    exec ${saxon}/bin/saxon "$@"
+    EOF
+    chmod +x $out/bin/saxon-xslt
+  '';
+in
 stdenv.mkDerivation rec {
   version = "5.2.0";
   pname = "darktable";
@@ -97,6 +109,7 @@ stdenv.mkDerivation rec {
     perl
     pkg-config
     wrapGAppsHook3
+    saxon-xslt # Use Saxon instead of libxslt to fix XSLT generate-id() consistency issues
   ];
 
   buildInputs =
@@ -138,7 +151,6 @@ stdenv.mkDerivation rec {
       libtiff
       libwebp
       libxml2
-      libxslt
       lua
       openexr
       openjpeg


### PR DESCRIPTION
The build was failing due to inconsistent ID generation in XSLT transformations. The generate_prefs.xsl uses generate-id() which produces different IDs between function declarations and their usage when using libxslt.

Switching to Saxon XSLT processor resolves this issue as it handles generate-id() more consistently.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
