### PR TITLE
nixos/wpa_supplicant: harden and run as unprivileged user

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -55,6 +55,16 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - The Bash implementation of the `nixos-rebuild` program is removed. All switchable systems now use the Python rewrite. Any prior usage of `system.rebuild.enableNg` must now be removed. If you have any outstanding issues with the new implementation, please open an issue on GitHub.
 
+- The `networking.wireless` module has been security hardened: the `wpa_supplicant` daemon now runs under an unprivileged user with restricted access to the system.
+
+  As part of these changes, `/etc/wpa_supplicant.conf` has been deprecated: the NixOS-generated configuration file is now linked to `/etc/wpa_supplicant/nixos.conf` and `/etc/wpa_supplicant/imperative.conf` has been added for imperatively configuring `wpa_supplicant` or when using [allowAuxiliaryImperativeNetworks](#opt-networking.wireless.allowAuxiliaryImperativeNetworks).
+
+  If client certificates, keys or other files are needed, these should be stored under `/etc/wpa_supplicant` and owned by `wpa_supplicant` to ensure the daemon can read them.
+
+  Also, the {option}`networking.wireless.userControlled.group` option has been removed since there is now a dedicated `wpa_supplicant` group to control the daemon, and {option}`networking.wireless.userControlled.enable` has been renamed to [](#opt-networking.wireless.userControlled).
+
+  No functionality should have been impacted by these changes (including controlling via `wpa_cli`, integration with NetworkManager or connman), but if you find any problems, please open an issue on GitHub.
+
 - `services.angrr` now uses TOML for configuration. Define policies with `services.angrr.settings` (generate TOML file) or point to a file using `services.angrr.configFile`. The legacy options `services.angrr.period`, `services.angrr.ownedOnly`, and `services.angrr.removeRoot` have been removed. See `man 5 angrr` and the description of `services.angrr.settings` options for examples and details.
 
 - `services.pingvin-share` has been removed as the `pingvin-share.backend` package was broken and the project was archived upstream.

--- a/nixos/modules/services/networking/connman.nix
+++ b/nixos/modules/services/networking/connman.nix
@@ -165,6 +165,7 @@ in
       wireless = {
         enable = lib.mkIf (!enableIwd) true;
         dbusControlled = true;
+        autoDetectInterfaces = false;
         iwd = lib.mkIf enableIwd {
           enable = true;
         };

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -11,7 +11,8 @@ let
   cfg = config.networking.networkmanager;
   ini = pkgs.formats.ini { };
 
-  delegateWireless = config.networking.wireless.enable == true && cfg.unmanaged != [ ];
+  # Whether wpa_supplicant is managed independently
+  delegateWireless = config.networking.wireless.networks != { } && cfg.unmanaged != [ ];
 
   enableIwd = cfg.wifi.backend == "iwd";
 
@@ -136,10 +137,7 @@ let
     cfg.package
   ]
   ++ cfg.plugins
-  ++ pluginRuntimeDeps
-  ++ lib.optionals (!delegateWireless && !enableIwd) [
-    pkgs.wpa_supplicant
-  ];
+  ++ pluginRuntimeDeps;
 in
 {
 
@@ -541,9 +539,9 @@ in
 
     assertions = [
       {
-        assertion = config.networking.wireless.enable == true -> cfg.unmanaged != [ ];
+        assertion = config.networking.wireless.networks != { } -> cfg.unmanaged != [ ];
         message = ''
-          You can not use networking.networkmanager with networking.wireless.
+          You can not use networking.networkmanager with networking.wireless.networks.
           Except if you mark some interfaces as <literal>unmanaged</literal> by NetworkManager.
         '';
       }
@@ -674,6 +672,13 @@ in
     networking = mkMerge [
       (mkIf (!delegateWireless) {
         useDHCP = false;
+      })
+
+      (mkIf (!delegateWireless && !enableIwd) {
+        # Enable wpa_supplicant but fully control it over DBus
+        wireless.enable = true;
+        wireless.autoDetectInterfaces = false;
+        wireless.dbusControlled = true;
       })
 
       (mkIf enableIwd {

--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -199,7 +199,12 @@ let
       script = ''
         iface_args="-s ${optionalString cfg.dbusControlled "-u"} -D${cfg.driver} ${configStr}"
         ${
-          if iface == null then
+          if iface != null then
+            ''
+              # add known interface to the daemon arguments
+              args="-i${iface} $iface_args"
+            ''
+          else if cfg.autoDetectInterfaces then
             ''
               # detect interfaces automatically
 
@@ -222,10 +227,7 @@ let
               done
             ''
           else
-            ''
-              # add known interface to the daemon arguments
-              args="-i${iface} $iface_args"
-            ''
+            "args=$iface_args"
         }
 
         # finally start daemon
@@ -251,13 +253,18 @@ in
           "wlan1"
         ];
         description = ''
-          The interfaces {command}`wpa_supplicant` will use. If empty, it will
+          The interfaces {command}`wpa_supplicant` will use. If empty and
+          [](#opt-networking.wireless.autoDetectInterfaces) is true it will
           automatically use all wireless interfaces.
 
           ::: {.note}
           A separate wpa_supplicant instance will be started for each interface.
           :::
         '';
+      };
+
+      autoDetectInterfaces = mkEnableOption "automatic detection of wireless interfaces" // {
+        default = true;
       };
 
       driver = mkOption {

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -14,6 +14,7 @@
   readline,
   withPcsclite ? !stdenv.hostPlatform.isStatic,
   pcsclite,
+  unprivileged ? true,
 }:
 
 stdenv.mkDerivation rec {
@@ -33,8 +34,6 @@ stdenv.mkDerivation rec {
       hash = "sha256-X6mBbj7BkW66aYeSCiI3JKBJv10etLQxaTRfRgwsFmM=";
       revert = true;
     })
-    ./unsurprising-ext-password.patch
-    ./multiple-configs.patch
     (fetchpatch {
       name = "suppress-ctrl-event-signal-change.patch";
       url = "https://w1.fi/cgit/hostap/patch/?id=c330b5820eefa8e703dbce7278c2a62d9c69166a";
@@ -45,7 +44,10 @@ stdenv.mkDerivation rec {
       url = "https://git.w1.fi/cgit/hostap/patch/?id=1ce37105da371c8b9cf3f349f78f5aac77d40836";
       hash = "sha256-leCk0oexNBZyVK5Q5gR4ZcgWxa0/xt/aU+DssTa0UwE=";
     })
-  ];
+    ./unsurprising-ext-password.patch
+    ./multiple-configs.patch
+  ]
+  ++ lib.optional unprivileged ./unprivileged-daemon.patch;
 
   # TODO: Patch epoll so that the dbus actually responds
   # TODO: Figure out how to get privsep working, currently getting SIGBUS

--- a/pkgs/os-specific/linux/wpa_supplicant/unprivileged-daemon.patch
+++ b/pkgs/os-specific/linux/wpa_supplicant/unprivileged-daemon.patch
@@ -1,0 +1,96 @@
+commit 24e932357ee3041763135b931206dfc0bbe0441e
+Author: rnhmjoj <rnhmjoj@inventati.org>
+Date:   Wed Jul 23 10:18:55 2025 +0200
+
+    Fixes for running wpa_supplicant unprivileged
+    
+    1. Change the dbus service user to "wpa_supplicant"
+    
+    2. Ensure appropriate group ownership and permissions on the client sockets.
+       Motivation: clients communicate with the daemon by creating "client"
+       sockets; by default this is owned by the user running the client,
+       so it may be inaccessible by the daemon.
+    
+    3. Move the "control" sockets under a subdirectory of /run/wpa_supplicant.
+       Motivation: wpa_supplicant will try to adjust the ownership of the
+       sockets directory, even if they are fine, and fail.
+    
+    4. Move the "client" under a subdirectory of /run/wpa_supplicant instead
+       of tmp. Motivation: this allows to unshare /tmp
+
+diff --git a/src/common/wpa_ctrl.c b/src/common/wpa_ctrl.c
+index 7e197f0..6bfb091 100644
+--- a/src/common/wpa_ctrl.c
++++ b/src/common/wpa_ctrl.c
+@@ -15,6 +15,8 @@
+ #include <fcntl.h>
+ #include <sys/un.h>
+ #include <unistd.h>
++#include <sys/types.h>
++#include <grp.h>
+ #include <fcntl.h>
+ #endif /* CONFIG_CTRL_IFACE_UNIX */
+ #ifdef CONFIG_CTRL_IFACE_UDP_REMOTE
+@@ -165,6 +167,14 @@ try_again:
+ 		return NULL;
+ 	}
+ 
++	/* Set the client socket owner group to "wpa_supplicant"
++	 * and ensure group and user permissions are the same */
++	struct group *grp = getgrnam("wpa_supplicant");
++	if (grp != NULL) {
++		lchown(ctrl->local.sun_path, -1, grp->gr_gid);
++		chmod(ctrl->local.sun_path, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
++	}
++
+ #ifdef ANDROID
+ 	/* Set group even if we do not have privileges to change owner */
+ 	lchown(ctrl->local.sun_path, -1, AID_WIFI);
+--- a/wpa_supplicant/dbus/dbus-wpa_supplicant.conf
++++ b/wpa_supplicant/dbus/dbus-wpa_supplicant.conf
+@@ -2,9 +2,15 @@
+  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+ <busconfig>
+-        <policy user="root">
++        <policy user="wpa_supplicant">
+                 <allow own="fi.w1.wpa_supplicant1"/>
+-
++        </policy>
++        <policy user="root">
++                <allow send_destination="fi.w1.wpa_supplicant1"/>
++                <allow send_interface="fi.w1.wpa_supplicant1"/>
++                <allow receive_sender="fi.w1.wpa_supplicant1" receive_type="signal"/>
++        </policy>
++        <policy group="wpa_supplicant">
+                 <allow send_destination="fi.w1.wpa_supplicant1"/>
+                 <allow send_interface="fi.w1.wpa_supplicant1"/>
+                 <allow receive_sender="fi.w1.wpa_supplicant1" receive_type="signal"/>
+diff --git a/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in b/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in
+index d97ff39..367a7c6 100644
+--- a/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in
++++ b/wpa_supplicant/dbus/fi.w1.wpa_supplicant1.service.in
+@@ -1,5 +1,5 @@
+ [D-BUS Service]
+ Name=fi.w1.wpa_supplicant1
+ Exec=@BINDIR@/wpa_supplicant -u
+-User=root
++User=wpa_supplicant
+ SystemdService=wpa_supplicant.service
+diff --git a/wpa_supplicant/wpa_cli.c b/wpa_supplicant/wpa_cli.c
+index af00e79..840b307 100644
+--- a/wpa_supplicant/wpa_cli.c
++++ b/wpa_supplicant/wpa_cli.c
+@@ -44,10 +44,10 @@ static int wpa_cli_attached = 0;
+ static int wpa_cli_connected = -1;
+ static int wpa_cli_last_id = 0;
+ #ifndef CONFIG_CTRL_IFACE_DIR
+-#define CONFIG_CTRL_IFACE_DIR "/var/run/wpa_supplicant"
++#define CONFIG_CTRL_IFACE_DIR "/run/wpa_supplicant/control"
+ #endif /* CONFIG_CTRL_IFACE_DIR */
+ static const char *ctrl_iface_dir = CONFIG_CTRL_IFACE_DIR;
+-static const char *client_socket_dir = NULL;
++static const char *client_socket_dir = "/run/wpa_supplicant/client";
+ static char *ctrl_ifname = NULL;
+ static const char *global = NULL;
+ static const char *pid_file = NULL;


### PR DESCRIPTION
One more step towards zero services running as root.
Inspired by https://github.com/NixOS/nixpkgs/pull/305722

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested
  - [x] `nixosTests.wpa_supplicant`
  - [x] `nixosTests.networking.networkmanager`
  - [x] `nixosTests.connman`
  - [x] wpa_supplicant, wpa_cli on my machine
  - [x]  connman on actual hardware
  - [x] networkmanager on actual hardware
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
