### PR TITLE
lib.attrsets.foldAttrs': init

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -827,6 +827,48 @@ rec {
     ) { } list_of_attrs;
 
   /**
+    Apply fold function to values grouped by key. Like
+    [`lib.attrsets.foldAttrs`](#function-library-lib.attrsets.foldAttrs), but
+    passes an attribute name as a first argument to `op`.
+
+    # Inputs
+
+    `op`
+
+    : A function, given an attribute name, a value and a collector combines the later two.
+
+    `nul`
+
+    : The starting value.
+
+    `list_of_attrs`
+
+    : A list of attribute sets to fold together by key.
+
+    # Type
+
+    ```
+    foldAttrs' :: (String -> Any -> Any -> Any) -> Any -> [AttrSets] -> Any
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.foldAttrs'` usage example
+
+    ```nix
+    foldAttrs' (name: item: acc: ["${name}${toString item}"] ++ acc) [] [{ a = 2; b = 3; } { a = 4; }]
+    => { a = [ "a2" "a4" ]; b = [ "b3" ]; }
+    ```
+
+    :::
+  */
+  foldAttrs' =
+    op: nul: list_of_attrs:
+    foldr (
+      n: a: foldr (name: o: o // { ${name} = op name n.${name} (a.${name} or nul); }) a (attrNames n)
+    ) { } list_of_attrs;
+
+  /**
     Recursively collect sets that verify a given predicate named `pred`
     from the set `attrs`. The recursion is stopped when the predicate is
     verified.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -197,6 +197,7 @@ let
         filterAttrsRecursive
         foldlAttrs
         foldAttrs
+        foldAttrs'
         collect
         nameValuePair
         mapAttrs

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -52,6 +52,7 @@ let
     fix
     fold
     foldAttrs
+    foldAttrs'
     foldl
     foldl'
     foldlAttrs
@@ -1629,6 +1630,34 @@ runTests {
       ];
       b = [ 7 ];
       c = [ 8 ];
+    };
+  };
+
+  testFoldAttrs' = {
+    expr =
+      foldAttrs'
+        (
+          name: n: a:
+          [ "${name}${toString n}" ] ++ a
+        )
+        [ ]
+        [
+          {
+            a = 2;
+            b = 7;
+          }
+          {
+            a = 3;
+            c = 8;
+          }
+        ];
+    expected = {
+      a = [
+        "a2"
+        "a3"
+      ];
+      b = [ "b7" ];
+      c = [ "c8" ];
     };
   };
 


### PR DESCRIPTION
Same as `foldAttrs`, but passing attribute name to the function.
This is helpful in cases when the function needs to log or throw errors with attribute names included in the message. For example:

```
assertUniqueAttrs = foldAttrs' (
  name: v: acc:
  assert (assertMsg (acc == null) "${name} is defined in multiple sets");
  v
) null
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
