### PR TITLE
iio-sensor-proxy: Fix on cros-ec devices (e.g. Framework 12)

### DIFF
--- a/pkgs/by-name/ii/iio-sensor-proxy/package.nix
+++ b/pkgs/by-name/ii/iio-sensor-proxy/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  fetchpatch2,
   glib,
   cmake,
   libxml2,
@@ -25,6 +26,26 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-MAfh6bgh39J5J3rlyPjyCkk5KcfWHMZLytZcBRPHaJE=";
   };
+
+  # Fix devices with cros-ec-accel, like Chromebooks and Framework Laptop 12
+  # https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/merge_requests/400
+  patches = [
+    (fetchpatch2 {
+      name = "mr400_1.patch";
+      url = "https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/commit/f35d293e65841a3b9c0de778300c7fa58b181fd0.patch";
+      hash = "sha256-Gk8Wpy+KFhHAsR3XklcsL3Eo4fHjQuFT6PCN5hz9KHk=";
+    })
+    (fetchpatch2 {
+      name = "mr400_2.patch";
+      url = "https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/commit/7416edf4da98d8e3b75f9eddb7e5c488ac4a4c54.patch";
+      hash = "sha256-5UnYam6P+paBHAI0qKXDAvrFM8JYhRVTUFePRTHCp+U=";
+    })
+    (fetchpatch2 {
+      name = "mr400_3.patch";
+      url = "https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/commit/d00109194422a4fe3e9a7bc1235ffc492459c61a.patch";
+      hash = "sha256-58KrXbdpR1eWbPmsr8b0ke67hX5J0o0gtqzrz3dc+ck=";
+    })
+  ];
 
   postPatch = ''
     # upstream meson.build currently doesn't have an option to change the default polkit dir


### PR DESCRIPTION
https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/merge_requests/400 has finally been merged and fixed the regression in version 3.7. Since the merging has taken a long time, I don't expect a new release soon and we should include the patches.

Also see https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/issues/411 Now monitor-sensor can show the display orientation and GNOME/KDE pick it up.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
