### PR TITLE
nixos/lib/testing: add separate configuration option for composability 

### DIFF
--- a/nixos/lib/testing/nodes.nix
+++ b/nixos/lib/testing/nodes.nix
@@ -82,6 +82,14 @@ in
 {
 
   options = {
+    configurations = mkOption {
+      # we use types.raw instead of submodules or other because
+      # we get the path back from it
+      type = types.lazyAttrsOf types.raw;
+      description = "Path to a node's test configuration";
+      default = { };
+    };
+
     sshBackdoor = {
       enable = mkOption {
         default = config.enableDebugHook;
@@ -199,6 +207,8 @@ in
             config;
       }
     ) config.nodes;
+
+    nodes = mapAttrs (_: v: { imports = [ v ]; }) config.configurations;
 
     passthru.nodes = config.nodesCompat;
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -203,7 +203,7 @@ in
   alice-lg = runTest ./alice-lg.nix;
   alloy = runTest ./alloy.nix;
   allTerminfo = runTest ./all-terminfo.nix;
-  alps = runTest ./alps.nix;
+  alps = runTest ./alps/alps.nix;
   amazon-cloudwatch-agent = runTest ./amazon-cloudwatch-agent.nix;
   amazon-init-shell = runTest ./amazon-init-shell.nix;
   amazon-ssm-agent = runTest ./amazon-ssm-agent.nix;

--- a/nixos/tests/alps/alps-client.nix
+++ b/nixos/tests/alps/alps-client.nix
@@ -1,0 +1,26 @@
+{ nodes, config, ... }:
+
+let
+  certs = import ../common/acme/server/snakeoil-certs.nix;
+  domain = certs.domain;
+in
+{
+  security.pki.certificateFiles = [
+    certs.ca.cert
+  ];
+  networking.extraHosts = ''
+    ${nodes.server.networking.primaryIPAddress} ${domain}
+  '';
+  services.alps = {
+    enable = true;
+    theme = "alps";
+    imaps = {
+      host = domain;
+      port = 993;
+    };
+    smtps = {
+      host = domain;
+      port = 465;
+    };
+  };
+}

--- a/nixos/tests/alps/alps-server.nix
+++ b/nixos/tests/alps/alps-server.nix
@@ -1,0 +1,37 @@
+{ pkgs, ... }:
+
+let
+  certs = import ../common/acme/server/snakeoil-certs.nix;
+  domain = certs.domain;
+in
+{
+  imports = [ ../common/user-account.nix ];
+  security.pki.certificateFiles = [
+    certs.ca.cert
+  ];
+  networking.extraHosts = ''
+    127.0.0.1 ${domain}
+  '';
+  networking.firewall.allowedTCPPorts = [
+    25
+    465
+    993
+  ];
+  services.postfix = {
+    enable = true;
+    enableSubmission = true;
+    enableSubmissions = true;
+    tlsTrustedAuthorities = "${certs.ca.cert}";
+    config.smtpd_tls_chain_files = [
+      "${certs.${domain}.key}"
+      "${certs.${domain}.cert}"
+    ];
+  };
+  services.dovecot2 = {
+    enable = true;
+    enableImap = true;
+    sslCACert = "${certs.ca.cert}";
+    sslServerCert = "${certs.${domain}.cert}";
+    sslServerKey = "${certs.${domain}.key}";
+  };
+}

--- a/nixos/tests/stalwart/stalwart-mail.nix
+++ b/nixos/tests/stalwart/stalwart-mail.nix
@@ -10,13 +10,10 @@ in
 {
   name = "stalwart-mail";
 
+  configurations.main = ./stalwart-mail-config.nix;
   nodes.main =
     { pkgs, ... }:
     {
-      imports = [
-        ./stalwart-mail-config.nix
-      ];
-
       environment.systemPackages = [
         (pkgs.writers.writePython3Bin "test-smtp-submission" { } ''
           from smtplib import SMTP


### PR DESCRIPTION
Ready for feedback!


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
