### PR TITLE
[25.05] phpExtensions.blackfire: 1.92.32 -> 1.92.40; add aarch64-darwin

### DIFF
--- a/pkgs/by-name/bl/blackfire/php-probe.nix
+++ b/pkgs/by-name/bl/blackfire/php-probe.nix
@@ -16,50 +16,50 @@ let
   phpMajor = lib.versions.majorMinor php.version;
   inherit (stdenv.hostPlatform) system;
 
-  version = "1.92.38";
+  version = "1.92.39";
 
   hashes = {
     "x86_64-linux" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-W8VlvHa6vmNbDX5r5FG8pB0vpXRn5hPu61td9aARecA=";
-        "8.2" = "sha256-f3AKwh9mUCoFDaXM+EwTORk0/TFyArtEa+sv7cMZmDs=";
-        "8.3" = "sha256-6zigke1VY439IIxrQg5Dxcggn+7Q0BE/spPycvxdyik=";
-        "8.4" = "sha256-n89OCTUGsWhpc61P9WvKyjdJ52wJHoj6NEb2mcs0whA=";
+        "8.1" = "sha256-SsemBK7XYPmYakcUs3vLY9yh5jg3uQEksrokMztzilU=";
+        "8.2" = "sha256-lZYsPDkWWUbmG+k5nNcp2GxhzaMj9UCQswRiU7K5N40=";
+        "8.3" = "sha256-5dHAU3EtwzWrKUE9FjevDFRtdfO+dXX8y4wAD0VdTcM=";
+        "8.4" = "sha256-MsUh0OOztJ++vwXuDbQ8Krf1wANQHYhWXSiHAU5pm4M=";
       };
     };
     "i686-linux" = {
       system = "i386";
       hash = {
-        "8.1" = "sha256-31lJOGL9i8kL22zH8zzYZtxB94ssJiw+qXQRmQilR+c=";
-        "8.2" = "sha256-f+D7DZvLQk6ebLfJ43qFSqWzU6YQoP/7nVGajLRll5g=";
-        "8.3" = "sha256-56/+604Vymb+otL7oria3d/w4b1o8Pt199aXK4nfJC4=";
-        "8.4" = "sha256-K26Dy0S9w0uWTX7GkIjh0jUtaa768B+ls9gq8LXNZUA=";
+        "8.1" = "sha256-lxmH2lg11dP6ivqFq+lB2S87qlKKM7e0W95mfesNrf4=";
+        "8.2" = "sha256-7jTEuXYspgo6zTG0R4pA38cGQVIts0rMHHegJ+FZtUc=";
+        "8.3" = "sha256-aRrM6GnXBaiggwoPLq6U8T1YaXmYm6Zhd3Ex8JKMCuA=";
+        "8.4" = "sha256-tagBg+7FkuK/zsTMG3GmnqPsApdCP8RnqQozY5Nufzk=";
       };
     };
     "aarch64-linux" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-aSjOxMZdP+Lrd4FaXgkbHykmKBn9WuzGumrYpJEKpS8=";
-        "8.2" = "sha256-ckhHA/EYeRlhSrc5nMUl6jS0iAaW1q1sZAYYxjcGOwQ=";
-        "8.3" = "sha256-p3P94uPTbekbxgICuC72NEA5XFpYng2MZI+9L+0R/Ew=";
-        "8.4" = "sha256-KCMRNpS2A5Tb5Td8fpBusu70FNIOfJ+6pYRUgw/5kDg=";
+        "8.1" = "sha256-P6sBM2B/w65P+lInWgn3FxZHX4tS0oo6YELsu8aXmIw=";
+        "8.2" = "sha256-qYglYx4icFch5KJuWCTgC19EowZNzHFIsh5qK7t/gDk=";
+        "8.3" = "sha256-Ob0rg6A7fJBKApGnugV+BAC5HjFc2UpZmxJ0oYnQVRg=";
+        "8.4" = "sha256-+cH7t3ElpNPZUbDEkjkeV8d+74hF3kFzI7xY9ruwy1Y=";
       };
     };
     "aarch64-darwin" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-5JPn9lNsh6NJemCRmrBrTIvhEUQfjmIGbASaoiKoZDo=";
