### PR TITLE
pff-tools: init at 0-unstable-2025-07-22

### DIFF
--- a/pkgs/by-name/pf/pff-tool/package.nix
+++ b/pkgs/by-name/pf/pff-tool/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libpff,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pff-tools";
+  version = "0-unstable-2025-07-22";
+
+  src = fetchFromGitHub {
+    owner = "avranju";
+    repo = "pff-tools";
+    rev = "d8776cd45e62c82adbbcc04f2f636b569de057ca";
+    hash = "sha256-MDMrKaq/iz5WdLhh3rv2ODFdaMoaeFtacT8xmRf3Qec=";
+  };
+
+  cargoHash = "sha256-SL+FTuVkgq0ll8SH7FgVapvemarc7ci0KtoGG16zxCM=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    libpff
+  ];
+
+  # Tests require a sample PST/OST file.
+  doCheck = false;
+
+  meta = {
+    description = "Command-line tools to process PFF files";
+    homepage = "https://github.com/avranju/pff-tools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ d3vil0p3r ];
+    mainProgram = "pff-cli";
+  };
+})


### PR DESCRIPTION
Related to : https://github.com/NixOS/nixpkgs/pull/427421

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
