### PR TITLE
wmidump: init at 0-unstable-2026-03-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19696,6 +19696,12 @@
     github = "nigelgbanks";
     githubId = 487373;
   };
+  nikableh = {
+    email = "nika@nikableh.moe";
+    github = "nikableh";
+    githubId = 61655860;
+    name = "Nika Krasnova";
+  };
   nikitavoloboev = {
     email = "nikita.voloboev@gmail.com";
     github = "nikivdev";

--- a/pkgs/by-name/wm/wmidump/package.nix
+++ b/pkgs/by-name/wm/wmidump/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "wmidump";
+  version = "0-unstable-2026-03-13";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "iksaif";
+    repo = "wmidump";
+    rev = "9c3109cb9b24b8b989bc57ba829d5b1c48b82a96";
+    hash = "sha256-MQySsGxvCYOaiuNzjlkhafLu3EawqOvfewSmIR0zBeM=";
+  };
+
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "Dump WMI informations from ACPI tables";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "wmidump";
+    homepage = "https://github.com/iksaif/wmidump";
+    maintainers = [ lib.maintainers.nikableh ];
+  };
+}


### PR DESCRIPTION
Init https://github.com/iksaif/wmidump/ at commit №17. There is no version, but I've created an [issue](https://github.com/iksaif/wmidump/issues/5) about it.

The program is useful for developing kernel [WMI drivers](https://lwn.net/Articles/391230/#:~:text=A%20good%20way%20to%20do%20it%20is%20to%20use%20wmidump%2C%20it%20will%20parse%20the%20buffer%20returned%20by%20the%20_WDG%20method%2C%20and%20display%20it%20in%20a%20humanly%20readable%20form.). 

I've also tested the cross-compilation:

```
nix-build -A wmidump --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc