### PR TITLE
python3Packages.{langchain,langgraph}: 250730 update

### DIFF
--- a/pkgs/development/python-modules/langchain-anthropic/default.nix
+++ b/pkgs/development/python-modules/langchain-anthropic/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-anthropic";
-  version = "0.3.15";
+  version = "0.3.17";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-anthropic==${version}";
-    hash = "sha256-GOD6pMuUDCfrQ6MP+/HXZIg5wHUDRysosEjXjewY/9M=";
+    hash = "sha256-oUT4Mu/vG+bVF6zLQX2RbVUglJ6VMyBt8XtCBSlBlpU=";
   };
 
   sourceRoot = "${src.name}/libs/partners/anthropic";

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "0.3.66";
+  version = "0.3.72";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${version}";
-    hash = "sha256-k9B2ApNyX3w6RTt/XdOl2FvU87NuZSi96vvfJOnBltM=";
+    hash = "sha256-Q2uGMiODUtwkPdOyuSqp8vqjlLjiXk75QjXp7rr20tc=";
   };
 
   sourceRoot = "${src.name}/libs/core";

--- a/pkgs/development/python-modules/langchain-ollama/default.nix
+++ b/pkgs/development/python-modules/langchain-ollama/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-ollama";
-  version = "0.3.5";
+  version = "0.3.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-ollama==${version}";
-    hash = "sha256-UmfbCctAb0D8mETICl5OJ58vghwhQKWkM1drkPt1aAg=";
+    hash = "sha256-GQkyJaYvwRbjDR0Rfen7/X5hFhY2+WU74B6/9Ufhpo4=";
   };
 
   sourceRoot = "${src.name}/libs/partners/ollama";

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -128,6 +128,9 @@ buildPythonPackage rec {
     "test_serializable_mapping"
     "test_person"
     "test_aliases_hidden"
+    # AssertionError: (failed string match due to terminal control chars in output)
+    # https://github.com/langchain-ai/langchain/issues/32150
+    "test_filecallback"
   ];
 
   disabledTestPaths = [
@@ -143,6 +146,13 @@ buildPythonPackage rec {
     "tests/unit_tests/output_parsers/test_retry.py"
     # pydantic.errors.PydanticUserError: `LLMSummarizationCheckerChain` is not fully defined; you should define `BaseCache`, then call `LLMSummarizationCheckerChain.model_rebuild()`.
     "tests/unit_tests/chains/test_llm_summarization_checker.py"
+
+    # TODO Remove on next update
+    # NotImplemented Error / AssertionError re: _HashedDocument
+    # HashedDocument was removed as a public entry in langchain-core > 0.3.66
+    # and langchain is still using the old code. (Will be fixed on next update)
+    "tests/unit_tests/indexes/test_hashed_document.py"
+    "tests/unit_tests/indexes/test_indexing.py"
   ];
 
   pythonImportsCheck = [ "langchain" ];
@@ -150,6 +160,8 @@ buildPythonPackage rec {
   passthru.updateScript = gitUpdater {
     rev-prefix = "langchain==";
   };
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Building applications with LLMs through composability";

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -44,14 +44,14 @@
 
 buildPythonPackage rec {
   pname = "langchain";
-  version = "0.3.26";
+  version = "0.3.27";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain==${version}";
-    hash = "sha256-xxkayOtC2GtgtF3tPkTGKOS9VQ/y2gRPopvKq48/Kq0=";
+    hash = "sha256-bqzJ0017Td65rhDCr2wfx+SCaJzPZTFzQpzy3RlaRj4=";
   };
 
   sourceRoot = "${src.name}/libs/langchain";
@@ -146,13 +146,6 @@ buildPythonPackage rec {
     "tests/unit_tests/output_parsers/test_retry.py"
     # pydantic.errors.PydanticUserError: `LLMSummarizationCheckerChain` is not fully defined; you should define `BaseCache`, then call `LLMSummarizationCheckerChain.model_rebuild()`.
     "tests/unit_tests/chains/test_llm_summarization_checker.py"
-
-    # TODO Remove on next update
-    # NotImplemented Error / AssertionError re: _HashedDocument
-    # HashedDocument was removed as a public entry in langchain-core > 0.3.66
-    # and langchain is still using the old code. (Will be fixed on next update)
-    "tests/unit_tests/indexes/test_hashed_document.py"
-    "tests/unit_tests/indexes/test_indexing.py"
   ];
 
   pythonImportsCheck = [ "langchain" ];

--- a/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-postgres/default.nix
@@ -5,7 +5,7 @@
   stdenvNoCC,
 
   # build system
-  poetry-core,
+  hatchling,
 
   # dependencies
   langgraph-checkpoint,
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-postgres";
-  version = "2.0.21";
+  version = "2.0.23";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpointpostgres==${version}";
-    hash = "sha256-hl1EBOtUkSfHGxsM+LOZPLSvkW7hdHS08klpvA7/Bd0=";
+    hash = "sha256-QAzT8T3bf3R3gwI/iWDYYDz0SxgLZsP61oMk72dYz4s=";
   };
 
   postgresqlTestSetupPost = ''
@@ -44,7 +44,7 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/libs/checkpoint-postgres";
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     langgraph-checkpoint

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build system
-  poetry-core,
+  hatchling,
 
   # dependencies
   langchain-core,
@@ -13,6 +13,8 @@
 
   # testing
   dataclasses-json,
+  numpy,
+  pandas,
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
@@ -23,19 +25,19 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint";
-  version = "2.0.26";
+  version = "2.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpoint==${version}";
-    hash = "sha256-DSkjaxUfpsOg2ex0dgfO/UJ7WiQb5wQsAGgHPTckF6o=";
+    hash = "sha256-UY3AChShKfOrtOQzOm5vi3Yy3rlBc+TAje9L2L6My/U=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint";
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     langchain-core
@@ -48,6 +50,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     dataclasses-json
+    numpy
+    pandas
     pytest-asyncio
     pytest-mock
     pytestCheckHook

--- a/pkgs/development/python-modules/langgraph-prebuilt/default.nix
+++ b/pkgs/development/python-modules/langgraph-prebuilt/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  hatchling,
 
   # dependencies
   langchain-core,
@@ -21,6 +21,7 @@
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
+  syrupy,
   xxhash,
 
   # passthru
@@ -30,19 +31,19 @@
 # It exists so the langgraph team can iterate on it without having to rebuild langgraph.
 buildPythonPackage rec {
   pname = "langgraph-prebuilt";
-  version = "0.1.8";
+  version = "0.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "prebuilt==${version}";
-    hash = "sha256-mYcj7HRbB5H6G0CVLOICKgdtR5Wlv9WeTIBjQJqlhOE=";
+    hash = "sha256-8mubZSV1CDgYzykKaaWqn04yJldAgdGmgZDm54towWc=";
   };
 
   sourceRoot = "${src.name}/libs/prebuilt";
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     langchain-core
@@ -66,6 +67,7 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-mock
     pytestCheckHook
+    syrupy
     xxhash
   ];
 
