### PR TITLE
python3Packages.chromadb: disable flaky tests

### DIFF
--- a/pkgs/by-name/ve/vectorcode/package.nix
+++ b/pkgs/by-name/ve/vectorcode/package.nix
@@ -85,6 +85,7 @@ let
           # ValueError: An instance of Chroma already exists for ephemeral with different settings
           "chromadb/test/test_chroma.py"
           "chromadb/test/test_client.py"
+          "chromadb/test/ef/test_multimodal_ef.py"
         ];
       });
     };

--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -57,6 +57,7 @@
   pytestCheckHook,
   sqlite,
   starlette,
+  writableTmpDirAsHomeHook,
 
   # passthru
   nixosTests,
@@ -165,6 +166,7 @@ buildPythonPackage rec {
     pytestCheckHook
     sqlite
     starlette
+    writableTmpDirAsHomeHook
   ];
 
   # Disable on aarch64-linux due to broken onnxruntime
@@ -238,6 +240,10 @@ buildPythonPackage rec {
 
     # Cannot find protobuf file while loading test
     "chromadb/test/distributed/test_log_failover.py"
+
+    # ValueError: An instance of Chroma already exists for ephemeral with different settings
+    "chromadb/test/test_chroma.py"
+    "chromadb/test/ef/test_multimodal_ef.py"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Multiple tests `python3Packages.chromadb` fails the check phase sporadically with "ValueError: An instance of Chroma already exists for ephemeral with different settings". The common cause seems to be when two copies are running simultaneously and a test calls through to `chromadb/api/shared_system_client.py`.

So far, these errors have been:
1. Isolated to two files.
2. And involve writing to disk (and break in the sandbox). 

Fixes:
1. Disable the known test hotspots (main `chromadb` and embedded `chromadb` in `vectorcode`)
2. Enable the writeable temp dir as HOME (main `chromadb`)

Fixes #427878

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
