### PR TITLE
mealie: 2.8.0 -> 3.0.2

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -80,6 +80,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `mealie` has been updated to 3.0.1: This update introduces breaking changes in some API endpoints (see the [release changelog](https://github.com/mealie-recipes/mealie/releases/tag/v3.0.0))
+
 ### Breaking changes {#sec-nixpkgs-release-25.11-lib-breaking}
 
 - `reaction` has been updated to version 2, which includes some breaking changes.

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -80,7 +80,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- `mealie` has been updated to 3.0.1: This update introduces breaking changes in some API endpoints (see the [release changelog](https://github.com/mealie-recipes/mealie/releases/tag/v3.0.0))
+- `mealie` has been updated to 3.0.2: This update introduces breaking changes in some API endpoints (see the [release changelog](https://github.com/mealie-recipes/mealie/releases/tag/v3.0.0))
 
 ### Breaking changes {#sec-nixpkgs-release-25.11-lib-breaking}
 

--- a/nixos/tests/mealie.nix
+++ b/nixos/tests/mealie.nix
@@ -15,6 +15,7 @@
         services.mealie = {
           enable = true;
           port = 9001;
+          settings.ALLOW_SIGNUP = "true";
         };
       };
       postgres = {
@@ -27,16 +28,83 @@
     };
 
   testScript = ''
-    start_all()
+    import json
+    import urllib.parse
+
+    def api_get(node, path, qry={}, **headers):
+      url = f"http://localhost:9001/api{path}"
+      if len(qry) > 0:
+        url += "?" + "&".join([f"{k}={urllib.parse.quote(v)}" for k, v in qry.items()])
+
+      headers = " ".join([f"-H '{k}: {str(v)}'" for k, v in headers.items()])
+
+      got = node.succeed(f"curl -s -X GET {headers} --fail {url}")
+      print(f"* GET {path}\n{got}")
+      return json.loads(got)
+
+    def api_post(node, path, method="POST", urlencode=False, body={}, qry={}, **headers):
+      url = f"http://localhost:9001/api{path}"
+      if len(qry) > 0:
+        url += "?" + "&".join([f"{k}={urllib.parse.quote(v)}" for k, v in qry.items()])
+
+      if urlencode:
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+        print("BODY", body)
+        body = "&".join([f"{k}={urllib.parse.quote(str(v))}" for k, v in body.items()])
+      else:
+        headers["Content-Type"] = "application/json"
+        body = json.dumps(body)
+
+      headers["Accept"] = "application/json"
+      headers = " ".join([f"-H '{k}: {str(v)}'" for k, v in headers.items()])
+
+      got = node.succeed(f"curl -v --fail -X {method} {url} {headers} -d '{body}'")
+      print(f"* POST {path}\n{got}")
+      return json.loads(got)
 
     def test_mealie(node):
       node.wait_for_unit("mealie.service")
       node.wait_for_open_port(9001)
       node.succeed("curl --fail http://localhost:9001")
 
+      got = api_get(node, "/app/about")
+      assert got["version"] == "v${pkgs.mealie.version}"
+
+      new_user = dict(
+        email=node.name + ".nomail@no.mail",
+        username="noname-" + node.name,
+        fullName="No Name" + node.name,
+        password="SuperSecure" + node.name,
+        passwordConfirm="SuperSecure" + node.name,
+        group="mygroup" + node.name,
+      )
+      got = api_post(node, "/users/register", body=new_user)
+      got = api_post(node, "/auth/token", urlencode=True, body={
+        "username": new_user["username"],
+        "password": new_user["password"],
+        "remember_me": False,
+      })
+      assert "access_token" in got
+      token = "Bearer " + got["access_token"]
+
+      got = api_get(node, "/recipes", authorization=token)
+      assert got["total"] == 0
+
+      slug = api_post(node, "/recipes", body={"name": "TestRecipe"}, authorization=token)
+      recipe = { "description": "Test recipe" }
+      got = api_post(node, f"/recipes/{slug}", body=recipe, method="PATCH", authorization=token)
+      got = api_get(node, "/recipes", authorization=token)
+      assert got["total"] > 0
+      assert got["items"][0]["description"] == recipe["description"]
+
+    postgres.start()
+    test_mealie(postgres)
+    postgres.send_monitor_command("quit")
+    postgres.wait_for_shutdown()
+
+    sqlite.start()
     test_mealie(sqlite)
     sqlite.send_monitor_command("quit")
     sqlite.wait_for_shutdown()
-    test_mealie(postgres)
   '';
 }

--- a/pkgs/by-name/me/mealie/mealie-frontend.nix
+++ b/pkgs/by-name/me/mealie/mealie-frontend.nix
@@ -3,7 +3,6 @@ src: version:
   lib,
   fetchFromGitHub,
   fetchYarnDeps,
-  dart,
   dart-sass,
   nodePackages_latest,
   fixup-yarn-lock,

--- a/pkgs/by-name/me/mealie/mealie-frontend.nix
+++ b/pkgs/by-name/me/mealie/mealie-frontend.nix
@@ -1,39 +1,45 @@
 src: version:
 {
   lib,
+  fetchFromGitHub,
   fetchYarnDeps,
-  nodejs_20,
+  dart,
+  dart-sass,
+  nodePackages_latest,
   fixup-yarn-lock,
   stdenv,
   yarn,
-}:
-stdenv.mkDerivation {
+}: let
+  nodejs = nodePackages_latest.nodejs;
+in stdenv.mkDerivation {
   name = "mealie-frontend";
   inherit version;
   src = "${src}/frontend";
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/frontend/yarn.lock";
-    hash = "sha256-a2kIOQHaMzaMWId6+SSYN+SPQM2Ipa+F1ztFZgo3R6A=";
+    hash = "sha256-712mc/xksjXgnc0inthxE+ztSDl/4107oXw3vKcZD2g=";
   };
 
   nativeBuildInputs = [
     fixup-yarn-lock
-    nodejs_20
-    (yarn.override { nodejs = nodejs_20; })
+    nodejs
+    (yarn.override { inherit nodejs; })
   ];
 
   configurePhase = ''
     runHook preConfigure
 
+    sed -i 's+"@nuxt/fonts",+// NUXT FONTS DISABLED+g' nuxt.config.ts
+
     export HOME=$(mktemp -d)
     yarn config --offline set yarn-offline-mirror "$yarnOfflineCache"
     fixup-yarn-lock yarn.lock
-    # TODO: Remove --ignore-engines once upstream supports nodejs_20+
-    # https://github.com/mealie-recipes/mealie/issues/5400
-    # https://github.com/mealie-recipes/mealie/pull/5184
-    yarn install --frozen-lockfile --offline --no-progress --non-interactive --ignore-engines
+    yarn install --frozen-lockfile --offline --no-progress --non-interactive
     patchShebangs node_modules/
+
+    mkdir -p node_modules/sass-embedded/dist/lib/src/vendor/dart-sass
+    ln -s ${dart-sass}/bin/dart-sass node_modules/sass-embedded/dist/lib/src/vendor/dart-sass/sass
 
     runHook postConfigure
   '';
@@ -50,7 +56,7 @@ stdenv.mkDerivation {
 
   installPhase = ''
     runHook preInstall
-    mv dist $out
+    mv .output/public $out
     runHook postInstall
   '';
 

--- a/pkgs/by-name/me/mealie/mealie-frontend.nix
+++ b/pkgs/by-name/me/mealie/mealie-frontend.nix
@@ -9,9 +9,11 @@ src: version:
   fixup-yarn-lock,
   stdenv,
   yarn,
-}: let
+}:
+let
   nodejs = nodePackages_latest.nodejs;
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   name = "mealie-frontend";
   inherit version;
   src = "${src}/frontend";

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -11,12 +11,12 @@
 }:
 
 let
-  version = "3.0.1";
+  version = "3.0.2";
   src = fetchFromGitHub {
     owner = "mealie-recipes";
     repo = "mealie";
     tag = "v${version}";
-    hash = "sha256-ev5S/JGj9lYejuKTRMbZ49qqupJpNF5Vc12VFsJPqpc=";
+    hash = "sha256-0GlHfyoVEqmfTDSN9BGXrLRkStRjWjv2qzZac2oYu7Q=";
   };
 
   frontend = callPackage (import ./mealie-frontend.nix src version) { };

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -55,6 +55,7 @@ in pythonpkgs.buildPythonApplication rec {
       orjson
       paho-mqtt
       pillow-heif
+      psycopg2
       pydantic-settings
       pyhumps
       pyjwt

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -23,123 +23,124 @@ let
 
   pythonpkgs = python3Packages;
   python = pythonpkgs.python;
-in pythonpkgs.buildPythonApplication rec {
-    pname = "mealie";
-    inherit version src;
-    pyproject = true;
+in
+pythonpkgs.buildPythonApplication rec {
+  pname = "mealie";
+  inherit version src;
+  pyproject = true;
 
-    build-system = with pythonpkgs; [ poetry-core ];
+  build-system = with pythonpkgs; [ poetry-core ];
 
-    nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
-    dontWrapPythonPrograms = true;
+  dontWrapPythonPrograms = true;
 
-    pythonRelaxDeps = true;
+  pythonRelaxDeps = true;
 
-    dependencies = with pythonpkgs; [
-      aiofiles
-      alembic
-      aniso8601
-      appdirs
-      apprise
-      authlib
-      bcrypt
-      fastapi
-      html2text
-      httpx
-      ingredient-parser-nlp
-      itsdangerous
-      jinja2
-      lxml
-      openai
-      orjson
-      paho-mqtt
-      pillow-heif
-      psycopg2
-      pydantic-settings
-      pyhumps
-      pyjwt
-      python-dateutil
-      python-dotenv
-      python-ldap
-      python-multipart
-      python-slugify
-      pyyaml
-      rapidfuzz
-      recipe-scrapers
-      sqlalchemy
-      tzdata
-      uvicorn
-    ];
+  dependencies = with pythonpkgs; [
+    aiofiles
+    alembic
+    aniso8601
+    appdirs
+    apprise
+    authlib
+    bcrypt
+    fastapi
+    html2text
+    httpx
+    ingredient-parser-nlp
+    itsdangerous
+    jinja2
+    lxml
+    openai
+    orjson
+    paho-mqtt
+    pillow-heif
+    psycopg2
+    pydantic-settings
+    pyhumps
+    pyjwt
+    python-dateutil
+    python-dotenv
+    python-ldap
+    python-multipart
+    python-slugify
+    pyyaml
+    rapidfuzz
+    recipe-scrapers
+    sqlalchemy
+    tzdata
+    uvicorn
+  ];
 
-    postPatch = ''
-      rm -rf dev # Do not need dev scripts & code
+  postPatch = ''
+    rm -rf dev # Do not need dev scripts & code
 
-      substituteInPlace mealie/__init__.py \
-        --replace-fail '__version__ = ' '__version__ = "v${version}" #'
+    substituteInPlace mealie/__init__.py \
+      --replace-fail '__version__ = ' '__version__ = "v${version}" #'
+  '';
+
+  postInstall =
+    let
+      start_script = writeShellScript "start-mealie" ''
+        ${lib.getExe pythonpkgs.gunicorn} "$@" -k uvicorn.workers.UvicornWorker mealie.app:app;
+      '';
+      init_db = writeShellScript "init-mealie-db" ''
+        ${python.interpreter} $OUT/${python.sitePackages}/mealie/db/init_db.py
+      '';
+    in
+    ''
+      mkdir -p $out/bin $out/libexec
+      rm -f $out/bin/*
+
+      makeWrapper ${start_script} $out/bin/mealie \
+        --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
+        --set STATIC_FILES "${frontend}"
+
+      makeWrapper ${init_db} $out/libexec/init_db \
+        --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
+        --set OUT "$out"
     '';
 
-    postInstall =
-      let
-        start_script = writeShellScript "start-mealie" ''
-          ${lib.getExe pythonpkgs.gunicorn} "$@" -k uvicorn.workers.UvicornWorker mealie.app:app;
-        '';
-        init_db = writeShellScript "init-mealie-db" ''
-          ${python.interpreter} $OUT/${python.sitePackages}/mealie/db/init_db.py
-        '';
-      in
-      ''
-        mkdir -p $out/bin $out/libexec
-        rm -f $out/bin/*
+  nativeCheckInputs = with pythonpkgs; [ pytestCheckHook ];
 
-        makeWrapper ${start_script} $out/bin/mealie \
-          --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
-          --set STATIC_FILES "${frontend}"
+  # Needed for tests
+  preCheck = ''
+    export NLTK_DATA=${nltk-data.averaged-perceptron-tagger-eng}
+  '';
 
-        makeWrapper ${init_db} $out/libexec/init_db \
-          --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
-          --set OUT "$out"
-      '';
+  disabledTestPaths = [
+    # KeyError: 'alembic_version'
+    "tests/unit_tests/services_tests/backup_v2_tests/test_backup_v2.py"
+    "tests/unit_tests/services_tests/backup_v2_tests/test_alchemy_exporter.py"
+    # sqlite3.OperationalError: no such table
+    "tests/unit_tests/services_tests/scheduler/tasks/test_create_timeline_events.py"
+    "tests/unit_tests/test_ingredient_parser.py"
+    "tests/unit_tests/test_security.py"
+  ];
 
-    nativeCheckInputs = with pythonpkgs; [ pytestCheckHook ];
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) mealie;
+    };
+  };
 
-    # Needed for tests
-    preCheck = ''
-      export NLTK_DATA=${nltk-data.averaged-perceptron-tagger-eng}
+  meta = with lib; {
+    description = "Self hosted recipe manager and meal planner";
+    longDescription = ''
+      Mealie is a self hosted recipe manager and meal planner with a REST API and a reactive frontend
+      application built in NuxtJS for a pleasant user experience for the whole family. Easily add recipes into your
+      database by providing the URL and Mealie will automatically import the relevant data or add a family recipe with
+      the UI editor.
     '';
-
-    disabledTestPaths = [
-      # KeyError: 'alembic_version'
-      "tests/unit_tests/services_tests/backup_v2_tests/test_backup_v2.py"
-      "tests/unit_tests/services_tests/backup_v2_tests/test_alchemy_exporter.py"
-      # sqlite3.OperationalError: no such table
-      "tests/unit_tests/services_tests/scheduler/tasks/test_create_timeline_events.py"
-      "tests/unit_tests/test_ingredient_parser.py"
-      "tests/unit_tests/test_security.py"
+    homepage = "https://mealie.io";
+    changelog = "https://github.com/mealie-recipes/mealie/releases/tag/${src.rev}";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [
+      litchipi
+      anoa
     ];
-
-    passthru = {
-      updateScript = nix-update-script { };
-      tests = {
-        inherit (nixosTests) mealie;
-      };
-    };
-
-    meta = with lib; {
-      description = "Self hosted recipe manager and meal planner";
-      longDescription = ''
-        Mealie is a self hosted recipe manager and meal planner with a REST API and a reactive frontend
-        application built in NuxtJS for a pleasant user experience for the whole family. Easily add recipes into your
-        database by providing the URL and Mealie will automatically import the relevant data or add a family recipe with
-        the UI editor.
-      '';
-      homepage = "https://mealie.io";
-      changelog = "https://github.com/mealie-recipes/mealie/releases/tag/${src.rev}";
-      license = licenses.agpl3Only;
-      maintainers = with maintainers; [
-        litchipi
-        anoa
-      ];
-      mainProgram = "mealie";
-    };
-  }
+    mainProgram = "mealie";
+  };
+}

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -11,139 +11,134 @@
 }:
 
 let
-  version = "2.8.0";
+  version = "3.0.1";
   src = fetchFromGitHub {
     owner = "mealie-recipes";
     repo = "mealie";
     tag = "v${version}";
-    hash = "sha256-0LUT7OdYoOZTdR/UXJO2eL2Afo2Y7GjBPIrjWUt205E=";
+    hash = "sha256-ev5S/JGj9lYejuKTRMbZ49qqupJpNF5Vc12VFsJPqpc=";
   };
 
   frontend = callPackage (import ./mealie-frontend.nix src version) { };
 
   pythonpkgs = python3Packages;
   python = pythonpkgs.python;
-in
+in pythonpkgs.buildPythonApplication rec {
+    pname = "mealie";
+    inherit version src;
+    pyproject = true;
 
-pythonpkgs.buildPythonApplication rec {
-  pname = "mealie";
-  inherit version src;
-  pyproject = true;
+    build-system = with pythonpkgs; [ poetry-core ];
 
-  build-system = with pythonpkgs; [ poetry-core ];
+    nativeBuildInputs = [ makeWrapper ];
 
-  nativeBuildInputs = [ makeWrapper ];
+    dontWrapPythonPrograms = true;
 
-  dontWrapPythonPrograms = true;
+    pythonRelaxDeps = true;
 
-  pythonRelaxDeps = true;
-
-  dependencies = with pythonpkgs; [
-    aiofiles
-    alembic
-    aniso8601
-    appdirs
-    apprise
-    authlib
-    bcrypt
-    extruct
-    fastapi
-    gunicorn
-    html2text
-    httpx
-    ingredient-parser-nlp
-    itsdangerous
-    jinja2
-    lxml
-    openai
-    orjson
-    paho-mqtt
-    pillow
-    pillow-heif
-    psycopg2
-    pydantic-settings
-    pyhumps
-    pyjwt
-    python-dotenv
-    python-ldap
-    python-multipart
-    python-slugify
-    pyyaml
-    rapidfuzz
-    recipe-scrapers
-    sqlalchemy
-    tzdata
-    uvicorn
-  ];
-
-  postPatch = ''
-    rm -rf dev # Do not need dev scripts & code
-
-    substituteInPlace mealie/__init__.py \
-      --replace-fail '__version__ = ' '__version__ = "v${version}" #'
-  '';
-
-  postInstall =
-    let
-      start_script = writeShellScript "start-mealie" ''
-        ${lib.getExe pythonpkgs.gunicorn} "$@" -k uvicorn.workers.UvicornWorker mealie.app:app;
-      '';
-      init_db = writeShellScript "init-mealie-db" ''
-        ${python.interpreter} $OUT/${python.sitePackages}/mealie/db/init_db.py
-      '';
-    in
-    ''
-      mkdir -p $out/bin $out/libexec
-      rm -f $out/bin/*
-
-      makeWrapper ${start_script} $out/bin/mealie \
-        --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
-        --set STATIC_FILES "${frontend}"
-
-      makeWrapper ${init_db} $out/libexec/init_db \
-        --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
-        --set OUT "$out"
-    '';
-
-  nativeCheckInputs = with pythonpkgs; [ pytestCheckHook ];
-
-  # Needed for tests
-  preCheck = ''
-    export NLTK_DATA=${nltk-data.averaged-perceptron-tagger-eng}
-  '';
-
-  disabledTestPaths = [
-    # KeyError: 'alembic_version'
-    "tests/unit_tests/services_tests/backup_v2_tests/test_backup_v2.py"
-    "tests/unit_tests/services_tests/backup_v2_tests/test_alchemy_exporter.py"
-    # sqlite3.OperationalError: no such table
-    "tests/unit_tests/services_tests/scheduler/tasks/test_create_timeline_events.py"
-    "tests/unit_tests/test_ingredient_parser.py"
-    "tests/unit_tests/test_security.py"
-  ];
-
-  passthru = {
-    updateScript = nix-update-script { };
-    tests = {
-      inherit (nixosTests) mealie;
-    };
-  };
-
-  meta = with lib; {
-    description = "Self hosted recipe manager and meal planner";
-    longDescription = ''
-      Mealie is a self hosted recipe manager and meal planner with a REST API and a reactive frontend
-      application built in NuxtJS for a pleasant user experience for the whole family. Easily add recipes into your
-      database by providing the URL and Mealie will automatically import the relevant data or add a family recipe with
-      the UI editor.
-    '';
-    homepage = "https://mealie.io";
-    changelog = "https://github.com/mealie-recipes/mealie/releases/tag/${src.rev}";
-    license = licenses.agpl3Only;
-    maintainers = with maintainers; [
-      litchipi
-      anoa
+    dependencies = with pythonpkgs; [
+      aiofiles
+      alembic
+      aniso8601
+      appdirs
+      apprise
+      authlib
+      bcrypt
+      fastapi
+      html2text
+      httpx
+      ingredient-parser-nlp
+      itsdangerous
+      jinja2
+      lxml
+      openai
+      orjson
+      paho-mqtt
+      pillow-heif
+      pydantic-settings
+      pyhumps
+      pyjwt
+      python-dateutil
+      python-dotenv
+      python-ldap
+      python-multipart
+      python-slugify
+      pyyaml
+      rapidfuzz
+      recipe-scrapers
+      sqlalchemy
+      tzdata
+      uvicorn
     ];
-    mainProgram = "mealie";
-  };
-}
+
+    postPatch = ''
+      rm -rf dev # Do not need dev scripts & code
+
+      substituteInPlace mealie/__init__.py \
+        --replace-fail '__version__ = ' '__version__ = "v${version}" #'
+    '';
+
+    postInstall =
+      let
+        start_script = writeShellScript "start-mealie" ''
+          ${lib.getExe pythonpkgs.gunicorn} "$@" -k uvicorn.workers.UvicornWorker mealie.app:app;
+        '';
+        init_db = writeShellScript "init-mealie-db" ''
+          ${python.interpreter} $OUT/${python.sitePackages}/mealie/db/init_db.py
+        '';
+      in
+      ''
+        mkdir -p $out/bin $out/libexec
+        rm -f $out/bin/*
+
+        makeWrapper ${start_script} $out/bin/mealie \
+          --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
+          --set STATIC_FILES "${frontend}"
+
+        makeWrapper ${init_db} $out/libexec/init_db \
+          --set PYTHONPATH "$out/${python.sitePackages}:${pythonpkgs.makePythonPath dependencies}" \
+          --set OUT "$out"
+      '';
+
+    nativeCheckInputs = with pythonpkgs; [ pytestCheckHook ];
+
+    # Needed for tests
+    preCheck = ''
+      export NLTK_DATA=${nltk-data.averaged-perceptron-tagger-eng}
+    '';
+
+    disabledTestPaths = [
+      # KeyError: 'alembic_version'
+      "tests/unit_tests/services_tests/backup_v2_tests/test_backup_v2.py"
+      "tests/unit_tests/services_tests/backup_v2_tests/test_alchemy_exporter.py"
+      # sqlite3.OperationalError: no such table
+      "tests/unit_tests/services_tests/scheduler/tasks/test_create_timeline_events.py"
+      "tests/unit_tests/test_ingredient_parser.py"
+      "tests/unit_tests/test_security.py"
+    ];
+
+    passthru = {
+      updateScript = nix-update-script { };
+      tests = {
+        inherit (nixosTests) mealie;
+      };
+    };
+
+    meta = with lib; {
+      description = "Self hosted recipe manager and meal planner";
+      longDescription = ''
+        Mealie is a self hosted recipe manager and meal planner with a REST API and a reactive frontend
+        application built in NuxtJS for a pleasant user experience for the whole family. Easily add recipes into your
+        database by providing the URL and Mealie will automatically import the relevant data or add a family recipe with
+        the UI editor.
+      '';
+      homepage = "https://mealie.io";
+      changelog = "https://github.com/mealie-recipes/mealie/releases/tag/${src.rev}";
+      license = licenses.agpl3Only;
+      maintainers = with maintainers; [
+        litchipi
+        anoa
+      ];
+      mainProgram = "mealie";
+    };
+  }


### PR DESCRIPTION
Closes #424672

Bumps the version of mealie to `3.0.2`, removes unnecessary dependencies, and fixup a build issue on the NuxtJS frontend setup.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
