### PR TITLE
adios2: build on loongarch64

### DIFF
--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -22,6 +22,7 @@
   zfp,
   zlib,
   ucx,
+  libffi,
   yaml-cpp,
   nlohmann_json,
   llvmPackages,
@@ -94,7 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
     pugixml
     sqlite
     zeromq
-    zfp
     zlib
     yaml-cpp
     nlohmann_json
@@ -104,8 +104,12 @@ stdenv.mkDerivation (finalAttrs: {
     # mgard
   ]
   ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform ucx) ucx
+  ++ lib.optional (stdenv.hostPlatform.isLoongArch64) libffi
+  ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform zfp) zfp
   # openmp required by zfp
-  ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
+  ++ lib.optional (
+    lib.meta.availableOn stdenv.hostPlatform zfp && stdenv.cc.isClang
+  ) llvmPackages.openmp;
 
   propagatedBuildInputs =
     lib.optional mpiSupport mpi
@@ -122,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ADIOS2_USE_EXTERNAL_DEPENDENCIES" true)
     (lib.cmakeBool "ADIOS2_USE_Blosc2" true)
     (lib.cmakeBool "ADIOS2_USE_BZip2" true)
-    (lib.cmakeBool "ADIOS2_USE_ZFP" true)
+    (lib.cmakeBool "ADIOS2_USE_ZFP" (lib.meta.availableOn stdenv.hostPlatform zfp))
     (lib.cmakeBool "ADIOS2_USE_SZ" false)
     (lib.cmakeBool "ADIOS2_USE_LIBPRESSIO" false)
     (lib.cmakeBool "ADIOS2_USE_MGARD" false)


### PR DESCRIPTION
zfp is not avaiable on loongarch64, hence an optional buildInputs.
thirdParty module DIll has no native code for loongarch64, hence use libffi for emulation, see:
https://github.com/ornladios/ADIOS2/blob/b7a5957a15e5458f6e3650a01a88d73950f6c161/thirdparty/dill/dill/CMakeLists.txt#L209-212

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
