### PR TITLE
headscale: support PKCE verifier

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -406,6 +406,31 @@ in
                 '';
                 example = [ "alice@example.com" ];
               };
+
+              pkce = {
+                enabled = lib.mkOption {
+                  type = lib.types.bool;
+                  default = false;
+                  description = ''
+                    Enable or disable PKCE (Proof Key for Code Exchange) support.
+                    PKCE adds an additional layer of security to the OAuth 2.0
+                    authorization code flow by preventing authorization code
+                    interception attacks
+                    See https://datatracker.ietf.org/doc/html/rfc7636
+                  '';
+                  example = true;
+                };
+
+                method = lib.mkOption {
+                  type = lib.types.str;
+                  default = "S256";
+                  description = ''
+                    PKCE method to use:
+                      - plain: Use plain code verifier
+                      - S256: Use SHA256 hashed code verifier (default, recommended)
+                  '';
+                };
+              };
             };
 
             tls_letsencrypt_hostname = lib.mkOption {


### PR DESCRIPTION
The headscale [0.24.0](https://github.com/juanfont/headscale/blob/main/CHANGELOG.md#0240-2025-01-17) introduced support for PKCE verifier. Add options to set these parameters in the config.

Tested with my Headscale instance + Pocket-ID (with enabled PKCE).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
