### PR TITLE
syzkaller: Use cross compilation

### DIFF
--- a/pkgs/by-name/sy/syzkaller/package.nix
+++ b/pkgs/by-name/sy/syzkaller/package.nix
@@ -5,6 +5,17 @@
   go,
   ncurses,
 }:
+let
+  cpus = {
+    "x86_64" = "amd64";
+    "i686" = "386";
+    "aarch64" = "arm64";
+  };
+  targetSystem = lib.systems.parse.mkSystemFromString stdenv.targetPlatform.system;
+  targetOS = targetSystem.kernel.name;
+  targetArch = cpus.${targetSystem.cpu.name};
+  targetVMArch = cpus.${(lib.systems.parse.mkSystemFromString stdenv.hostPlatform.system).cpu.name};
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "syzkaller";
   version = "0-unstable-2024-01-09";
@@ -47,6 +58,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postConfigure
   '';
 
+  makeFlags = [
+    "TARGETOS=${targetOS}"
+    "TARGETVMARCH=${targetVMArch}"
+    "TARGETARCH=${targetArch}"
+  ];
+
   dontInstall = true;
 
   meta = {
@@ -54,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/google/syzkaller";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.msanft ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     mainProgram = "syz-manager";
   };
 })


### PR DESCRIPTION
Previously `syzkaller` was built assuming the targets being fuzzed were the same architecture and OS as the host system.
This patch builds `syzkaller` with [cross compilation in mind](https://github.com/google/syzkaller/blob/85deaf45cc57320362fabb5ef83eb8cf413f4274/docs/linux/setup.md?plain=1#L52-L53); this doesn't change anything if `targetSystem==hostSystem` (how things were before), but it allows building syzkaller to fuzz e.g. an `x86_64-linux` guest on an `aarch64-darwin` host.

Consequently, this also expands the supported platforms to include Darwin.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
