### PR TITLE
Configuration fixes for ghc-9.12.x

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -116,6 +116,7 @@ with haskellLib;
   ] super.ghc-exactprint_1_12_0_0;
   timezone-series = doJailbreak super.timezone-series; # time <1.14
   cabal-plan = doJailbreak super.cabal-plan; # base <4.21
+  dbus = doJailbreak super.dbus; # template-haskell <2.23
 
   #
   # Test suite issues

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -114,6 +114,7 @@ with haskellLib;
     self.syb
     self.HUnit
   ] super.ghc-exactprint_1_12_0_0;
+  timezone-series = doJailbreak super.timezone-series; # time <1.14
 
   #
   # Test suite issues

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -115,6 +115,7 @@ with haskellLib;
     self.HUnit
   ] super.ghc-exactprint_1_12_0_0;
   timezone-series = doJailbreak super.timezone-series; # time <1.14
+  timezone-olson = doJailbreak super.timezone-olson; # time <1.14
   cabal-plan = doJailbreak super.cabal-plan; # base <4.21
   dbus = doJailbreak super.dbus; # template-haskell <2.23
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -118,6 +118,7 @@ with haskellLib;
   timezone-olson = doJailbreak super.timezone-olson; # time <1.14
   cabal-plan = doJailbreak super.cabal-plan; # base <4.21
   dbus = doJailbreak super.dbus; # template-haskell <2.23
+  xmobar = doJailbreak super.xmobar; # base <4.21
 
   #
   # Test suite issues

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -115,6 +115,7 @@ with haskellLib;
     self.HUnit
   ] super.ghc-exactprint_1_12_0_0;
   timezone-series = doJailbreak super.timezone-series; # time <1.14
+  cabal-plan = doJailbreak super.cabal-plan; # base <4.21
 
   #
   # Test suite issues


### PR DESCRIPTION
I added a couple of trivial jailbreaks to `configuration-ghc-9.12.x.nix` to fix ghc-9.12.x builds of important packages like xmonad, xmobar, etc.