-        "8.2" = "sha256-e9tsXi3SML9HZ81XD5LhGcm7L8Ag9fOvyTo0Gy42YRw=";
-        "8.3" = "sha256-RCmYyrcSi7hfkbGOSp8ywFkm1IFGy0bgu8tmdrTID6c=";
+        "8.1" = "sha256-5EW9BkG154HQ6TrMyan5EhXiGlSRFPXMMTUasIwuC/U=";
+        "8.2" = "sha256-hRjh9Bf04LVBtS08fWMxrE1iyn6SGBQfNNLuSyQPjes=";
+        "8.3" = "sha256-WWsDPQhu1GXMDe6NhlMuVcwi7wGzRLJcJwxItxFCOiI=";
       };
     };
     "x86_64-darwin" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-SuD9iDjxMBt2GZtDXPIjCCl1mEt9K2GciuC7S9ppNZQ=";
-        "8.2" = "sha256-om1L/VQiwdV4D2awuz98ko7Oz9h1GYRtqYZrQRZpy7E=";
-        "8.3" = "sha256-H1xkneOLk7DCPqtbknLlQX2iKe/U6/ilmToOOtiRabs=";
+        "8.1" = "sha256-w56HItrNtHA8jj9K5LhGTKFRX5i9UYJpxVwR0eFQe4E=";
+        "8.2" = "sha256-vkEAVyZ6Vs3VjWb3oNrlRz5zAzPbgIngeoDAHZLme3Q=";
+        "8.3" = "sha256-uzobd13RzYGFrXHyFH0Ud9Qg7AWMPAA5dvHCp7R3HrU=";
       };
     };
   };

--- a/pkgs/by-name/bl/blackfire/php-probe.nix
+++ b/pkgs/by-name/bl/blackfire/php-probe.nix
@@ -16,50 +16,50 @@ let
   phpMajor = lib.versions.majorMinor php.version;
   inherit (stdenv.hostPlatform) system;
 
-  version = "1.92.32";
+  version = "1.92.36";
 
   hashes = {
     "x86_64-linux" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-oRd6PbBLOboH9EVRfZl5u71ZoVMFO4K/uftxlL/vm18=";
-        "8.2" = "sha256-95qBidNHIGLGCb3QbUIzBMHsRi2GTPhwAjJg+JTteDk=";
-        "8.3" = "sha256-8TO28o4YYFK1r2tInjXKenki/izHzZL0Dblaippekl8=";
-        "8.4" = "sha256-Dg+Q0W6Rh2L4J7hmxLxuM3l/dKYHT499Mix4Zpu2Vno=";
+        "8.1" = "sha256-Fn+6aZi8UuyF0f94t09SwhUwvHqjvN6m2HBq2mbr/CA=";
+        "8.2" = "sha256-b8YyT9P+KQonwHqXSn17EDRTdTw9CuvIX0PzjvGlmCo=";
+        "8.3" = "sha256-YLQi530JkoQfAx/ZBR9w2dthK6IsDSyqq3U+rGugUPw=";
+        "8.4" = "sha256-zpXYElris1fjMlwpTwuRDkCdO3MNHCLp3D24x5X/S88=";
       };
     };
     "i686-linux" = {
       system = "i386";
       hash = {
-        "8.1" = "sha256-mXJ1hO8NcODG7Wj3lQ+5lkSjcbkKLN5OOzcobigScKI=";
-        "8.2" = "sha256-P5fQTVfE/DvLD4E3kUPE+eeOM9YVNNixgWVRq3Ca5M4=";
-        "8.3" = "sha256-rMUv2EUlepBahMaEvs60i7RFTmaBe4P4qB1hcARqP9Y=";
-        "8.4" = "sha256-g7v7oN7wfrER9VPk6bGhr+l6GMh2iYHUihcXF9T4GOc=";
+        "8.1" = "sha256-3mNgyfrkgiZBkLE8ppans7R72lOeXFup2nwLoP6Gve0=";
+        "8.2" = "sha256-PT7virnfH8Ujkol/fK84TmVTc4jK4xGfaDL1kb9bj/4=";
+        "8.3" = "sha256-h4Gf4YR2I+R9dMDiFpAN1WB2o6BNP3C80fX7vKEN6Gs=";
+        "8.4" = "sha256-lRunm8coAkwiLvPELWquAsoNQEZv0LvL13Hdg+9dOfA=";
       };
     };
     "aarch64-linux" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-Tj7LHXS4m9hF9gY/9vfOQPJVP+vHM1h8XdBY9vyRhFo=";
