### PR TITLE
[Backport release-25.05] openvpn3: 24.1 -> 25; add `passthru.updateScript`

### DIFF
--- a/pkgs/by-name/op/openvpn3/package.nix
+++ b/pkgs/by-name/op/openvpn3/package.nix
@@ -22,12 +22,12 @@
   gdbuspp,
   cmake,
   git,
+  nix-update-script,
   enableSystemdResolved ? true,
 }:
 
 stdenv.mkDerivation rec {
   pname = "openvpn3";
-  # also update openvpn3-core
   version = "24.1";
 
   src = fetchFromGitHub {
@@ -113,6 +113,8 @@ stdenv.mkDerivation rec {
   '';
 
   NIX_LDFLAGS = "-lpthread";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "OpenVPN 3 Linux client";

--- a/pkgs/by-name/op/openvpn3/package.nix
+++ b/pkgs/by-name/op/openvpn3/package.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "openvpn3";
-  version = "24.1";
+  version = "25";
 
   src = fetchFromGitHub {
     owner = "OpenVPN";
     repo = "openvpn3-linux";
     tag = "v${version}";
-    hash = "sha256-E6SBVPHmejXB18RuNCNq62yWOJslZfIjVbNUdRIk5Sw=";
+    hash = "sha256-Fme8OT49h2nZw5ypyeKdHlqv2Hk92LW2KVisd0jC66s=";
     # `openvpn3-core` is a submodule.
     # TODO: make it into a separate package
     fetchSubmodules = true;


### PR DESCRIPTION
Manual backport of #402044 and #426972 to `release-25.05`.

* Release notes: https://codeberg.org/OpenVPN/openvpn3-linux/releases/tag/v25. Note that there aren't breaking changes, only a deprecation and some enhancements.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.