### PR TITLE
sncli: init at 0.4.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23309,6 +23309,12 @@
     githubId = 28259;
     name = "Michael Witrant";
   };
+  sigmonsays = {
+    name = "sigmonsays";
+    email = "sigmonsays@picklerick.it";
+    github = "sigmonsays";
+    githubId = 123410;
+  };
   sikmir = {
     email = "sikmir@disroot.org";
     matrix = "@sikmir:matrix.org";

--- a/pkgs/by-name/sn/sncli/package.nix
+++ b/pkgs/by-name/sn/sncli/package.nix
@@ -1,8 +1,7 @@
 {
-  fetchFromGitHub,
   lib,
   python3Packages,
-  ...
+  fetchFromGitHub,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "sncli";
@@ -12,17 +11,16 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "insanum";
     repo = "sncli";
-    rev = "0.4.4";
+    tag = version;
     hash = "sha256-Ldm8oQdJvZXjD2ZdnkK+HZjMkbDXGkJSkai3iuhNziw";
   };
 
-  build-system = [ python3Packages.setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
   dependencies = with python3Packages; [
-    urwid
     requests
     simperium3
-    setuptools
+    urwid
   ];
 
   pythonImportsCheck = [ "simplenote_cli" ];

--- a/pkgs/by-name/sn/sncli/package.nix
+++ b/pkgs/by-name/sn/sncli/package.nix
@@ -1,0 +1,40 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+  ...
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "sncli";
+  version = "0.4.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "insanum";
+    repo = "sncli";
+    rev = "0.4.4";
+    hash = "sha256-Ldm8oQdJvZXjD2ZdnkK+HZjMkbDXGkJSkai3iuhNziw";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    urwid
+    requests
+    simperium3
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "simplenote_cli" ];
+
+  # No tests available
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/insanum/sncli";
+    maintainers = with lib.maintainers; [ sigmonsays ];
+    license = lib.licenses.mit;
+    description = "Simplenote CLI";
+    mainProgram = "sncli";
+  };
+}

--- a/pkgs/development/python-modules/simperium3/default.nix
+++ b/pkgs/development/python-modules/simperium3/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  requests,
+  setuptools,
+  fetchPypi,
+}:
+buildPythonPackage rec {
+  pname = "Simperium3";
+  version = "0.1.5";
+  pyproject = true;
+
+  # No tags on the GitHub repo.
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-eLgYa+GIaa1f2F6D3VDsK5StT0c9D22fneOYoQEU0Tc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+  ];
+
+  pythonImportsCheck = [ "simperium" ];
+
+  meta = {
+    description = "Simperium client library for Python";
+    homepage = "https://github.com/Simperium/simperium-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sigmonsays ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16369,6 +16369,8 @@ self: super: with self; {
 
   simber = callPackage ../development/python-modules/simber { };
 
+  simperium3 = callPackage ../development/python-modules/simperium3 { };
+
   simpful = callPackage ../development/python-modules/simpful { };
 
   simple-dftd3 = callPackage ../development/libraries/science/chemistry/simple-dftd3/python.nix {


### PR DESCRIPTION
sncli is a simple note cli tool from https://github.com/insanum/sncli


## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
