### PR TITLE
opensmalltalk-vm: don't throw without aliases

### DIFF
--- a/pkgs/development/compilers/opensmalltalk-vm/default.nix
+++ b/pkgs/development/compilers/opensmalltalk-vm/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   stdenv,
   lib,
   fetchFromGitHub,
@@ -190,7 +191,11 @@ let
 
   platform = stdenv.targetPlatform.system;
 in
-vmsByPlatform.${platform} or (throw (
-  "Unsupported platform ${platform}: only the following platforms are supported: "
-  + builtins.toString (builtins.attrNames vmsByPlatform)
-))
+if (!config.allowAliases && !(vmsByPlatform ? platform)) then
+  # Don't throw without aliases to not break CI.
+  null
+else
+  vmsByPlatform.${platform} or (throw (
+    "Unsupported platform ${platform}: only the following platforms are supported: "
+    + builtins.toString (builtins.attrNames vmsByPlatform)
+  ))


### PR DESCRIPTION
CI needs ugly workarounds to catch a `throw` on unsupported platforms. If aliases are disabled, as is the case in CI, we simply return `null` for this leaf package. This will ignore it for CI purposes, while still giving a proper error message for end users.

Similar solution to those in #426645.

Related: #426629.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
