### PR TITLE
haxor-news: unstable-2020-10-20 -> unstable-2022-04-22

### DIFF
--- a/pkgs/by-name/ha/haxor-news/package.nix
+++ b/pkgs/by-name/ha/haxor-news/package.nix
@@ -2,51 +2,23 @@
   lib,
   fetchFromGitHub,
   fetchPypi,
-  python3,
+  python3Packages,
 }:
 
-let
-  py = python3.override {
-    self = py;
-    packageOverrides = self: super: {
-      # not compatible with prompt_toolkit >=2.0
-      prompt-toolkit = super.prompt-toolkit.overridePythonAttrs (oldAttrs: rec {
-        name = "${oldAttrs.pname}-${version}";
-        version = "1.0.18";
-        src = oldAttrs.src.override {
-          inherit version;
-          hash = "sha256-3U/KAsgGlJetkxotCZFMaw0bUBUc6Ha8Fb3kx0cJASY=";
-        };
-      });
-      # Use click 7
-      click = super.click.overridePythonAttrs (old: rec {
-        version = "7.1.2";
-        src = fetchPypi {
-          pname = "click";
-          inherit version;
-          hash = "sha256-0rUlXHxjSbwb0eWeCM0SrLvWPOZJ8liHVXg6qU37axo=";
-        };
-        disabledTests = [ "test_bytes_args" ];
-      });
-    };
-  };
-in
-with py.pkgs;
-
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "haxor-news";
-  version = "unstable-2020-10-20";
+  version = "unstable-2022-04-22";
   format = "setuptools";
 
   # haven't done a stable release in 3+ years, but actively developed
   src = fetchFromGitHub {
     owner = "donnemartin";
     repo = "haxor-news";
-    rev = "811a5804c09406465b2b02eab638c08bf5c4fa7f";
-    hash = "sha256-5v61b49ttwqPOvtoykJBBzwVSi7S8ARlakccMr12bbw=";
+    rev = "8294e4498858f036a344b06e82f08b834c2a8270";
+    hash = "sha256-0eVk5zj7F3QDFvV0Kv9aeV1oeKxr/Kza6M3pK6hyYuY=";
   };
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3Packages; [
     click
     colorama
     requests
@@ -58,7 +30,7 @@ buildPythonApplication rec {
   # will fail without pre-seeded config files
   doCheck = false;
 
-  nativeCheckInputs = [
+  nativeCheckInputs = with python3Packages; [
     unittestCheckHook
     mock
   ];


### PR DESCRIPTION
Package was not building with error, I removed the manual package
overrides and it built fine.

Also updated to the most recent unstable commit afterwards.

From what I tested it seems to work fine.

```
error: builder for '/nix/store/15l75w52cxc77zwdqv2w41cz0sylky0q-python3.13-prompt-toolkit-1.0.18.drv' failed with exit code 1;
       last 21 log lines:
       > Sourcing python-remove-tests-dir-hook
       > Sourcing python-catch-conflicts-hook.sh
       > Sourcing python-remove-bin-bytecode-hook.sh
       > Sourcing pypa-build-hook
       > Using pypaBuildPhase
       > Sourcing python-runtime-deps-check-hook
       > Using pythonRuntimeDepsCheckHook
       > Sourcing pypa-install-hook
       > Using pypaInstallPhase
       > Sourcing python-imports-check-hook.sh
       > Using pythonImportsCheckPhase
       > Sourcing python-namespaces-hook
       > Sourcing python-catch-conflicts-hook.sh
       > Sourcing pytest-check-hook
       > Using pytestCheckPhase
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/hxiafm537za17sivpcljvqr6qlsclc8n-prompt_toolkit-1.0.18.tar.gz
       > source root is prompt_toolkit-1.0.18
       > setting SOURCE_DATE_EPOCH to timestamp 1570133629 of file "prompt_toolkit-1.0.18/setup.cfg"
       > Running phase: patchPhase
       > substitute(): ERROR: file 'src/prompt_toolkit/__init__.py' does not exist
       For full logs, run:
         nix log /nix/store/15l75w52cxc77zwdqv2w41cz0sylky0q-python3.13-prompt-toolkit-1.0.18.drv
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
