### PR TITLE
electrs: 0.10.9 -> 0.10.10

### DIFF
--- a/pkgs/by-name/el/electrs/package.nix
+++ b/pkgs/by-name/el/electrs/package.nix
@@ -10,18 +10,18 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "electrs";
-  version = "0.10.9";
+  version = "0.10.10";
 
   src = fetchFromGitHub {
     owner = "romanz";
     repo = "electrs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Xo7aqP4tIh/kYthPucscxnl+ZtVioEja4TTFdH0Q350=";
+    hash = "sha256-FSsTo2m88U7t6wMXaSuYhF5bCMRq11EBQsq6uiMdF7c=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-wDEtVsgkddGv89tTy96wYzNWVicn34Gxi+YAo7yAfQA=";
+    hash = "sha256-hVPtnMqaFH+1QJ52ZG9vZ3clsMTsEpvF5JjTKWoKSPE=";
   };
 
   # needed for librocksdb-sys

--- a/pkgs/by-name/el/electrs/package.nix
+++ b/pkgs/by-name/el/electrs/package.nix
@@ -8,19 +8,21 @@
 let
   rocksdb = rocksdb_7_10;
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "electrs";
   version = "0.10.9";
 
   src = fetchFromGitHub {
     owner = "romanz";
     repo = "electrs";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-Xo7aqP4tIh/kYthPucscxnl+ZtVioEja4TTFdH0Q350=";
   };
 
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-wDEtVsgkddGv89tTy96wYzNWVicn34Gxi+YAo7yAfQA=";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-wDEtVsgkddGv89tTy96wYzNWVicn34Gxi+YAo7yAfQA=";
+  };
 
   # needed for librocksdb-sys
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
@@ -38,4 +40,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with maintainers; [ prusnak ];
     mainProgram = "electrs";
   };
-}
+})

--- a/pkgs/by-name/el/electrs/update.sh
+++ b/pkgs/by-name/el/electrs/update.sh
@@ -2,6 +2,8 @@
 #!nix-shell -i bash -p coreutils curl jq git gnupg common-updater-scripts
 set -euo pipefail
 
+trap 'echo "Error at ${BASH_SOURCE[0]}:$LINENO"' ERR
+
 # Fetch latest release, GPG-verify the tag, update derivation
 
 scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
@@ -34,6 +36,6 @@ git -C $repo verify-tag v${version}
 rm -rf $repo/.git
 hash=$(nix --extra-experimental-features nix-command hash path $repo)
 
-(cd "$nixpkgs" && update-source-version electrs "$version" "$hash" && update-source-version electrs --ignore-same-version --source-key=cargoDeps)
+(cd "$nixpkgs" && update-source-version electrs "$version" "$hash" && update-source-version electrs --ignore-same-version --source-key=cargoDeps.vendorStaging)
 echo
 echo "electrs: $oldVersion -> $version"


### PR DESCRIPTION
https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#01010-jul-19-2025

- [x] Built and run on `x86_64-linux`

cc @prusnak