### PR TITLE
tests-stdenv-gcc-stageCompare: delay asserts

### DIFF
--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -176,5 +176,5 @@ in
   xfsprogs = linux;
   xkeyboard_config = linux;
   zip = all;
-  tests-stdenv-gcc-stageCompare = all;
+  tests-stdenv-gcc-stageCompare = linux;
 }))


### PR DESCRIPTION
The removed assert is covered by `meta.platforms = linux`, which will throw an "unsupported system" error on darwin. Since the platforms are restricted to linux anyway, it doesn't make sense to have this set to `all` in `release-small.nix` - `linux` should suffice. Right?

The other assert is delayed until after the evaluation of `meta`. This allows the "unsupported system" error on darwin to be thrown at all, without triggering the assert before. This helps CI, which can't catch asserts properly, but can do so with `meta.platforms` based errors.

Also added another assert for the other checksum provider - because it's not necessarily defined in which order they'd be evaluated and thus, they could throw a much worse error because `checksum` is not found.

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
