### PR TITLE
hplipWithPlugin: remove assert

### DIFF
--- a/pkgs/by-name/hp/hplip/package.nix
+++ b/pkgs/by-name/hp/hplip/package.nix
@@ -72,12 +72,6 @@ let
 
 in
 
-assert
-  withPlugin
-  ->
-    builtins.elem hplipArch pluginArches
-    || throw "HPLIP plugin not supported on ${stdenv.hostPlatform.system}";
-
 python3Packages.buildPythonApplication {
   inherit pname version;
   format = "other";
@@ -362,13 +356,7 @@ python3Packages.buildPythonApplication {
           bsd2
           gpl2Plus
         ];
-    platforms = [
-      "i686-linux"
-      "x86_64-linux"
-      "armv6l-linux"
-      "armv7l-linux"
-      "aarch64-linux"
-    ];
+    platforms = lib.attrNames hplipPlatforms;
     maintainers = with lib.maintainers; [ ttuegel ];
   };
 }


### PR DESCRIPTION
This assert is already handled by `meta.platforms`, which can be better caught by CI than an `assert`. Also set `meta.platforms` to the earlier defined `hplipPlatforms` for a single source of truth.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
