### PR TITLE
stunner-webrtc: init at 0.5.8

### DIFF
--- a/pkgs/by-name/st/stunner-webrtc/package.nix
+++ b/pkgs/by-name/st/stunner-webrtc/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "stunner";
+  version = "0.5.8";
+
+  src = fetchFromGitHub {
+    owner = "firefart";
+    repo = "stunner";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-A/k43ZOk/JIpCHBI1ygFBjmbDWWmLMIzuDbM6+8FKdw=";
+  };
+
+  vendorHash = "sha256-cXvHNn4BbVVUVgy5IwCe/K1ISV8CyDilJrNYEK2QFU8=";
+
+  meta = {
+    description = "Test and exploit STUN, TURN and TURN over TCP servers";
+    homepage = "https://github.com/firefart/stunner";
+    changelog = "https://github.com/firefart/stunner/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.cc-by-nc-sa-40;
+    maintainers = with lib.maintainers; [ hougo ];
+    mainProgram = "stunner";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Stunner](https://github.com/firefart/stunner) is a tool to test and exploit STUN, TURN and TURN over TCP servers. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
