### PR TITLE
[Backport release-25.05] zoom-us: 6.4.6.* -> 6.5.7.*

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -60,23 +60,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.4.6.53970";
-  versions.x86_64-darwin = "6.4.6.53970";
-  versions.x86_64-linux = "6.4.6.1370";
+  versions.aarch64-darwin = "6.4.10.56141";
+  versions.x86_64-darwin = "6.4.10.56141";
+  versions.x86_64-linux = "6.4.10.2027";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-yNsiFZNte4432d8DUyDhPUOVbLul7gUdvr+3qK/Y+tk=";
+      hash = "sha256-LIQl+s/2WfYFIEG/ZsvpWlsWRhToB+5+ymAXCMhDqWE=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-Ut93qQFFN0d58wXD5r8u0B17HbihFg3FgY3a1L8nsIA=";
+      hash = "sha256-jP9ajDCo8iImS8YGFLjNMOLLh9g8uSqYIRl3aqhJAaM=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-Y+8garSqDcKLCVv1cTiqGEfrGKpK3UoXIq8X4E8CF+8=";
+      hash = "sha256-BwYO8IlQJjZwwn/qokZ+gAgcgmAjG34uExHCajchVqs=";
     };
   };
 
@@ -246,7 +246,10 @@ else
     version = versions.${system} or "";
 
     targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
-    extraPreBwrapCmds = "unset QT_PLUGIN_PATH";
+    extraPreBwrapCmds = ''
+      unset QT_PLUGIN_PATH
+      unset LANG  # would break settings dialog on non-"en_XX" locales
+    '';
     extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
     runScript = "/opt/zoom/ZoomLauncher";
 

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -151,8 +151,9 @@ let
       license = lib.licenses.unfree;
       platforms = builtins.attrNames srcs;
       maintainers = with lib.maintainers; [
-        danbst
-        tadfisher
+        philiptaron
+        ryan4yin
+        yarny
       ];
       mainProgram = "zoom";
     };

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -246,10 +246,6 @@ else
     version = versions.${system} or "";
 
     targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
-    extraPreBwrapCmds = ''
-      unset QT_PLUGIN_PATH
-      unset LANG  # would break settings dialog on non-"en_XX" locales
-    '';
     extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
     runScript = "/opt/zoom/ZoomLauncher";
 

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -60,23 +60,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.5.1.58208";
-  versions.x86_64-darwin = "6.5.1.58208";
-  versions.x86_64-linux = "6.5.1.2550";
+  versions.aarch64-darwin = "6.5.3.58803";
+  versions.x86_64-darwin = "6.5.3.58803";
+  versions.x86_64-linux = "6.5.3.2773";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-hIYZ2OU5lww4MyRZOhcV4qQDGEN8Hdolw6a4g/ItcFQ=";
+      hash = "sha256-Cwr4xshh3PJ3Vi4tH60/qeAp9OsvqdGkoj8Fwe88K/0=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-t/xIrVfjAl6dM9RWa+imyFHqS2KIJsKnoU0fiDQL9dQ=";
+      hash = "sha256-45N/IhJpxZrxGVvqNWJC6ZiC6B3Srjd1Ucqxx+mc6eE=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-1YcbAlnUEk9R95r7RIuxAxNfRymdIOAjKkCw7a+1Lm4=";
+      hash = "sha256-laZg8uAo4KhgntYetAZGoGp0QPkK9EXPQh6kJ6VEkgE=";
     };
   };
 

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -60,23 +60,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.5.3.58803";
-  versions.x86_64-darwin = "6.5.3.58803";
-  versions.x86_64-linux = "6.5.3.2773";
+  versions.aarch64-darwin = "6.5.7.60598";
+  versions.x86_64-darwin = "6.5.7.60598";
+  versions.x86_64-linux = "6.5.7.3298";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-Cwr4xshh3PJ3Vi4tH60/qeAp9OsvqdGkoj8Fwe88K/0=";
+      hash = "sha256-o7ZxDYQS0J9Tl8kECSms1XQ6CVgxt453lDuFyZSZBv4=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-45N/IhJpxZrxGVvqNWJC6ZiC6B3Srjd1Ucqxx+mc6eE=";
+      hash = "sha256-y5/8xNtQTAbsXwbajFfzx0iNPEMQ0S+DAw2eS2mf5SQ=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-laZg8uAo4KhgntYetAZGoGp0QPkK9EXPQh6kJ6VEkgE=";
+      hash = "sha256-6gzgJmB+/cwcEToQpniVVZyQZcqzblQG/num0X+xUIE=";
     };
   };
 

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -60,23 +60,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.4.10.56141";
-  versions.x86_64-darwin = "6.4.10.56141";
-  versions.x86_64-linux = "6.4.10.2027";
+  versions.aarch64-darwin = "6.4.12.56699";
+  versions.x86_64-darwin = "6.4.12.56699";
+  versions.x86_64-linux = "6.4.13.2309";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-LIQl+s/2WfYFIEG/ZsvpWlsWRhToB+5+ymAXCMhDqWE=";
+      hash = "sha256-rsO4HAvA6hCiGDBuLQj/qYWHR6Dlo+G9rkfhxvKBp4g=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-jP9ajDCo8iImS8YGFLjNMOLLh9g8uSqYIRl3aqhJAaM=";
+      hash = "sha256-MZ5dPHKH1uQuFA8Vej8Hh4CFZAjJFZe04le+e4LPDJc=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-BwYO8IlQJjZwwn/qokZ+gAgcgmAjG34uExHCajchVqs=";
+      hash = "sha256-gBUpsIUcsn+5u/1CchuS9mggnAFD8VW5J4RBv0Ziu+Y=";
     };
   };
 

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -60,23 +60,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.4.12.56699";
-  versions.x86_64-darwin = "6.4.12.56699";
-  versions.x86_64-linux = "6.4.13.2309";
+  versions.aarch64-darwin = "6.5.1.58208";
+  versions.x86_64-darwin = "6.5.1.58208";
+  versions.x86_64-linux = "6.5.1.2550";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-rsO4HAvA6hCiGDBuLQj/qYWHR6Dlo+G9rkfhxvKBp4g=";
+      hash = "sha256-hIYZ2OU5lww4MyRZOhcV4qQDGEN8Hdolw6a4g/ItcFQ=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-MZ5dPHKH1uQuFA8Vej8Hh4CFZAjJFZe04le+e4LPDJc=";
+      hash = "sha256-t/xIrVfjAl6dM9RWa+imyFHqS2KIJsKnoU0fiDQL9dQ=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-gBUpsIUcsn+5u/1CchuS9mggnAFD8VW5J4RBv0Ziu+Y=";
+      hash = "sha256-1YcbAlnUEk9R95r7RIuxAxNfRymdIOAjKkCw7a+1Lm4=";
     };
   };
 


### PR DESCRIPTION
Backport to `release-25.05` for these PRs:

- https://github.com/NixOS/nixpkgs/pull/410244
- https://github.com/NixOS/nixpkgs/pull/414415
- https://github.com/NixOS/nixpkgs/pull/419757
- https://github.com/NixOS/nixpkgs/pull/422532
- https://github.com/NixOS/nixpkgs/pull/425420
- https://github.com/NixOS/nixpkgs/pull/427520
- https://github.com/NixOS/nixpkgs/pull/293422

* [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  * Even as a non-committer, if you find that it is not acceptable, leave a comment.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
