### PR TITLE
gnupg: Various improvements

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -93,9 +93,7 @@
   gnupg = [
     "https://gnupg.org/ftp/gcrypt/"
     "https://mirrors.dotsrc.org/gcrypt/"
-    "https://ftp.heanet.ie/mirrors/ftp.gnupg.org/gcrypt/"
     "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/"
-    "http://www.ring.gr.jp/pub/net/"
   ];
 
   # IBiblio (former metalab/sunsite)

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -21,6 +21,7 @@
   readline,
   sqlite,
   zlib,
+  openssh,
   enableMinimal ? false,
   withPcsc ? !enableMinimal,
   pcsclite,
@@ -145,6 +146,8 @@ stdenv.mkDerivation rec {
   configureFlags =
     [
       "--sysconfdir=/etc"
+      # Needed for large RSA key support (patch 0033)
+      "--enable-large-secmem"
       "--with-libgpg-error-prefix=${libgpg-error.dev}"
       "--with-libgcrypt-prefix=${libgcrypt.dev}"
       "--with-libassuan-prefix=${libassuan.dev}"
@@ -179,6 +182,12 @@ stdenv.mkDerivation rec {
       '';
 
   enableParallelBuilding = true;
+
+  nativeCheckInputs = [
+    # A test would be skipped without SSH
+    openssh
+  ];
+  doCheck = !enableMinimal;
 
   passthru.tests = nixosTests.gnupg;
 


### PR DESCRIPTION
- Remove broken mirrors
- Make sure all patches have comments
- Enable test suite
  - Enable support for large RSA keys (part of the test added by the corresponding freepg patch)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built `gnupg`, `gnupg.tests` and `systemd` on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
