### PR TITLE
clojure-lsp: Use the check hooks and remove redundant version checks

### DIFF
--- a/pkgs/by-name/cl/clojure-lsp/package.nix
+++ b/pkgs/by-name/cl/clojure-lsp/package.nix
@@ -5,6 +5,8 @@
   fetchurl,
   fetchFromGitHub,
   writeScript,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
   testers,
 }:
 
@@ -25,21 +27,11 @@ buildGraalvmNativeImage (finalAttrs: {
     "--features=clj_easy.graal_build_time.InitClojureClasses"
   ];
 
-  doCheck = true;
-  checkPhase = ''
-    runHook preCheck
-
-    export HOME="$(mktemp -d)"
-    ./clojure-lsp --version | fgrep -q '${finalAttrs.version}'
-
-    runHook postCheck
-  '';
-
-  passthru.tests.version = testers.testVersion {
-    inherit (finalAttrs) version;
-    package = finalAttrs.finalPackage;
-    command = "clojure-lsp --version";
-  };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
 
   passthru.updateScript = writeScript "update-clojure-lsp" ''
     #!/usr/bin/env nix-shell


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Remove the custom version check in the `checkPhase`
2. Add hooks for the installCheckPhase

I also attempted to add a passthru test for running the integration tests, but I was not able to get them to work. I had something like

```patch
diff --git a/pkgs/by-name/cl/clojure-lsp/package.nix b/pkgs/by-name/cl/clojure-lsp/package.nix
index 9ccd78034f..dddefee208 100644
--- a/pkgs/by-name/cl/clojure-lsp/package.nix
+++ b/pkgs/by-name/cl/clojure-lsp/package.nix
@@ -8,6 +8,12 @@
   writableTmpDirAsHomeHook,
   versionCheckHook,
   testers,
+  babashka,
+  git,
+  cacert,
+  clojure,
+  boot,
+  nodejs
 }:
 
 buildGraalvmNativeImage (finalAttrs: {
@@ -33,6 +39,17 @@
     versionCheckHook
   ];
 
+  passthru.tests.integration = testers.runCommand {
+  name = "integration-tests";
+  nativeBuildInputs = [ writableTmpDirAsHomeHook babashka git cacert clojure boot clojure.jdk nodejs ];
+  script = ''
+    git clone https://github.com/clojure-lsp/clojure-lsp.git --branch ${finalAttrs.version} --depth 1
+
+    pushd clojure-lsp/cli
+    bb integration-test ${lib.getExe finalAttrs.finalPackage}
+    popd
+  '';
+  };
   passthru.updateScript = writeScript "update-clojure-lsp" ''
     #!/usr/bin/env nix-shell
     #!nix-shell -i bash -p curl common-updater-scripts gnused jq nix

```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
