### PR TITLE
crun-krun: init at 1.22

### DIFF
--- a/pkgs/by-name/cr/crun-krun/package.nix
+++ b/pkgs/by-name/cr/crun-krun/package.nix
@@ -1,0 +1,117 @@
+{
+  stdenv,
+  lib,
+  fetchgit,
+  autoreconfHook,
+  go-md2man,
+  pkg-config,
+  libcap,
+  libseccomp,
+  python3,
+  systemd,
+  yajl,
+  nixosTests,
+  criu,
+  libkrun,
+  libkrun-sev,
+  nix-update-script,
+}:
+
+let
+  # these tests require additional permissions
+  disabledTests = [
+    "test_capabilities.py"
+    "test_cwd.py"
+    "test_delete.py"
+    "test_detach.py"
+    "test_exec.py"
+    "test_hooks.py"
+    "test_hostname.py"
+    "test_oci_features"
+    "test_paths.py"
+    "test_pid.py"
+    "test_pid_file.py"
+    "test_preserve_fds.py"
+    "test_resources"
+    "test_seccomp"
+    "test_start.py"
+    "test_uid_gid.py"
+    "test_update.py"
+    "tests_libcrun_utils"
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "crun-krun";
+  version = "1.22";
+
+  src = fetchgit {
+    url = "https://github.com/containers/crun";
+    sha256 = "sha256-IZzG+khiJb5LBPqUOuZbexvFppjyLE216QUndllylu0=";
+    tag = finalAttrs.version;
+    fetchSubmodules = true;
+    leaveDotGit = true;
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    go-md2man
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    criu
+    libcap
+    libseccomp
+    libkrun
+    libkrun-sev
+    systemd
+    yajl
+  ];
+
+  enableParallelBuilding = true;
+  strictDeps = true;
+
+  NIX_LDFLAGS = "-lcriu -lkrun -lkrun-sev";
+
+  # we need this before autoreconfHook does its thing in order to initialize
+  # config.h with the correct values
+  postPatch = ''
+    echo ${finalAttrs.version} > .tarball-version
+    echo '#define GIT_VERSION "${finalAttrs.src.rev}"' > git-version.h
+
+    ${lib.concatMapStringsSep "\n" (
+      e: "substituteInPlace Makefile.am --replace 'tests/${e}' ''"
+    ) disabledTests}
+  '';
+
+  doCheck = true;
+
+  configurePhase = ''
+    runHook preConfigure
+
+    mkdir -p /build
+    chmod +w /build
+    ./autogen.sh
+    ./configure \
+      --prefix=$out \
+      --enable-shared \
+      --enable-dynamic \
+      --with-libkrun
+
+    runHook postConfigure
+  '';
+
+  passthru.tests = { inherit (nixosTests) podman; };
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/containers/crun/releases/tag/${finalAttrs.version}";
+    description = "Fast and lightweight fully featured OCI runtime and C library for running containers";
+    homepage = "https://github.com/containers/crun";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ miampf ];
+    mainProgram = "krun";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR packages `crun-krun`, a sub package of `crun` to run containers in microvms. Closes https://github.com/NixOS/nixpkgs/issues/358585. I decided to put this in an extra package to not interfer with the existing `crun` package, even tho `crun` is also an output binary (due to `krun` being a symlink to `crun` linked with appropriate libraries). If this should instead be an option enabled by a variable flag in `crun`, I can change it accordingly :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
