### PR TITLE
nixos/hedgedoc: add configureNginx option

### DIFF
--- a/nixos/modules/services/web-apps/hedgedoc.nix
+++ b/nixos/modules/services/web-apps/hedgedoc.nix
@@ -47,6 +47,12 @@ in
     package = lib.mkPackageOption pkgs "hedgedoc" { };
     enable = lib.mkEnableOption "the HedgeDoc Markdown Editor";
 
+    configureNginx = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to configure nginx as a reverse proxy.";
+    };
+
     settings = mkOption {
       type = types.submodule {
         freeformType = settingsFormat.type;
@@ -249,10 +255,32 @@ in
       isSystemUser = true;
     };
 
-    services.hedgedoc.settings = {
-      defaultNotePath = lib.mkDefault "${cfg.package}/share/hedgedoc/public/default.md";
-      docsPath = lib.mkDefault "${cfg.package}/share/hedgedoc/public/docs";
-      viewPath = lib.mkDefault "${cfg.package}/share/hedgedoc/public/views";
+    services = {
+      hedgedoc.settings = {
+        defaultNotePath = lib.mkDefault "${cfg.package}/share/hedgedoc/public/default.md";
+        docsPath = lib.mkDefault "${cfg.package}/share/hedgedoc/public/docs";
+        viewPath = lib.mkDefault "${cfg.package}/share/hedgedoc/public/views";
+      };
+
+      nginx = lib.mkIf cfg.configureNginx.enable {
+        enable = true;
+        upstreams.hedgedoc.servers."unix:${config.services.hedgedoc.settings.path}" = { };
+        virtualHosts."${cfg.settings.domain}" = {
+          enableACME = true;
+          forceSSL = true;
+          locations = {
+            "/" = {
+              proxyPass = "http://hedgedoc";
+              recommendedProxySettings = true;
+            };
+            "/socket.io/" = {
+              proxyPass = "http://hedgedoc";
+              proxyWebsockets = true;
+              recommendedProxySettings = true;
+            };
+          };
+        };
+      };
     };
 
     systemd.services.hedgedoc = {


### PR DESCRIPTION
I forgot to configure that web sockets are proxied...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] with a real world deployment
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
