### PR TITLE
nixos/tandoor-recipes: fix database leak when serving media

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -62,6 +62,12 @@
   "module-boot-plymouth-tpm2-totp-quick-start-enable": [
     "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
   ],
+  "module-services-tandoor-recipes-migrating-media-option-1": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-1"
+  ],
+  "module-services-tandoor-recipes-migrating-media-option-2": [
+    "index.html#module-services-tandoor-recipes-migrating-media-option-2"
+  ],
   "sec-override-nixos-test": [
     "index.html#sec-override-nixos-test"
   ],
@@ -1121,6 +1127,12 @@
   ],
   "module-services-samba-configuring-file-share": [
     "index.html#module-services-samba-configuring-file-share"
+  ],
+  "module-services-tandoor-recipes": [
+    "index.html#module-services-tandoor-recipes"
+  ],
+  "module-services-tandoor-recipes-migrating-media": [
+    "index.html#module-services-tandoor-recipes-migrating-media"
   ],
   "module-services-litestream": [
     "index.html#module-services-litestream"

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -40,6 +40,8 @@
 
 - `services.crabfit` was removed because its upstream packages are unmaintained and insecure.
 
+- `services.tandoor-recipes` now uses a sub-directory for media files by default starting with `26.05`. Existing setups should move media files out of the data directory and adjust `services.tandoor-recipes.extraConfig.MEDIA_ROOT` accordingly. See [Migrating media files for pre 26.05 installations](#module-services-tandoor-recipes-migrating-media).
+
 - `services.kubernetes.addons.dns.coredns` has been renamed to `services.kubernetes.addons.dns.corednsImage` and now expects a
 package instead of attrs. Now, by default, nixpkgs.coredns in conjunction with dockerTools.buildImage is used, instead
 of pulling the upstream container image from Docker Hub. If you want the old behavior, you can set:

--- a/nixos/modules/services/misc/tandoor-recipes.md
+++ b/nixos/modules/services/misc/tandoor-recipes.md
@@ -1,0 +1,19 @@
+# Tandoor Recipes {#module-services-tandoor-recipes}
+
+## Dealing with `MEDIA_ROOT` for installations prior 26.05 {#module-services-tandoor-recipes-migrating-media}
+
+See https://github.com/NixOS/nixpkgs/issues/338339 for some background.
+
+### Option 1: Migrate media to new `MEDIA_ROOT` {#module-services-tandoor-recipes-migrating-media-option-1}
+
+1. Stop the currently running service: `systemctl stop tandoor-recipes.service`
+2. Create a media folder. NixOS `26.05` creates the media path at `/var/lib/tandoor-recipes/media` by default, but you may choose any other path as well. `mkdir -p /var/lib/tandoor-recipes/media`
+3. Move existing media to the new path: `mv /var/lib/tandoor-recipes/{files,recipes} /var/lib/tandoor-recipes/media`
+4. Set `services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes/media";` in your NixOS configuration (not needed if `system.stateVersion >= 26.05`).
+5. Rebuild and switch!
+
+These changes can be reverted by moving the files back into the state directory.
+
+### Option 2: Keep existing directory (may be insecure) {#module-services-tandoor-recipes-migrating-media-option-2}
+
+To keep the existing directory, set `services.tandoor-recipes.extraConfig.MEDIA_ROOT = "/var/lib/tandoor-recipes";`.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1552,6 +1552,7 @@ in
   szurubooru = handleTest ./szurubooru.nix { };
   taler = handleTest ./taler { };
   tandoor-recipes = runTest ./tandoor-recipes.nix;
+  tandoor-recipes-media = runTest ./tandoor-recipes-media.nix;
   tandoor-recipes-script-name = runTest ./tandoor-recipes-script-name.nix;
   tang = runTest ./tang.nix;
   taskchampion-sync-server = runTest ./taskchampion-sync-server.nix;

--- a/nixos/tests/tandoor-recipes-media.nix
+++ b/nixos/tests/tandoor-recipes-media.nix
@@ -1,0 +1,91 @@
+{ ... }:
+{
+  name = "tandoor-recipes-media";
+
+  nodes.machine = {
+    services.tandoor-recipes = {
+      enable = true;
+      # This setting is not recommended, but it's an easy way serve the media
+      # folder in this test.
+      extraConfig = {
+        GUNICORN_MEDIA = true;
+      };
+    };
+
+    specialisation.oldVersion.configuration = {
+      system.stateVersion = "25.11";
+      services.tandoor-recipes = {
+        enable = true;
+        extraConfig = {
+          GUNICORN_MEDIA = true;
+          # Explicitly set insecure value (skips warning)
+          MEDIA_ROOT = "/var/lib/tandoor-recipes";
+        };
+      };
+    };
+
+    specialisation.oldVersionOverrideMedia.configuration = {
+      system.stateVersion = "25.11";
+      services.tandoor-recipes = {
+        enable = true;
+        extraConfig = {
+          GUNICORN_MEDIA = true;
+          MEDIA_ROOT = "/var/lib/tandoor-recipes/media";
+        };
+      };
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      specBase = "${nodes.machine.system.build.toplevel}/specialisation";
+      oldVersion = "${specBase}/oldVersion";
+      oldVersionOverrideMedia = "${specBase}/oldVersionOverrideMedia";
+    in
+    # python
+    ''
+      def wait_for_tandoor():
+        machine.wait_for_unit("tandoor-recipes.service")
+        machine.wait_for_open_port(8080)
+
+
+      def stop_and_rm():
+        machine.systemctl("stop tandoor-recipes")
+        machine.succeed("rm -r /var/lib/tandoor-recipes")
+
+
+      db_path = "http://localhost:8080/media/db.sqlite3"
+
+
+      # The media folder shouldn't contain the database. Subsequently it
+      # should **not** get served, resulting in a 404. Previously the
+      # database was located in the media folder. Therefore serving the media
+      # folder would expose the database. See #338339.
+      wait_for_tandoor()
+      machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 404 Not Found\"")
+
+
+      # Switch to NixOS 24.11 to check if the setup still functions the same
+      # as before.
+      stop_and_rm()
+      machine.succeed("${oldVersion}/bin/switch-to-configuration test")
+
+      # With the old setup the media folder should contain the database.
+      # Subsequently it should get served, resulting in a 200.
+      wait_for_tandoor()
+      machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 200 OK\"")
+
+
+      # Switch to NixOS 24.11 with the MEDIA_ROOT already set to
+      # /var/lib/tandoor-recipes/media.
+      stop_and_rm()
+      machine.succeed("${oldVersionOverrideMedia}/bin/switch-to-configuration test")
+
+      # With MEDIA_ROOT being set to /var/lib/tandoor-recipes/media the media
+      # folder shouldn't contain the database. Subsequently it should **not**
+      # get served, resulting in a 404.
+      wait_for_tandoor()
+      machine.succeed(f"curl --head {db_path} | grep \"HTTP/1.1 404 Not Found\"")
+    '';
+}

--- a/pkgs/by-name/ta/tandoor-recipes/package.nix
+++ b/pkgs/by-name/ta/tandoor-recipes/package.nix
@@ -166,7 +166,7 @@ python.pkgs.buildPythonPackage {
     updateScript = ./update.sh;
 
     tests = {
-      inherit (nixosTests) tandoor-recipes tandoor-recipes-script-name;
+      inherit (nixosTests) tandoor-recipes tandoor-recipes-script-name tandoor-recipes-media;
     };
   };
 


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/338339
Supersedes https://github.com/NixOS/nixpkgs/pull/386167
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
