### PR TITLE
pyairtable: init at 3.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24232,6 +24232,12 @@
     githubId = 1315818;
     name = "Felix Bühler";
   };
+  stupidcomputer = {
+    email = "ryan@beepboop.systems";
+    github = "stupidcomputer";
+    githubId = 108326967;
+    name = "Ryan Marina";
+  };
   stupremee = {
     email = "jutus.k@protonmail.com";
     github = "Stupremee";

--- a/pkgs/development/python-modules/pyairtable/default.nix
+++ b/pkgs/development/python-modules/pyairtable/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+
+  inflection,
+  pydantic,
+  requests,
+  urllib3,
+  click,
+
+  pytest,
+  pytest-cov,
+  mock,
+  requests-mock,
+  tox,
+}:
+
+buildPythonPackage rec {
+  pname = "pyairtable";
+  version = "3.1.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-sYX+8SEZ8kng5wSrTksVopCA/Ikq1NVRoQU6G7YJ7y4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    setuptools
+    inflection
+    pydantic
+    requests
+    urllib3
+    click
+  ];
+
+  nativeCheckInputs = [
+    pytest
+    pytest-cov
+    mock
+    requests-mock
+    tox
+  ];
+
+  pythonImportsCheck = [ "pyairtable" ];
+
+  meta = {
+    description = "Python API Client for Airtable";
+    homepage = "https://pyairtable.readthedocs.io/";
+    changelog = "https://pyairtable.readthedocs.io/en/${version}/changelog.html";
+    license = lib.licenses.mit;
+    mainProgram = "pyairtable";
+    maintainers = with lib.maintainers; [ stupidcomputer ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12261,6 +12261,8 @@ self: super: with self; {
 
   pyairports = callPackage ../development/python-modules/pyairports { };
 
+  pyairtable = callPackage ../development/python-modules/pyairtable { };
+
   pyairvisual = callPackage ../development/python-modules/pyairvisual { };
 
   pyais = callPackage ../development/python-modules/pyais { };


### PR DESCRIPTION

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
