### PR TITLE
hydra-check: patch to fix x86_64-darwin, rust 1.88

### DIFF
--- a/pkgs/by-name/hy/hydra-check/fix-cargo-1_88-reqwest.patch
+++ b/pkgs/by-name/hy/hydra-check/fix-cargo-1_88-reqwest.patch
@@ -1,0 +1,15 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index bb8d370..7c5b7ac 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -35,6 +35,10 @@ anyhow = "1.0.89"
+ insta.opt-level = 3
+ similar.opt-level = 3
+ 
++# work around https://github.com/NixOS/nixpkgs/issues/427072
++[profile.release.package.hyper]
++opt-level = 0
++
+ [lints.clippy]
+ pedantic = { level = "warn", priority = -1 }
+ cargo = { level = "warn", priority = -1 }

--- a/pkgs/by-name/hy/hydra-check/package.nix
+++ b/pkgs/by-name/hy/hydra-check/package.nix
@@ -23,6 +23,15 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-G9M+1OWp2jlDeSDFagH/YOCdxGQbcru1KFyKEUcMe7g=";
 
+  patches =
+    lib.optional (stdenv.hostPlatform.system == "x86_64-darwin")
+      # work around rust 1.88 compiler / linker bug for x86_64-darwin. This is
+      # applied conditionally because it will introduce a performance penalty on
+      # other host platforms. NOTE: Please check the patch applies if you update
+      # the package on a different platform (e.g x86_64-linux).
+      # see: https://github.com/NixOS/nixpkgs/issues/427072
+      ./fix-cargo-1_88-reqwest.patch;
+
   nativeBuildInputs = [
     pkg-config
     installShellFiles


### PR DESCRIPTION
Works around the issue reported in:
- https://github.com/nix-community/hydra-check/issues/79
	- patched upstream in https://github.com/nix-community/hydra-check/pull/80)
- https://github.com/NixOS/nixpkgs/issues/427072 

This is a band-aid that works around the compiler / linker bug that breaks all http requests on x86_64-darwin with rust 1.88. The issue will disappear once rust is bumped to 1.89, so the patch is conditioned on the current rust version (1.88) and should only apply on x86_64-darwin. Expecting no rebuild for other platforms.

Before this patch (in a nixpkgs checkout):
```console
$ nix run --file . --option system x86_64-darwin hydra-check
Evaluations of jobset nixpkgs/trunk @ https://hydra.nixos.org/jobset/nixpkgs/trunk/evals
Error: error sending request for url (https://hydra.nixos.org/jobset/nixpkgs/trunk/evals)

Caused by:
    0: client error (SendRequest)
    1: invalid HTTP version parsed
```
After this patch:
```console
$ nix run --file . --option system x86_64-darwin hydra-check
Evaluations of jobset nixpkgs/trunk @ https://hydra.nixos.org/jobset/nixpkgs/trunk/evals
⧖ nixpkgs → 9b00558  4h ago   ✔ 250415  ✖ 6296  ⧖ 1586  Δ ~     https://hydra.nixos.org/eval/1817062
⧖ nixpkgs → 83e677f  12h ago  ✔ 251672  ✖ 6538  ⧖ 1     Δ +10   https://hydra.nixos.org/eval/1817056
✔ nixpkgs → 8aed177  21h ago  ✔ 251662  ✖ 6525  ⧖ 0     Δ +7    https://hydra.nixos.org/eval/1817046
...
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
