### PR TITLE
buildGoModule: add buildTestBinaries option, add tests

### DIFF
--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -194,6 +194,12 @@ Specifies the contents of the `go.sum` file and triggers rebuilds when it change
 
 Defaults to `null`
 
+### `buildTestBinaries` {#var-go-buildTestBinaries}
+
+This option allows to compile test binaries instead of the usual binaries produced by a package.
+Go can [compile test into binaries](https://pkg.go.dev/cmd/go#hdr-Test_packages) using the `go test -c` command.
+These binaries can then be executed at a later point (outside the Nix sandbox) to run the tests.
+This is mostly useful for downstream consumers to run integration or end-to-end tests that won't work in the Nix sandbox, for example because they require network access.
 
 ## Versioned toolchains and builders {#ssec-go-toolchain-versions}
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -532,6 +532,9 @@
   "typst-package-scope-and-usage": [
     "index.html#typst-package-scope-and-usage"
   ],
+  "var-go-buildTestBinaries": [
+    "index.html#var-go-buildTestBinaries"
+  ],
   "var-meta-teams": [
     "index.html#var-meta-teams"
   ],

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -64,6 +64,12 @@ lib.extendMkDerivation {
       # Go build flags.
       GOFLAGS ? [ ],
 
+      # Instead of building binary targets with 'go install', build test binaries with 'go test'.
+      # The binaries found in $out/bin can be executed as go tests outside of the sandbox.
+      # This is mostly useful outside of nixpkgs, for example to build integration/e2e tests
+      # that won't run within the sandbox.
+      buildTestBinaries ? false,
+
       ...
     }@args:
     {
@@ -338,8 +344,18 @@ lib.extendMkDerivation {
                   export NIX_BUILD_CORES=1
               fi
               for pkg in $(getGoDirs ""); do
-                echo "Building subPackage $pkg"
-                buildGoDir install "$pkg"
+                ${
+                  if buildTestBinaries then
+                    ''
+                      echo "Building test binary for $pkg"
+                      buildGoDir "test -c -o $GOPATH/bin/" "$pkg"
+                    ''
+                  else
+                    ''
+                      echo "Building subPackage $pkg"
+                      buildGoDir install "$pkg"
+                    ''
+                }
               done
             ''
           + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
@@ -359,7 +375,7 @@ lib.extendMkDerivation {
           ''
         );
 
-      doCheck = args.doCheck or true;
+      doCheck = args.doCheck or (!buildTestBinaries);
       checkPhase =
         args.checkPhase or ''
           runHook preCheck

--- a/pkgs/build-support/go/tests.nix
+++ b/pkgs/build-support/go/tests.nix
@@ -1,0 +1,9 @@
+{
+  lib,
+  callPackage,
+}:
+
+lib.packagesFromDirectoryRecursive {
+  inherit callPackage;
+  directory = ./tests;
+}

--- a/pkgs/build-support/go/tests/build-test-binaries/go.mod
+++ b/pkgs/build-support/go/tests/build-test-binaries/go.mod
@@ -1,0 +1,3 @@
+module build-test-binaries
+
+go 1.24

--- a/pkgs/build-support/go/tests/build-test-binaries/main_test.go
+++ b/pkgs/build-support/go/tests/build-test-binaries/main_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestHelloFromTest(t *testing.T) {
+	t.Log("Hello from test")
+}

--- a/pkgs/build-support/go/tests/build-test-binaries/package.nix
+++ b/pkgs/build-support/go/tests/build-test-binaries/package.nix
@@ -1,0 +1,34 @@
+{
+  buildGoModule,
+  runCommandCC,
+}:
+
+let
+  testPackage = buildGoModule {
+    name = "build-test-binaries";
+    src = ./.;
+    vendorHash = null;
+    buildTestBinaries = true;
+  };
+in
+
+runCommandCC "build-test-binaries-check"
+  {
+    nativeBuildInputs = [ testPackage ];
+    passthru = { inherit testPackage; };
+  }
+  ''
+    fail() {
+      echo "Test failed: $1" >&2
+      exit 1
+    }
+
+    command -v build-test-binaries.test ||
+      fail "build-test-binaries.test not found in PATH"
+
+    build-test-binaries.test -test.v | tee $out ||
+      fail "build-test-binaries.test failed"
+
+    grep -q "Hello from test" $out ||
+      fail "Output does not contain expected string"
+  ''

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -148,6 +148,8 @@ with pkgs;
 
   php = recurseIntoAttrs (callPackages ./php { });
 
+  go = recurseIntoAttrs (callPackage ../build-support/go/tests.nix { });
+
   pkg-config = recurseIntoAttrs (callPackage ../top-level/pkg-config/tests.nix { }) // {
     __recurseIntoDerivationForReleaseJobs = true;
   };


### PR DESCRIPTION
This adds a `buildTestBinaries` option to build test binaries instead of the usual package targets.
It also introduces a test suit for `buildGoModule` and adds a test for the new option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
