### PR TITLE
python3Packages.wheel: fix outdated hash

### DIFF
--- a/pkgs/by-name/ha/havoc/package.nix
+++ b/pkgs/by-name/ha/havoc/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "havoc";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "ii8";
     repo = "havoc";
     rev = finalAttrs.version;
-    hash = "sha256-YCZdAlIDptVLMUko40gfp2BCAbhGNsYyVTDB14VTNSE=";
+    hash = "sha256-Hn0HrAgxrkfN+iXAt+C4rOd3/Z+ZKFVk3GGNgVtro7A=";
   };
 
   depsBuildBuild = [

--- a/pkgs/development/python-modules/wheel/default.nix
+++ b/pkgs/development/python-modules/wheel/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     owner = "pypa";
     repo = "wheel";
     tag = version;
-    hash = "sha256-tgueGEWByS5owdA5rhXGn3qh1Vtf0HGYC6+BHfrnGAs=";
+    hash = "sha256-iyGfGr3pLVZSEIHetjsPbIIXkuXrmIPiSqqOw31l9Qw=";
   };
 
   nativeBuildInputs = [ flit-core ];


### PR DESCRIPTION
The hash wasn't updated when the version was updated in b2fc3a5923ff2. Builds are using the previous source obtained from cache.nixos.org. When the source is fetched from upstream, builds fail with a hash mismatch.

```
$ nix-prefetch-git https://github.com/pypa/wheel 0.46.1
Initialized empty Git repository in /tmp/git-checkout-tmp-n9zs0G2A/wheel/.git/
remote: Enumerating objects: 62, done.
remote: Counting objects: 100% (62/62), done.
remote: Compressing objects: 100% (59/59), done.
remote: Total 62 (delta 0), reused 34 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (62/62), 61.04 KiB | 811.00 KiB/s, done.
From https://github.com/pypa/wheel
 * tag               0.46.1     -> FETCH_HEAD
Switched to a new branch 'fetchgit'
removing `.git'...

git revision is 7a0ea7f7c3dd73747e37368bb074cd0d9fb49259
path is /nix/store/z6010nnppj1p8xncvsv5y2niwx4x6man-wheel
git human-readable version is -- none --
Commit date is 2025-04-08 23:53:52 +0300
hash is 037mcmyw73ma9bi8767bwn91g0kc1wxvdpl12195cbg9pld9y8cb
{
  "url": "https://github.com/pypa/wheel",
  "rev": "7a0ea7f7c3dd73747e37368bb074cd0d9fb49259",
  "date": "2025-04-08T23:53:52+03:00",
  "path": "/nix/store/z6010nnppj1p8xncvsv5y2niwx4x6man-wheel",
  "sha256": "037mcmyw73ma9bi8767bwn91g0kc1wxvdpl12195cbg9pld9y8cb",
  "hash": "sha256-iyGfGr3pLVZSEIHetjsPbIIXkuXrmIPiSqqOw31l9Qw=",
  "fetchLFS": false,
  "fetchSubmodules": false,
  "deepClone": false,
  "fetchTags": false,
  "leaveDotGit": false
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
