### PR TITLE
nixos/postfix: add a package option and use it treewide

### DIFF
--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -58,7 +58,7 @@ let
   # TODO: Should this be RFC42-ised so that users can set additional options without modifying the module?
   postfixMtaConfig = pkgs.writeText "mailman-postfix.cfg" ''
     [postfix]
-    postmap_command: ${config.services.postfix.package}/bin/postmap
+    postmap_command: ${lib.getExe' config.services.postfix.package "postmap"}
     transport_file_type: hash
   '';
 

--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -58,7 +58,7 @@ let
   # TODO: Should this be RFC42-ised so that users can set additional options without modifying the module?
   postfixMtaConfig = pkgs.writeText "mailman-postfix.cfg" ''
     [postfix]
-    postmap_command: ${pkgs.postfix}/bin/postmap
+    postmap_command: ${config.services.postfix.package}/bin/postmap
     transport_file_type: hash
   '';
 

--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -166,8 +166,8 @@ in
       };
       preStart = ''
         ${concatMapLines (createList cfg.listDomain) cfg.mailLists}
-        ${pkgs.postfix}/bin/postmap /etc/postfix/virtual
-        ${pkgs.postfix}/bin/postmap /etc/postfix/transport
+        ${config.services.postfix.package}/bin/postmap /etc/postfix/virtual
+        ${config.services.postfix.package}/bin/postmap /etc/postfix/transport
       '';
     };
 

--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -166,8 +166,8 @@ in
       };
       preStart = ''
         ${concatMapLines (createList cfg.listDomain) cfg.mailLists}
-        ${config.services.postfix.package}/bin/postmap /etc/postfix/virtual
-        ${config.services.postfix.package}/bin/postmap /etc/postfix/transport
+        ${lib.getExe' config.services.postfix.package "postmap"} /etc/postfix/virtual
+        ${lib.getExe' config.services.postfix.package "postmap"} /etc/postfix/transport
       '';
     };
 

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -357,6 +357,8 @@ in
         description = "Whether to run the Postfix mail server.";
       };
 
+      package = lib.mkPackageOption pkgs "postfix" { };
+
       enableSmtp = lib.mkOption {
         type = lib.types.bool;
         default = true;
@@ -882,12 +884,12 @@ in
           etc.postfix.source = "/var/lib/postfix/conf";
 
           # This makes it comfortable to run 'postqueue/postdrop' for example.
-          systemPackages = [ pkgs.postfix ];
+          systemPackages = [ cfg.package ];
         };
 
         services.mail.sendmailSetuidWrapper = lib.mkIf config.services.postfix.setSendmail {
           program = "sendmail";
-          source = "${pkgs.postfix}/bin/sendmail";
+          source = "${cfg.package}/bin/sendmail";
           owner = "root";
           group = setgidGroup;
           setuid = false;
@@ -896,7 +898,7 @@ in
 
         security.wrappers.mailq = {
           program = "mailq";
-          source = "${pkgs.postfix}/bin/mailq";
+          source = "${cfg.package}/bin/mailq";
           owner = "root";
           group = setgidGroup;
           setuid = false;
@@ -905,7 +907,7 @@ in
 
         security.wrappers.postqueue = {
           program = "postqueue";
-          source = "${pkgs.postfix}/bin/postqueue";
+          source = "${cfg.package}/bin/postqueue";
           owner = "root";
           group = setgidGroup;
           setuid = false;
@@ -914,7 +916,7 @@ in
 
         security.wrappers.postdrop = {
           program = "postdrop";
-          source = "${pkgs.postfix}/bin/postdrop";
+          source = "${cfg.package}/bin/postdrop";
           owner = "root";
           group = setgidGroup;
           setuid = false;
@@ -948,7 +950,7 @@ in
               mv /var/postfix /var/lib/postfix
             fi
 
-            # All permissions set according ${pkgs.postfix}/etc/postfix/postfix-files script
+            # All permissions set according ${cfg.package}/etc/postfix/postfix-files script
             mkdir -p /var/lib/postfix /var/lib/postfix/queue/{pid,public,maildrop}
             chmod 0755 /var/lib/postfix
             chown root:root /var/lib/postfix
@@ -956,20 +958,20 @@ in
             rm -rf /var/lib/postfix/conf
             mkdir -p /var/lib/postfix/conf
             chmod 0755 /var/lib/postfix/conf
-            ln -sf ${pkgs.postfix}/etc/postfix/postfix-files /var/lib/postfix/conf/postfix-files
+            ln -sf ${cfg.package}/etc/postfix/postfix-files /var/lib/postfix/conf/postfix-files
             ln -sf ${mainCfFile} /var/lib/postfix/conf/main.cf
             ln -sf ${masterCfFile} /var/lib/postfix/conf/master.cf
 
             ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList (to: from: ''
                 ln -sf ${from} /var/lib/postfix/conf/${to}
-                ${pkgs.postfix}/bin/postalias -o -p /var/lib/postfix/conf/${to}
+                ${cfg.package}/bin/postalias -o -p /var/lib/postfix/conf/${to}
               '') cfg.aliasFiles
             )}
             ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList (to: from: ''
                 ln -sf ${from} /var/lib/postfix/conf/${to}
-                ${pkgs.postfix}/bin/postmap -o -p /var/lib/postfix/conf/${to}
+                ${cfg.package}/bin/postmap -o -p /var/lib/postfix/conf/${to}
               '') cfg.mapFiles
             )}
 
