### PR TITLE
octasine: init at 0.9.1

### DIFF
--- a/pkgs/by-name/oc/octasine/package.nix
+++ b/pkgs/by-name/oc/octasine/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  python3,
+  libGL,
+  freetype,
+  expat,
+  xorg,
+  rustPlatform,
+  nix-update-script,
+  enableVST2 ? false,
+}:
+let
+  version = "0.9.1";
+in
+rustPlatform.buildRustPackage {
+  pname = "octasine";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "greatest-ape";
+    repo = "octasine";
+    tag = "v${version}";
+    hash = "sha256-Vr1L5B7dF0pJieE/Zww/T6XbZadWMK5Fdq66qRfQFF0=";
+  };
+
+  cargoHash = "sha256-I+iZxngM8o4BIzjpowjf8l2m6MSY/NSSOd4TcYFjrIc=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    python3
+  ];
+
+  buildInputs = [
+    libGL
+    freetype
+    expat
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libxcb
+    xorg.xcbutilwm
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    cargo xtask bundle -p octasine --release --features "clap"
+
+    ${lib.optionalString enableVST2 ''
+      cargo xtask bundle -p octasine --release --features "vst2"
+    ''}
+
+    cd octasine-cli
+    cargo build --release
+    cd ..
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/clap
+    install -Dm755 target/bundled/octasine.clap $out/lib/clap
+
+
+    ${lib.optionalString enableVST2 ''
+      mkdir -p $out/lib/vst
+      install -Dm755 target/bundled/octasine.so $out/lib/vst
+    ''}
+
+    mkdir -p $out/bin
+    install -Dm755 target/release/octasine-cli $out/bin
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Frequency modulation synthesizer plugin (VST2, CLAP).";
+    homepage = "https://github.com/greatest-ape/OctaSine";
+    mainProgram = "octasine-cli";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.agpl3Only ] ++ lib.optional enableVST2 lib.licenses.unfree;
+    maintainers = [ lib.maintainers.l1npengtul ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Octasine is a 4OP FM synthesizer built in Rust. https://github.com/greatest-ape/octasine

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
