### PR TITLE
ceph: arrow 19 compilation fix with protobuf 30; snappy: restore of RTTI patch

### DIFF
--- a/pkgs/by-name/sn/snappy/package.nix
+++ b/pkgs/by-name/sn/snappy/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  fetchpatch,
   static ? stdenv.hostPlatform.isStatic,
 }:
 
@@ -19,6 +20,22 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./revert-PUBLIC.patch
+    # Re-enable RTTI, without which other applications can't subclass snappy::Source
+    # While the patch was rejected upstream, it does not make it any less necessary to carry forward.
+    # ==> lack of RTTI *breaks* Ceph (and others) <==
+    #
+    # https://tracker.ceph.com/issues/53060
+    # https://build.opensuse.org/package/show/openSUSE:Factory/snappy
+    #
+    # Should this patch fail to apply use the above site to get the updated patch (rev in the url below).
+    # On the page there's a "latest revision" section which lists the last request which was merged into it.
+    # Click the "Request <insert number>" link, then view any file using "View file", and copy the rev from your address bar.
+    # For a different revision (in case nixpkgs is behind or something) you can go through the full revision history.
+    # Should the patch not be available for the nixpkgs version, ideally wait until the patch becomes available before bumping, or vendor it if necessary.
+    (fetchpatch {
+      url = "https://build.opensuse.org/public/source/openSUSE:Factory/snappy/reenable-rtti.patch?rev=e3449869b466869fc6b8a03a1a528fa6";
+      hash = "sha256-JhVhkHh7XPx1Bzf5xnOgWLgwh1oihX3O+emQWzE4Dho=";
+    })
   ];
 
   outputs = [

--- a/pkgs/tools/filesystems/ceph/arrow-cpp-19.nix
+++ b/pkgs/tools/filesystems/ceph/arrow-cpp-19.nix
@@ -8,6 +8,7 @@
   stdenv,
   lib,
   fetchurl,
+  fetchpatch2,
   fetchFromGitHub,
   fixDarwinDylibNames,
   autoconf,
@@ -42,7 +43,7 @@
   openssl,
   perl,
   pkg-config,
-  protobuf_29,
+  protobuf,
   python3,
   rapidjson,
   re2,
@@ -67,9 +68,6 @@
 }:
 
 let
-  # https://github.com/apache/arrow/issues/45807
-  protobuf = protobuf_29;
-
   arrow-testing = fetchFromGitHub {
     name = "arrow-testing";
     owner = "apache";
@@ -100,6 +98,15 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   sourceRoot = "${finalAttrs.src.name}/cpp";
+
+  patches = [
+    (fetchpatch2 {
+      name = "protobuf-30-compat.patch";
+      url = "https://github.com/apache/arrow/pull/46136.patch";
+      hash = "sha256-WTpe/eT3himlCHN/R78w1sF0HG859mE2ZN70U+9N8Ag=";
+      stripLen = 1;
+    })
+  ];
 
   # versions are all taken from
   # https://github.com/apache/arrow/blob/apache-arrow-${version}/cpp/thirdparty/versions.txt


### PR DESCRIPTION
It seems that Arrow 20 which broke compilation initially causes issues with our tests when the patch which was merged upstream is applied. At the same time the bundled Arrow 17 can't work with current Re2 due to its C++ version. The thing that broke the Arrow 19 build is because Arrow 19 is itself not compatible with Protobuf 30, which is pulled in somewhere along the dependency graph by something else causing linking issues. However, the patch for Protobuf 30 compat applies cleanly to our Arrow 19, which means we can dump the older version pin and instead use this patch to get Arrow 19 working again.

---

Resolves #426401
Supersedes #426609 (here's to hoping the next Ceph major version will have less issues with arrow)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
