### PR TITLE
pkgsStatic.nix-eval-jobs: reduce closure size

### DIFF
--- a/pkgs/tools/package-management/nix-eval-jobs/default.nix
+++ b/pkgs/tools/package-management/nix-eval-jobs/default.nix
@@ -35,6 +35,11 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   # Since this package is intimately tied to a specific Nix release, we
   # propagate the Nix used for building it to make it easier for users
   # downstream to reference it.

--- a/pkgs/tools/package-management/nix-eval-jobs/default.nix
+++ b/pkgs/tools/package-management/nix-eval-jobs/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "nix-community";
-    repo = pname;
-    rev = "v${version}";
+    repo = "nix-eval-jobs";
+    tag = "v${version}";
     hash = "sha256-AJ22q6yWc1hPkqssXMxQqD6QUeJ6hbx52xWHhKsmuP0=";
   };
 


### PR DESCRIPTION
The runtime closure *for the static build* is reduced from 430 MB to 40 MB this way.

Needs https://github.com/NixOS/nixpkgs/pull/424520 to build in `pkgsStatic` in the first place.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
