### PR TITLE
Haskell updates: Fixing haskellPackages.smh

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3237,6 +3237,7 @@ with haskellLib;
 
   # 2025-7-21: Jailbreak to relax bounds lens <5.3, megaparsec <9.7.
   # The test suite does not know how to find the 'smh' binary. (Expects a ./smh executable.)
+  # Test files are not included in installation tar, so fetch them from GitHub repo.
   smh = overrideCabal (drv: {
     src = pkgs.fetchFromGitHub {
       owner = "DanRyba253";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3234,6 +3234,21 @@ with haskellLib;
   # and therefore aren't uploaded to hackage
   # Needs to be fixed upstream
   haskore = dontCheck (doJailbreak super.haskore);
+
+  # 2025-7-21: Jailbreak to relax bounds lens <5.3, megaparsec <9.7.
+  # The test suite does not know how to find the 'smh' binary. (Expects a ./smh executable.)
+  smh = overrideCabal (drv: {
+    src = pkgs.fetchFromGitHub {
+      owner = "DanRyba253";
+      repo = "smh";
+      rev = "b791ee558d2a2e5c0eb7653c68f3f8a8ae58a551";
+      sha256 = "sha256-p4Q4z2iQeO7PqKk1Ou4EVaMZkjIGmEV9PjFfi5Fz+LA=";
+    };
+    testSystemDepends = (drv.testSystemDepends or [ ]) ++ [ pkgs.which ];
+    preCheck = ''ln -sf dist/build/smh/smh ./smh
+               chmod +x ./smh'';
+   }) (doJailbreak super.smh);
+
 }
 // import ./configuration-tensorflow.nix { inherit pkgs haskellLib; } self super
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5622,7 +5622,6 @@ broken-packages:
   - smawk # failure in job https://hydra.nixos.org/build/233258699 at 2023-09-02
   - sme # failure in job https://hydra.nixos.org/build/233208306 at 2023-09-02
   - smerdyakov # failure in job https://hydra.nixos.org/build/233238735 at 2023-09-02
-  - smh # failure in job https://hydra.nixos.org/build/253695707 at 2024-03-31
   - smiles # failure in job https://hydra.nixos.org/build/233197831 at 2023-09-02
   - SmithNormalForm # failure in job https://hydra.nixos.org/build/233253620 at 2023-09-02
   - smoothie # failure in job https://hydra.nixos.org/build/233250042 at 2023-09-02


### PR DESCRIPTION
**Reason for changes**: `haskellPackages.smh` was marked as "broken". The underlying problems were:

- Overly strict dependecy bounds in smh.cabal (`lens` and `megaparsec`).
- Testing failure due to inability to locate built binary and testing file.

**Changes**:

- Jailbreaking the package to escape strict bounds.
- Temporarily adding binary to $PATH and making it executable.
- Fetching src from package repository to include testing files.
- Removed "broken" label from `smh`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
