### PR TITLE
vacuum-tube: init at 1.3.15

### DIFF
--- a/pkgs/by-name/va/vacuum-tube/package.nix
+++ b/pkgs/by-name/va/vacuum-tube/package.nix
@@ -1,0 +1,72 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  electron,
+  makeWrapper,
+  writableTmpDirAsHomeHook,
+}:
+
+buildNpmPackage rec {
+  pname = "vacuum-tube";
+  version = "1.3.15";
+
+  src = fetchFromGitHub {
+    owner = "shy1132";
+    repo = "VacuumTube";
+    tag = "v${version}";
+    hash = "sha256-dwUmAMogBBzpMFsoF2OP0otMz1tH9Jo3fchjWqMWIV0=";
+  };
+
+  npmDepsHash = "sha256-Qi9oMV8nFSfXXbhNYRDRZgLx+kQ8JbdgM8BK3hiEH44=";
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = true;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    writableTmpDirAsHomeHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    npx electron-builder -l --dir \
+      -c.electronDist="${electron.dist}" \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt
+    cp -r ./dist/*-unpacked $out/opt/VacuumTube
+
+    for i in 16 32 48 64 256 512; do
+      install -Dm644 "assets/icons/$i"x"$i.png" \
+        "$out/share/icons/hicolor/$i"x"$i/apps/rocks.shy.VacuumTube.png"
+    done
+
+    install -Dm644 flatpak/rocks.shy.VacuumTube.desktop $out/share/applications/VacuumTube.desktop
+
+    substituteInPlace $out/share/applications/VacuumTube.desktop \
+      --replace-fail 'Exec=startvacuumtube' 'Exec=VacuumTube'
+
+    makeWrapper "${electron}/bin/electron" "$out/bin/VacuumTube" \
+      --add-flags "$out/opt/VacuumTube/resources/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "YouTube Leanback on the desktop, with enhancements";
+    homepage = "https://github.com/shy1132/VacuumTube";
+    mainProgram = "VacuumTube";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ theCapypara ];
+  };
+}


### PR DESCRIPTION
This adds VacuumTube, an application that runs Youtube TV/Leanback.

Source: https://github.com/shy1132/VacuumTube

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
