### PR TITLE
orbstack: init at 1.11.3-19358

### DIFF
--- a/pkgs/by-name/or/orbstack/package.nix
+++ b/pkgs/by-name/or/orbstack/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+}:
+let
+  inherit (stdenvNoCC.hostPlatform) system;
+  version = "1.11.3-19358";
+  version' = lib.replaceString "-" "_" version;
+  sources = {
+    aarch64-darwin = fetchurl {
+      url = "https://cdn-updates.orbstack.dev/arm64/OrbStack_v${version'}_arm64.dmg";
+      hash = "sha256-/zujkmctMdJUm3d7Rjjeic8QrvWSlEAUhjFgouBXeNw=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://cdn-updates.orbstack.dev/amd64/OrbStack_v${version'}_amd64.dmg";
+      hash = "sha256-oLOTKekDU880p9DtzcR/muwzPuFA3vu789aEYNFbcx8=";
+    };
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "orbstack";
+  inherit version;
+
+  src = sources.${system} or (throw "unsupported system ${system}");
+
+  # fix "ERROR: Dangerous symbolic link path was ignored"
+  unpackCmd = "7zz x -snld $curSrc";
+
+  nativeBuildInputs = [ _7zz ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    # Fix "this app is damaged and can't be opened"
+    #
+    # When extracting an APFS .dmg with 7zz (7-Zip), it may incorrectly turn
+    # macOS extended attributes (like quarantine or macl) into real files:
+    #   Info.plist:com.apple.quarantine
+    #   Info.plist:com.apple.macl
+    #
+    # These bogus files corrupt the .app bundle and prevent it from launching.
+    # Delete them to restore proper behavior.
+    find OrbStack.app -name '*:com.apple.*' -delete
+
+    mkdir -p "$out/Applications"
+    cp -R OrbStack.app "$out/Applications"
+
+    mkdir -p "$out/bin"
+    for bindir in bin xbin; do
+      for binary in "$out/Applications/OrbStack.app/Contents/MacOS/$bindir"/*; do
+        if [[ -f "$binary" ]]; then
+          ln -s "$binary" "$out/bin/$(basename "$binary")"
+        fi
+      done
+    done
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit sources;
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    changelog = "https://docs.orbstack.dev/release-notes#${
+      builtins.replaceStrings [ "." ] [ "-" ] version
+    }";
+    description = "Fast, light, and easy way to run Docker containers and Linux machines";
+    homepage = "https://orbstack.dev/";
+    license = lib.licenses.unfree;
+    mainProgram = "orb";
+    maintainers = with lib.maintainers; [ asterismono ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/or/orbstack/update.sh
+++ b/pkgs/by-name/or/orbstack/update.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+#shellcheck shell=bash
+
+set -eu -o pipefail
+
+update_arch() {
+  local arch="$1"
+  local system="$2"
+
+  local source_url
+  source_url="$(curl -L -I "https://orbstack.dev/download/stable/latest/$arch" | grep -i "location:" | awk '{print $2}' | tr -d '\r')"
+
+  local version
+  version="$(echo "$source_url" | grep -o '\([0-9]\+\.\)\{2\}[0-9]\+_[0-9]\+' | sed 's/_/-/')"
+
+  local hash
+  hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 "$(nix-prefetch-url --type sha256 "$source_url")")
+
+  update-source-version orbstack "$version" "$hash" --system="$system" --source-key="sources.$system" --ignore-same-version
+}
+
+update_arch "arm64" "aarch64-darwin"
+update_arch "amd64" "x86_64-darwin"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added `orbstack`, a fast, lightweight, and efficient alternative to Docker Desktop for macOS. It provides support for running containers and Linux VMs seamlessly on macOS, with features focused on speed and low resource usage.

- homepage URL: [orbstack.dev](https://orbstack.dev/)
- source URL: [orbstack.dev](https://orbstack.dev/) (Proprietary software; no public source code available)
- license: Proprietary
- platforms: darwin (macOS)

May close #365576.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
