### PR TITLE
gp-saml: migrate to by-name

### DIFF
--- a/pkgs/by-name/gp/gp-saml-gui/package.nix
+++ b/pkgs/by-name/gp/gp-saml-gui/package.nix
@@ -2,16 +2,14 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  buildPythonPackage,
+  python3Packages,
   webkitgtk_4_1,
   wrapGAppsHook3,
   glib-networking,
   gobject-introspection,
   openconnect,
-  pygobject3,
-  requests,
 }:
-buildPythonPackage rec {
+python3Packages.buildPythonPackage rec {
   pname = "gp-saml-gui";
   version = "0.1+20240731-${lib.strings.substring 0 7 src.rev}";
   format = "setuptools";
@@ -20,7 +18,7 @@ buildPythonPackage rec {
     owner = "dlenski";
     repo = "gp-saml-gui";
     rev = "c46af04b3a6325b0ecc982840d7cfbd1629b6d43";
-    sha256 = "sha256-4MFHad1cuCWawy2hrqdXOgud0pXpYiV9J3Jwqyg4Udk=";
+    hash = "sha256-4MFHad1cuCWawy2hrqdXOgud0pXpYiV9J3Jwqyg4Udk=";
   };
 
   buildInputs = lib.optional stdenv.hostPlatform.isLinux glib-networking;
@@ -31,12 +29,16 @@ buildPythonPackage rec {
     glib-networking
   ];
 
-  propagatedBuildInputs = [
-    requests
-    pygobject3
-    openconnect
-  ]
-  ++ lib.optional stdenv.hostPlatform.isLinux webkitgtk_4_1;
+  dependencies =
+    with python3Packages;
+    [
+      requests
+      pygobject3
+    ]
+    ++ [
+      openconnect
+    ]
+    ++ lib.optional stdenv.hostPlatform.isLinux webkitgtk_4_1;
 
   preFixup = ''
     gappsWrapperArgs+=(
@@ -44,11 +46,11 @@ buildPythonPackage rec {
     )
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Interactively authenticate to GlobalProtect VPNs that require SAML";
     mainProgram = "gp-saml-gui";
     homepage = "https://github.com/dlenski/gp-saml-gui";
-    license = licenses.gpl3Only;
-    maintainers = [ maintainers.pallix ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ pallix ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1085,8 +1085,6 @@ with pkgs;
     }
   );
 
-  gp-saml-gui = python3Packages.callPackage ../tools/networking/gp-saml-gui { };
-
   inherit (callPackages ../tools/networking/ivpn/default.nix { })
     ivpn
     ivpn-service


### PR DESCRIPTION
migrate gp-saml to by-name
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
