### PR TITLE
pcscliteWithPolkit: mark as broken on darwin

### DIFF
--- a/pkgs/by-name/pc/pcsclite/package.nix
+++ b/pkgs/by-name/pc/pcsclite/package.nix
@@ -23,9 +23,6 @@
   polkitSupport ? false,
 }:
 
-assert polkitSupport -> dbusSupport;
-assert systemdSupport -> dbusSupport;
-
 stdenv.mkDerivation (finalAttrs: {
   inherit pname;
   version = "2.3.0";
@@ -132,5 +129,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.anthonyroussel ];
     pkgConfigModules = [ "libpcsclite" ];
     platforms = lib.platforms.unix;
+    broken = !(polkitSupport -> dbusSupport) || !(systemdSupport -> dbusSupport);
   };
 })


### PR DESCRIPTION
This enable polkit, which requires dbus, which is not enabled for darwin. This fails eval with the triggered assert and can't be caught without hacks in CI. `meta.broken` can be caught nicely, so using that instead.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
