### PR TITLE
zenith-nvidia: move assert to meta.platforms check

### DIFF
--- a/pkgs/by-name/ze/zenith/package.nix
+++ b/pkgs/by-name/ze/zenith/package.nix
@@ -7,8 +7,6 @@
   makeWrapper,
 }:
 
-assert nvidiaSupport -> stdenv.hostPlatform.isLinux;
-
 rustPlatform.buildRustPackage rec {
   pname = "zenith";
   version = "0.14.1";
@@ -45,6 +43,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/bvaisvil/zenith";
     license = licenses.mit;
     maintainers = with maintainers; [ wegank ];
-    platforms = platforms.unix;
+    platforms = if nvidiaSupport then platforms.linux else platforms.unix;
   };
 }


### PR DESCRIPTION
Using asserts for these kinds of checks breaks CI and requires ugly workarounds to catch them. Errors reported via `meta.platforms` can be caught and ignored nicely.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