@@ -82,6 +84,9 @@ buildPythonPackage rec {
     # psycopg.OperationalError: connection failed: connection to server at "127.0.0.1", port 5442 failed: Connection refused
     # Is the server running on that host and accepting TCP/IP connections?
     "tests/test_react_agent.py"
+
+    # Utilities to import
+    "tests/conftest.py"
   ];
 
   passthru.updateScript = gitUpdater {

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  hatchling,
 
   # dependencies
   httpx,
@@ -18,19 +18,19 @@
 
 buildPythonPackage rec {
   pname = "langgraph-sdk";
-  version = "0.1.69";
+  version = "0.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "sdk==${version}";
-    hash = "sha256-MRs5crbUEak/fr17+lerGFY+xTm7sanUW1lZXbPBAeg=";
+    hash = "sha256-uhVdtB/fLy0hfZKfzNV2eoO83bvKppGVl4Lm8IEscL0=";
   };
 
   sourceRoot = "${src.name}/libs/sdk-py";
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     httpx

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -5,13 +5,14 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  hatchling,
 
   # dependencies
   langchain-core,
   langgraph-checkpoint,
   langgraph-prebuilt,
   langgraph-sdk,
+  pydantic,
   xxhash,
 
   # tests
@@ -23,7 +24,6 @@
   langgraph-checkpoint-sqlite,
   langsmith,
   psycopg,
-  pydantic,
   pytest-asyncio,
   pytest-mock,
   pytest-repeat,
@@ -38,30 +38,33 @@
 }:
 buildPythonPackage rec {
   pname = "langgraph";
-  version = "0.4.1";
+  version = "0.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = version;
-    hash = "sha256-bTxtfduuuyRITZqhk15aWwxNwiZ7TMTgBOEPat6zVIc=";
+    hash = "sha256-8mubZSV1CDgYzykKaaWqn04yJldAgdGmgZDm54towWc=";
   };
 
   postgresqlTestSetupPost = ''