@@ -979,7 +981,7 @@ in
             ln -sf /var/spool/mail /var/
 
             #Finally delegate to postfix checking remain directories in /var/lib/postfix and set permissions on them
-            ${pkgs.postfix}/bin/postfix set-permissions config_directory=/var/lib/postfix/conf
+            ${cfg.package}/bin/postfix set-permissions config_directory=/var/lib/postfix/conf
           '';
         };
 
@@ -993,15 +995,15 @@ in
             "postfix-setup.service"
           ];
           requires = [ "postfix-setup.service" ];
-          path = [ pkgs.postfix ];
+          path = [ cfg.package ];
 
           serviceConfig = {
             Type = "forking";
             Restart = "always";
             PIDFile = "/var/lib/postfix/queue/pid/master.pid";
-            ExecStart = "${pkgs.postfix}/bin/postfix start";
-            ExecStop = "${pkgs.postfix}/bin/postfix stop";
-            ExecReload = "${pkgs.postfix}/bin/postfix reload";
+            ExecStart = "${cfg.package}/bin/postfix start";
+            ExecStop = "${cfg.package}/bin/postfix stop";
+            ExecReload = "${cfg.package}/bin/postfix reload";
 
             # Hardening
             PrivateTmp = true;
@@ -1025,7 +1027,7 @@ in
 
         services.postfix.settings.main =
           (lib.mapAttrs (_: v: lib.mkDefault v) {
-            compatibility_level = pkgs.postfix.version;
+            compatibility_level = cfg.package.version;
             mail_owner = cfg.user;
             default_privs = "nobody";
 
@@ -1034,16 +1036,16 @@ in
             queue_directory = "/var/lib/postfix/queue";
 
             # Default location of everything in package
-            meta_directory = "${pkgs.postfix}/etc/postfix";
-            command_directory = "${pkgs.postfix}/bin";
+            meta_directory = "${cfg.package}/etc/postfix";
+            command_directory = "${cfg.package}/bin";
             sample_directory = "/etc/postfix";
-            newaliases_path = "${pkgs.postfix}/bin/newaliases";
-            mailq_path = "${pkgs.postfix}/bin/mailq";
+            newaliases_path = "${cfg.package}/bin/newaliases";
+            mailq_path = "${cfg.package}/bin/mailq";
             readme_directory = false;
-            sendmail_path = "${pkgs.postfix}/bin/sendmail";
-            daemon_directory = "${pkgs.postfix}/libexec/postfix";
-            manpage_directory = "${pkgs.postfix}/share/man";
-            html_directory = "${pkgs.postfix}/share/postfix/doc/html";
+            sendmail_path = "${cfg.package}/bin/sendmail";
+            daemon_directory = "${cfg.package}/libexec/postfix";
+            manpage_directory = "${cfg.package}/share/man";
+            html_directory = "${cfg.package}/share/postfix/doc/html";
             shlib_directory = false;
             mail_spool_directory = "/var/spool/mail/";
             setgid_group = cfg.setgidGroup;

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -889,7 +889,7 @@ in
 
         services.mail.sendmailSetuidWrapper = lib.mkIf config.services.postfix.setSendmail {
           program = "sendmail";
-          source = "${cfg.package}/bin/sendmail";
+          source = lib.getExe' cfg.package "sendmail";
           owner = "root";
           group = setgidGroup;
           setuid = false;
@@ -898,7 +898,7 @@ in
 
         security.wrappers.mailq = {
           program = "mailq";
-          source = "${cfg.package}/bin/mailq";
+          source = lib.getExe' cfg.package "mailq";
           owner = "root";
           group = setgidGroup;
           setuid = false;
@@ -907,7 +907,7 @@ in
 
         security.wrappers.postqueue = {
           program = "postqueue";
-          source = "${cfg.package}/bin/postqueue";
+          source = lib.getExe' cfg.package "postqueue";
           owner = "root";
           group = setgidGroup;
           setuid = false;
@@ -916,7 +916,7 @@ in
 
         security.wrappers.postdrop = {
           program = "postdrop";
-          source = "${cfg.package}/bin/postdrop";
+          source = lib.getExe' cfg.package "postdrop";
           owner = "root";
           group = setgidGroup;
           setuid = false;
@@ -965,13 +965,13 @@ in
             ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList (to: from: ''
                 ln -sf ${from} /var/lib/postfix/conf/${to}
-                ${cfg.package}/bin/postalias -o -p /var/lib/postfix/conf/${to}
+                ${lib.getExe' cfg.package "postalias"} -o -p /var/lib/postfix/conf/${to}
               '') cfg.aliasFiles
             )}
             ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList (to: from: ''
                 ln -sf ${from} /var/lib/postfix/conf/${to}
-                ${cfg.package}/bin/postmap -o -p /var/lib/postfix/conf/${to}
+                ${lib.getExe' cfg.package "postmap"} -o -p /var/lib/postfix/conf/${to}
               '') cfg.mapFiles
             )}
 
@@ -981,7 +981,7 @@ in
             ln -sf /var/spool/mail /var/
 
             #Finally delegate to postfix checking remain directories in /var/lib/postfix and set permissions on them
-            ${cfg.package}/bin/postfix set-permissions config_directory=/var/lib/postfix/conf
+            ${lib.getExe' cfg.package "postfix"} set-permissions config_directory=/var/lib/postfix/conf
           '';
         };
 
@@ -1001,9 +1001,9 @@ in
             Type = "forking";
             Restart = "always";
             PIDFile = "/var/lib/postfix/queue/pid/master.pid";
-            ExecStart = "${cfg.package}/bin/postfix start";
-            ExecStop = "${cfg.package}/bin/postfix stop";
-            ExecReload = "${cfg.package}/bin/postfix reload";
+            ExecStart = "${lib.getExe' cfg.package "postfix"} start";
+            ExecStop = "${lib.getExe' cfg.package "postfix"} stop";
+            ExecReload = "${lib.getExe' cfg.package "postfix"} reload";
 
             # Hardening
             PrivateTmp = true;
@@ -1039,10 +1039,10 @@ in
             meta_directory = "${cfg.package}/etc/postfix";
             command_directory = "${cfg.package}/bin";
             sample_directory = "/etc/postfix";
-            newaliases_path = "${cfg.package}/bin/newaliases";
-            mailq_path = "${cfg.package}/bin/mailq";
+            newaliases_path = lib.getExe' cfg.package "newaliases";
+            mailq_path = lib.getExe' cfg.package "mailq";
             readme_directory = false;
-            sendmail_path = "${cfg.package}/bin/sendmail";
+            sendmail_path = lib.getExe' cfg.package "sendmail";
             daemon_directory = "${cfg.package}/libexec/postfix";
             manpage_directory = "${cfg.package}/share/man";
             html_directory = "${cfg.package}/share/postfix/doc/html";

--- a/nixos/modules/services/mail/sympa.nix
+++ b/nixos/modules/services/mail/sympa.nix
@@ -400,7 +400,7 @@ in
       })
       // (lib.optionalAttrs (cfg.mta.type == "postfix") {
         sendmail_aliases = "${dataDir}/sympa_transport";
-        aliases_program = "${config.services.postfix.package}/bin/postmap";
+        aliases_program = lib.getExe' config.services.postfix.package "postmap";
         aliases_db_type = "hash";
       })
       // (lib.optionalAttrs cfg.web.enable {
@@ -502,8 +502,8 @@ in
         ''}
 
         ${lib.optionalString (cfg.mta.type == "postfix") ''
-          ${config.services.postfix.package}/bin/postmap hash:${dataDir}/virtual.sympa
-          ${config.services.postfix.package}/bin/postmap hash:${dataDir}/transport.sympa
+          ${lib.getExe' config.services.postfix.package "postmap"} hash:${dataDir}/virtual.sympa
+          ${lib.getExe' config.services.postfix.package "postmap"} hash:${dataDir}/transport.sympa
         ''}
         ${pkg}/bin/sympa_newaliases.pl
         ${pkg}/bin/sympa.pl --health_check

--- a/nixos/modules/services/mail/sympa.nix
+++ b/nixos/modules/services/mail/sympa.nix
@@ -400,7 +400,7 @@ in
       })
       // (lib.optionalAttrs (cfg.mta.type == "postfix") {
         sendmail_aliases = "${dataDir}/sympa_transport";
