### PR TITLE
ncurses: Recognise linux-gnuabielfv{1,2}

### DIFF
--- a/pkgs/development/libraries/ncurses/1001-ncurses-Support-gnuabielfv1-2.patch
+++ b/pkgs/development/libraries/ncurses/1001-ncurses-Support-gnuabielfv1-2.patch
@@ -1,0 +1,72 @@
+diff '--color=auto' -ruN a/aclocal.m4 b/aclocal.m4
+--- a/aclocal.m4	2025-07-19 18:19:51.000000000 +0200
++++ b/aclocal.m4	2025-07-25 14:11:19.900876172 +0200
+@@ -10290,7 +10290,7 @@
+ 	cf_xopen_source="-D_SGI_SOURCE"
+ 	cf_XOPEN_SOURCE=
+ 	;;
+-(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
++(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnuabielfv*|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
+ 	CF_GNU_SOURCE($cf_XOPEN_SOURCE)
+ 	;;
+ linux*musl)
+diff '--color=auto' -ruN a/Ada95/aclocal.m4 b/Ada95/aclocal.m4
+--- a/Ada95/aclocal.m4	2025-07-19 18:38:31.000000000 +0200
++++ b/Ada95/aclocal.m4	2025-07-25 14:11:57.495783459 +0200
+@@ -5430,7 +5430,7 @@
+ 	cf_xopen_source="-D_SGI_SOURCE"
+ 	cf_XOPEN_SOURCE=
+ 	;;
+-(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
++(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnuabielfv*|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
+ 	CF_GNU_SOURCE($cf_XOPEN_SOURCE)
+ 	;;
+ linux*musl)
+diff '--color=auto' -ruN a/Ada95/configure b/Ada95/configure
+--- a/Ada95/configure	2025-07-19 18:40:05.000000000 +0200
++++ b/Ada95/configure	2025-07-25 14:11:49.981449762 +0200
+@@ -13955,7 +13955,7 @@
+ 	cf_xopen_source="-D_SGI_SOURCE"
+ 	cf_XOPEN_SOURCE=
+ 	;;
+-(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
++(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnuabielfv*|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
+ 
+ cf_gnu_xopen_source=$cf_XOPEN_SOURCE
+ 
+diff '--color=auto' -ruN a/configure b/configure
+--- a/configure	2025-07-19 19:00:40.000000000 +0200
++++ b/configure	2025-07-25 14:11:02.884551699 +0200
+@@ -10737,7 +10737,7 @@
+ 	cf_xopen_source="-D_SGI_SOURCE"
+ 	cf_XOPEN_SOURCE=
+ 	;;
+-(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
++(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnuabielfv*|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
+ 
+ cf_gnu_xopen_source=$cf_XOPEN_SOURCE
+ 
+diff '--color=auto' -ruN a/test/aclocal.m4 b/test/aclocal.m4
+--- a/test/aclocal.m4	2025-07-19 18:42:37.000000000 +0200
++++ b/test/aclocal.m4	2025-07-25 14:11:41.551475534 +0200
+@@ -4658,7 +4658,7 @@
+ 	cf_xopen_source="-D_SGI_SOURCE"
+ 	cf_XOPEN_SOURCE=
+ 	;;
+-(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
++(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnuabielfv*|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
+ 	CF_GNU_SOURCE($cf_XOPEN_SOURCE)
+ 	;;
+ linux*musl)
+diff '--color=auto' -ruN a/test/configure b/test/configure
+--- a/test/configure	2025-06-14 15:40:22.000000000 +0200
++++ b/test/configure	2025-07-25 14:11:34.529155110 +0200
+@@ -4183,7 +4183,7 @@
+ 	cf_xopen_source="-D_SGI_SOURCE"
+ 	cf_XOPEN_SOURCE=
+ 	;;
+-(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
++(linux*gnu|linux*gnuabi64|linux*gnuabin32|linux*gnuabielfv*|linux*gnueabi|linux*gnueabihf|linux*gnux32|uclinux*|gnu*|mint*|k*bsd*-gnu|cygwin|msys|mingw*|linux*uclibc)
+ 
+ cf_gnu_xopen_source=$cf_XOPEN_SOURCE
+ 

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -33,6 +33,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   setOutputFlags = false; # some aren't supported
 
+  patches = [
+    # linux-gnuabielfv{1,2} is not in ncurses' list of GNU-ish targets (or smth like that?).
+    # Causes some defines (_XOPEN_SOURCE=600, _DEFAULT_SOURCE) to not get set, so wcwidth is not exposed by system headers, which causes a FTBFS.
+    # Reported and fix submitted to upstream in https://lists.gnu.org/archive/html/bug-ncurses/2025-07/msg00040.html
+    # Backported to the 6.5 release (dropped some hunks for code that isn't in this release yet)
+    ./1001-ncurses-Support-gnuabielfv1-2.patch
+  ];
+
   postPatch = ''
     sed -i '1i #include <stdbool.h>' include/curses.h.in
   '';


### PR DESCRIPTION
[ncurses has a list of GNU-ish targets](https://github.com/mirror/ncurses/blob/87c2c84cbd2332d6d94b12a1dcaf12ad1a51a938/aclocal.m4#L9991), for deciding which flags need to be set to get certain POSIX features. `linux-gnuabielfv{1,2}` fails to match that list, so certain defines don't get set.

This causes the build to fail for such targets, due to `wcwidth` being gated in the system headers behind an `_XOPEN_SOURCE` check:

```
In file included from ../ncurses/./base/lib_addch.c:37:
../ncurses/./base/lib_addch.c: In function 'waddch_literal':
../ncurses/curses.priv.h:1941:28: error: implicit declaration of function 'wcwidth' [-Wimplicit-function-declaration]
 1941 | #define _nc_wacs_width(ch) wcwidth(ch)
      |                            ^~~~~~~
../ncurses/curses.priv.h:1474:25: note: in definition of macro 'if_WIDEC'
 1474 | #define if_WIDEC(code)  code
      |                         ^~~~
../ncurses/./base/lib_addch.c:321:19: note: in expansion of macro '_nc_wacs_width'
  321 |         int len = _nc_wacs_width(CharOf(ch));
      |                   ^~~~~~~~~~~~~~
```

Fix this issue by adding the pattern `linux*gnuabielfv*` to the list.

This makes (cross-)compiling `ncurses` for `powerpc64-unknown-linux-gnuabielfv1` work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] powerpc64-linux (ELFv1, native & cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
