### PR TITLE
[Backport release-25.05] p2pool: 4.4 -> 4.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11021,6 +11021,13 @@
     githubId = 45084216;
     keys = [ { fingerprint = "1BF9 8D10 E0D0 0B41 5723  5836 4C13 3A84 E646 9228"; } ];
   };
+  JacoMalan1 = {
+    name = "Jaco Malan";
+    email = "jacom@codelog.co.za";
+    github = "JacoMalan1";
+    githubId = 10290409;
+    keys = [ { fingerprint = "339C 9213 7F2D 5D6E 2B6A  6E98 240B B4C4 27BC 327A"; } ];
+  };
   jaculabilis = {
     name = "Tim Van Baak";
     email = "tim.vanbaak@gmail.com";

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "p2pool";
-  version = "4.7";
+  version = "4.8";
 
   src = fetchFromGitHub {
     owner = "SChernykh";
     repo = "p2pool";
     rev = "v${version}";
-    hash = "sha256-F8kgoGgnFk6vE1nNnV6TShwnEAnqxD1wbsCAnL7mHRM=";
+    hash = "sha256-D1yQMcgRYVZf3/VGCmp6ZGu5YlWUmvlCx3pZqQF7JDM=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "p2pool";
-  version = "4.4";
+  version = "4.7";
 
   src = fetchFromGitHub {
     owner = "SChernykh";
     repo = "p2pool";
     rev = "v${version}";
-    hash = "sha256-+wkcTkHhGNanCznL5d9yUezi9wLIchxt6TPPpEUqgN8=";
+    hash = "sha256-F8kgoGgnFk6vE1nNnV6TShwnEAnqxD1wbsCAnL7mHRM=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "p2pool";
-  version = "4.8";
+  version = "4.8.1";
 
   src = fetchFromGitHub {
     owner = "SChernykh";
     repo = "p2pool";
     rev = "v${version}";
-    hash = "sha256-D1yQMcgRYVZf3/VGCmp6ZGu5YlWUmvlCx3pZqQF7JDM=";
+    hash = "sha256-UnvMR4s6o8n7K+9hig3iSFtbN/BmR6yqjc64X443ctk=";
     fetchSubmodules = true;
   };
 
@@ -58,7 +58,10 @@ stdenv.mkDerivation rec {
     description = "Decentralized pool for Monero mining";
     homepage = "https://github.com/SChernykh/p2pool";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ ratsclub ];
+    maintainers = with maintainers; [
+      ratsclub
+      JacoMalan1
+    ];
     mainProgram = "p2pool";
     platforms = platforms.all;
   };


### PR DESCRIPTION
Manual backport of #405522 #418430 #423205 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.