### PR TITLE
zabbix70: 7.0.16 -> 7.0.17

### DIFF
--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -8,8 +8,8 @@ generic: {
     hash = "sha256-US+TP6qtCT3LlnELWR93t7nf8A1Y1xRPI+300GA1v8g=";
   };
   v70 = generic {
-    version = "7.0.16";
-    hash = "sha256-puolxEye+RpDJcyobH8UFaiWRE9ECbHLY5b2i5NW0WM=";
+    version = "7.0.17";
+    hash = "sha256-FLdfMpurJ0xiW73Z1EcR3MlmoxdVWsH5G1vSfE31iAw=";
   };
   v60 = generic {
     version = "6.0.36";


### PR DESCRIPTION
https://github.com/zabbix/zabbix/blob/master/ChangeLog

--------------------------------------------------------------------------------
Changes for 7.0.17

7.0.17rc2 was released as 7.0.17 without any changes

--------------------------------------------------------------------------------
Changes for 7.0.17rc2

New features:
.......PS. [ZBXNEXT-10119] improved preprocessing diagnostics by highlighting top item IDs with the longest processing times (vso)

Bug fixes:
.......PS. [ZBX-26693] fixed high memory usage by excluding values without preprocessing from being sent to the preprocessing manager (vso)
........S. [ZBX-26661] fixed deadlock on autoreg_host table (vso)

--------------------------------------------------------------------------------
Changes for 7.0.17rc1

New features:
....I...S. [ZBXNEXT-9770] prepared for removal of TimescaleDB API calls deprecated since TimescaleDB 2.18.0 (mprihodko)
.........T [ZBXNEXT-9959] added Cisco Secure Firewall Threat Defense by HTTP template (egordymov)
.........T [ZBXNEXT-9926] added a new self-test item and improved self-test trigger for both SMART by Zabbix agent 2 templates (knaglis)
........S. [ZBXNEXT-10018] updated maximum supported TimescaleDB version to 2.20 (mprihodko)
.........T [ZBXNEXT-9674] added AssumeRole usage with metadata authentication for AWS templates (egordymov)

Bug fixes:
A......... [ZBX-26439] prevented data integrity loss caused by simultaneous API change request execution (vmaksimovs)
...G...PS. [ZBX-26082] fixed agent2 and proxy redirection bug related to incorrect IPv6 string format (vsmelovs)
..F....... [ZBX-25958] fixed incorrect dependency hosts format in trigger form (esekace)
A......... [ZBX-26436] prevented redundant row locks in the database when deleting hosts in parallel API requests (vmaksimovs)
.......PS. [ZBX-26528] fixed improper handling of long or corrupted ODBC error messages (dgoloscapov)
.........T [ZBX-25313] added boot time item to VMware Guest template (akotsegubov)
........S. [ZBX-26495] added parameter support for database down script media type (askolmeisters)
........S. [ZBX-25859] fixed connection reuse for Elasticsearch (rtrizna)
.........T [ZBX-26230] added missing namespace filter to Prometheus preprocessing of pod metrics in Kubernetes cluster state by HTTP template (drasikhov)
........S. [ZBX-26591] fixed detection of read-only state in PostgreSQL replicated database (sboidenko)
.........T [ZBX-24674] updated filesystem discovery low space trigger prototype override in F5 Big-IP by SNMP template (drasikhov)
.........T [ZBX-26444] fixed swap utilization trigger recovery expression in F5 Big-IP by SNMP template (drasikhov)
.........T [ZBX-23216] added application token support in GLPi media type, updated documentation; removed Zammad mentions from non-related media types (drasikhov)
...G...... [ZBX-22770] added self_test_in_progress tag for Zabbix agent 2 S.M.A.R.T plugin (lsurvilo)
.........T [ZBX-26484] fixed event tags verification in Telegram media type to be checked only for supported event sources (drasikhov)
.........T [ZBX-22022] removed client certificate expiration histogram metrics from Kubernetes API server by HTTP template (drasikhov)
.......PS. [ZBX-25545] fixed host interface duplication in autoregistration mode (vsmelovs)
..F....... [ZBX-21955] fixed display of mapped numerical values in Latest data of multiple items (wczerneha)
.........T [ZBX-25975] fixed incorrect OID in CPU temperature LLD rule in MikroTik templates (drasikhov)
...G...... [ZBX-26477] fixed vfs.dir.get ignoring entries with 0 unixtime and fixed vfs.file.get having null values for time fields in this case (dgoloscapov)
...G...... [ZBX-26209] fixed remote command output routing from Stderr to Stdout in Zabbix agent 2 (opucka)
.........T [ZBX-25104] converted SNMP templates to get[OID] method of polling of single OIDs; converted dynamic indexes items to walk[OID] method; converted TrueNAS, pfSense and OPNsense templates to walk[OID] method (drasikhov)
..F....... [ZBX-25956] removed excess suggestions from item copy target list (talbergs)
........S. [ZBX-26410] fixed split brain HA nodes after system pause (sboidenko)
..F....... [ZBX-25952] fixed inconsistent duo 'client secret' field validation (aluchko)
.......PS. [ZBX-26571] added support of source IP for libssh-based items (MVekslers)
..F....... [ZBX-26273] fixed inability to use LLD macro as update interval of item prototype (aluchko)
.........T [ZBX-26567] added new inventory items to the Cisco Meraki device by HTTP template (aiantsen)
.........T [ZBX-26604] fixed JavaScript in AWS Cost Explorer by HTTP template due to syntax changes in GetCostAndUsage API request (egordymov)
..F....... [ZBX-26481] fixed parameter trimming in item preprocessing steps (apoga)
..F....... [ZBX-26300] fixed showing previous element edit form when right clicking on another map element (msnihach)
.......P.. [ZBX-25499] fixed vault secrets resolution on Zabbix proxy (sboidenko)
...G...... [ZBX-26143] fixed duplicated address issue after redirection and disabled history upload on Agent connection failure until the connection is re-established (sboidenko)
..F....... [ZBX-25913] fixed Gauge widget description not updating on refresh (apoga)
..F....... [ZBX-24047] fixed value mapping update error when mapping name contains quotes (isharha)
..F....... [ZBX-26454] set a readonly property for the "Allowed Hosts" input for discovered items (msnihach)
........S. [ZBX-26486] fixed errors in Zabbix server log on second and subsequent server starts with TimescaleDB (mprihodko)
........S. [ZBX-25413] fixed race condition that could lead to user macro changes not be synced with Zabbix proxy (vso)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
