### PR TITLE
[25.05] bind: 9.20.9 -> 9.20.11

### DIFF
--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bind";
-  version = "9.20.10";
+  version = "9.20.11";
 
   src = fetchurl {
     url = "https://downloads.isc.org/isc/bind9/${finalAttrs.version}/bind-${finalAttrs.version}.tar.xz";
-    hash = "sha256-D7O6LDN7tIjKaPXfKWxDXNJVBY+2PQgi6R2wI1yQVxY=";
+    hash = "sha256-TaLVMuZovCHog/bm2dPYF5TZ7GCxgVMDhWSaVvRu4Xo=";
   };
 
   outputs = [

--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bind";
-  version = "9.20.9";
+  version = "9.20.10";
 
   src = fetchurl {
-    url = "https://downloads.isc.org/isc/bind9/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
-    hash = "sha256-PSaQDtnJqFkHP/6puX4pLBJI2tGCebF7BfyyPDCR+G0=";
+    url = "https://downloads.isc.org/isc/bind9/${finalAttrs.version}/bind-${finalAttrs.version}.tar.xz";
+    hash = "sha256-D7O6LDN7tIjKaPXfKWxDXNJVBY+2PQgi6R2wI1yQVxY=";
   };
 
   outputs = [


### PR DESCRIPTION
Fixes CVE-2025-40777 / https://kb.isc.org/docs/cve-2025-40777

Handled some conflicts resolution when backporting 9.20.10.

https://bind9.readthedocs.io/en/v9.20.11/changelog.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 427546`
Commit: `58fdb09505d5464c0333d5c66d17d5da8eec345f`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package blacklisted:</summary>
  <ul>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 59 packages built:</summary>
  <ul>
    <li>acme-sh</li>
    <li>asn</li>
    <li>autofs5</li>
    <li>bashSnippets</li>
    <li>bind</li>
    <li>bind.dev</li>
    <li>dig (bind.dnsutils, dig.dev, dig.dnsutils, dig.host, dig.lib, dig.man, dnsutils, dnsutils.dev, dnsutils.dnsutils, dnsutils.host, dnsutils.lib, dnsutils.man)</li>
    <li>host (bind.host, host.dev, host.dnsutils, host.host, host.lib, host.man)</li>
    <li>bind.lib</li>
    <li>bind.man</li>
    <li>blueberry</li>
    <li>cinnamon-common</li>
    <li>cinnamon-gsettings-overrides</li>
    <li>cinnamon-screensaver</li>
    <li>cinnamon-session</li>
    <li>dwm-status</li>
    <li>freeipa</li>
    <li>gnome-nettool</li>
    <li>hw-probe</li>
    <li>hypnotix</li>
    <li>inxi</li>
    <li>lbd</li>
    <li>librenms</li>
    <li>lightdm-slick-greeter</li>
    <li>monitoring-plugins</li>
    <li>nagiosPlugins.check_ssl_cert</li>
    <li>nagiosPlugins.check_wmi_plus</li>
    <li>nemo</li>
    <li>nemo-fileroller</li>
    <li>nemo-preview</li>
    <li>nemo-python</li>
    <li>nemo-seahorse</li>
    <li>nemo-with-extensions</li>
    <li>nemo.dev</li>
    <li>nmapsi4</li>
    <li>pix</li>
    <li>python312Packages.python-xapp</li>
    <li>python313Packages.python-xapp</li>
    <li>sssd</li>
    <li>sticky</li>
    <li>tests.devShellTools.nixos</li>
    <li>tests.testers.lycheeLinkCheck.network</li>
    <li>tests.testers.nixosTest-example</li>
    <li>tests.testers.runNixOSTest-example</li>
    <li>tests.trivial-builders.references</li>
    <li>testssl</li>
    <li>themechanger</li>
    <li>timeshift</li>
    <li>timeshift-minimal</li>
    <li>timeshift-unwrapped</li>
    <li>twa</li>
    <li>warpinator</li>
    <li>wsl-vpnkit</li>
    <li>xapp</li>
    <li>xapp.dev</li>
    <li>xdg-desktop-portal-xapp</li>
    <li>xed-editor</li>
    <li>xreader</li>
    <li>xviewer</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
