### PR TITLE
io: 2017.09.06 -> 2019.05.22-alpha

### DIFF
--- a/pkgs/by-name/io/io/package.nix
+++ b/pkgs/by-name/io/io/package.nix
@@ -36,12 +36,14 @@
 
 stdenv.mkDerivation {
   pname = "io";
-  version = "2017.09.06";
+  version = "2019.05.22-alpha";
+
   src = fetchFromGitHub {
     owner = "stevedekorte";
     repo = "io";
-    rev = "b8a18fc199758ed09cd2f199a9bc821f6821072a";
-    sha256 = "07rg1zrz6i6ghp11cm14w7bbaaa1s8sb0y5i7gr2sds0ijlpq223";
+    tag = "2019.05.22-alpha";
+    fetchSubmodules = true;
+    hash = "sha256-6w0JZE9H30X5j83YgSn7hG2l0LdhdRZfe/kWpx1/aoM=";
   };
 
   patches = [
@@ -107,15 +109,11 @@ stdenv.mkDerivation {
     $out/bin/io_static
   '';
 
-  # for gcc5; c11 inline semantics breaks the build
-  env.NIX_CFLAGS_COMPILE = "-fgnu89-inline";
-
-  meta = with lib; {
+  meta = {
     description = "Io programming language";
     homepage = "https://iolanguage.org/";
-    license = licenses.bsd3;
-
-    maintainers = with maintainers; [
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
       raskin
       maggesi
     ];


### PR DESCRIPTION
Update [io](https://github.com/IoLanguage/io) to the latest (unstable) tag. Fixes build issues for GCC 14. Compiles and runs correctly.

- https://github.com/NixOS/nixpkgs/issues/388196

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
