### PR TITLE
[Backport release-25.05] p2pool: 4.4 -> 4.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11014,6 +11014,13 @@
     githubId = 45084216;
     keys = [ { fingerprint = "1BF9 8D10 E0D0 0B41 5723  5836 4C13 3A84 E646 9228"; } ];
   };
+  JacoMalan1 = {
+    name = "Jaco Malan";
+    email = "jacom@codelog.co.za";
+    github = "JacoMalan1";
+    githubId = 10290409;
+    keys = [ { fingerprint = "339C 9213 7F2D 5D6E 2B6A  6E98 240B B4C4 27BC 327A"; } ];
+  };
   jaculabilis = {
     name = "Tim Van Baak";
     email = "tim.vanbaak@gmail.com";

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "p2pool";
-  version = "4.7";
+  version = "4.8";
 
   src = fetchFromGitHub {
     owner = "SChernykh";
     repo = "p2pool";
     rev = "v${version}";
-    hash = "sha256-F8kgoGgnFk6vE1nNnV6TShwnEAnqxD1wbsCAnL7mHRM=";
+    hash = "sha256-D1yQMcgRYVZf3/VGCmp6ZGu5YlWUmvlCx3pZqQF7JDM=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "p2pool";
-  version = "4.8.1";
+  version = "4.9";
 
   src = fetchFromGitHub {
     owner = "SChernykh";
     repo = "p2pool";
     rev = "v${version}";
-    hash = "sha256-UnvMR4s6o8n7K+9hig3iSFtbN/BmR6yqjc64X443ctk=";
+    hash = "sha256-nFoR5n6vm6Q1UBxX+3U6O6NExcrM1Mab+WjEOgRSKCE=";
     fetchSubmodules = true;
   };
 
@@ -64,5 +64,6 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "p2pool";
     platforms = platforms.all;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "p2pool";
-  version = "4.4";
+  version = "4.7";
 
   src = fetchFromGitHub {
     owner = "SChernykh";
     repo = "p2pool";
     rev = "v${version}";
-    hash = "sha256-+wkcTkHhGNanCznL5d9yUezi9wLIchxt6TPPpEUqgN8=";
+    hash = "sha256-F8kgoGgnFk6vE1nNnV6TShwnEAnqxD1wbsCAnL7mHRM=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "p2pool";
-  version = "4.8";
+  version = "4.8.1";
 
   src = fetchFromGitHub {
     owner = "SChernykh";
     repo = "p2pool";
     rev = "v${version}";
-    hash = "sha256-D1yQMcgRYVZf3/VGCmp6ZGu5YlWUmvlCx3pZqQF7JDM=";
+    hash = "sha256-UnvMR4s6o8n7K+9hig3iSFtbN/BmR6yqjc64X443ctk=";
     fetchSubmodules = true;
   };
 
@@ -58,7 +58,10 @@ stdenv.mkDerivation rec {
     description = "Decentralized pool for Monero mining";
     homepage = "https://github.com/SChernykh/p2pool";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ ratsclub ];
+    maintainers = with maintainers; [
+      ratsclub
+      JacoMalan1
+    ];
     mainProgram = "p2pool";
     platforms = platforms.all;
   };


### PR DESCRIPTION
Backporting recent updates to p2pool. This is effectively updating p2pool on 25.05 from p2pool 4.4 -> 4.9

Supercedes #427608

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