-    substituteInPlace tests/conftest.py \
+    substituteInPlace tests/conftest_store.py \
+      --replace-fail "DEFAULT_POSTGRES_URI = \"postgres://postgres:postgres@localhost:5442/\"" "DEFAULT_POSTGRES_URI = \"postgres:///$PGDATABASE\""
+    substituteInPlace tests/conftest_checkpointer.py \
       --replace-fail "DEFAULT_POSTGRES_URI = \"postgres://postgres:postgres@localhost:5442/\"" "DEFAULT_POSTGRES_URI = \"postgres:///$PGDATABASE\""
   '';
 
   sourceRoot = "${src.name}/libs/langgraph";
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     langchain-core
     langgraph-checkpoint
     langgraph-prebuilt
     langgraph-sdk
+    pydantic
     xxhash
   ];
 
@@ -96,10 +99,6 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # test is flaky due to pydantic error on the exception
-    "test_doesnt_warn_valid_schema"
-    "test_tool_node_inject_store"
-
     # Disabling tests that requires to create new random databases
     "test_cancel_graph_astream"
     "test_cancel_graph_astream_events_v2"
@@ -114,9 +113,9 @@ buildPythonPackage rec {
     "test_pending_writes_resume"
     "test_remove_message_via_state_update"
 
-    # pydantic.errors.PydanticForbiddenQualifier,
-    # see https://github.com/langchain-ai/langgraph/issues/4360
-    "test_state_schema_optional_values"
+    # Requires `langgraph dev` to be running
+    "test_remote_graph_basic_invoke"
+    "test_remote_graph_stream_messages_tuple"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/ormsgpack/default.nix
+++ b/pkgs/development/python-modules/ormsgpack/default.nix
@@ -19,19 +19,19 @@
 
 buildPythonPackage rec {
   pname = "ormsgpack";
-  version = "1.9.1";
+  version = "1.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aviramha";
     repo = "ormsgpack";
     tag = version;
-    hash = "sha256-lFKHXTYtYEjtu+nXemQnB0yjkFD69gr0n7XfJ1Hy3J0=";
+    hash = "sha256-7VESiHAkDynf31xrQQh0Vv5vSfMOjnVXRFackUQdB68=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-jOEryJcE5+b0Y588fbDSyPcz5h4zYz2+40+lIfRDV1M=";
+    hash = "sha256-um6PzwL0M5lz4gDkTO/lvWJ0wwuCneNKRW8qysKMmM0=";
   };
 
   build-system = [


### PR DESCRIPTION
1. Ran update script
2. Replaced `pdm-backend` with `hatchling` as needed to keep up with upstream
3. Updated prerequisites `python3Packages.anthropic` and `python3Packages.orgmsgpack` to match requirements

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