-        "8.2" = "sha256-6kfotMptfVLPL414mr6LeJZ3ODnjepYQYnKvg4fHIAg=";
-        "8.3" = "sha256-M/GTdinOi3Em7GJOm1iUKkuDNg8La3iQpG+wGHp0ycE=";
-        "8.4" = "sha256-/wwgP76liAb6//uvDLGD5l+skh4P22Q8KdZN7nlEbXI=";
+        "8.1" = "sha256-DDco6F8cD/D4J3KM1B111bjcJkRxd++CLR+x0azcR0g=";
+        "8.2" = "sha256-AQPQQM5Q5wlhvkXOnVNgPLcQpZ5xda/CYFqvm5J7e0c=";
+        "8.3" = "sha256-Yae7UVRrIdShIVZDSza9IrukYHgfX5CrVIpuH4rEAek=";
+        "8.4" = "sha256-l0+DN5zEqGJLg8Ig5U4PvZGms1O0eZ/PqjXgSw4bCA4=";
       };
     };
     "aarch64-darwin" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-TZ6D8sTlLuM+8707ncECPNQlpySc7BYKIwSEth3MUT8=";
-        "8.2" = "sha256-4VJBo1TzEkstKo2ed9bxb/3g0JFjHlfTIfmDq2dCfUk=";
-        "8.3" = "sha256-gIIoRRNCed5cgbcFxvwXKgWZs4HgoOMCx6k0urVPxbs=";
+        "8.1" = "sha256-xb28nloEKKfJfddrDShBFuLHPOIyBo74erHWB9H5im4=";
+        "8.2" = "sha256-vmjjmGem7SdEkBWIjDfxgLQhmO9B/x1gIP5GSlAPPDs=";
+        "8.3" = "sha256-l6XrHQIigav6gMpgg7HEwm+2PeuU76AX3je8UVrcPEQ=";
       };
     };
     "x86_64-darwin" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-tO52c8FKZXXgx7+0IGiwy5rPLEsU/5ji/c79wzb1S34=";
-        "8.2" = "sha256-eUkM5KzZLPK2hCnFqRN8eOwLiX54qXuLkdfxJdjuZTk=";
-        "8.3" = "sha256-CaRs3DI5TTHNSk91pqFaHt1OVQzGozATOUs7GNi8cqY=";
+        "8.1" = "sha256-xY/5UQuLM/UrdDvA1WUF117m+Coj3ElEgV3cbelfKvM=";
+        "8.2" = "sha256-bGpijGg++VJNZFHN9K6Gx1R+jBn3o+Qeh/RpmPC8NPE=";
+        "8.3" = "sha256-3uiTuEmEsp3sKOOR0WxH72pVPCs5ogR1yi3VQ7+/fw8=";
       };
     };
   };

--- a/pkgs/by-name/bl/blackfire/php-probe.nix
+++ b/pkgs/by-name/bl/blackfire/php-probe.nix
@@ -16,50 +16,50 @@ let
   phpMajor = lib.versions.majorMinor php.version;
   inherit (stdenv.hostPlatform) system;
 
