### PR TITLE
hayabusa-sec: init at 3.3.0-unstable-2025-07-17

### DIFF
--- a/pkgs/by-name/ha/hayabusa-sec/package.nix
+++ b/pkgs/by-name/ha/hayabusa-sec/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  rust-jemalloc-sys,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "hayabusa-sec";
+  version = "3.3.0-unstable-2025-07-17";
+
+  src = fetchFromGitHub {
+    owner = "Yamato-Security";
+    repo = "hayabusa";
+    rev = "feaa165b4c0af34919ad26f634cb684e23172359";
+    hash = "sha256-h08InhNVW33IjPA228gv6Enlg6EKmj0yHb/UvJ/f7uw=";
+    # Include the hayabusa-rules
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-wcH1Ron5Zx2ypWyaW0z7L9rCanAcosvpPQnP60qbvWQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    rust-jemalloc-sys # transitive dependency via the hayabusa-evtx crate
+  ];
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  # Several checks panic
+  # Skipping individual checks causes failure as `--skip` flags
+  # end up passed to executing `hayabusa`
+  # > error: unexpected argument '--skip' found
+  doCheck = false;
+
+  meta = {
+    description = "Sigma-based threat hunting and fast forensics timeline generator for Windows event logs";
+    homepage = "https://github.com/Yamato-Security/hayabusa";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [
+      d3vil0p3r
+      jk
+    ];
+    mainProgram = "hayabusa";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
