### PR TITLE
ocamlPackages.reason-react(-ppx): 0.15.0 -> 0.16.0

### DIFF
--- a/pkgs/development/ocaml-modules/reason-react/default.nix
+++ b/pkgs/development/ocaml-modules/reason-react/default.nix
@@ -1,6 +1,5 @@
 {
   buildDunePackage,
-  fetchpatch,
   melange,
   reason,
   reason-react-ppx,
@@ -9,14 +8,6 @@
 buildDunePackage {
   pname = "reason-react";
   inherit (reason-react-ppx) version src;
-  patches = [
-    # Makes tests compatible with melange 5.0.0
-    (fetchpatch {
-      url = "https://github.com/reasonml/reason-react/commit/661e93553ae48af410895477c339be4f0a203437.patch";
-      includes = [ "test/*" ];
-      hash = "sha256-khxPxC/GpByjcEZDoQ1NdXoM/yQBAKmnUnt/d2k6WfQ=";
-    })
-  ];
   nativeBuildInputs = [
     reason
     melange

--- a/pkgs/development/ocaml-modules/reason-react/ppx.nix
+++ b/pkgs/development/ocaml-modules/reason-react/ppx.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "0.15.0";
+  version = "0.16.0";
 in
 buildDunePackage {
   pname = "reason-react-ppx";
@@ -14,7 +14,7 @@ buildDunePackage {
   minimalOCamlVersion = "4.14";
   src = fetchurl {
     url = "https://github.com/reasonml/reason-react/releases/download/${version}/reason-react-${version}.tbz";
-    hash = "sha256-+pPJo/b50vp4pAC/ygI1LHB5O0pDJ1xpcQZOdFP8Q80=";
+    hash = "sha256-esPB+mvHHTQ3mUYILrkOjMELJxRDIsWleFcxIwOPQ1w=";
   };
   buildInputs = [ ppxlib ];
   doCheck = false; # Needs to run in reason-react, see default.nix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
