### PR TITLE
vim-full: fix build when built with GUI support

### DIFF
--- a/pkgs/applications/editors/vim/full.nix
+++ b/pkgs/applications/editors/vim/full.nix
@@ -26,6 +26,7 @@
   libXmu,
   libsodium,
   libICE,
+  wayland-scanner,
   vimPlugins,
   makeWrapper,
   wrapGAppsHook3,
@@ -33,6 +34,7 @@
   features ? "huge", # One of tiny, small, normal, big or huge
   wrapPythonDrv ? false,
   guiSupport ? config.vim.gui or (if stdenv.hostPlatform.isDarwin then "gtk2" else "gtk3"),
+  waylandSupport ? !stdenv.hostPlatform.isDarwin,
   luaSupport ? config.vim.lua or true,
   perlSupport ? config.vim.perl or false, # Perl interpreter
   pythonSupport ? config.vim.python or true, # Python interpreter
@@ -121,6 +123,7 @@ stdenv.mkDerivation {
       "--disable-nextaf_check"
       "--disable-carbon_check"
       "--disable-gtktest"
+      (lib.strings.enableFeature waylandSupport "wayland")
     ]
     ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "vim_cv_toupper_broken=no"
@@ -188,6 +191,7 @@ stdenv.mkDerivation {
     ]
     ++ lib.optional (guiSupport == "gtk2") gtk2-x11
     ++ lib.optional (guiSupport == "gtk3") gtk3-x11
+    ++ lib.optional waylandSupport wayland-scanner
     ++ lib.optional luaSupport lua
     ++ lib.optional pythonSupport python3
     ++ lib.optional tclSupport tcl


### PR DESCRIPTION
wayland-scanner is now needed since https://github.com/vim/vim/commit/b90c2395b2c055aed38e0c5fd40c1841f43dab4b

This should fix the regression introduced in #426497

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
