### PR TITLE
wayback-x11: 0-unstable-2025-07-20 -> 0.2

### DIFF
--- a/pkgs/by-name/wa/wayback-x11/package.nix
+++ b/pkgs/by-name/wa/wayback-x11/package.nix
@@ -2,13 +2,14 @@
   fetchFromGitLab,
   lib,
   libxkbcommon,
+  makeWrapper,
   meson,
   ninja,
+  nix-update-script,
   pixman,
   pkg-config,
   scdoc,
   stdenv,
-  unstableGitUpdater,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -16,16 +17,16 @@
   xwayland,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wayback";
-  version = "0-unstable-2025-07-20";
+  version = "0.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "wayback";
     repo = "wayback";
-    rev = "4b1b4c59f67a2639e960d6b19e1282cf03fc3660";
-    hash = "sha256-+4fPMVVPoUAYbt0jgfl+dmt0ZNyGGWF7xuF1UzZ2uiU=";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-8pfW1tu7OI6dLSR9iiVuJDdK76fRgpQmesW5wJUVN/0=";
   };
 
   strictDeps = true;
@@ -35,6 +36,7 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [
+    makeWrapper
     meson
     ninja
     pkg-config
@@ -51,14 +53,20 @@ stdenv.mkDerivation {
     xwayland
   ];
 
-  passthru.updateScript = unstableGitUpdater { };
+  postInstall = ''
+    wrapProgram "$out/bin/wayback-session" \
+      --set XWAYBACK_PATH "$out/bin/Xwayback"
+  '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "X11 compatibility layer leveraging wlroots and Xwayland";
     homepage = "https://wayback.freedesktop.org";
+    changelog = "https://gitlab.freedesktop.org/wayback/wayback/-/releases/${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    mainProgram = "wayback-session";
+    mainProgram = "Xwayback";
     maintainers = with lib.maintainers; [ dramforever ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~wayback 0.1 proper has an accidental forkbomb bug, so this is a draft waiting for 0.1.1 bugfix release, which should be really soon. But this is what the expression will look like when we start tracking tags instead of `unstableGitUpdater`.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
