### PR TITLE
onlykey-agent: modernize and clean up dependencies

### DIFF
--- a/pkgs/by-name/on/onlykey-agent/package.nix
+++ b/pkgs/by-name/on/onlykey-agent/package.nix
@@ -2,79 +2,74 @@
   lib,
   python3Packages,
   fetchPypi,
-  onlykey-cli,
 }:
 
 let
-  bech32 =
-    with python3Packages;
-    buildPythonPackage rec {
-      pname = "bech32";
-      version = "1.2.0";
-      format = "setuptools";
+  # onlykey requires a fork of libagent called lib-agent
+  lib-agent = python3Packages.buildPythonPackage rec {
+    pname = "lib-agent";
+    version = "1.0.6";
+    pyproject = true;
 
-      src = fetchPypi {
-        inherit pname version;
-        sha256 = "sha256-fW24IUYDvXhx/PpsCCbvaLhbCr2Q+iHChanF4h0r2Jk=";
-      };
+    src = fetchPypi {
+      inherit version;
+      pname = "lib-agent";
+      hash = "sha256-IrJizIHDIPHo4tVduUat7u31zHo3Nt8gcMOyUUqkNu0=";
     };
 
-  # onlykey requires a patched version of libagent
-  lib-agent =
-    with python3Packages;
-    libagent.overridePythonAttrs (oa: rec {
-      version = "1.0.6";
-      src = fetchPypi {
-        inherit version;
-        pname = "lib-agent";
-        sha256 = "sha256-IrJizIHDIPHo4tVduUat7u31zHo3Nt8gcMOyUUqkNu0=";
-      };
-      propagatedBuildInputs = oa.propagatedBuildInputs or [ ] ++ [
-        bech32
-        cryptography
-        cython
-        docutils
-        pycryptodome
-        pynacl
-        wheel
-      ];
+    build-system = with python3Packages; [ setuptools ];
 
-      # turn off testing because I can't get it to work
-      doCheck = false;
-      pythonImportsCheck = [ "libagent" ];
+    dependencies = with python3Packages; [
+      bech32
+      cryptography
+      pycryptodome
+      docutils
+      python-daemon
+      backports-shutil-which
+      configargparse
+      python-daemon
+      ecdsa
+      pynacl
+      mnemonic
+      pymsgbox
+      semver
+      unidecode
 
-      meta = oa.meta // {
-        description = "Using OnlyKey as hardware SSH and GPG agent";
-        homepage = "https://github.com/trustcrypto/onlykey-agent/tree/ledger";
-        maintainers = with lib.maintainers; [ kalbasit ];
-      };
-    });
+      setuptools # pkg_resources is imported during runtime
+    ];
+
+    pythonImportsCheck = [ "libagent" ];
+
+    meta = {
+      description = "Using OnlyKey as hardware SSH and GPG agent";
+      homepage = "https://github.com/trustcrypto/onlykey-agent/tree/ledger";
+      license = lib.licenses.lgpl3Only;
+      maintainers = with lib.maintainers; [ kalbasit ];
+    };
+  };
 in
 python3Packages.buildPythonApplication rec {
   pname = "onlykey-agent";
   version = "1.1.15";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-SbGb7CjcD7cFPvASZtip56B4uxRiFKZBvbsf6sb8fds=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
-    lib-agent
-    onlykey-cli
-    setuptools
-  ];
-
-  # move the python library into the sitePackages.
-  postInstall = ''
-    mkdir $out/${python3Packages.python.sitePackages}/onlykey_agent
-    mv $out/bin/onlykey_agent.py $out/${python3Packages.python.sitePackages}/onlykey_agent/__init__.py
-    chmod a-x $out/${python3Packages.python.sitePackages}/onlykey_agent/__init__.py
+  postPatch = ''
+    # we don't need this python script to be installed into $out/bin
+    substituteInPlace setup.py \
+      --replace-fail "scripts=['onlykey_agent.py']," ""
   '';
 
-  # no tests
-  doCheck = false;
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = [ lib-agent ];
+
+  pythonRemoveDeps = [ "onlykey" ]; # doesn't seem to be imported anywhere
+
   pythonImportsCheck = [ "onlykey_agent" ];
 
   meta = with lib; {


### PR DESCRIPTION
Note: I don't use this software, so please do check if everything still works!

---

Changes:
- Use `pyproject = true` + `build-system = [ setuptools ]` instead of `format = "setuptools"`
- Remove `bech32` since it has been added to the python package set. (It was not part of it when this package was created)
- Don't use `overridePythonAttrs`, just package `lib-agent` using `buildPythonPackage` like normal. This way we can avoid breakage.
- Move the `setuptools` dependency into `lib-agent` since https://github.com/NixOS/nixpkgs/pull/287758 added it into the wrong place.
- Remove the custom `postInstall` logic in favor of just removing `scripts=['onlykey_agent.py']` from setup.py
- Remove the dependency on `onlykey-cli`. It doesn't seem to be used anywhere in the app, but it is declared as a dependency.
  - Maybe they did this so that when you try to install it through `pip` it will also download `onlykey-cli`. In any case, this doesn't seem to be required for nixpkgs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
