### PR TITLE
python3Packages.groq: 0.19.0 -> 0.30.0

### DIFF
--- a/pkgs/development/python-modules/groq/default.nix
+++ b/pkgs/development/python-modules/groq/default.nix
@@ -66,6 +66,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/groq/groq-python";
     changelog = "https://github.com/groq/groq-python/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = with lib.maintainers; [
+      fab
+      sarahec
+    ];
   };
 }

--- a/pkgs/development/python-modules/groq/default.nix
+++ b/pkgs/development/python-modules/groq/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  aiohttp,
   anyio,
   buildPythonPackage,
   dirty-equals,
@@ -7,10 +8,12 @@
   fetchFromGitHub,
   hatch-fancy-pypi-readme,
   hatchling,
+  httpx-aiohttp,
   httpx,
   nest-asyncio,
   pydantic,
   pytest-asyncio,
+  pytest-xdist,
   pytestCheckHook,
   respx,
   sniffio,
@@ -19,15 +22,21 @@
 
 buildPythonPackage rec {
   pname = "groq";
-  version = "0.19.0";
+  version = "0.30.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "groq";
     repo = "groq-python";
     tag = "v${version}";
-    hash = "sha256-+1us/LPQEMeswxxHvydfTCod+RimUD2lKtlAZ3pDZOA=";
+    hash = "sha256-URjfgZC+6YIY7SBfaOmDavQ73YWAqHf9KHunyvniy2E=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "hatchling==1.26.3" \
+      "hatchling>=1.26.3"
+  '';
 
   build-system = [
     hatch-fancy-pypi-readme
@@ -43,13 +52,21 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
+  optional-dependencies = {
+    aiohttp = [
+      aiohttp
+      httpx-aiohttp
+    ];
+  };
+
   nativeCheckInputs = [
     dirty-equals
     nest-asyncio
     pytest-asyncio
+    pytest-xdist
     pytestCheckHook
     respx
-  ];
+  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   pythonImportsCheck = [ "groq" ];
 


### PR DESCRIPTION
release: https://github.com/groq/groq-python/releases/tag/v0.30.0

1. Version bump
2. Added optional `aiohttp` dependencies.
3. Added self as maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. --> 

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
