### PR TITLE
supersonic-wayland: drop darwin as supported platform

### DIFF
--- a/pkgs/by-name/su/supersonic/package.nix
+++ b/pkgs/by-name/su/supersonic/package.nix
@@ -16,8 +16,6 @@
   waylandSupport ? false,
 }:
 
-assert waylandSupport -> stdenv.hostPlatform.isLinux;
-
 buildGoModule rec {
   pname = "supersonic" + lib.optionalString waylandSupport "-wayland";
   version = "0.17.0";
@@ -97,7 +95,7 @@ buildGoModule rec {
     mainProgram = "supersonic" + lib.optionalString waylandSupport "-wayland";
     description = "Lightweight cross-platform desktop client for Subsonic music servers";
     homepage = "https://github.com/dweymouth/supersonic";
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.linux ++ lib.optionals (!waylandSupport) platforms.darwin;
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
       zane


### PR DESCRIPTION
Wayland support is only possible on Linux. Instead of the assert, which can't be caught by CI properly, do this via the list of supported platforms in `meta.platforms`. This works much better for CI.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
