### PR TITLE
lash: delay assert behind eval of `meta`

### DIFF
--- a/pkgs/by-name/la/lash/package.nix
+++ b/pkgs/by-name/la/lash/package.nix
@@ -12,8 +12,6 @@
   readline,
 }:
 
-assert libuuid != null;
-
 stdenv.mkDerivation rec {
   pname = "lash";
   version = "0.5.4";
@@ -40,7 +38,9 @@ stdenv.mkDerivation rec {
     libxml2
     readline
   ];
-  propagatedBuildInputs = [ libuuid ];
+  propagatedBuildInputs =
+    assert libuuid != null;
+    [ libuuid ];
   NIX_LDFLAGS = "-lm -lpthread -luuid";
 
   postInstall = ''


### PR DESCRIPTION
This allows CI to evaluate `meta.platforms` to see that this package is not supported on darwin. Working around the assert before that requires much more hackery.

I'm not 100% sure whether the assert is needed, but it doesn't hurt to keep it in this place.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
