### PR TITLE
elixir-ls: force local installation

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -89,7 +89,7 @@ let
         inherit fetchMixDeps mixRelease;
       };
 
-      elixir-ls = callPackage ./elixir-ls { inherit elixir fetchMixDeps mixRelease; };
+      elixir-ls = callPackage ./elixir-ls { inherit elixir; };
 
       lfe = lfe_2_1;
       lfe_2_1 = lib'.callLFE ../interpreters/lfe/2.1.nix { inherit erlang buildRebar3 buildHex; };

--- a/pkgs/development/beam-modules/elixir-ls/launch.sh.patch
+++ b/pkgs/development/beam-modules/elixir-ls/launch.sh.patch
@@ -1,6 +1,6 @@
-diff --git i/scripts/launch.sh w/scripts/launch.sh
-index 21afbb1e..975cbdf0 100755
---- i/scripts/launch.sh
+diff --git c/scripts/launch.sh w/scripts/launch.sh
+index 21afbb1e..6b61f0b4 100755
+--- c/scripts/launch.sh
 +++ w/scripts/launch.sh
 @@ -1,125 +1,4 @@
 -#!/bin/sh
@@ -140,7 +140,7 @@ index 21afbb1e..975cbdf0 100755
 -  SCRIPTPATH=${ELS_INSTALL_PREFIX}
 -fi
 +SCRIPT=$(readlink -f "$0")
-+SCRIPTPATH=$(dirname "$SCRIPT")/../libexec
++SCRIPTPATH=$(dirname "$SCRIPT")/../scripts
  
  export MIX_ENV=prod
  # Mix.install prints to stdout and reads from stdin


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Stop needlessly compiling beam files that'll never be used. elixir-ls is designed to install into a project dir an entire new mix project, and we weren't even packaging the beam files anyway.

This is now a patched source that'll force elixir-ls to read its source from the nix store instead of going out to hex/git.

With this PR:

```
[ERROR][2025-07-23 13:01:57] ...p/_transport.lua:36     "rpc"   "elixir-ls"     "stderr"        "Running /nix/store/cqs84kfdnibkgcwv29xyqqxy2znqmqzz-elixir-ls-0.28.1/scripts/launch.sh\n"
[ERROR][2025-07-23 13:01:57] ...p/_transport.lua:36     "rpc"   "elixir-ls"     "stderr"        "Installing local ElixirLS from /nix/store/cqs84kfdnibkgcwv29xyqqxy2znqmqzz-elixir-ls-0.28.1\n"
[ERROR][2025-07-23 13:01:57] ...p/_transport.lua:36     "rpc"   "elixir-ls"     "stderr"        "Running in /Users/adam/git/elixir-test\n"
[ERROR][2025-07-23 13:01:57] ...p/_transport.lua:36     "rpc"   "elixir-ls"     "stderr"        "* Getting elixir_sense (https://github.com/elixir-lsp/elixir_sense.git - 5965af7e7a1b743f0c2c475fa2215ec2b23f70c5)\n"
[ERROR][2025-07-23 13:01:59] ...p/_transport.lua:36     "rpc"   "elixir-ls"     "stderr"        "* Getting jason_v (https://github.com/elixir-lsp/jason.git - f1c10fa9c445cb9f300266122ef18671054b2330)\n"
[ERROR][2025-07-23 13:01:59] ...p/_transport.lua:36     "rpc"   "elixir-ls"     "stderr"        "* Getting dialyxir_vendored (https://github.com/elixir-lsp/dialyxir.git - f8f64cfb6797c518294687e7c03ae817bacbc6ee)\n"
[ERROR][2025-07-23 13:02:00] ...p/_transport.lua:36     "rpc"   "elixir-ls"     "stderr"        "* Getting erlex_vendored (https://github.com/elixir-lsp/erlex.git - c0e448db27bcbb3f369861d13e3b0607ed37048d)\n"
[ERROR][2025-07-23 13:02:00] ...p/_transport.lua:36     "rpc"   "elixir-ls"     "stderr"        "* Getting erl2ex_vendored (https://github.com/elixir-lsp/erl2ex.git - 073ac6b9a44282e718b6050c7b27cedf9217a12a)\n"
[ERROR][2025-07-23 13:02:01] ...p/_transport.lua:36     "rpc"   "elixir-ls"     "stderr"        "* Getting path_glob_vendored (https://github.com/elixir-lsp/path_glob.git - 965350dc41def7be4a70a23904195c733a2ecc84)\n"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
