### PR TITLE
ocamlPackages.logs-syslog: init at 0.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/logs-syslog/default.nix
+++ b/pkgs/development/ocaml-modules/logs-syslog/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  logs,
+  syslog-message,
+  ptime,
+  version ? "0.5.0",
+}:
+
+buildDunePackage {
+  pname = "logs-syslog";
+  inherit version;
+  src = fetchurl {
+    url = "https://github.com/hannesm/logs-syslog/releases/download/v${version}/logs-syslog-${version}.tbz";
+    hash = "sha256-rx7mksA8y1BCEisNTQwSsJaet42eR7tZ3gYzvCqrYNQ=";
+  };
+
+  propagatedBuildInputs = [
+    logs
+    syslog-message
+    ptime
+  ];
+
+  meta = {
+    description = "Logs reporter to syslog (UDP/TCP/TLS)";
+    homepage = "https://github.com/hannesm/logs-syslog";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1070,6 +1070,8 @@ let
 
         logs = callPackage ../development/ocaml-modules/logs { };
 
+        logs-syslog = callPackage ../development/ocaml-modules/logs-syslog { };
+
         lru = callPackage ../development/ocaml-modules/lru { };
 
         lsp = callPackage ../development/ocaml-modules/ocaml-lsp/lsp.nix { };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
