### PR TITLE
igir: 2.11.0 -> 4.1.1

### DIFF
--- a/pkgs/by-name/ig/igir/package.nix
+++ b/pkgs/by-name/ig/igir/package.nix
@@ -1,26 +1,31 @@
 {
-  lib,
-  buildNpmPackage,
-  fetchFromGitHub,
-
   # for patching bundled 7z binary from the 7zip-bin node module
   # at lib/node_modules/igir/node_modules/7zip-bin/linux/x64/7za
   autoPatchelfHook,
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  libusb1,
+  libuv,
+  libz,
+  lz4,
+  sdl2-compat,
   stdenv,
+  udev,
 }:
 
 buildNpmPackage rec {
   pname = "igir";
-  version = "2.11.0";
+  version = "4.1.1";
 
   src = fetchFromGitHub {
     owner = "emmercm";
     repo = "igir";
     rev = "v${version}";
-    hash = "sha256-NG0ZP8LOm7fZVecErTuLOfbp1yvXwHnwPkWTBzUJXWE=";
+    hash = "sha256-f/3XIBFMxSPwJpfZTBhuznU/psChfnQEwZASOoH4Ij0=";
   };
 
-  npmDepsHash = "sha256-ADIEzr6PkGaJz27GKSVyTsrbz5zbud7BUb+OXPtP1Vo=";
+  npmDepsHash = "sha256-qPyS2F5jt1C5SZxvRuyPX4+TkYZKTffcekanWtH82EY=";
 
   # I have no clue why I have to do this
   postPatch = ''
@@ -29,7 +34,15 @@ buildNpmPackage rec {
 
   nativeBuildInputs = [ autoPatchelfHook ];
 
-  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
+  buildInputs = [
+    (lib.getLib stdenv.cc.cc)
+    libusb1
+    libuv
+    libz
+    lz4
+    sdl2-compat
+    udev
+  ];
 
   # from lib/node_modules/igir/node_modules/@node-rs/crc32-linux-x64-musl/crc32.linux-x64-musl.node
   # Irrelevant to our use


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc