### PR TITLE
cudaPackages.nccl: 2.26.2 -> 2.27.6

### DIFF
--- a/pkgs/development/cuda-modules/packages/nccl.nix
+++ b/pkgs/development/cuda-modules/packages/nccl.nix
@@ -24,10 +24,10 @@ let
     ;
   # versions 2.26+ with CUDA 11.x error with
   # fatal error: cuda/atomic: No such file or directory
-  version = if cudaAtLeast "12.0" then "2.26.2-1" else "2.25.1-1";
+  version = if cudaAtLeast "12.0" then "2.27.6-1" else "2.25.1-1";
   hash =
     if cudaAtLeast "12.0" then
-      "sha256-iLEuru3gaNLcAdH4V8VIv3gjdTGjgb2/Mr5UKOh69N4="
+      "sha256-/BiLSZaBbVIqOfd8nQlgUJub0YR3SR4B93x2vZpkeiU="
     else
       "sha256-3snh0xdL9I5BYqdbqdl+noizJoI38mZRVOJChgEE1I8=";
 in
@@ -74,12 +74,7 @@ backendStdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs ./src/device/generate.py
-  ''
-  # CUDA 12.8 uses GCC 14 and we need to bump C++ standard to C++14
-  # in order to work with new constexpr handling
-  + lib.optionalString (cudaAtLeast "12.8") ''
-    substituteInPlace ./makefiles/common.mk \
-      --replace-fail "-std=c++11" "-std=c++14"
+    patchShebangs ./src/device/symmetric/generate.py
   '';
 
   makeFlags = [


### PR DESCRIPTION
Update nccl from 2.26.2 to 2.27.6.

nccl 2.27 is required for the upcoming torch 2.8, might as well get ahead of it :)

nccl 2.27.6 changed its CXXSTD from cpp11 to 14, so the makefile patch workaround is no longer required.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (N/A)
  - [ ] aarch64-darwin (N/A)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