-  version = "1.92.37";
+  version = "1.92.38";
 
   hashes = {
     "x86_64-linux" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-NuWxVeVueKz64jDIE1KPzLEco+MoUyuc/9/hsTaRrAI=";
-        "8.2" = "sha256-NJlrEwSY55INO7q5GAvPojnLdkAYJ4eCIjxFH55Pdmg=";
-        "8.3" = "sha256-KGpNPp2bOAmY/GUPnUxTJ4z6X8AdvZAG6YC3pLTjbGI=";
-        "8.4" = "sha256-3HrbezGcdVMtdPrfRpLEhY/1AXlGUIMraeie7LEmiC8=";
+        "8.1" = "sha256-W8VlvHa6vmNbDX5r5FG8pB0vpXRn5hPu61td9aARecA=";
+        "8.2" = "sha256-f3AKwh9mUCoFDaXM+EwTORk0/TFyArtEa+sv7cMZmDs=";
+        "8.3" = "sha256-6zigke1VY439IIxrQg5Dxcggn+7Q0BE/spPycvxdyik=";
+        "8.4" = "sha256-n89OCTUGsWhpc61P9WvKyjdJ52wJHoj6NEb2mcs0whA=";
       };
     };
     "i686-linux" = {
       system = "i386";
       hash = {
-        "8.1" = "sha256-Z9D6yoDSTdvzAQw+LhCk37J+LPMLEthUzbB1YQdr7AY=";
-        "8.2" = "sha256-ES2Y2RewFSP0R5wuYF2sm7NAVlCRvRPSpfPt7X2uYqs=";
-        "8.3" = "sha256-jqcS97JcHU/LzdU08MwNXDepH7OzIa4Fo7s3hg+x6hA=";
-        "8.4" = "sha256-xel7bbb4S16YddLuw0sDINbKQ0zoJeeRSI4g+tpqYz0=";
+        "8.1" = "sha256-31lJOGL9i8kL22zH8zzYZtxB94ssJiw+qXQRmQilR+c=";
+        "8.2" = "sha256-f+D7DZvLQk6ebLfJ43qFSqWzU6YQoP/7nVGajLRll5g=";
+        "8.3" = "sha256-56/+604Vymb+otL7oria3d/w4b1o8Pt199aXK4nfJC4=";
+        "8.4" = "sha256-K26Dy0S9w0uWTX7GkIjh0jUtaa768B+ls9gq8LXNZUA=";
       };
     };
     "aarch64-linux" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-l3mz8n1PjBUTcLN4Kyjg573Ip20dFV85yNT2krYq6Z0=";
-        "8.2" = "sha256-EyxrVMitvupQzAwhFDwMO56PUhyLb35aqWgJeH+211E=";
-        "8.3" = "sha256-T6UkTtQl1Ce95tA4/J9mSk/pBWAZJJz0pHb3xMIGYvc=";
-        "8.4" = "sha256-udvqUMbbVcFOocu1F0rSgi0+bg5VPq2Qw2LrRqNRQHw=";
+        "8.1" = "sha256-aSjOxMZdP+Lrd4FaXgkbHykmKBn9WuzGumrYpJEKpS8=";
+        "8.2" = "sha256-ckhHA/EYeRlhSrc5nMUl6jS0iAaW1q1sZAYYxjcGOwQ=";
+        "8.3" = "sha256-p3P94uPTbekbxgICuC72NEA5XFpYng2MZI+9L+0R/Ew=";
+        "8.4" = "sha256-KCMRNpS2A5Tb5Td8fpBusu70FNIOfJ+6pYRUgw/5kDg=";
       };
     };
     "aarch64-darwin" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-PoXihk7e+xT6fat48dnD/3lZqQKpgBHs4Eao08J4dMs=";
