### PR TITLE
libsoup_2_4: mark vulnerable

### DIFF
--- a/pkgs/by-name/gv/gvfs/package.nix
+++ b/pkgs/by-name/gv/gvfs/package.nix
@@ -43,8 +43,10 @@
   libmsgraph,
   python3,
   gsettings-desktop-schemas,
+  googleSupport ? false, # dependency on vulnerable libsoup versions
 }:
 
+assert googleSupport -> gnomeSupport;
 stdenv.mkDerivation (finalAttrs: {
   pname = "gvfs";
   version = "1.57.2";
@@ -106,8 +108,10 @@ stdenv.mkDerivation (finalAttrs: {
     glib-networking # TLS support
     gnome-online-accounts
     libsecret
-    libgdata
     libmsgraph
+  ]
+  ++ lib.optionals googleSupport [
+    libgdata
   ];
 
   mesonFlags = [
@@ -130,8 +134,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dgcr=false"
     "-Dgoa=false"
     "-Dkeyring=false"
-    "-Dgoogle=false"
     "-Donedrive=false"
+  ]
+  ++ lib.optionals (!googleSupport) [
+    "-Dgoogle=false"
   ]
   ++ lib.optionals (avahi == null) [
     "-Ddnssd=false"

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -139,5 +139,31 @@ stdenv.mkDerivation rec {
       "libsoup-2.4"
       "libsoup-gnome-2.4"
     ];
+    knownVulnerabilities = [
+      ''
+        libsoup 2 is EOL, with many known unfixed CVEs.
+        The last release happened 2023-10-11,
+        with few security backports since and no stable release.
+
+        Vulnerabilities likely include (incomplete list):
+        - CVE-2025-4948: https://gitlab.gnome.org/GNOME/libsoup/-/issues/449
+        - CVE-2025-46421: https://gitlab.gnome.org/GNOME/libsoup/-/issues/439
+        - CVE-2025-32914: https://gitlab.gnome.org/GNOME/libsoup/-/issues/436
+        - CVE-2025-32913: https://gitlab.gnome.org/GNOME/libsoup/-/issues/435
+        - CVE-2025-32912: https://gitlab.gnome.org/GNOME/libsoup/-/issues/434
+        - CVE-2025-32911: https://gitlab.gnome.org/GNOME/libsoup/-/issues/433
+        - CVE-2025-32910: https://gitlab.gnome.org/GNOME/libsoup/-/issues/432
+        - CVE-2025-32909: https://gitlab.gnome.org/GNOME/libsoup/-/issues/431
+        - CVE-2025-32907: https://gitlab.gnome.org/GNOME/libsoup/-/issues/428
+        - CVE-2025-32053: https://gitlab.gnome.org/GNOME/libsoup/-/issues/426
+        - CVE-2025-32052: https://gitlab.gnome.org/GNOME/libsoup/-/issues/425
+        - CVE-2025-32050: https://gitlab.gnome.org/GNOME/libsoup/-/issues/424
+        - CVE-2024-52531: https://gitlab.gnome.org/GNOME/libsoup/-/issues/423
+        - CVE-2025-2784: https://gitlab.gnome.org/GNOME/libsoup/-/issues/422
+
+        These vulnerabilities were fixed in libsoup 3,
+        with the vulnerable code present in libsoup 2 versions.
+      ''
+    ];
   };
 }

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -168,7 +168,6 @@ in
   util-linux = linux;
   util-linuxMinimal = linux;
   w3m = all;
-  webkitgtk_4_0 = linux;
   wget = all;
   which = all;
   wirelesstools = linux;


### PR DESCRIPTION
libsoup 2 is EOL, with many known unfixed CVEs.
The last release happened 2023-10-11,
with few security backports since and no stable release.

Vulnerabilities likely include (incomplete list):
- CVE-2025-4948: https://gitlab.gnome.org/GNOME/libsoup/-/issues/449
- CVE-2025-46421: https://gitlab.gnome.org/GNOME/libsoup/-/issues/439
- CVE-2025-32914: https://gitlab.gnome.org/GNOME/libsoup/-/issues/436
- CVE-2025-32913: https://gitlab.gnome.org/GNOME/libsoup/-/issues/435
- CVE-2025-32912: https://gitlab.gnome.org/GNOME/libsoup/-/issues/434
- CVE-2025-32911: https://gitlab.gnome.org/GNOME/libsoup/-/issues/433
- CVE-2025-32910: https://gitlab.gnome.org/GNOME/libsoup/-/issues/432
- CVE-2025-32909: https://gitlab.gnome.org/GNOME/libsoup/-/issues/431
- CVE-2025-32907: https://gitlab.gnome.org/GNOME/libsoup/-/issues/428
- CVE-2025-32053: https://gitlab.gnome.org/GNOME/libsoup/-/issues/426
- CVE-2025-32052: https://gitlab.gnome.org/GNOME/libsoup/-/issues/425
- CVE-2025-32050: https://gitlab.gnome.org/GNOME/libsoup/-/issues/424
- CVE-2024-52531: https://gitlab.gnome.org/GNOME/libsoup/-/issues/423
- CVE-2025-2784: https://gitlab.gnome.org/GNOME/libsoup/-/issues/422

These vulnerabilities were fixed in libsoup 3,
with the vulnerable code present in libsoup 2 versions.

Part of https://github.com/NixOS/nixpkgs/issues/360897

I confirmed the graphical ISO installer does no longer depend on `libsoup_2_4`, this should not cause issues.

`gvfs` used old libsoup for google support. Seeing as our test suite and various other popular things still use gvfs in places, i split google support into an additional option (default false) to remove the `libsoup_2_4` dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
