### PR TITLE
nixos/meilisearch: harden

### DIFF
--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -237,6 +237,45 @@ in
         WorkingDirectory = "%S/meilisearch";
         RuntimeDirectory = "meilisearch";
         RuntimeDirectoryMode = "0700";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        PrivateTmp = true;
+        PrivateMounts = true;
+        PrivateUsers = true;
+        PrivateDevices = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+
+        ProcSubset = "pid";
+        ProtectProc = "invisible";
+
+        NoNewPrivileges = true;
+
+        # Meilisearch does not support listening on AF_UNIX sockets,
+        # so we currently restrict it to only AF_INET and AF_INET6.
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+
+        CapabilityBoundingSet = "";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged @resources"
+        ];
+
+        UMask = "0077";
       };
     };
   };


### PR DESCRIPTION
`systemd-analyze security` is a nice tool to get a general gist of what services are the most "exposed" in terms of attack surface. I noticed the meilisearch service on my system has a pretty high exposure rating. It doesn't configure any hardening options in systemd. Thing is, it's just a network service that listens on a TCP port, and does its own lil' thingy in its state directory. It doesn't need any capabilities. So, i revoked almost all of them. This way, if there's some vulnerability, potential issues are mitigated.

These changes take the exposure level from `8.2 EXPOSED 🙁` to `1.1 OK 🙂` (the guy is smiling now isn't that just adorable)

Most of the options i touch are documented [in this manpage](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Sandboxing).

---

The main option missing here that probably could be configured but isn't, is `PrivateNetwork=`. Besides like, the telemetry we disable by default, i don't think there's any reason why it should be accessing the internet? We could put it in a private networking namespace, and have the one port it does open proxied into other namespaces (e.g. `systemd-socket-proxyd`), but that's all fairly nontrivial to set up, so i didn't bother.

I could also probably be setting `RootDirectory=`. But, that too, is just kinda painful to set up correctly, so i also didn't bother. We already have `ProtectSystem=` and `ProtectHome=`, which make the rootfs readonly and puts an empty tmpfs over `/home`; the main benefit of putting it in a chroot jail would be that it can no longer access paths in `/var/lib`, at all; but anything sensitive there ought already deny access to the dynamic user.

In the `systemd-analyze security` report, one might also notice that it has `DeviceAllow=` read-only access to a realtime clock? That's provided by `ProtectClock=`, idk why it's docking points for that. `IPAddresssDeny=` also isn't being set: meilisearch can be configured to do SSL, so it's "okay" to accept arbitrary connections. Realistically, it should only be accepting localhost if it's behind a reverse proxy (or not exposed to the internet at all); but not in the general case; so i didn't wanna configure such restrictions at this level. A technically-inclined user may, however, configure an IP address allow list on their own system (and put it in a `PrivateNetwork=` namespace, or whatever)

The tests also saved me from submitting a broken PR. I initially tried `UMask="0777";` (no permission bits on new files), because i based these hardening options largely on [a service that doesn't create files at all](https://github.com/sodiboo/system/blob/25859a4e39cf5162181891b12de9d40d60e5ba6b/web/modules/systemd-socket-proxyd/systemd-socket-proxyd.nix#L127-L165). This caused no issues on my system, as the database could still be read and written to, but when running the NixOS tests, it blew up in my face because the first boot created a database that it didn't have permission to read. So, yay tests, for catching a fairly serious bug! I wouldn't have noticed that, if there were no tests.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
