### PR TITLE
nixos/szurubooru: load secrets with systemd credentials + config permissions

### DIFF
--- a/nixos/modules/services/web-apps/szurubooru.nix
+++ b/nixos/modules/services/web-apps/szurubooru.nix
@@ -305,8 +305,9 @@ in
             export SZURUBOORU_SMTP_PASS=$(<$CREDENTIALS_DIRECTORY/smtp)
           ''}
           install -m0640 ${cfg.server.package.src}/config.yaml.dist ${cfg.dataDir}/config.yaml.dist
+          touch ${cfg.dataDir}/config.yaml
+          chmod 0640 ${cfg.dataDir}/config.yaml
           envsubst -i ${configFile} -o ${cfg.dataDir}/config.yaml
-          chmod 0640 config.yaml
           sed 's|script_location = |script_location = ${cfg.server.package.src}/|' ${cfg.server.package.src}/alembic.ini > ${cfg.dataDir}/alembic.ini
           alembic upgrade head
           waitress-serve --port ${toString cfg.server.port} --threads ${toString cfg.server.threads} szurubooru.facade:app

--- a/nixos/modules/services/web-apps/szurubooru.nix
+++ b/nixos/modules/services/web-apps/szurubooru.nix
@@ -299,10 +299,10 @@ in
           ]);
 
         script = ''
-          export SZURUBOORU_SECRET="$(<${cfg.server.settings.secretFile})"
-          export SZURUBOORU_DATABASE_PASSWORD="$(<${cfg.database.passwordFile})"
+          export SZURUBOORU_SECRET="$(<$CREDENTIALS_DIRECTORY/secret)"
+          export SZURUBOORU_DATABASE_PASSWORD="$(<$CREDENTIALS_DIRECTORY/database)"
           ${lib.optionalString (cfg.server.settings.smtp.passFile != null) ''
-            export SZURUBOORU_SMTP_PASS=$(<${cfg.server.settings.smtp.passFile})
+            export SZURUBOORU_SMTP_PASS=$(<$CREDENTIALS_DIRECTORY/smtp)
           ''}
           install -m0640 ${cfg.server.package.src}/config.yaml.dist ${cfg.dataDir}/config.yaml.dist
           envsubst -i ${configFile} -o ${cfg.dataDir}/config.yaml
@@ -312,6 +312,15 @@ in
         '';
 
         serviceConfig = {
+          LoadCredential =
+            [
+              "secret:${cfg.server.settings.secretFile}"
+              "database:${cfg.database.passwordFile}"
+            ]
+            ++ (lib.optionals (cfg.server.settings.smtp.passFile != null) [
+              "smtp:${cfg.server.settings.smtp.passFile}"
+            ]);
+
           User = cfg.user;
           Group = cfg.group;
 

--- a/nixos/modules/services/web-apps/szurubooru.nix
+++ b/nixos/modules/services/web-apps/szurubooru.nix
@@ -314,14 +314,13 @@ in
         '';
 
         serviceConfig = {
-          LoadCredential =
-            [
-              "secret:${cfg.server.settings.secretFile}"
-              "database:${cfg.database.passwordFile}"
-            ]
-            ++ (lib.optionals (cfg.server.settings.smtp.passFile != null) [
-              "smtp:${cfg.server.settings.smtp.passFile}"
-            ]);
+          LoadCredential = [
+            "secret:${cfg.server.settings.secretFile}"
+            "database:${cfg.database.passwordFile}"
+          ]
+          ++ (lib.optionals (cfg.server.settings.smtp.passFile != null) [
+            "smtp:${cfg.server.settings.smtp.passFile}"
+          ]);
 
           User = cfg.user;
           Group = cfg.group;

--- a/nixos/modules/services/web-apps/szurubooru.nix
+++ b/nixos/modules/services/web-apps/szurubooru.nix
@@ -306,6 +306,7 @@ in
           ''}
           install -m0640 ${cfg.server.package.src}/config.yaml.dist ${cfg.dataDir}/config.yaml.dist
           envsubst -i ${configFile} -o ${cfg.dataDir}/config.yaml
+          chmod 0640 config.yaml
           sed 's|script_location = |script_location = ${cfg.server.package.src}/|' ${cfg.server.package.src}/alembic.ini > ${cfg.dataDir}/alembic.ini
           alembic upgrade head
           waitress-serve --port ${toString cfg.server.port} --threads ${toString cfg.server.threads} szurubooru.facade:app


### PR DESCRIPTION
- Change the way secret files are loaded to load them as systemd credentials, this removes the need for the service user to have read permissions on the secret files.
- Ensure the generated config file with secrets isn't world readable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
