### PR TITLE
nixos/lact: allow configuring declaratively

### DIFF
--- a/nixos/modules/services/hardware/lact.nix
+++ b/nixos/modules/services/hardware/lact.nix
@@ -4,9 +4,10 @@
   pkgs,
   ...
 }:
-
 let
   cfg = config.services.lact;
+  configFormat = pkgs.formats.yaml { };
+  configFile = configFormat.generate "lact-config.yaml" cfg.settings;
 in
 {
   meta.maintainers = [ lib.maintainers.johnrtitor ];
@@ -25,15 +26,42 @@ in
     };
 
     package = lib.mkPackageOption pkgs "lact" { };
+
+    settings = lib.mkOption {
+      default = { };
+      type = lib.types.submodule {
+        freeformType = configFormat.type;
+      };
+
+      description = ''
+        Settings for LACT.
+
+        The easiest method of acquiring the settings is to delete
+        {file}`/etc/lact/config.yaml`, enter your settings and look
+        at the file.
+
+        ::: {.note}
+        When `settings` is populated, the config file will be a symbolic link
+        and thus LACT daemon will not be able to modify it through the GUI.
+        :::
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
     systemd.packages = [ cfg.package ];
 
+    environment.etc."lact/config.yaml" = lib.mkIf (cfg.settings != { }) {
+      source = configFile;
+    };
+
     systemd.services.lactd = {
       description = "LACT GPU Control Daemon";
       wantedBy = [ "multi-user.target" ];
+
+      # Restart when the config file changes.
+      restartTriggers = lib.mkIf (cfg.settings != { }) [ configFile ];
     };
   };
 }


### PR DESCRIPTION
LACT supports reading a configuration file from `/etc/lact/config.yaml`. This is
helpful to me as I prefer bootstrapping the LACT daemon automatically when I
`nixos-install` my machine, of which I already know the hardware quirks.

With this PR we write the config file if (and only if) the user fills out the
`settings` but since we

1. provide a warning in the description
2. make settings opt-in

this is an acceptable compromise. I haven't been able to test yet due to an ongoing power outage, but I'm pretty positive everything works as intended as changes. The submodule is grafted from my personal LACT module that I have been running for a while.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
