### PR TITLE
snphost: 0.6.0 -> 0.6.1, add versionCheckHook

### DIFF
--- a/pkgs/by-name/sn/snphost/package.nix
+++ b/pkgs/by-name/sn/snphost/package.nix
@@ -14,17 +14,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "snphost";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "virtee";
     repo = "snphost";
     tag = "v${version}";
-    hash = "sha256-sBEIQQ0vfwQh5eqsC6x37VDlbXuBUybRh4LNUjfEJ5A=";
+    hash = "sha256-FvHawwoIqCiZ+Jm1itDWspaI+vDN6xDfeI11KoiO/DU=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-aNXv6Av3JvnTqTbxX70FmwEF4jJaQmD6FHjvh7om9iE=";
+  cargoHash = "sha256-ZOXOfFYingTBq5LfJqHRf6ZdvrdY1Zve/ZMnAE25kPM=";
 
   nativeBuildInputs = [
     asciidoctor
@@ -38,6 +38,8 @@ rustPlatform.buildRustPackage rec {
     openssl
     zlib
   ];
+
+  env.OPENSSL_NO_VENDOR = true;
 
   # man page is placed in cargo's $OUT_DIR, which is randomized.
   # Contacted upstream about it, for now use find to locate it.

--- a/pkgs/by-name/sn/snphost/package.nix
+++ b/pkgs/by-name/sn/snphost/package.nix
@@ -10,6 +10,7 @@
   nix-update-script,
   findutils,
   installShellFiles,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -46,6 +47,9 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     installManPage $(find target/x86_64-unknown-linux-gnu/release/build -name "snphost.1")
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
https://github.com/virtee/snphost/releases/tag/v0.6.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
