### PR TITLE
szurubooru: 2.5-unstable-2025-02-11 -> 2.5-unstable-2025-07-19, fix build for python3.13

### DIFF
--- a/nixos/modules/services/web-apps/szurubooru.nix
+++ b/nixos/modules/services/web-apps/szurubooru.nix
@@ -15,7 +15,7 @@ let
     types
     ;
   format = pkgs.formats.yaml { };
-  python = pkgs.python312;
+  python = pkgs.python3;
 in
 
 {

--- a/pkgs/servers/web-apps/szurubooru/default.nix
+++ b/pkgs/servers/web-apps/szurubooru/default.nix
@@ -5,12 +5,12 @@
 }:
 
 let
-  version = "2.5-unstable-2025-02-11";
+  version = "2.5-unstable-2025-07-19";
   src = fetchFromGitHub {
     owner = "rr-";
     repo = "szurubooru";
-    rev = "376f687c386f65522b2f65e98b998b21af26ee29";
-    hash = "sha256-4w1iOYp+CVg60dYxRilj08D4Hle6R9Y0v+Nd3fws1Zc=";
+    rev = "5a0f8867f3af1556d82c1ad7e29977903300c2dd";
+    hash = "sha256-ihocmBS4h23bb4ZRhHEXvnHiNfRMPdUe94B5K9bi2E4=";
   };
 in
 

--- a/pkgs/servers/web-apps/szurubooru/server.nix
+++ b/pkgs/servers/web-apps/szurubooru/server.nix
@@ -56,6 +56,7 @@ python.pkgs.buildPythonApplication {
     certifi
     coloredlogs
     heif-image-plugin
+    legacy-cgi
     numpy
     pillow-avif-plugin
     pillow


### PR DESCRIPTION
Updated szurubooru to latest bugfix and fixed a build issue caused by a breaking change introduced in python3.13.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