-        aliases_program = "${pkgs.postfix}/bin/postmap";
+        aliases_program = "${config.services.postfix.package}/bin/postmap";
         aliases_db_type = "hash";
       })
       // (lib.optionalAttrs cfg.web.enable {
@@ -502,8 +502,8 @@ in
         ''}
 
         ${lib.optionalString (cfg.mta.type == "postfix") ''
-          ${pkgs.postfix}/bin/postmap hash:${dataDir}/virtual.sympa
-          ${pkgs.postfix}/bin/postmap hash:${dataDir}/transport.sympa
+          ${config.services.postfix.package}/bin/postmap hash:${dataDir}/virtual.sympa
+          ${config.services.postfix.package}/bin/postmap hash:${dataDir}/transport.sympa
         ''}
         ${pkg}/bin/sympa_newaliases.pl
         ${pkg}/bin/sympa.pl --health_check

--- a/nixos/modules/services/networking/hylafax/options.nix
+++ b/nixos/modules/services/networking/hylafax/options.nix
@@ -221,8 +221,7 @@ in
 
     sendmailPath = mkOption {
       type = path;
-      example = literalExpression ''"''${pkgs.postfix}/bin/sendmail"'';
-      # '' ;  # fix vim
+      example = literalExpression ''"''${config.services.postfix.package}/bin/sendmail"'';
       description = ''
         Path to {file}`sendmail` program.
         The default uses the local sendmail wrapper

--- a/nixos/modules/services/networking/hylafax/options.nix
+++ b/nixos/modules/services/networking/hylafax/options.nix
@@ -221,7 +221,7 @@ in
 
     sendmailPath = mkOption {
       type = path;
-      example = literalExpression ''"''${config.services.postfix.package}/bin/sendmail"'';
+      example = literalExpression ''lib.getExe' config.services.postfix.package "sendmail"'';
       description = ''
         Path to {file}`sendmail` program.
         The default uses the local sendmail wrapper


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
