### PR TITLE
workflows/build: build nixpkgs tarball

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
         include:
           - runner: ubuntu-24.04
             system: x86_64-linux
-            builds: [shell, manual-nixos, lib-tests]
-            desc: shell, docs, lib
+            builds: [shell, manual-nixos, lib-tests, tarball]
+            desc: shell, docs, lib, tarball
           - runner: ubuntu-24.04-arm
             system: aarch64-linux
             builds: [shell, manual-nixos, manual-nixpkgs, manual-nixpkgs-tests]
@@ -84,6 +84,10 @@ jobs:
       - name: Build lib tests
         if: contains(matrix.builds, 'lib-tests') && !cancelled()
         run: nix-build untrusted/ci -A lib-tests
+
+      - name: Build tarball
+        if: contains(matrix.builds, 'tarball') && !cancelled()
+        run: nix-build untrusted/ci -A tarball
 
       - name: Upload NixOS manual
         if: |

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -89,7 +89,7 @@ let
     };
 
 in
-{
+rec {
   inherit pkgs fmt;
   requestReviews = pkgs.callPackage ./request-reviews { };
   codeownersValidator = pkgs.callPackage ./codeowners-validator { };
@@ -113,4 +113,18 @@ in
     minimum = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.minimum; };
   };
   shell = import ../shell.nix { inherit nixpkgs system; };
+  tarball = import ../pkgs/top-level/make-tarball.nix {
+    # Mirrored from top-level release.nix:
+    nixpkgs = {
+      outPath = pkgs.lib.cleanSource ../.;
+      revCount = 1234;
+      shortRev = "abcdef";
+      revision = "0000000000000000000000000000000000000000";
+    };
+    officialRelease = false;
+    inherit pkgs lib-tests;
+    # 2.28 / 2.29 take 9x longer than 2.30 or Lix.
+    # TODO: Switch back to nixVersions.latest
+    nix = pkgs.lix;
+  };
 }


### PR DESCRIPTION
This adds a build job for the tarball, which might help uncover eval issues on attributes not normally touched by Eval, aka those added in `pkgs/top-level/packages-config.nix`.

Resolves #393430.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
