### PR TITLE
mihomo: backport security patches

### DIFF
--- a/pkgs/by-name/mi/mihomo/package.nix
+++ b/pkgs/by-name/mi/mihomo/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   buildGoModule,
   nixosTests,
+  fetchpatch,
 }:
 
 buildGoModule rec {
@@ -15,6 +16,19 @@ buildGoModule rec {
     rev = "v${version}";
     hash = "sha256-nt2bnfKzGU+6gUaSqHfnbCnWLMDoAcISmlNYFeM4Xu8=";
   };
+
+  patches = [
+    # https://github.com/MetaCubeX/mihomo/pull/2178
+    (fetchpatch {
+      url = "https://github.com/MetaCubeX/mihomo/commit/63ad95e10f40ffc90ec93497aac562765af7a471.patch";
+      hash = "sha256-ZE2dlr0t//Q1CVy2ql/TWuLEALdF1ZCYTOVK87bKWQg=";
+    })
+    # https://github.com/MetaCubeX/mihomo/pull/2177
+    (fetchpatch {
+      url = "https://github.com/MetaCubeX/mihomo/commit/b06ec5bef810ec8d009f52428188440df0484ce4.patch";
+      hash = "sha256-XQhlST4pa//+Bg5hWc2zADulz8FeEiHwB99Rw9o24b0=";
+    })
+  ];
 
   vendorHash = "sha256-k/Zjnq07+Sg+dwwcAf+ziInaDvlXn3bEG+QuxZ5lcM8=";
 


### PR DESCRIPTION
See https://cherr.cc/mihomo-0days

- https://github.com/MetaCubeX/mihomo/pull/2178
Unfiltered SUID files may result in LPE.

- https://github.com/MetaCubeX/mihomo/pull/2177
Improper filtering of `rule-provider` paths may cause arbitrary file read vulnerabilities.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
