### PR TITLE
nixos/tlsrpt: fix permissions for postfix

### DIFF
--- a/nixos/modules/services/mail/tlsrpt.nix
+++ b/nixos/modules/services/mail/tlsrpt.nix
@@ -270,9 +270,17 @@ in
       };
     };
 
-    systemd.services.postfix.serviceConfig.SupplementaryGroups = mkIf (
-      config.services.postfix.enable && cfg.collectd.configurePostfix
-    ) [ "tlsrpt" ];
+    users.users.tlsrpt = {
+      isSystemUser = true;
+      group = "tlsrpt";
+    };
+    users.groups.tlsrpt = { };
+
+    users.users.postfix.extraGroups =
+      lib.mkIf (config.services.postfix.enable && cfg.collectd.configurePostfix)
+        [
+          "tlsrpt"
+        ];
 
     systemd.services.tlsrpt-collectd = {
       description = "TLSRPT datagram collector";

--- a/nixos/tests/tlsrpt.nix
+++ b/nixos/tests/tlsrpt.nix
@@ -35,7 +35,7 @@
 
     # Enabling postfix should put sendmail as the sendmail setting
     machine.succeed("grep -q sendmail_script=sendmail /etc/tlsrpt/reportd.cfg")
-    machine.succeed("systemctl show --property SupplementaryGroups postfix.service | grep tlsrpt")
+    machine.succeed("getent group tlsrpt | grep -q postfix")
 
     machine.log(machine.succeed("systemd-analyze security tlsrpt-collectd.service tlsrpt-reportd.service | grep -v ✓"))
   '';


### PR DESCRIPTION
Same as with other services giving postfix access, this needs to happen for the postfix user. Adding supplementary group permissions to the systemd unit does not propagate to child processes that ultimately call the unix domain socket.

Tested in my private mail setup.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
