### PR TITLE
[release-25.05] rustfmt: fix on x86_64-darwin

### DIFF
--- a/pkgs/development/compilers/rust/rustfmt.nix
+++ b/pkgs/development/compilers/rust/rustfmt.nix
@@ -46,6 +46,13 @@ rustPlatform.buildRustPackage {
   CFG_RELEASE = rustc.version;
   CFG_RELEASE_CHANNEL = if asNightly then "nightly" else "stable";
 
+  env = lib.optionalAttrs (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) {
+    # error: install_name_tool: changing install names or rpaths can't be redone for: /nix/store/.../bin/rustfmt
+    # (for architecture x86_64) because larger updated load commands do not fit (the program must
+    # be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
+    NIX_LDFLAGS = "-headerpad_max_install_names";
+  };
+
   postInstall = ''
     wrapProgram $out/bin/cargo-fmt \
       --suffix PATH : ${lib.makeBinPath [ cargo ]}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
error: install_name_tool: changing install names or rpaths can't be redone for: /nix/store/r6l56mfq2yds1h2fvwz51lmx2yn3p6ks-rustfmt-1.86.0/bin/rustfmt (for architecture x86_64) because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
```

cc @globin @basvandijk

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
