### PR TITLE
python3: fix passthru tests after b937eac

### DIFF
--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -19,7 +19,7 @@ let
   # we aim to support.
   environmentTests =
     let
-      envs =
+      environments =
         let
           inherit python;
           pythonEnv = python.withPackages (ps: with ps; [ ]);
@@ -36,8 +36,8 @@ let
         {
           # Plain Python interpreter
           plain = rec {
-            env = python;
-            interpreter = env.interpreter;
+            environment = python;
+            interpreter = environment.interpreter;
             is_venv = "False";
             is_nixenv = "False";
             is_virtualenv = "False";
@@ -48,11 +48,11 @@ let
           # Fails on darwin with
           #   virtualenv: error: argument dest: the destination . is not write-able at /nix/store
           nixenv-virtualenv = rec {
-            env = runCommand "${python.name}-virtualenv" { } ''
+            environment = runCommand "${python.name}-virtualenv" { } ''
               ${pythonVirtualEnv.interpreter} -m virtualenv venv
               mv venv $out
             '';
-            interpreter = "${env}/bin/${python.executable}";
+            interpreter = "${environment}/bin/${python.executable}";
             is_venv = "False";
             is_nixenv = "True";
             is_virtualenv = "True";
@@ -61,8 +61,8 @@ let
         // lib.optionalAttrs (python.implementation != "graal") {
           # Python Nix environment (python.buildEnv)
           nixenv = rec {
-            env = pythonEnv;
-            interpreter = env.interpreter;
+            environment = pythonEnv;
+            interpreter = environment.interpreter;
             is_venv = "False";
             is_nixenv = "True";
             is_virtualenv = "False";
@@ -73,10 +73,10 @@ let
           # Python 2 does not support venv
           # TODO: PyPy executable name is incorrect, it should be pypy-c or pypy-3c instead of pypy and pypy3.
           plain-venv = rec {
-            env = runCommand "${python.name}-venv" { } ''
+            environment = runCommand "${python.name}-venv" { } ''
               ${python.interpreter} -m venv $out
             '';
-            interpreter = "${env}/bin/${python.executable}";
+            interpreter = "${environment}/bin/${python.executable}";
             is_venv = "True";
             is_nixenv = "False";
             is_virtualenv = "False";
@@ -88,10 +88,10 @@ let
           # TODO: Cannot create venv from a  nix env
           # Error: Command '['/nix/store/ddc8nqx73pda86ibvhzdmvdsqmwnbjf7-python3-3.7.6-venv/bin/python3.7', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1.
           nixenv-venv = rec {
-            env = runCommand "${python.name}-venv" { } ''
+            environment = runCommand "${python.name}-venv" { } ''
               ${pythonEnv.interpreter} -m venv $out
             '';
-            interpreter = "${env}/bin/${pythonEnv.executable}";
+            interpreter = "${environment}/bin/${pythonEnv.executable}";
             is_venv = "True";
             is_nixenv = "True";
             is_virtualenv = "False";
@@ -117,7 +117,7 @@ let
           '';
 
     in
-    lib.mapAttrs testfun envs;
+    lib.mapAttrs testfun environments;
 
   # Integration tests involving the package set.
   # All PyPy package builds are broken at the moment

--- a/pkgs/development/interpreters/python/tests/test_environments/test_python.py
+++ b/pkgs/development/interpreters/python/tests/test_environments/test_python.py
@@ -12,7 +12,7 @@ import unittest
 import site
 
 
-ENV = "@env@"
+ENV = "@environment@"
 INTERPRETER = "@interpreter@"
 PYTHON_VERSION = "@pythonVersion@"
 


### PR DESCRIPTION
Was broken due to #426211.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
