### PR TITLE
python3Packages.craft-application: 5.4.0 -> 5.5.0

### DIFF
--- a/pkgs/by-name/ro/rockcraft/package.nix
+++ b/pkgs/by-name/ro/rockcraft/package.nix
@@ -60,6 +60,11 @@ python3Packages.buildPythonApplication rec {
     "test_run_init_django"
     # Mock is broken for Unix FHS reasons.
     "test_run_pack_services"
+    # Later version of craft-application is being used, which adds an
+    # additional kind of file to be ignored, and invalidates a somewhat
+    # static assertion. Can be removed in a later version once rockcraft
+    # catches up with craft-application version.
+    "test_lifecycle_args"
   ];
 
   versionCheckProgramArg = "--version";

--- a/pkgs/by-name/sn/snapcraft/esm-test.patch
+++ b/pkgs/by-name/sn/snapcraft/esm-test.patch
@@ -1,0 +1,14 @@
+diff --git i/tests/unit/test_application.py w/tests/unit/test_application.py
+index d5da2454c..2a9bcd6f9 100644
+--- i/tests/unit/test_application.py
++++ w/tests/unit/test_application.py
+@@ -391,7 +391,8 @@ def test_esm_error(snapcraft_yaml, base, monkeypatch, capsys):
+     _, err = capsys.readouterr()
+ 
+     assert re.match(
+-        rf"^Base {base!r} is not supported by this version of Snapcraft.\n"
++        rf"^Running snapcraft without a command will not be possible in future releases. Use 'snapcraft pack' instead.\n"
++        rf"Base {base!r} is not supported by this version of Snapcraft.\n"
+         rf"Recommended resolution: Use Snapcraft .* from the '.*' channel of snapcraft where {base!r} was last supported.\n"
+         r"For more information, check out: .*/reference/bases\n",
+         err,

--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -26,6 +26,12 @@ python312Packages.buildPythonApplication rec {
   };
 
   patches = [
+    # We're using a later version of `craft-cli` than expected, which
+    # adds an extra deprecation warning to the CLI output, meaning that
+    # an expected error message looks slightly different. This patch corrects
+    # that by checking for the updated error message and can be dropped in a
+    # later release of snapcraft.
+    ./esm-test.patch
     # Snapcraft is only officially distributed as a snap, as is LXD. The socket
     # path for LXD must be adjusted so that it's at the correct location for LXD
     # on NixOS. This patch will likely never be accepted upstream.

--- a/pkgs/development/python-modules/craft-application/default.nix
+++ b/pkgs/development/python-modules/craft-application/default.nix
@@ -31,19 +31,19 @@
 
 buildPythonPackage rec {
   pname = "craft-application";
-  version = "5.4.0";
+  version = "5.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "canonical";
     repo = "craft-application";
     tag = version;
-    hash = "sha256-xWGcKJY5ov6SN8CCRK33rVDsDcvKtEnv7Zy9VBLJYYc=";
+    hash = "sha256-eNca9+CBAGTQe6URMUYRaJR7TXFJA+dWcYIJdKyB3bw=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools==75.8.0" "setuptools"
+      --replace-fail "setuptools==75.9.1" "setuptools"
 
       substituteInPlace craft_application/git/_utils.py \
         --replace-fail "/snap/core22/current/etc/ssl/certs" "${cacert}/etc/ssl/certs"
@@ -98,6 +98,12 @@ buildPythonPackage rec {
     # derivation. Once charmcraft has moved to craft-application >= 5, `--replace-fail` can be added.
     substituteInPlace tests/conftest.py \
       --replace "include_lsb=False, include_uname=False, include_oslevel=False" "include_lsb=False, include_uname=False, include_oslevel=False, os_release_file='$HOME/os-release'"
+
+    # The project attempts to write into the user's runtime directory, usually
+    # '/run/user/<uid>', which fails in the build environment. By setting this
+    # variable, we redirect the runtime directory lookup to the temp directory
+    # created by the 'writableTmpDirAsHomeHook'.
+    export XDG_RUNTIME_DIR="$HOME"
   '';
 
   pythonImportsCheck = [ "craft_application" ];

--- a/pkgs/development/python-modules/craft-cli/default.nix
+++ b/pkgs/development/python-modules/craft-cli/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "craft-cli";
-  version = "3.0.0";
+  version = "3.1.2";
 
   pyproject = true;
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-cli";
     tag = version;
-    hash = "sha256-RAnvx5519iXZnJm8jtY635e0DEL7jnIgZtTCindqMTY=";
+    hash = "sha256-ryNHl/c8Pg2mGQHE9Dbd0bLU80NyCyxfhd2YQGEBN40=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/craft-providers/default.nix
+++ b/pkgs/development/python-modules/craft-providers/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "craft-providers";
-  version = "2.3.1";
+  version = "2.4.0";
 
   pyproject = true;
 
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-providers";
     tag = version;
-    hash = "sha256-MeQOqw0F4OwaooHHrUh3qITTOFNXG1Qg1oJcYxRQTz0=";
+    hash = "sha256-frcRv+19czsZ948SEKfYsMUP6n9MbJv6gxXUAdwFw4Y=";
   };
 
   patches = [
@@ -51,7 +51,7 @@ buildPythonPackage rec {
     # The urllib3 incompat: https://github.com/msabramo/requests-unixsocket/pull/69
     # This is already patched in nixpkgs.
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools==75.2.0" "setuptools"
+      --replace-fail "setuptools==75.9.1" "setuptools"
   '';
 
   pythonRelaxDeps = [ "requests" ];

--- a/pkgs/development/python-modules/craft-providers/inject-snaps.patch
+++ b/pkgs/development/python-modules/craft-providers/inject-snaps.patch
@@ -1,8 +1,8 @@
-diff --git a/craft_providers/base.py b/craft_providers/base.py
-index 3c914a2..d9c2cf9 100644
---- a/craft_providers/base.py
-+++ b/craft_providers/base.py
-@@ -655,37 +655,22 @@ class Base(ABC):
+diff --git i/craft_providers/base.py w/craft_providers/base.py
+index 00f56ec..302f359 100644
+--- i/craft_providers/base.py
++++ w/craft_providers/base.py
+@@ -655,40 +655,24 @@ class Base(ABC):
                      ),
                  )
  
@@ -21,6 +21,9 @@ index 3c914a2..d9c2cf9 100644
 -                            f" channel {snap.channel!r} in target environment."
 -                        ),
 -                        details=error.details,
+-                        resolution=(
+-                            "Check Snap store status at https://status.snapcraft.io"
+-                        ),
 -                    ) from error
 -            else:
 -                try:
@@ -38,20 +41,22 @@ index 3c914a2..d9c2cf9 100644
 -                        details=error.details,
 -                    ) from error
 +            try:
-+                channel = "latest/beta"
 +                snap_installer.install_from_store(
 +                    executor=executor,
 +                    snap_name=snap.name,
-+                    channel=channel,
++                    channel=snap.channel,
 +                    classic=snap.classic,
 +                )
 +            except SnapInstallationError as error:
 +                raise BaseConfigurationError(
 +                    brief=(
 +                        f"failed to install snap {snap.name!r} from store"
-+                        f" channel {channel!r} in target environment."
++                        f" channel {snap.channel!r} in target environment."
 +                    ),
 +                    details=error.details,
++                    resolution=(
++                        "Check Snap store status at https://status.snapcraft.io"
++                    ),
 +                ) from error
  
      def wait_until_ready(self, executor: Executor) -> None:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Bumped craft-* libraries using the maintainer scripts, and added a couple of changes to snapcraft and rockcraft to avoid test regressions induced by using mismatched library versions.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
