### PR TITLE
[25.05] python313Packages.textfsm: 1.1.3 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/napalm/default.nix
+++ b/pkgs/development/python-modules/napalm/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   pythonOlder,
 
   # build-system
@@ -45,6 +46,16 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-Abw3h69qTFwOOFeAfivqAIWLozErJ1yZZfx7CbMy1AI=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/napalm-automation/napalm/commit/7e509869f7cb56892380629d1cb5f99e3e2c6190.patch";
+      hash = "sha256-vJDACa5SmSJ/rcmKEow4Prqju/jYcCrzGpTdEYsAPq0=";
+      includes = [
+        "napalm/ios/ios.py"
+      ];
+    })
+  ];
 
   nativeBuildInputs = [ setuptools ];
 

--- a/pkgs/development/python-modules/ntc-templates/default.nix
+++ b/pkgs/development/python-modules/ntc-templates/default.nix
@@ -28,7 +28,9 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [ textfsm ];
+  pythonRelaxDeps = [ "textfsm" ];
+
+  dependencies = [ textfsm ];
 
   nativeCheckInputs = [
     invoke

--- a/pkgs/development/python-modules/textfsm/default.nix
+++ b/pkgs/development/python-modules/textfsm/default.nix
@@ -2,33 +2,23 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  six,
-  future,
+  setuptools,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "textfsm";
-  version = "1.1.3";
-  format = "setuptools";
+  version = "2.1.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-IHgKG8v0X+LSK6purWBdwDnI/BCs5XA12ZJixuqqXWg=";
+    tag = "v${version}";
+    hash = "sha256-ygVcDdT85mRN+qYfTZqraRVyp2JlLwwujBW1e/pPJNc=";
   };
 
-  # upstream forgot to update the release version
-  postPatch = ''
-    substituteInPlace textfsm/__init__.py \
-      --replace "1.1.2" "1.1.3"
-  '';
-
-  propagatedBuildInputs = [
-    six
-    future
-  ];
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
Backport of c4469f9b92813d267fe10556537741313f44fe02 from #408185. According to the diff, the breaking change seems to be the removal of python2 support, so backportable.

Bisecting tells me that this fixes eval of `python313Packages.ansible`, which otherwise throws with `error: future-1.0.0 not supported for interpreter python3.13`.

Not sure how many rebuilds this brings or whether downstream dependencies might be affected. Let's see.

My goal is to do #426629 on the release branch, too.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
