### PR TITLE
phpactor: use supplied php package for runtime basis (add enabled extension)

### DIFF
--- a/pkgs/by-name/ph/phpactor/package.nix
+++ b/pkgs/by-name/ph/phpactor/package.nix
@@ -3,6 +3,14 @@
   fetchFromGitHub,
   installShellFiles,
   php,
+  phpRuntime ? php.withExtensions (
+    { all, ... }:
+    with all;
+    [
+      mbstring
+      tokenizer
+    ]
+  ),
   versionCheckHook,
 }:
 
@@ -21,14 +29,7 @@ php.buildComposerProject2 (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  php = php.withExtensions (
-    { all, ... }:
-    with all;
-    [
-      mbstring
-      tokenizer
-    ]
-  );
+  php = phpRuntime;
 
   postInstall = ''
     installShellCompletion --cmd phpactor \

--- a/pkgs/by-name/ph/phpactor/package.nix
+++ b/pkgs/by-name/ph/phpactor/package.nix
@@ -3,14 +3,6 @@
   fetchFromGitHub,
   installShellFiles,
   php,
-  phpRuntime ? php.withExtensions (
-    { all, ... }:
-    with all;
-    [
-      mbstring
-      tokenizer
-    ]
-  ),
   versionCheckHook,
 }:
 
@@ -29,7 +21,14 @@ php.buildComposerProject2 (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  php = phpRuntime;
+  php = php.withExtensions (
+    { all, enabled, ... }:
+    with all;
+    enabled ++ [
+      mbstring
+      tokenizer
+    ]
+  );
 
   postInstall = ''
     installShellCompletion --cmd phpactor \


### PR DESCRIPTION
Upon overriding phpactor with custom php such as below,

```
  phpactor = pkgs.callPackage "${pkgs.path}/pkgs/by-name/ph/phpactor/package.nix" {
    php = pkgs.php83.withExtensions ({ all, enabled }: enabled ++ with all; [ simplexml ]);
  };
```

The resulting `phpactor` binary doesn't use the passed php with customized extension.
Moreover, `phpactor` support running `psalm` and `php-cs-fixer` which needs some PHP extensions enabled. Consequently, with current derivation, neither `psalm` nor `php-cs-fixer` can be activated.

This change allow customized `php` to be used as the runtime for `phpactor`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
