### PR TITLE
gdash: init at 0-unstable-2023-06-24

### DIFF
--- a/pkgs/by-name/gd/gdash/package.nix
+++ b/pkgs/by-name/gd/gdash/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromBitbucket,
+  pkg-config,
+  glib,
+  gtk3,
+  SDL2_mixer,
+  SDL2_image,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gdash";
+  version = "0-unstable-2023-06-24";
+
+  src = fetchFromBitbucket {
+    owner = "czirkoszoltan";
+    repo = "gdash";
+    rev = "f980da7f4318f5296424720416911876bdb8d6bf";
+    hash = "sha256-tYUaWT9cHKgCeu7y0pjHaZ+z4jSr43lAq/jAVE3DSDg=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    glib
+    gtk3
+    SDL2_mixer
+    SDL2_image
+  ];
+
+  env.NIX_CFLAGS_COMPILE = " -I${SDL2_image}/include/SDL2";
+
+  doCheck = true;
+
+  checkTarget = "check";
+
+  meta = {
+    description = "Maze-based puzzle video game, a clone of the original Boulder Dash";
+    homepage = "https://bitbucket.org/czirkoszoltan/gdash";
+    changelog = "https://bitbucket.org/czirkoszoltan/gdash/src/master/ChangeLog";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.kupac ];
+    mainProgram = "gdash";
+    platforms = lib.platforms.all;
+    # Fails on darwin with:
+    # ld: symbol(s) not found for architecture x86_64
+    # clang++: error: linker command failed with exit code 1
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