-        "8.2" = "sha256-lLham3VjXvszjOU8NvxZsjz5vfEK58QG1tE4X06luzQ=";
-        "8.3" = "sha256-rAsJ71P+yM939JqhhwDbxfL0EwB4q7SNqvSdN0n6ES0=";
+        "8.1" = "sha256-5JPn9lNsh6NJemCRmrBrTIvhEUQfjmIGbASaoiKoZDo=";
+        "8.2" = "sha256-e9tsXi3SML9HZ81XD5LhGcm7L8Ag9fOvyTo0Gy42YRw=";
+        "8.3" = "sha256-RCmYyrcSi7hfkbGOSp8ywFkm1IFGy0bgu8tmdrTID6c=";
       };
     };
     "x86_64-darwin" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-6RoANqMjuyaLcMzg5R0unhTwOSbsQhEXCkjQ2kjnnCg=";
-        "8.2" = "sha256-PjvLjRsnhHgXOEj7J7ekWM0fFuaOuiYJhXbINClaFtU=";
-        "8.3" = "sha256-NoY788iBgeVMrQp3tm6vbAnwBZB7yMjCVmH7jr32HWU=";
+        "8.1" = "sha256-SuD9iDjxMBt2GZtDXPIjCCl1mEt9K2GciuC7S9ppNZQ=";
+        "8.2" = "sha256-om1L/VQiwdV4D2awuz98ko7Oz9h1GYRtqYZrQRZpy7E=";
+        "8.3" = "sha256-H1xkneOLk7DCPqtbknLlQX2iKe/U6/ilmToOOtiRabs=";
       };
     };
   };

--- a/pkgs/by-name/bl/blackfire/php-probe.nix
+++ b/pkgs/by-name/bl/blackfire/php-probe.nix
@@ -16,50 +16,50 @@ let
   phpMajor = lib.versions.majorMinor php.version;
   inherit (stdenv.hostPlatform) system;
 
-  version = "1.92.36";
+  version = "1.92.37";
 
   hashes = {
     "x86_64-linux" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-Fn+6aZi8UuyF0f94t09SwhUwvHqjvN6m2HBq2mbr/CA=";
-        "8.2" = "sha256-b8YyT9P+KQonwHqXSn17EDRTdTw9CuvIX0PzjvGlmCo=";
-        "8.3" = "sha256-YLQi530JkoQfAx/ZBR9w2dthK6IsDSyqq3U+rGugUPw=";
-        "8.4" = "sha256-zpXYElris1fjMlwpTwuRDkCdO3MNHCLp3D24x5X/S88=";
+        "8.1" = "sha256-NuWxVeVueKz64jDIE1KPzLEco+MoUyuc/9/hsTaRrAI=";
+        "8.2" = "sha256-NJlrEwSY55INO7q5GAvPojnLdkAYJ4eCIjxFH55Pdmg=";
+        "8.3" = "sha256-KGpNPp2bOAmY/GUPnUxTJ4z6X8AdvZAG6YC3pLTjbGI=";
+        "8.4" = "sha256-3HrbezGcdVMtdPrfRpLEhY/1AXlGUIMraeie7LEmiC8=";
       };
     };
     "i686-linux" = {
       system = "i386";
       hash = {
-        "8.1" = "sha256-3mNgyfrkgiZBkLE8ppans7R72lOeXFup2nwLoP6Gve0=";
-        "8.2" = "sha256-PT7virnfH8Ujkol/fK84TmVTc4jK4xGfaDL1kb9bj/4=";
-        "8.3" = "sha256-h4Gf4YR2I+R9dMDiFpAN1WB2o6BNP3C80fX7vKEN6Gs=";
-        "8.4" = "sha256-lRunm8coAkwiLvPELWquAsoNQEZv0LvL13Hdg+9dOfA=";
+        "8.1" = "sha256-Z9D6yoDSTdvzAQw+LhCk37J+LPMLEthUzbB1YQdr7AY=";
+        "8.2" = "sha256-ES2Y2RewFSP0R5wuYF2sm7NAVlCRvRPSpfPt7X2uYqs=";
+        "8.3" = "sha256-jqcS97JcHU/LzdU08MwNXDepH7OzIa4Fo7s3hg+x6hA=";
+        "8.4" = "sha256-xel7bbb4S16YddLuw0sDINbKQ0zoJeeRSI4g+tpqYz0=";
       };
     };
     "aarch64-linux" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-DDco6F8cD/D4J3KM1B111bjcJkRxd++CLR+x0azcR0g=";
