### PR TITLE
[25.05] writeReferencesToFile: move throw to aliases

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -780,9 +780,6 @@ rec {
         ''
       );
 
-  # Remove after 25.05 branch-off
-  writeReferencesToFile = throw "writeReferencesToFile has been removed. Use writeClosure instead.";
-
   # Docs in doc/build-helpers/trivial-build-helpers.chapter.md
   # See https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-writeClosure
   writeClosure =

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2039,6 +2039,7 @@ mapAliases {
   wrapLisp_old = throw "Lisp packages have been redesigned. See 'lisp-modules' in the nixpkgs manual."; # Added 2024-05-07
   wmii_hg = wmii;
   wrapGAppsHook = wrapGAppsHook3; # Added 2024-03-26
+  writeReferencesToFile = throw "writeReferencesToFile has been removed. Use writeClosure instead."; # Added 2024-11-22
   write_stylus = styluslabs-write-bin; # Added 2024-10-09
   wtf = lib.warnOnInstantiate "'wtf' has been renamed to 'wtfutil'." wtfutil; # Added 2025-03-01
 


### PR DESCRIPTION
The throw has been removed on master in #409948. We should keep it on 25.05, but turn it into an alias.

Will enable the backport of #426629.