### PR TITLE
tracy-wayland: drop darwin as supported platform

### DIFF
--- a/pkgs/by-name/tr/tracy/package.nix
+++ b/pkgs/by-name/tr/tracy/package.nix
@@ -25,7 +25,6 @@
 }:
 
 assert withGtkFileSelector -> stdenv.hostPlatform.isLinux;
-assert withWayland -> stdenv.hostPlatform.isLinux;
 
 stdenv.mkDerivation rec {
   pname = if withWayland then "tracy-wayland" else "tracy-glfw";
@@ -130,6 +129,6 @@ stdenv.mkDerivation rec {
       mpickering
       nagisa
     ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.linux ++ lib.optionals (!withWayland) platforms.darwin;
   };
 }


### PR DESCRIPTION
Wayland support is only possible on Linux. Instead of the assert, which can't be caught by CI properly, do this via the list of supported platforms in meta.platforms. This works much better for CI.

I did not touch the `withGtkFileSelector` assert, because it doesn't trigger in CI - it only does when overriding this argument manually.

Related: https://github.com/NixOS/nixpkgs/pull/426629

Similar to: #427196

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
