### PR TITLE
haskell.compiler: (make built) also patch rts.cabal.in in numa patch

### DIFF
--- a/pkgs/development/compilers/ghc/ghc-8.10-9.2-rts-package-db-libnuma-dirs.patch
+++ b/pkgs/development/compilers/ghc/ghc-8.10-9.2-rts-package-db-libnuma-dirs.patch
@@ -1,4 +1,4 @@
-From adef13bb81cdb49a8da8a22db261e48d8c4bbb5d Mon Sep 17 00:00:00 2001
+From 3d17e6fa39fb18d4300fbf2a0c4b9ddb4adf746b Mon Sep 17 00:00:00 2001
 From: sterni <sternenseemann@systemli.org>
 Date: Thu, 17 Jul 2025 21:21:29 +0200
 Subject: [PATCH] rts: record libnuma include and lib dirs in package conf
@@ -16,11 +16,14 @@ While the make build system knows when to link against libnuma, it won't
 enforce its specific directories by adding them to rts.conf in the
 package db. This commit implements this retroactively for the make build
 system, modeled after how make does the same sort of thing for Libdw.
+The Libdw logic also affects the bindist configure file in
+distrib/configure.ac which isn't replicate since we don't need it.
 ---
  mk/config.mk.in     | 4 ++++
  rts/ghc.mk          | 8 ++++++++
  rts/package.conf.in | 5 +++--
- 3 files changed, 15 insertions(+), 2 deletions(-)
+ rts/rts.cabal.in    | 1 +
+ 4 files changed, 16 insertions(+), 2 deletions(-)
 
 diff --git a/mk/config.mk.in b/mk/config.mk.in
 index 35f6e2d087..d2b1329eb5 100644
@@ -80,6 +83,18 @@ index 9bdbf3659a..46f728b09a 100644
  #endif
  
  includes:               Stg.h
+diff --git a/rts/rts.cabal.in b/rts/rts.cabal.in
+index 0a06414d95..f71fb079ec 100644
+--- a/rts/rts.cabal.in
++++ b/rts/rts.cabal.in
+@@ -150,6 +150,7 @@ library
+     include-dirs: build ../includes includes
+                   includes/dist-derivedconstants/header @FFIIncludeDir@
+                   @LibdwIncludeDir@
++                  @LibNumaIncludeDir@
+     includes: Stg.h
+     install-includes: Cmm.h HsFFI.h MachDeps.h Rts.h RtsAPI.h Stg.h
+                       ghcautoconf.h ghcconfig.h ghcplatform.h ghcversion.h
 -- 
-2.49.0
+2.50.0
 

--- a/pkgs/development/compilers/ghc/ghc-9.4-rts-package-db-libnuma-dirs.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4-rts-package-db-libnuma-dirs.patch
@@ -1,4 +1,4 @@
-From f9625ba94522bec93b4c5d46ee5fd97f537a7dfa Mon Sep 17 00:00:00 2001
+From a0b547f41939304adfc0c430314c342dd69306ae Mon Sep 17 00:00:00 2001
 From: sterni <sternenseemann@systemli.org>
 Date: Thu, 17 Jul 2025 21:21:29 +0200
 Subject: [PATCH] rts: record libnuma include and lib dirs in package conf
@@ -16,11 +16,14 @@ While the make build system knows when to link against libnuma, it won't
 enforce its specific directories by adding them to rts.conf in the
 package db. This commit implements this retroactively for the make build
 system, modeled after how make does the same sort of thing for Libdw.
+The Libdw logic also affects the bindist configure file in
+distrib/configure.ac which isn't replicate since we don't need it.
 ---
  mk/config.mk.in     | 4 ++++
  rts/ghc.mk          | 8 ++++++++
  rts/package.conf.in | 5 +++--
- 3 files changed, 15 insertions(+), 2 deletions(-)
+ rts/rts.cabal.in    | 1 +
+ 4 files changed, 16 insertions(+), 2 deletions(-)
 
 diff --git a/mk/config.mk.in b/mk/config.mk.in
 index 2ff2bea9b6..d95f927dbd 100644
@@ -80,6 +83,18 @@ index cb5a436f5c..9e5ae48adb 100644
  #endif
  
  includes:               Rts.h
+diff --git a/rts/rts.cabal.in b/rts/rts.cabal.in
+index a8882268ac..debf2ba0a0 100644
+--- a/rts/rts.cabal.in
++++ b/rts/rts.cabal.in
+@@ -154,6 +154,7 @@ library
+     include-dirs: include
+                   @FFIIncludeDir@
+                   @LibdwIncludeDir@
++                  @LibNumaIncludeDir@
+     includes: Rts.h
+     install-includes: Cmm.h HsFFI.h MachDeps.h Rts.h RtsAPI.h Stg.h
+                       ghcautoconf.h ghcconfig.h ghcplatform.h ghcversion.h
 -- 
-2.49.0
+2.50.0
 


### PR DESCRIPTION
This is the part of the autoconf/make logic that may be relevant to us which wasn't replicated from Libdw. For completeness' sake, do this here. The extra logic in distrib/configure.ac.in is not relevant to us since we don't build bindists for make built GHCs.

Follow up to #426196, as mentioned in https://github.com/NixOS/nixpkgs/pull/426196#issuecomment-3092361601. Tested GHC 9.4 and 9.2 static as well as patch application agains. All seems to be well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