-        "8.2" = "sha256-AQPQQM5Q5wlhvkXOnVNgPLcQpZ5xda/CYFqvm5J7e0c=";
-        "8.3" = "sha256-Yae7UVRrIdShIVZDSza9IrukYHgfX5CrVIpuH4rEAek=";
-        "8.4" = "sha256-l0+DN5zEqGJLg8Ig5U4PvZGms1O0eZ/PqjXgSw4bCA4=";
+        "8.1" = "sha256-l3mz8n1PjBUTcLN4Kyjg573Ip20dFV85yNT2krYq6Z0=";
+        "8.2" = "sha256-EyxrVMitvupQzAwhFDwMO56PUhyLb35aqWgJeH+211E=";
+        "8.3" = "sha256-T6UkTtQl1Ce95tA4/J9mSk/pBWAZJJz0pHb3xMIGYvc=";
+        "8.4" = "sha256-udvqUMbbVcFOocu1F0rSgi0+bg5VPq2Qw2LrRqNRQHw=";
       };
     };
     "aarch64-darwin" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-xb28nloEKKfJfddrDShBFuLHPOIyBo74erHWB9H5im4=";
-        "8.2" = "sha256-vmjjmGem7SdEkBWIjDfxgLQhmO9B/x1gIP5GSlAPPDs=";
-        "8.3" = "sha256-l6XrHQIigav6gMpgg7HEwm+2PeuU76AX3je8UVrcPEQ=";
+        "8.1" = "sha256-PoXihk7e+xT6fat48dnD/3lZqQKpgBHs4Eao08J4dMs=";
+        "8.2" = "sha256-lLham3VjXvszjOU8NvxZsjz5vfEK58QG1tE4X06luzQ=";
+        "8.3" = "sha256-rAsJ71P+yM939JqhhwDbxfL0EwB4q7SNqvSdN0n6ES0=";
       };
     };
     "x86_64-darwin" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-xY/5UQuLM/UrdDvA1WUF117m+Coj3ElEgV3cbelfKvM=";
-        "8.2" = "sha256-bGpijGg++VJNZFHN9K6Gx1R+jBn3o+Qeh/RpmPC8NPE=";
-        "8.3" = "sha256-3uiTuEmEsp3sKOOR0WxH72pVPCs5ogR1yi3VQ7+/fw8=";
+        "8.1" = "sha256-6RoANqMjuyaLcMzg5R0unhTwOSbsQhEXCkjQ2kjnnCg=";
+        "8.2" = "sha256-PjvLjRsnhHgXOEj7J7ekWM0fFuaOuiYJhXbINClaFtU=";
+        "8.3" = "sha256-NoY788iBgeVMrQp3tm6vbAnwBZB7yMjCVmH7jr32HWU=";
       };
     };
   };

--- a/pkgs/by-name/bl/blackfire/php-probe.nix
+++ b/pkgs/by-name/bl/blackfire/php-probe.nix
@@ -16,52 +16,52 @@ let
   phpMajor = lib.versions.majorMinor php.version;
   inherit (stdenv.hostPlatform) system;
 
