### PR TITLE
kssd: 2.21 -> 2.21-unstable-2024-05-27

### DIFF
--- a/pkgs/by-name/ks/kssd/package.nix
+++ b/pkgs/by-name/ks/kssd/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kssd";
-  version = "2.21";
+  version = "2.21-unstable-2024-05-27";
 
   src = fetchFromGitHub {
     owner = "yhg926";
     repo = "public_kssd";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-D/s1jL2oKE0rSdRMVljskYFsw5UPOv1L95Of+K+e17w=";
+    rev = "ce96b66dddc2d6c1ce611ad84cdf4c7ba62b4aa5";
+    hash = "sha256-qafPyDl+pDfnJ7S6mHBHht2OcQEQeV2kQM+ir5LTGFA=";
   };
 
   patches = [
@@ -47,12 +47,12 @@ stdenv.mkDerivation (finalAttrs: {
     '';
   };
 
-  meta = with lib; {
+  meta = {
     description = "K-mer substring space decomposition";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     homepage = "https://github.com/yhg926/public_kssd";
-    maintainers = with maintainers; [ unode ];
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ unode ];
+    platforms = lib.platforms.linux;
     mainProgram = "kssd";
   };
 })


### PR DESCRIPTION
Upgrade kssd to the latest commit. This fixes build issues and allows the kssd to build on GCC 14 without errors. Tests pass.

- https://github.com/NixOS/nixpkgs/issues/388196

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
