### PR TITLE
treewide: add rewine as maintainer for some wayland-related packages

### DIFF
--- a/pkgs/by-name/sw/swayidle/package.nix
+++ b/pkgs/by-name/sw/swayidle/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     mainProgram = "swayidle";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ rewine ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/sw/swaylock/package.nix
+++ b/pkgs/by-name/sw/swaylock/package.nix
@@ -66,6 +66,6 @@ stdenv.mkDerivation rec {
     mainProgram = "swaylock";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ rewine ];
   };
 }

--- a/pkgs/by-name/wa/wayland-utils/package.nix
+++ b/pkgs/by-name/wa/wayland-utils/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.freedesktop.org/wayland/wayland-utils";
     license = licenses.mit; # Expat version
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ rewine ];
     mainProgram = "wayland-info";
   };
 }

--- a/pkgs/by-name/we/wev/package.nix
+++ b/pkgs/by-name/we/wev/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
       X11 tool xev.
     '';
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ rewine ];
     platforms = platforms.linux;
     mainProgram = "wev";
   };

--- a/pkgs/by-name/wl/wlsunset/package.nix
+++ b/pkgs/by-name/wl/wlsunset/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     changelog = "https://git.sr.ht/~kennylevinsen/wlsunset/refs/${version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ rewine ];
     mainProgram = "wlsunset";
   };
 }

--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.freedesktop.org/wayland/wayland-protocols";
     license = lib.licenses.mit; # Expat version
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ rewine ];
     pkgConfigModules = [ "wayland-protocols" ];
   };
 


### PR DESCRIPTION
These packages were previously maintained by primeos who became inactive and was removed in #415587, leaving some packages without a maintainer.

I would like to take over maintenance of the following packages that I'm interested in:
  - swayidle
  - swaylock
  - wayland-utils
  - wev
  - wlsunset
  - wayland-protocols


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
