### PR TITLE
linux: remove assert on linux

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -94,8 +94,6 @@ let
     # cgit) that are needed here should be included directly in Nixpkgs as
     # files.
 
-    assert stdenv.hostPlatform.isLinux;
-
     let
       # Dirty hack to make sure that `version` & `src` have
       # `<nixpkgs/pkgs/os-specific/linux/kernel/linux-x.y.nix>` as position

--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -55,5 +55,6 @@ stdenv.mkDerivation rec {
       mic92
       mbbx6spp
     ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -21,14 +21,14 @@ let
     label = "test";
   };
 in
-pkgs.recurseIntoAttrs {
-
-  nixos-test =
-    (pkgs.nixos {
-      system.nixos = dummyVersioning;
-      boot.loader.grub.enable = false;
-      fileSystems."/".device = "/dev/null";
-      system.stateVersion = lib.trivial.release;
-    }).toplevel;
-
-}
+lib.optionalAttrs (stdenv.hostPlatform.isLinux) (
+  pkgs.recurseIntoAttrs {
+    nixos-test =
+      (pkgs.nixos {
+        system.nixos = dummyVersioning;
+        boot.loader.grub.enable = false;
+        fileSystems."/".device = "/dev/null";
+        system.stateVersion = lib.trivial.release;
+      }).toplevel;
+  }
+)


### PR DESCRIPTION
Asserting the host platform for `linux` is bad, because it can't be caught by CI. For the `linux` package itself, it doesn't make a difference, because it also has `meta.platforms = linux` set, so this will fail evaluation - and in a way that can nicely be caught by CI. Also, this error will propagate everywhere else.

Almost everywhere at least, so we add a conditional on running the `pkgs.nixos` test only on Linux. This was previously guarded by the assert, but would now throw eval errors deep into the NixOS eval - there are certain assumptions about packages there (`glibcLocales` not being `null` the first I hit) that only work on Linux. Which is fine.

Hopefully this has zero rebuilds, let's see...

Related: #426629

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