-  version = "1.92.39";
+  version = "1.92.40";
 
   hashes = {
     "x86_64-linux" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-SsemBK7XYPmYakcUs3vLY9yh5jg3uQEksrokMztzilU=";
-        "8.2" = "sha256-lZYsPDkWWUbmG+k5nNcp2GxhzaMj9UCQswRiU7K5N40=";
-        "8.3" = "sha256-5dHAU3EtwzWrKUE9FjevDFRtdfO+dXX8y4wAD0VdTcM=";
-        "8.4" = "sha256-MsUh0OOztJ++vwXuDbQ8Krf1wANQHYhWXSiHAU5pm4M=";
+        "8.1" = "sha256-5yfhpseazq9XADYR4/Wo3xg6jGNbSdFrTn+cP+pCbN4=";
+        "8.2" = "sha256-ipUXh7pV9qiol6j9PpOyAyxriHDpBHDWin/dIxl4AqA=";
+        "8.3" = "sha256-6JcS+aTYhT14D2/wwxJad4MnsilgSjsckSzsx+lVvOM=";
+        "8.4" = "sha256-XYcRjHRLhF3f8INEnyGNnhrZlwQGt0wIdGtY3TTnA7s=";
       };
     };
     "i686-linux" = {
       system = "i386";
       hash = {
-        "8.1" = "sha256-lxmH2lg11dP6ivqFq+lB2S87qlKKM7e0W95mfesNrf4=";
-        "8.2" = "sha256-7jTEuXYspgo6zTG0R4pA38cGQVIts0rMHHegJ+FZtUc=";
-        "8.3" = "sha256-aRrM6GnXBaiggwoPLq6U8T1YaXmYm6Zhd3Ex8JKMCuA=";
-        "8.4" = "sha256-tagBg+7FkuK/zsTMG3GmnqPsApdCP8RnqQozY5Nufzk=";
+        "8.1" = "sha256-+ApXqJCew4/LKNc+nzDDat+jyqCs8P/kX7Sxt7fAnIE=";
+        "8.2" = "sha256-IxarxqbjA3Rei7eR/AUSOHSCoLAsHPwebIXQJYW05Ig=";
+        "8.3" = "sha256-HZAOO+VnK3qax/++jAKllHSbCVAgUeEmlSr/HVsXPQY=";
+        "8.4" = "sha256-uRG07BkUmZFMvMzVsuF0qRF/wv74QqP2YtGV1Emgcsg=";
       };
     };
     "aarch64-linux" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-P6sBM2B/w65P+lInWgn3FxZHX4tS0oo6YELsu8aXmIw=";
