### PR TITLE
graalvmPackages.graalvm-ce-musl: remove assert

### DIFF
--- a/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/buildGraalvm.nix
@@ -23,7 +23,6 @@
   ...
 }@args:
 
-assert useMusl -> stdenv.hostPlatform.isLinux;
 let
   extraArgs = builtins.removeAttrs args [
     "lib"


### PR DESCRIPTION
This will fail with an "musl is not supported on this system" anyway. The difference is, that this error via `musl`'s `meta.platforms` can be caught properly by CI, but the assert can not without ugly workarounds.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
