### PR TITLE
byzanz: fix build with gettext 0.25

### DIFF
--- a/pkgs/by-name/by/byzanz/gettext-0.25.patch
+++ b/pkgs/by-name/by/byzanz/gettext-0.25.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 620bb26..ce48364 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -29,6 +29,8 @@ AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE], "$GETTEXT_PACKAGE",
+ AM_GLIB_GNU_GETTEXT
+ AM_GLIB_DEFINE_LOCALEDIR(GNOMELOCALEDIR)
+ 
++AM_GNU_GETTEXT_VERSION([0.25])
++AM_GNU_GETTEXT([external])
+ 
+ AC_PROG_CC
+ AM_PROG_CC_C_O

--- a/pkgs/by-name/by/byzanz/package.nix
+++ b/pkgs/by-name/by/byzanz/package.nix
@@ -4,6 +4,7 @@
   fetchgit,
   wrapGAppsHook3,
   cairo,
+  gettext,
   glib,
   gnome-common,
   gst_all_1,
@@ -25,7 +26,10 @@ stdenv.mkDerivation {
     hash = "sha256-3DUwXCPBAmeCRlDkiPUgwNyBa6bCvC/TLguMCK3bo4E=";
   };
 
-  patches = [ ./add-amflags.patch ];
+  patches = [
+    ./add-amflags.patch
+    ./gettext-0.25.patch
+  ];
 
   preBuild = ''
     ./autogen.sh --prefix=$out
@@ -36,6 +40,11 @@ stdenv.mkDerivation {
     "-Wno-error=incompatible-pointer-types"
     "-Wno-error=discarded-qualifiers"
   ];
+
+  preAutoreconf = ''
+    # error: possibly undefined macro: AM_NLS
+    cp ${gettext}/share/gettext/m4/nls.m4 macros/
+  '';
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
I am far from an autotools expert, but this does make the package
compile again. I cobbled this together from various workarounds posted
on <https://github.com/NixOS/nixpkgs/pull/405793>.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
