### PR TITLE
sope: 5.12.2 -> 5.12.3, apply patch for CVE-2025-53603

### DIFF
--- a/pkgs/by-name/so/sope/package.nix
+++ b/pkgs/by-name/so/sope/package.nix
@@ -2,6 +2,7 @@
   lib,
   clangStdenv,
   fetchFromGitHub,
+  fetchpatch,
   libxml2,
   openssl,
   openldap,
@@ -14,7 +15,7 @@
 
 clangStdenv.mkDerivation rec {
   pname = "sope";
-  version = "5.12.2";
+  version = "5.12.3";
 
   src = fetchFromGitHub {
     owner = "Alinto";
@@ -23,6 +24,15 @@ clangStdenv.mkDerivation rec {
     hash = "sha256-GeJ1o8Juw7jm3/pkfuMqVpfMxKewU6hQmBoPmb0HgTc=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "CVE-2025-53603.patch";
+      url = "https://github.com/Alinto/sope/commit/e954ab0cd254dc1837af690329b04504410cbe63.patch";
+      hash = "sha256-F/dexphHH8S90njmTDvm+NZChbKekv78tUgB+VFOsSY=";
+    })
+  ];
+
+  nativeBuildInputs = lib.optional (libpq != null) [ libpq.pg_config ];
   buildInputs = [
     gnustep-base
     libxml2
@@ -71,9 +81,9 @@ clangStdenv.mkDerivation rec {
   meta = {
     description = "Extensive set of frameworks which form a complete Web application server environment";
     license = lib.licenses.publicDomain;
-    homepage = "https://github.com/inverse-inc/sope";
+    homepage = "https://github.com/Alinto/sope";
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ jceb ];
-    knownVulnerabilities = [ "CVE-2025-53603" ];
+    knownVulnerabilities = [ ];
   };
 }


### PR DESCRIPTION
INFO: the git tag 5.12.3 points to the same commit as 5.12.2, therefore the hash didn't change.

I included the patch proposed to fix CVE-2025-53603. I'm not sure about how to backport the patch to NixOS 25.05. Help is appreciated.

Closes #424804.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
