### PR TITLE
go-httpbin: init at 2.18.3, nixos/go-httpbin: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -38,6 +38,8 @@
 
 - [Chhoto URL](https://github.com/SinTan1729/chhoto-url), a simple, blazingly fast, selfhosted URL shortener with no unnecessary features, written in Rust. Available as [services.chhoto-url](#opt-services.chhoto-url.enable).
 
+- [go-httpbin](https://github.com/mccutchen/go-httpbin), a reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib. Available as [services.go-httpbin](#opt-services.go-httpbin.enable).
+
 - [tuwunel](https://matrix-construct.github.io/tuwunel/), a federated chat server implementing the Matrix protocol, forked from Conduwuit. Available as [services.matrix-tuwunel](#opt-services.matrix-tuwunel.enable).
 
 - [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1575,6 +1575,7 @@
   ./services/web-apps/gerrit.nix
   ./services/web-apps/glance.nix
   ./services/web-apps/glitchtip.nix
+  ./services/web-apps/go-httpbin.nix
   ./services/web-apps/goatcounter.nix
   ./services/web-apps/gotify-server.nix
   ./services/web-apps/gotosocial.nix

--- a/nixos/modules/services/web-apps/go-httpbin.nix
+++ b/nixos/modules/services/web-apps/go-httpbin.nix
@@ -1,0 +1,111 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.go-httpbin;
+
+  environment = lib.mapAttrs (
+    _: value: if lib.isBool value then lib.boolToString value else toString value
+  ) cfg.settings;
+in
+
+{
+  meta.maintainers = with lib.maintainers; [ defelo ];
+
+  options.services.go-httpbin = {
+    enable = lib.mkEnableOption "go-httpbin";
+
+    package = lib.mkPackageOption pkgs "go-httpbin" { };
+
+    settings = lib.mkOption {
+      description = ''
+        Configuration of go-httpbin.
+        See <https://github.com/mccutchen/go-httpbin#configuration> for a list of options.
+      '';
+      example = {
+        HOST = "0.0.0.0";
+        PORT = 8080;
+      };
+
+      type = lib.types.submodule {
+        freeformType =
+          with lib.types;
+          attrsOf (oneOf [
+            str
+            int
+            bool
+          ]);
+
+        options = {
+          HOST = lib.mkOption {
+            type = lib.types.str;
+            description = "The host to listen on.";
+            default = "127.0.0.1";
+            example = "0.0.0.0";
+          };
+
+          PORT = lib.mkOption {
+            type = lib.types.port;
+            description = "The port to listen on.";
+            example = 8080;
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.go-httpbin = {
+      wantedBy = [ "multi-user.target" ];
+
+      inherit environment;
+
+      serviceConfig = {
+        User = "go-httpbin";
+        Group = "go-httpbin";
+        DynamicUser = true;
+
+        ExecStart = lib.getExe cfg.package;
+
+        # hardening
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = [ "" ];
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [ "AF_INET AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SocketBindAllow = "tcp:${toString cfg.settings.PORT}";
+        SocketBindDeny = "any";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -607,6 +607,7 @@ in
   gnupg = runTest ./gnupg.nix;
   goatcounter = runTest ./goatcounter.nix;
   go-camo = runTest ./go-camo.nix;
+  go-httpbin = runTest ./go-httpbin.nix;
   go-neb = runTest ./go-neb.nix;
   gobgpd = runTest ./gobgpd.nix;
   gocd-agent = runTest ./gocd-agent.nix;

--- a/nixos/tests/go-httpbin.nix
+++ b/nixos/tests/go-httpbin.nix
@@ -1,0 +1,38 @@
+{ lib, ... }:
+
+{
+  name = "go-httpbin";
+  meta.maintainers = with lib.maintainers; [ defelo ];
+
+  nodes.machine = {
+    services.go-httpbin = {
+      enable = true;
+      settings.PORT = 8000;
+    };
+  };
+
+  interactive.nodes.machine = {
+    services.go-httpbin.settings.HOST = "0.0.0.0";
+    networking.firewall.allowedTCPPorts = [ 8000 ];
+    virtualisation.forwardPorts = [
+      {
+        from = "host";
+        host.port = 8000;
+        guest.port = 8000;
+      }
+    ];
+  };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("go-httpbin.service")
+    machine.wait_for_open_port(8000)
+
+    resp = json.loads(machine.succeed("curl localhost:8000/get?foo=bar"))
+    assert resp["args"]["foo"] == ["bar"]
+    assert resp["method"] == "GET"
+    assert resp["origin"] == "127.0.0.1"
+    assert resp["url"] == "http://localhost:8000/get?foo=bar"
+  '';
+}

--- a/pkgs/by-name/go/go-httpbin/package.nix
+++ b/pkgs/by-name/go/go-httpbin/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-httpbin";
+  version = "2.18.3";
+
+  src = fetchFromGitHub {
+    owner = "mccutchen";
+    repo = "go-httpbin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ixEbmppQ+4Udc5ytV4YPOpOT/iEbhjQIYGoOGL0dIw8=";
+  };
+
+  vendorHash = null;
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # tests are flaky
+  doCheck = false;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/go-httpbin --help &> /dev/null
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib";
+    homepage = "https://github.com/mccutchen/go-httpbin";
+    changelog = "https://github.com/mccutchen/go-httpbin/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ defelo ];
+    mainProgram = "go-httpbin";
+  };
+})

--- a/pkgs/by-name/go/go-httpbin/package.nix
+++ b/pkgs/by-name/go/go-httpbin/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
   nix-update-script,
 }:
 
@@ -35,7 +36,10 @@ buildGoModule (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = { inherit (nixosTests) go-httpbin; };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib";


### PR DESCRIPTION
> A reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib.

https://github.com/mccutchen/go-httpbin

Supersedes and closes #358551

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
