### PR TITLE
junixsocket{,-native}-common: init at 2.10.1

### DIFF
--- a/pkgs/by-name/ju/junixsocket-common/package.nix
+++ b/pkgs/by-name/ju/junixsocket-common/package.nix
@@ -1,0 +1,18 @@
+{
+  fetchMavenArtifact,
+  lib,
+}:
+
+fetchMavenArtifact {
+  groupId = "com.kohlschutter.junixsocket";
+  artifactId = "junixsocket-common";
+  version = "2.10.1";
+  hash = "sha256-GeX3YVrSKT81Mrw/mRsxOWwRYYNOidmmqgx975OcZyk=";
+  meta = {
+    homepage = "https://kohlschutter.github.io/junixsocket/";
+    description = "Java/JNI library that allows the use of Unix Domain Sockets (AF_UNIX sockets) and other socket types, such as AF_TIPC and AF_VSOCK, from Java, using the standard Socket API";
+    license = lib.licenses.asl20;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    maintainers = [ lib.maintainers.vog ];
+  };
+}

--- a/pkgs/by-name/ju/junixsocket-native-common/package.nix
+++ b/pkgs/by-name/ju/junixsocket-native-common/package.nix
@@ -1,0 +1,16 @@
+{
+  fetchMavenArtifact,
+  junixsocket-common,
+  lib,
+}:
+
+fetchMavenArtifact {
+  groupId = "com.kohlschutter.junixsocket";
+  artifactId = "junixsocket-native-common";
+  inherit (junixsocket-common) version;
+  hash = "sha256-ASbOC68c61de9ReAfU0rFLnzLwYYAgThLsc6tKdyVno=";
+  meta = junixsocket-common.meta // {
+    description = "Binaries of the native JNI library for junixsocket for common platforms";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