-        "8.2" = "sha256-qYglYx4icFch5KJuWCTgC19EowZNzHFIsh5qK7t/gDk=";
-        "8.3" = "sha256-Ob0rg6A7fJBKApGnugV+BAC5HjFc2UpZmxJ0oYnQVRg=";
-        "8.4" = "sha256-+cH7t3ElpNPZUbDEkjkeV8d+74hF3kFzI7xY9ruwy1Y=";
+        "8.1" = "sha256-PkXmLsLwNF132SM+aOA1mfc+6EoaBlwpgoKTKXE0JFI=";
+        "8.2" = "sha256-edsH+Xb0lrw9Dg1aHHtjRGMjGS7+ZDxk/IJFZt5A5ho=";
+        "8.3" = "sha256-uP7bY8Pw/1GNdTd897eqsiVfQKr5HLVJ1BVHIloVdRA=";
+        "8.4" = "sha256-5MqridoL7fcMXnmC+XJoj3opkmrO1dVQWbZE1ot5y+E=";
       };
     };
     "aarch64-darwin" = {
       system = "arm64";
       hash = {
-        "8.1" = "sha256-5EW9BkG154HQ6TrMyan5EhXiGlSRFPXMMTUasIwuC/U=";
-        "8.2" = "sha256-hRjh9Bf04LVBtS08fWMxrE1iyn6SGBQfNNLuSyQPjes=";
-        "8.3" = "sha256-WWsDPQhu1GXMDe6NhlMuVcwi7wGzRLJcJwxItxFCOiI=";
-        "8.4" = "sha256-tRxQfrFJmyaGRTa5ZWXhSHLx3V6QcBGe0EzKYbOjmG8=";
+        "8.1" = "sha256-G2Zq6n1Ndx5MN3hbDlPDpT+wpNcYBm+mMnbnVNfAHvw=";
+        "8.2" = "sha256-9i65PvfjmyFWmgjQPyYRRLV/SOX88tFub2+XmnRlgVA=";
+        "8.3" = "sha256-Lf1p55Ae9pddT3Z82h7p/9jC7zN5Md3hOzXXLu/kDjM=";
+        "8.4" = "sha256-A3k/IEyDoLmGcJzl60nclB8f+lUmvWXKF851ZMpgwfM=";
       };
     };
     "x86_64-darwin" = {
       system = "amd64";
       hash = {
-        "8.1" = "sha256-w56HItrNtHA8jj9K5LhGTKFRX5i9UYJpxVwR0eFQe4E=";
-        "8.2" = "sha256-vkEAVyZ6Vs3VjWb3oNrlRz5zAzPbgIngeoDAHZLme3Q=";
-        "8.3" = "sha256-uzobd13RzYGFrXHyFH0Ud9Qg7AWMPAA5dvHCp7R3HrU=";
-        "8.4" = "sha256-PtMXo/NTV8E32b9aWuuxBoHeeFN3vP2ufEo1Ed0w2iI=";
+        "8.1" = "sha256-3uCvCbkpaawMnW6IXS9VPp8GU4SOwqh/9oxcP1W3h2E=";
+        "8.2" = "sha256-PCnUHwtNex9juVL5evY37qyuDRguZs4ByOfOnY7HQs0=";
+        "8.3" = "sha256-/3XZPG8+O71sbrVPDg0Thn+pTPGNYBTkJ3s/txI0Q3k=";
+        "8.4" = "sha256-XY2rS2p1WAVp1Rd1V8JUnCiTQe2WouLwlmtZTnRqs04=";
       };
     };
   };

--- a/pkgs/by-name/bl/blackfire/php-probe.nix
+++ b/pkgs/by-name/bl/blackfire/php-probe.nix
@@ -52,6 +52,7 @@ let
         "8.1" = "sha256-5EW9BkG154HQ6TrMyan5EhXiGlSRFPXMMTUasIwuC/U=";
         "8.2" = "sha256-hRjh9Bf04LVBtS08fWMxrE1iyn6SGBQfNNLuSyQPjes=";
         "8.3" = "sha256-WWsDPQhu1GXMDe6NhlMuVcwi7wGzRLJcJwxItxFCOiI=";
+        "8.4" = "sha256-tRxQfrFJmyaGRTa5ZWXhSHLx3V6QcBGe0EzKYbOjmG8=";
       };
     };
     "x86_64-darwin" = {
@@ -60,6 +61,7 @@ let
         "8.1" = "sha256-w56HItrNtHA8jj9K5LhGTKFRX5i9UYJpxVwR0eFQe4E=";
         "8.2" = "sha256-vkEAVyZ6Vs3VjWb3oNrlRz5zAzPbgIngeoDAHZLme3Q=";
         "8.3" = "sha256-uzobd13RzYGFrXHyFH0Ud9Qg7AWMPAA5dvHCp7R3HrU=";
+        "8.4" = "sha256-PtMXo/NTV8E32b9aWuuxBoHeeFN3vP2ufEo1Ed0w2iI=";
       };
     };
   };


### PR DESCRIPTION
Backport of #421482, for which I require #409816, #413086, #416068, #421366. Added #424250 for good measure.

I can't find a changelog for this, but given that it's only patch version bumps, I'll assume this is OK.

My goal is to fix this assertion error: `error: blackfire does not support PHP version 8.4 on aarch64-darwin.`, because it blocks doing #426629 on release-25.05.