### PR TITLE
docker: copy signatures into container

### DIFF
--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -206,6 +206,17 @@ Similarly, if you encounter errors similar to `Error_Protocol ("certificate has 
 
 : The `meta` attribute of the resulting derivation, as in `stdenv.mkDerivation`. Accepts `description`, `maintainers` and any other `meta` attributes.
 
+`includeNixDBHostSignatures` (Boolean; _optional_)
+
+: Copy the host builder's signatures for the Nix store paths into the image. The main purpose is to enable signature verification inside the container. Requires includeNixDB to be true.
+
+  :::{.caution}
+  Using this creates an image which is reproduceable under the assumption that the host has the same set of signatures for the image dependencies.
+  May break reproducibility, once dependencies are built and not signed immediately. Requires either sandbox turned off or building with relaxed mode.
+  :::
+
+  _Default value:_ `false`
+
 `contents` **DEPRECATED**
 
 : This attribute is deprecated, and users are encouraged to use `copyToRoot` instead.
@@ -642,6 +653,17 @@ This allows the function to produce reproducible images.
 `meta` (Attribute Set)
 
 : The `meta` attribute of the resulting derivation, as in `stdenv.mkDerivation`. Accepts `description`, `maintainers` and any other `meta` attributes.
+
+`includeNixDBHostSignatures` (Boolean; _optional_)
+
+: Copy the host builder's signatures for the Nix store paths into the image. The main purpose is to enable signature verification inside the container. Requires includeNixDB to be true.
+
+  :::{.caution}
+  Using this creates an image which is reproduceable under the assumption that the host has the same set of signatures for the image dependencies.
+  May break reproducibility, once dependencies are built and not signed immediately. Requires either sandbox turned off or building with relaxed mode.
+  :::
+
+  _Default value:_ `false`
 
 `passthru` (Attribute Set; _optional_)
 

--- a/nixos/tests/docker-tools-build.nix
+++ b/nixos/tests/docker-tools-build.nix
@@ -1,0 +1,57 @@
+let
+  pkgs = import ../.. { };
+  inherit (pkgs.dockerTools)
+    buildImage
+    streamLayeredImage
+    ;
+  inherit (pkgs)
+    nix
+    hello
+    ;
+
+in
+{
+  imageWithoutSigs = buildImage {
+    name = "image-without-sigs";
+    tag = "latest";
+    copyToRoot = [
+      nix
+      hello
+    ];
+    includeNixDB = true;
+    includeNixDBHostSignatures = false;
+  };
+
+  imageWithSigs = buildImage {
+    name = "image-with-sigs";
+    tag = "latest";
+    copyToRoot = [
+      nix
+      hello
+    ];
+    includeNixDB = true;
+    includeNixDBHostSignatures = true;
+  };
+
+  layeredImageWithoutSigs = streamLayeredImage {
+    name = "layered-image-without-sigs";
+    tag = "latest";
+    contents = [
+      nix
+      hello
+    ];
+    includeNixDB = true;
+    includeNixDBHostSignatures = false;
+  };
+
+  layeredImageWithSigs = streamLayeredImage {
+    name = "layered-image-with-sigs";
+    tag = "latest";
+    contents = [
+      nix
+      hello
+    ];
+    includeNixDB = true;
+    includeNixDBHostSignatures = true;
+  };
+}

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -86,6 +86,12 @@ let
       ];
     };
   };
+
+  signingKeyForSignatureTests = pkgs.runCommand "signingKey" { } ''
+    NIX_STATE_DIR=$(mktemp -d) ${pkgs.nix}/bin/nix-store --generate-binary-cache-key key $out /dev/null
+  '';
+
+  signatureTests = import ./docker-tools-build.nix;
 in
 {
   name = "docker-tools";
@@ -96,6 +102,8 @@ in
     ];
   };
 
+  node.pkgsReadOnly = false;
+
   nodes = {
     docker =
       { ... }:
@@ -104,6 +112,47 @@ in
           diskSize = 3072;
           docker.enable = true;
         };
+      };
+
+    # Host with relaxed sandbox for signature inclusion into build (impure)
+    dockerBuild =
+      {
+        config,
+        pkgs,
+        lib,
+        ...
+      }:
+      {
+        imports = [ ../modules/profiles/installation-device.nix ];
+
+        nix.settings = {
+          substituters = lib.mkForce [ ];
+          hashed-mirrors = null;
+          connect-timeout = 1;
+
+          sandbox = "relaxed";
+          secret-key-files = signingKeyForSignatureTests;
+          extra-experimental-features = [ "nix-command" ];
+        };
+
+        # include everything to build the image with & without signatures
+        environment.systemPackages = [
+          (pkgs.linkFarmFromDrvs "additional-packages" [
+            signatureTests.imageWithoutSigs
+            signatureTests.layeredImageWithoutSigs
+          ])
+        ];
+        system.includeBuildDependencies = true;
+
+        virtualisation = {
+          diskSize = 3072;
+          docker.enable = true;
+
+          cores = 2;
+          memorySize = 2048;
+          writableStore = true;
+        };
+
       };
   };
 
@@ -598,5 +647,40 @@ in
             "${nonRootTestImage} | docker load",
             "docker run --rm ${chownTestImage.imageName} | diff /dev/stdin <(echo 12345:12345)"
         )
+
+    dockerBuild.wait_for_unit("sockets.target")
+
+    with subtest("includeNixDBHostSignatures allows store verification"):
+        with subtest("for buildImage"):
+            # ensure local signature is present for downloaded path
+            dockerBuild.succeed("${pkgs.nix}/bin/nix store sign -k ${signingKeyForSignatureTests} ${pkgs.hello}")
+
+            dockerBuild.succeed("cat ${signatureTests.imageWithoutSigs} | docker load")
+            dockerBuild.fail("docker run -v /etc/nix/nix.conf:/etc/nix/nix.conf -v ${signingKeyForSignatureTests}:${signingKeyForSignatureTests} --rm image-without-sigs:latest ${pkgs.nix}/bin/nix store verify --sigs-needed 1 ${pkgs.hello}")
+            dockerBuild.succeed("docker image rm image-without-sigs:latest")
+
+            dockerBuild.fail("nix-build --option sandbox true -A imageWithSigs -o imageWithSigs ${pkgs.path}/nixos/tests/docker-tools-build.nix")
+            dockerBuild.succeed("nix-build -A imageWithSigs -o imageWithSigs ${pkgs.path}/nixos/tests/docker-tools-build.nix")
+
+            # mount exact nix.conf and secret key which was used for signature
+            dockerBuild.succeed("cat ./imageWithSigs | docker load")
+            dockerBuild.succeed("docker run -v /etc/nix/nix.conf:/etc/nix/nix.conf -v ${signingKeyForSignatureTests}:${signingKeyForSignatureTests} --rm image-with-sigs:latest ${pkgs.nix}/bin/nix store verify --sigs-needed 1 ${pkgs.hello}")
+            dockerBuild.succeed("docker image rm image-with-sigs:latest")
+
+        with subtest("for streamLayeredImage"):
+            # ensure local signature is present for downloaded path
+            dockerBuild.succeed("${pkgs.nix}/bin/nix store sign -k ${signingKeyForSignatureTests} ${pkgs.hello}")
+
+            dockerBuild.succeed("${signatureTests.layeredImageWithoutSigs} | docker load")
+            dockerBuild.fail("docker run -v /etc/nix/nix.conf:/etc/nix/nix.conf -v ${signingKeyForSignatureTests}:${signingKeyForSignatureTests} --rm layered-image-without-sigs:latest ${pkgs.nix}/bin/nix store verify --sigs-needed 1 ${pkgs.hello}")
+            dockerBuild.succeed("docker image rm layered-image-without-sigs:latest")
+
+            dockerBuild.fail("nix-build --option sandbox true -A layeredImageWithSigs -o layeredImageWithSigs ${pkgs.path}/nixos/tests/docker-tools-build.nix")
+            dockerBuild.succeed("nix-build -A layeredImageWithSigs -o layeredImageWithSigs ${pkgs.path}/nixos/tests/docker-tools-build.nix")
+
+            # mount exact nix.conf and secret key which was used for signature
+            dockerBuild.succeed("./layeredImageWithSigs | docker load")
+            dockerBuild.succeed("docker run -v /etc/nix/nix.conf:/etc/nix/nix.conf -v ${signingKeyForSignatureTests}:${signingKeyForSignatureTests} --rm layered-image-with-sigs:latest ${pkgs.nix}/bin/nix store verify --sigs-needed 1 ${pkgs.hello}")
+            dockerBuild.succeed("docker image rm layered-image-with-sigs:latest")
   '';
 }

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -56,7 +56,10 @@ let
     ;
 
   mkDbExtraCommand =
-    contents:
+    {
+      contents,
+      includeNixDBHostSignatures ? false,
+    }:
     let
       contentsList = if builtins.isList contents then contents else [ contents ];
     in
@@ -73,6 +76,11 @@ let
       ${lib.getExe' buildPackages.nix "nix-store"} --load-db < ${
         closureInfo { rootPaths = contentsList; }
       }/registration
+      ${lib.optionalString includeNixDBHostSignatures ''
+        # copy signatures from building system (-s "local?read-only=true") into "NIX_REMOTE=local?root=$PWD"
+        # readonly store is required to avoid write operations which might fail due to missing privileges
+        ${buildPackages.nix}/bin/nix store copy-sigs --all -s "local?read-only=true" --extra-experimental-features read-only-local-store --extra-experimental-features nix-command
+      ''}
       # Reset registration times to make the image reproducible
       ${lib.getExe buildPackages.sqlite} nix/var/nix/db/db.sqlite "UPDATE ValidPaths SET registrationTime = ''${SOURCE_DATE_EPOCH}"
 
@@ -429,6 +437,7 @@ rec {
       keepContentsDirlinks ? false,
       # Additional commands to run on the layer before it is tar'd up.
       extraCommands ? "",
+      includeNixDBHostSignatures ? false,
       uid ? 0,
       gid ? 0,
     }:
@@ -441,6 +450,9 @@ rec {
           rsync
           tarsum
         ];
+
+        # enable host signature inclusion even with relaxed sandbox
+        __noChroot = includeNixDBHostSignatures;
       }
       ''
         mkdir layer
@@ -505,11 +517,15 @@ rec {
       buildVMMemorySize ? 512,
       # Commands (bash) to run on the layer; these do not require sudo.
       extraCommands ? "",
+      includeNixDBHostSignatures ? false,
     }:
     # Generate an executable script from the `runAsRoot` text.
     let
       runAsRootScript = shellScript "run-as-root.sh" runAsRoot;
-      extraCommandsScript = shellScript "extra-commands.sh" extraCommands;
+      extraCommandsScript = (shellScript "extra-commands.sh" extraCommands).overrideAttrs {
+        # enable host signature inclusion even with relaxed sandbox
+        __noChroot = includeNixDBHostSignatures;
+      };
     in
     runWithOverlay {
       name = "docker-layer-${name}";
@@ -645,6 +661,8 @@ rec {
       compressor ? "gz",
       # Populate the nix database in the image with the dependencies of `copyToRoot`.
       includeNixDB ? false,
+      # If signatures was present on the builder, it will get copied into the image
+      includeNixDBHostSignatures ? false,
       # Deprecated.
       contents ? null,
       # Meta options to set on the resulting derivation.
@@ -689,9 +707,17 @@ rec {
 
       # TODO: add the dependencies of the config json.
       extraCommandsWithDB =
-        if includeNixDB then (mkDbExtraCommand rootContents) + extraCommands else extraCommands;
+        if includeNixDB then
+          (mkDbExtraCommand {
+            contents = rootContents;
+            inherit includeNixDBHostSignatures;
+          })
+          + extraCommands
+        else
+          extraCommands;
 
       layer =
+
         if runAsRoot == null then
           mkPureLayer {
             name = baseName;
@@ -700,6 +726,7 @@ rec {
               keepContentsDirlinks
               uid
               gid
+              includeNixDBHostSignatures
               ;
             extraCommands = extraCommandsWithDB;
             copyToRoot = rootContents;
@@ -716,6 +743,7 @@ rec {
               runAsRoot
               diskSize
               buildVMMemorySize
+              includeNixDBHostSignatures
               ;
             extraCommands = extraCommandsWithDB;
             copyToRoot = rootContents;
@@ -1016,6 +1044,7 @@ rec {
       enableFakechroot ? false,
       includeStorePaths ? true,
       includeNixDB ? false,
+      includeNixDBHostSignatures ? false,
       passthru ? { },
       meta ? { },
       # Pipeline used to produce docker layers. If not set, popularity contest
@@ -1070,7 +1099,12 @@ rec {
       customisationLayer = symlinkJoin {
         name = "${baseName}-customisation-layer";
         paths = contentsList;
-        extraCommands = (lib.optionalString includeNixDB (mkDbExtraCommand contents)) + extraCommands;
+        extraCommands =
+          (lib.optionalString includeNixDB (mkDbExtraCommand {
+            contents = contentsList;
+            inherit includeNixDBHostSignatures;
+          }))
+          + extraCommands;
         inherit fakeRootCommands;
         nativeBuildInputs = [
           fakeroot
@@ -1121,6 +1155,9 @@ rec {
             | cut -f 1 -d ' ' \
             > $out/checksum
         '';
+
+        # enable host signature inclusion even with relaxed sandbox
+        __noChroot = includeNixDBHostSignatures;
       };
 
       closureRoots = optionals includeStorePaths [


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
