### PR TITLE
mpremote: migrate to by-name

### DIFF
--- a/pkgs/by-name/mp/mpremote/package.nix
+++ b/pkgs/by-name/mp/mpremote/package.nix
@@ -1,14 +1,9 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  hatchling,
-  hatch-requirements-txt,
-  hatch-vcs,
-  pyserial,
-  importlib-metadata,
 }:
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "mpremote";
   version = "1.25.0";
 
@@ -21,24 +16,24 @@ buildPythonApplication rec {
   sourceRoot = "${src.name}/tools/mpremote";
   format = "pyproject";
 
-  nativeBuildInputs = [
+  nativeBuildInputs = with python3Packages; [
     hatchling
     hatch-requirements-txt
     hatch-vcs
   ];
-  propagatedBuildInputs = [
+  dependencies = with python3Packages; [
     pyserial
     importlib-metadata
   ];
 
   pythonImportsCheck = [ "mpremote" ];
 
-  meta = with lib; {
+  meta = {
     description = "Integrated set of utilities to remotely interact with and automate a MicroPython device over a serial connection";
     homepage = "https://github.com/micropython/micropython/blob/master/tools/mpremote/README.md";
-    platforms = platforms.unix;
-    license = licenses.mit;
-    maintainers = with maintainers; [ _999eagle ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ _999eagle ];
     mainProgram = "mpremote";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1108,8 +1108,6 @@ with pkgs;
 
   mkosi-full = mkosi.override { withQemu = true; };
 
-  mpremote = python3Packages.callPackage ../tools/misc/mpremote { };
-
   mpy-utils = python3Packages.callPackage ../tools/misc/mpy-utils { };
 
   networkd-notify = python3Packages.callPackage ../tools/networking/networkd-notify {


### PR DESCRIPTION
migrate mpremote to by-name
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
