### PR TITLE
lspx: init at 0.3.1

### DIFF
--- a/pkgs/by-name/ls/lspx/package.nix
+++ b/pkgs/by-name/ls/lspx/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  deno,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lspx";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "thefrontside";
+    repo = "lspx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NEwcNE5RxN/rl75bRxUQgANtqp26Y88HV/WKMtytt8k=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir --parent $out/lib
+    cp --recursive * $out/lib
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    makeWrapper ${lib.getExe' deno "deno"} $out/bin/${finalAttrs.meta.mainProgram} \
+      --add-flags "run --allow-all $out/lib/main.ts" \
+      --set DENO_NO_UPDATE_CHECK "1"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Language server multiplexer, supervisor, and interactive shell";
+    homepage = "https://github.com/thefrontside/lspx";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "lspx";
+    inherit (deno.meta) platforms;
+  };
+})


### PR DESCRIPTION
[`lspx`](https://github.com/thefrontside/lspx) is a language server multiplexer, supervisor, and interactive shell.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] ~~Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
