### PR TITLE
beetsPackages.yearfixer: init at 0.0.5

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -57,6 +57,7 @@ lib.makeExtensible (
     audible = callPackage ./plugins/audible.nix { beets = self.beets-minimal; };
     copyartifacts = callPackage ./plugins/copyartifacts.nix { beets = self.beets-minimal; };
     filetote = callPackage ./plugins/filetote.nix { beets = self.beets-minimal; };
+    yearfixer = callPackage ./plugins/yearfixer.nix { beets = self.beets-minimal; };
   }
   // lib.optionalAttrs config.allowAliases {
     extrafiles = throw "extrafiles is unmaintained since 2020 and broken since beets 2.0.0";

--- a/pkgs/tools/audio/beets/plugins/yearfixer.nix
+++ b/pkgs/tools/audio/beets/plugins/yearfixer.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  beets,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+  writableTmpDirAsHomeHook,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "beets-yearfixer";
+  version = "0.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adamjakab";
+    repo = "BeetsPluginYearFixer";
+    tag = "v${version}";
+    hash = "sha256-TDRkCihp+hB33e9LCBpUye+KobpTPrDMutMa4zHJQ68=";
+  };
+
+  nativeBuildInputs = [
+    beets
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    requests
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ]
+  ++ (with python3Packages; [
+    pytestCheckHook
+    six
+  ]);
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Beets plugin for obsessive-compulsive music geeks to fix missing album release date";
+    homepage = "https://github.com/adamjakab/BeetsPluginYearFixer";
+    maintainers = with lib.maintainers; [ bandithedoge ];
+    license = lib.licenses.mit;
+    inherit (beets.meta) platforms;
+  };
+}


### PR DESCRIPTION
Adapted from https://github.com/bandithedoge/nur-packages/blob/master/pkgs/beetsPackages/default.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
