### PR TITLE
WIP: rustPlatform.fetchCargoVendor: delegate vendor dir creation to cargoSetupHook

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -7,6 +7,7 @@
   cargo,
   nix-prefetch-git,
   cacert,
+  makeBinaryWrapper,
 }:
 
 let
@@ -87,17 +88,35 @@ let
     }
     // builtins.removeAttrs args removedArgs
   );
+
 in
 
-runCommand "${name}-vendor"
+(runCommand "${name}-vendor"
   {
     inherit vendorStaging;
-    nativeBuildInputs = [
-      fetchCargoVendorUtil
-      cargo
-      replaceWorkspaceValues
-    ];
+    nativeBuildInputs = [ makeBinaryWrapper ];
   }
   ''
-    fetch-cargo-vendor-util create-vendor "$vendorStaging" "$out"
+    makeBinaryWrapper ${fetchCargoVendorUtil}/bin/fetch-cargo-vendor-util $out/bin/unpack-vendor \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          cargo
+          replaceWorkspaceValues
+        ]
+      } \
+      --add-flags create-vendor \
+      --add-flags "$vendorStaging"
+
+    # just a decoration
+    ln -s "$vendorStaging" "$out/vendor-staging"
   ''
+).overrideAttrs # idk I just wanted to have access to finalAttrs
+  (
+    finalAttrs: _: {
+      passthru.vendorFetched =
+        runCommand "${name}-vendor-fetched" { nativeBuildInputs = [ finalAttrs.finalPackage ]; }
+          ''
+            unpack-vendor $out
+          '';
+    }
+  )

--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -8,7 +8,11 @@ cargoSetupPostUnpackHook() {
     if [ -z $cargoVendorDir ]; then
         if [ -d "$cargoDeps" ]; then
             local dest=$(stripHash "$cargoDeps")
-            cp -Lr --reflink=auto -- "$cargoDeps" "$dest"
+            if [ -e "$cargoDeps/bin/unpack-vendor" ]; then
+                "$cargoDeps/bin/unpack-vendor" "$dest"
+            else
+                cp -Lr --reflink=auto -- "$cargoDeps" "$dest"
+            fi
             chmod -R +644 -- "$dest"
         else
             unpackFile "$cargoDeps"


### PR DESCRIPTION
This is just a POC!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
