### PR TITLE
mariokart64recomp: init at 0.9.1-unstable-2025-10-02

### DIFF
--- a/pkgs/by-name/ma/mariokart64recomp/package.nix
+++ b/pkgs/by-name/ma/mariokart64recomp/package.nix
@@ -1,0 +1,171 @@
+{
+  lib,
+  mk64baserom ? null,
+  requireFile,
+  fetchFromGitHub,
+  llvmPackages_19,
+  cmake,
+  copyDesktopItems,
+  installShellFiles,
+  makeWrapper,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
+  SDL2,
+  gtk3,
+  vulkan-loader,
+  graphicsmagick,
+  makeDesktopItem,
+  n64recomp,
+  directx-shader-compiler,
+  sdl_gamecontrollerdb,
+  forceX11 ? false,
+}:
+
+let
+
+  baseRom =
+    if mk64baserom != null then
+      mk64baserom
+    else
+      requireFile {
+        name = "mk64.us.z64";
+        message = ''
+          mariokart64recomp only supports the US version of Mario Kart 64.
+          Please dump your copy and rename it to mk64.us.z64
+          and add it to the nix store using
+          nix-store --add-fixed sha256 mk64.us.z64
+          See https://dumping.guide/carts/nintendo/n64 for more details.
+        '';
+        hash = "sha256-1rhTjdY/ATLssoVufTKBbtPDDj5HmuzSPPg/troXpdo=";
+      };
+
+in
+
+llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
+  pname = "mariokart64recomp";
+  version = "0.9.1-unstable-2025-10-02";
+
+  src =
+    (fetchFromGitHub {
+      owner = "sonicdcer";
+      repo = "MarioKart64Recomp";
+      rev = "6f5791b3f4eae60bd341502b7af71372a9d531a9";
+      hash = "sha256-qVAXFUJYR4Q7WfbuY0h7ZhvIsgkfpD5W0eo5mUv4TEg=";
+      fetchSubmodules = true;
+    }).overrideAttrs
+      (_: {
+        GIT_CONFIG_COUNT = 1;
+        GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+        GIT_CONFIG_VALUE_0 = "git@github.com:";
+      });
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+    installShellFiles
+    llvmPackages_19.lld
+    makeWrapper
+    ninja
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    SDL2
+    gtk3
+    vulkan-loader
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "MarioKart64Recompiled";
+      icon = "MarioKart64Recompiled";
+      exec = "MarioKart64Recompiled";
+      comment = "Recompilation of MarioKart 64";
+      genericName = "Recompilation of MarioKart 64";
+      desktopName = "MarioKart64Recompiled";
+      categories = [ "Game" ];
+    })
+  ];
+
+  preConfigure = ''
+    ln -s ${baseRom} ./mk64.us.z64
+    cp ${n64recomp}/bin/* .
+
+    ./N64Recomp us.toml
+    ./RSPRecomp aspMain.us.toml
+
+    substituteInPlace lib/rt64/CMakeLists.txt \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/src/contrib/dxc/lib/x64" "${directx-shader-compiler}/lib/" \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/src/contrib/dxc/bin/x64/dxc-linux" "${directx-shader-compiler}/bin/dxc" \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/src/contrib/dxc/inc" "${directx-shader-compiler.src}/include/dxc"
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/lib/rt64/src/contrib/dxc/lib/x64" "${directx-shader-compiler}/lib/" \
+      --replace-fail "\''${PROJECT_SOURCE_DIR}/lib/rt64/src/contrib/dxc/bin/x64/dxc-linux" "${directx-shader-compiler}/bin/dxc"
+  '';
+
+  # This is required or else nothing will build
+  hardeningDisable = [
+    "format"
+    "pic"
+    "stackprotector"
+    "zerocallusedregs"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin MarioKart64Recompiled
+    install -Dm644 -t $out/share ../recompcontrollerdb.txt
+    install -Dm644 ../icons/512.png $out/share/icons/hicolor/scalable/apps/MarioKart64Recompiled.png
+    install -Dm644 ../flatpak/io.github.mariokart64recomp.mariokart64recomp.desktop $out/share/applications/MarioKart64Recompiled.desktop
+    cp -r ../assets $out/share/
+    ln -s $out/share/recompcontrollerdb.txt $out/bin/recompcontrollerdb.txt
+    ln -s $out/share/assets $out/bin/assets
+
+    install -Dm644 -t $out/share/licenses/mariokart64recompiled ../COPYING
+    install -Dm644 -t $out/share/licenses/mariokart64recompiled/N64ModernRuntime ../lib/N64ModernRuntime/COPYING
+    install -Dm644 -t $out/share/licenses/mariokart64recompiled/RmlUi ../lib/RmlUi/LICENSE.txt
+    install -Dm644 -t $out/share/licenses/mariokart64recompiled/lunasvg ../lib/lunasvg/LICENSE
+    install -Dm644 -t $out/share/licenses/mariokart64recompiled/rt64 ../lib/rt64/LICENSE
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+     )
+  '';
+
+  # This is needed as MarioKart64Recompiled will segfault when not run from the same
+  # directory as the binary. It also used to exit when run without X11. Recent rt64
+  # updates enabled wayland support, but leave the option to disable this on the
+  # application level if desired.
+  postFixup = ''
+    wrapProgram $out/bin/MarioKart64Recompiled --chdir "$out/bin/" \
+        ${lib.optionalString forceX11 ''--set SDL_VIDEODRIVER x11''}
+  '';
+
+  meta = {
+    description = "Recompilation of MarioKart 64";
+    homepage = "https://github.com/sonicdcer/MarioKart64Recomp";
+    license = with lib.licenses; [
+      # MarioKart64Recompiled, N64ModernRuntime
+      gpl3Only
+
+      # RT64, RmlUi, lunasvg, sse2neon
+      mit
+
+      # reverse engineering
+      unfree
+    ];
+    maintainers = with lib.maintainers; [ qubitnano ];
+    mainProgram = "MarioKart64Recompiled";
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/n6/n64recomp/package.nix
+++ b/pkgs/by-name/n6/n64recomp/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  zip,
+  unzip,
+  makeWrapper,
+  installShellFiles,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "n64recomp";
+  version = "0-unstable-2025-09-06";
+
+  src = fetchFromGitHub {
+    owner = "N64Recomp";
+    repo = "N64Recomp";
+    rev = "6888c1f1df03349906acdec1a7ed3b308c86020c";
+    hash = "sha256-xIpbGtnGyK+UYBBk8/+33H/oFzZKstGCv8Q/OF04ukE=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    installShellFiles
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin {N64Recomp,RSPRecomp,RecompModTool}
+    install -Dm644 -t $out/share/licenses/n64recomp ../LICENSE
+
+    wrapProgram $out/bin/RecompModTool \
+      --prefix PATH : ${zip}/bin \
+      --prefix PATH : ${unzip}/bin
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
+
+  meta = {
+    description = "Tool to statically recompile N64 games into native executables";
+    homepage = "https://github.com/N64Recomp/N64Recomp";
+    license = with lib.licenses; [
+      # N64Recomp
+      mit
+
+      # reverse engineering
+      unfree
+    ];
+    maintainers = with lib.maintainers; [ qubitnano ];
+    mainProgram = "N64Recomp";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/sonicdcer/MarioKart64Recomp

MarioKart 64: Recompiled is a project that uses [N64: Recompiled](https://github.com/Mr-Wiseguy/N64Recomp) to statically recompile MarioKart 64 into a native port with many new features and enhancements. This project uses [RT64](https://github.com/rt64/rt64) as the rendering engine to provide some of these enhancements.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
