### PR TITLE
Cinnamon updates 2025-07-22

### DIFF
--- a/pkgs/by-name/mi/mint-l-icons/package.nix
+++ b/pkgs/by-name/mi/mint-l-icons/package.nix
@@ -10,14 +10,14 @@
 
 stdenvNoCC.mkDerivation {
   pname = "mint-l-icons";
-  version = "1.7.4";
+  version = "1.7.5";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-l-icons";
     # They don't really do tags, this is just a named commit.
-    rev = "b442277c822c92f7bb68282cb82c7d1a98e3fd37";
-    hash = "sha256-vPDEribE/CZwoAK1C9fjbWQEO/NWMWCKCUO/Xw/SxZ0=";
+    rev = "64ee205dc270b13f3816030330eed108eaa30360";
+    hash = "sha256-4tavRQ1bWzVYcAAJtZ4avRHcBB+oTDhdXp6dlSGO4C8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/mi/mint-y-icons/package.nix
+++ b/pkgs/by-name/mi/mint-y-icons/package.nix
@@ -10,13 +10,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "mint-y-icons";
-  version = "1.8.3";
+  version = "1.8.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-y-icons";
     rev = version;
-    hash = "sha256-xGPihqXUraJy9lDCSVjQlNxrhETEcjBTYhyFsZGJRGo=";
+    hash = "sha256-ftiV9l7hTmWdtw36Z2GKpJZuRwQQ3MQWYIgb62VBde0=";
   };
 
   propagatedBuildInputs = [
@@ -30,6 +30,12 @@ stdenvNoCC.mkDerivation rec {
   ];
 
   dontDropIconThemeCache = true;
+
+  postPatch = ''
+    # Breaks gtk-update-icon-cache
+    # https://github.com/linuxmint/mint-y-icons/issues/494
+    find usr/share/icons/Mint-Y/apps/ -type l -name "1AC2_Battle.net Launcher.0.png" -delete
+  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/xr/xreader/package.nix
+++ b/pkgs/by-name/xr/xreader/package.nix
@@ -36,13 +36,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xreader";
-  version = "4.2.6";
+  version = "4.2.7";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xreader";
     rev = version;
-    hash = "sha256-ELqO8pYMWgU6DUS5vg+F+xFp3w3H6u0Jzms3xaNlTqE=";
+    hash = "sha256-APBVrrvLS5CFtfi0UlIDtYyg4pfCS8qLc2a4KDOU1Zk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xv/xviewer/package.nix
+++ b/pkgs/by-name/xv/xviewer/package.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xviewer";
-  version = "3.4.8";
+  version = "3.4.9";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xviewer";
     rev = version;
-    hash = "sha256-Wn1a/tGNIJNGbgDKoMMMo/oCXrqCXDM1nTUgCZt0O/U=";
+    hash = "sha256-WYGX57PUX+WUVVZ1F+oE3QNwKB7ii5FlJdQ/3j5heUA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--

xviewer: 3.4.8 -> 3.4.9
xreader: 4.2.6 -> 4.2.7
mint-l-icons: 1.7.4 -> 1.7.5
mint-y-icons: 1.8.3 -> 1.8.4

-->


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
