### PR TITLE
treewide: replace `rev` with `tag` in fetchFromGitHub

### DIFF
--- a/pkgs/by-name/as/ashuffle/package.nix
+++ b/pkgs/by-name/as/ashuffle/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "joshkunz";
     repo = "ashuffle";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-HQ4+vyTvX0mhfuRclbiC+MvllV3300ztAwL0IxrUiC8=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/au/augeas/package.nix
+++ b/pkgs/by-name/au/augeas/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "hercules-team";
     repo = "augeas";
-    rev = "release-${version}";
+    tag = "release-${version}";
     fetchSubmodules = true;
     hash = "sha256-U5tm3LDUeI/idHtL2Zy33BigkyvHunXPjToDC59G9VE=";
   };

--- a/pkgs/by-name/av/avalonia/package.nix
+++ b/pkgs/by-name/av/avalonia/package.nix
@@ -51,7 +51,7 @@ stdenvNoCC.mkDerivation (
       src = fetchFromGitHub {
         owner = "AvaloniaUI";
         repo = "Avalonia";
-        rev = version;
+        tag = version;
         fetchSubmodules = true;
         hash = "sha256-b7K8h2hqkLnXj3YIaRKUqlbWsDNhfWCEqH1W8K0lP6g=";
       };

--- a/pkgs/by-name/aw/awk-language-server/package.nix
+++ b/pkgs/by-name/aw/awk-language-server/package.nix
@@ -13,7 +13,7 @@ mkYarnPackage rec {
   src = fetchFromGitHub {
     owner = "Beaglefoot";
     repo = "awk-language-server";
-    rev = "server-${version}";
+    tag = "server-${version}";
     hash = "sha256-YtduDfMAUAoQY9tgyhgERFwx9TEgD52KdeHnX2MrjjI=";
     sparseCheckout = [ "server" ];
     postFetch = ''

--- a/pkgs/by-name/bc/bchoppr/package.nix
+++ b/pkgs/by-name/bc/bchoppr/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sjaehn";
     repo = "bchoppr";
-    rev = version;
+    tag = version;
     hash = "sha256-/aLoLUpWu66VKd9lwjli+FZZctblrZUPSEsdYH85HwQ=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/be/bespokesynth/package.nix
+++ b/pkgs/by-name/be/bespokesynth/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "BespokeSynth";
     repo = "bespokesynth";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ad8wdLos3jM0gRMpcfRKeaiUxJsPGqWd/7XeDz87ToQ=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/bi/bio-gappa/package.nix
+++ b/pkgs/by-name/bi/bio-gappa/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "lczech";
     repo = "gappa";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-WV8PO0v+e14tyjEm+xQGveQ0Pslgeh+osEMCqF8mue0=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/bi/biodiff/package.nix
+++ b/pkgs/by-name/bi/biodiff/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "8051Enthusiast";
     repo = "biodiff";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-ZLxjOV08sC5dKICvRUyL6FLMORkxwdLgNq7L45CDwa4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/bi/bitbox/package.nix
+++ b/pkgs/by-name/bi/bitbox/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "BitBoxSwiss";
     repo = "bitbox-wallet-app";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-zpkjYnGsmPKjxUpp2H1qSzqthOO1mTmki3bPqo35sBo=";
   };

--- a/pkgs/by-name/bl/blink1-tool/package.nix
+++ b/pkgs/by-name/bl/blink1-tool/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "todbot";
     repo = "blink1-tool";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-xuCjPSQUQ/KOcdsie/ndecUiEt+t46m4eI33PXJoAAY=";
   };

--- a/pkgs/by-name/bo/boa/package.nix
+++ b/pkgs/by-name/bo/boa/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "boa-dev";
     repo = "boa";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-foCIzzFoEpcE6i0QrSbiob3YHIOeTpjwpAMtcPGL8Vg=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/bo/bom/package.nix
+++ b/pkgs/by-name/bo/bom/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = "bom";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-nYzBaFtOJhqO0O6MJsxTw/mxsIOa+cnU27nOFRe2/uI=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.

--- a/pkgs/by-name/br/brewtarget/package.nix
+++ b/pkgs/by-name/br/brewtarget/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Brewtarget";
     repo = "brewtarget";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-VVdihVdNIAtPlugqGWDWvxMdOFGLnRmewPt6BgvbxBk=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/br/brickstore/package.nix
+++ b/pkgs/by-name/br/brickstore/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "rgriebl";
     repo = "brickstore";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-4sxPplZ1t8sSfwTCeeBtfU4U0gcE9FROt6dKvkfyO6Q=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/bs/bs2b-lv2/package.nix
+++ b/pkgs/by-name/bs/bs2b-lv2/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nilninull";
     repo = "bs2b-lv2";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-dOcDPtiKN9Kfs2cdaeDO/GkWrh5tfJSHfiHPBtxJXvc=";
   };

--- a/pkgs/by-name/bu/budgie-control-center/package.nix
+++ b/pkgs/by-name/bu/budgie-control-center/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "BuddiesOfBudgie";
     repo = "budgie-control-center";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-W5PF7BPdQdg/7xJ4J+fEnuDdpoG/lyhX56RDnX2DXoY=";
   };

--- a/pkgs/by-name/bu/budgie-desktop/package.nix
+++ b/pkgs/by-name/bu/budgie-desktop/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "BuddiesOfBudgie";
     repo = "budgie-desktop";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-lDsQlUAa79gnM8wC5pwyquvFyEiayH4W4gD/uyC5Koo=";
   };

--- a/pkgs/by-name/bu/bugdom/package.nix
+++ b/pkgs/by-name/bu/bugdom/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "jorio";
     repo = "bugdom";
-    rev = version;
+    tag = version;
     hash = "sha256-0c7v5tSqYuqtLOFl4sqD7+naJNqX/wlKHVntkZQGJ8A=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/bu/bulk_extractor/package.nix
+++ b/pkgs/by-name/bu/bulk_extractor/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "simsong";
     repo = "bulk_extractor";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Jj/amXESFBu/ZaiIRlDKmtWTBVQ2TEvOM2jBYP3y1L8=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ca/catppuccin-gtk/package.nix
+++ b/pkgs/by-name/ca/catppuccin-gtk/package.nix
@@ -70,7 +70,7 @@ lib.checkListOfEnum "${pname}: theme accent" validAccents accents lib.checkListO
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "gtk";
-      rev = "v${version}";
+      tag = "v${version}";
       fetchSubmodules = true;
       hash = "sha256-q5/VcFsm3vNEw55zq/vcM11eo456SYE5TQA3g2VQjGc=";
     };

--- a/pkgs/by-name/ch/chow-centaur/package.nix
+++ b/pkgs/by-name/ch/chow-centaur/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jatinchowdhury18";
     repo = "KlonCentaur";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-kDDom6q0Tgni0/L+FgBVZC1/sL9W9fRP60U4o4ijP1c=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ch/chow-kick/package.nix
+++ b/pkgs/by-name/ch/chow-kick/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Chowdhury-DSP";
     repo = "ChowKick";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-YYcNiJGGw21aVY03tyQLu3wHCJhxYiDNJZ+LWNbQdj4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ch/chow-phaser/package.nix
+++ b/pkgs/by-name/ch/chow-phaser/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jatinchowdhury18";
     repo = "ChowPhaser";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-9wo7ZFMruG3QNvlpILSvrFh/Sx6J1qnlWc8+aQyS4tQ=";
   };

--- a/pkgs/by-name/ch/chow-tape-model/package.nix
+++ b/pkgs/by-name/ch/chow-tape-model/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jatinchowdhury18";
     repo = "AnalogTapeModel";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-WriHi68Y6hAsrwE+74JtVlAKUR9lfTczj6UK9h2FOGM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/cl/cloudcompare/package.nix
+++ b/pkgs/by-name/cl/cloudcompare/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "CloudCompare";
     repo = "CloudCompare";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-a/0lf3Mt5ZpLFRM8jAoqZer8pY1ROgPRY4dPt34Bk3E=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/cm/cmdstan/package.nix
+++ b/pkgs/by-name/cm/cmdstan/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "stan-dev";
     repo = "cmdstan";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-9Dan86C0nxxxkIXaOSKExY0hngAgWTpL4RlI3rTnBZo=";
   };

--- a/pkgs/by-name/co/codecrafters-cli/package.nix
+++ b/pkgs/by-name/co/codecrafters-cli/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "codecrafters-io";
     repo = "cli";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-YgQPDc5BUIoEd44NLpRluxCKooW99qvcSTrFPm6qJKM=";
     # A shortened git commit hash is part of the version output, and is
     # needed at build time. Use the `.git` directory to retrieve the

--- a/pkgs/by-name/co/colima/package.nix
+++ b/pkgs/by-name/co/colima/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "abiosoft";
     repo = "colima";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-RQnHqEabxyoAKr8BfmVhk8z+l5oy8pa5JPTWk/0FV5g=";
     # We need the git revision
     leaveDotGit = true;

--- a/pkgs/by-name/co/convimg/package.nix
+++ b/pkgs/by-name/co/convimg/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mateoconlechuga";
     repo = "convimg";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-5insJ391Usef8GF3Yh74PEqE534zitQg9udFRPcz69g=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/cp/cp2k/package.nix
+++ b/pkgs/by-name/cp/cp2k/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cp2k";
     repo = "cp2k";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-04AFiEuv+EYubZVoYErQDdr9zipKlF7Gqy8DrUaYUMk=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/cp/cpp-netlib/package.nix
+++ b/pkgs/by-name/cp/cpp-netlib/package.nix
@@ -18,7 +18,7 @@ stdenvForCppNetlib.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cpp-netlib";
     repo = "cpp-netlib";
-    rev = "cpp-netlib-${version}";
+    tag = "cpp-netlib-${version}";
     sha256 = "18782sz7aggsl66b4mmi1i0ijwa76iww337fi9sygnplz2hs03a3";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/cp/cpp-redis/package.nix
+++ b/pkgs/by-name/cp/cpp-redis/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cpp-redis";
     repo = "cpp_redis";
-    rev = version;
+    tag = version;
     hash = "sha256-dLAnxgldylWWKO3WIyx+F7ylOpRH+0nD7NZjWSOxuwQ=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/cr/crc32c/package.nix
+++ b/pkgs/by-name/cr/crc32c/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "crc32c";
-    rev = version;
+    tag = version;
     sha256 = "0c383p7vkfq9rblww6mqxz8sygycyl27rr0j3bzb8l8ga71710ii";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/cr/criterion/package.nix
+++ b/pkgs/by-name/cr/criterion/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Snaipe";
     repo = "Criterion";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-5GH7AYjrnBnqiSmp28BoaM1Xmy8sPs1atfqJkGy3Yf0=";
   };

--- a/pkgs/by-name/de/design/package.nix
+++ b/pkgs/by-name/de/design/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "dubstar-04";
     repo = "Design";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-Q4R/Ztu4w8IRvq15xNXN/iP/6hIHe/W+me1jROGpYc8=";
   };

--- a/pkgs/by-name/de/detect-it-easy/package.nix
+++ b/pkgs/by-name/de/detect-it-easy/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "horsicq";
     repo = "DIE-engine";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-yHgxYig5myY2nExweUk2muKbJTKN3SiwOLgQcMIY/BQ=";
   };

--- a/pkgs/by-name/dr/dragmap/package.nix
+++ b/pkgs/by-name/dr/dragmap/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Illumina";
     repo = "DRAGMAP";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-f1jsOErriS1I/iUS4CzJ3+Dz8SMUve/ccb3KaE+L7U8=";
   };

--- a/pkgs/by-name/dr/dragonfly-reverb/package.nix
+++ b/pkgs/by-name/dr/dragonfly-reverb/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "michaelwillis";
     repo = "dragonfly-reverb";
-    rev = version;
+    tag = version;
     hash = "sha256-YXJ4U5J8Za+DlXvp6QduvCHIVC2eRJ3+I/KPihCaIoY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/dr/dragonflydb/package.nix
+++ b/pkgs/by-name/dr/dragonflydb/package.nix
@@ -32,7 +32,7 @@ let
   src = fetchFromGitHub {
     owner = pname;
     repo = "dragonfly";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-P6WMW/n+VezWDXGagT4B+ZYyCp8oufDV6MTrpKpLZcs=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/dr/drogon/package.nix
+++ b/pkgs/by-name/dr/drogon/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "drogonframework";
     repo = "drogon";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-eFOYmqfyb/yp83HRa0hWSMuROozR/nfnEp7k5yx8hj0=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/dx/dxvk_2/package.nix
+++ b/pkgs/by-name/dx/dxvk_2/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "doitsujin";
     repo = "dxvk";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-edu9JQAKu8yUZLh+37RB1s1A3+s8xeUYQ5Oibdes9ZI=";
     fetchSubmodules = true; # Needed for the DirectX headers and libdisplay-info
   };

--- a/pkgs/by-name/ed/editorconfig-core-c/package.nix
+++ b/pkgs/by-name/ed/editorconfig-core-c/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "editorconfig";
     repo = "editorconfig-core-c";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-myJNJxKwgmgm+P2MqnYmW8OC0oYcInL+Suyf/xwX9xo=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ei/eiwd/package.nix
+++ b/pkgs/by-name/ei/eiwd/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "illiliti";
     repo = "eiwd";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-rmkXR4RZbtD6lh8cGrHLWVGTw4fQqP9+Z9qaftG1ld0=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/en/encpipe/package.nix
+++ b/pkgs/by-name/en/encpipe/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "jedisct1";
     repo = "encpipe";
-    rev = version;
+    tag = version;
     hash = "sha256-YlEKSWzZuQyDi0mbwJh9Dfn4gKiOeqihSHPt4yY6YdY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/eo/eos-installer/package.nix
+++ b/pkgs/by-name/eo/eos-installer/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "endlessm";
     repo = "eos-installer";
-    rev = "Release_${version}";
+    tag = "Release_${version}";
     sha256 = "BqvZglzFJabGXkI8hnLiw1r+CvM7kSKQPj8IKYBB6S4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/er/erigon/package.nix
+++ b/pkgs/by-name/er/erigon/package.nix
@@ -15,7 +15,7 @@ buildGoModule {
   src = fetchFromGitHub {
     owner = "ledgerwatch";
     repo = "erigon";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-MQpHRlKxWCBD2Tj9isxMKwvYBy9HtDkQPyKPse8uB3g=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/et/eternity/package.nix
+++ b/pkgs/by-name/et/eternity/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "team-eternity";
     repo = "eternity";
-    rev = version;
+    tag = version;
     sha256 = "0dlz7axbiw003bgwk2hl43w8r2bwnxhi042i1xwdiwaja0cpnf5y";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ez/ezquake/package.nix
+++ b/pkgs/by-name/ez/ezquake/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "QW-Group";
     repo = pname + "-source";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-ThrsJfj+eP7Lv2ZSNLO6/b98VHrL6/rhwf2p0qMvTF8=";
   };

--- a/pkgs/by-name/fa/fastddsgen/package.nix
+++ b/pkgs/by-name/fa/fastddsgen/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "eProsima";
     repo = "Fast-DDS-Gen";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-4w6DYz0QhD8L27FE+SzptfoMjhiuJ6OFex2LNAqwmPw=";
   };

--- a/pkgs/by-name/fa/faust2/package.nix
+++ b/pkgs/by-name/fa/faust2/package.nix
@@ -28,7 +28,7 @@ let
   src = fetchFromGitHub {
     owner = "grame-cncm";
     repo = "faust";
-    rev = version;
+    tag = version;
     hash = "sha256-Rn+Cjpk4vttxARrkDSnpKdBdSRtgElsit8zu1BA8Jd4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/fa/faustlive/package.nix
+++ b/pkgs/by-name/fa/faustlive/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "grame-cncm";
     repo = "faustlive";
-    rev = version;
+    tag = version;
     hash = "sha256-RqtdDkP63l/30sL5PDocvpar5TI4LdKfeeliSNeOHog=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/fe/feather/package.nix
+++ b/pkgs/by-name/fe/feather/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "feather-wallet";
     repo = "feather";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-DZBRZBcoba32Z/bFThn/9siC8VESg5gdfoFO4Nw8JqM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/fi/firestarter/package.nix
+++ b/pkgs/by-name/fi/firestarter/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tud-zih-energy";
     repo = "FIRESTARTER";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "1ik6j1lw5nldj4i3lllrywqg54m9i2vxkxsb2zr4q0d2rfywhn23";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/fl/flutter_rust_bridge_codegen/package.nix
+++ b/pkgs/by-name/fl/flutter_rust_bridge_codegen/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "fzyzcjy";
     repo = "flutter_rust_bridge";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Us+LwT6tjBcTl2xclVsiLauSlIO8w+PiokpiDB+h1fI=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/fl/flycast/package.nix
+++ b/pkgs/by-name/fl/flycast/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "flyinghead";
     repo = "flycast";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-OnlSkwPDUrpj9uEPEAxZO1iSgd5ZiQUJLneu14v9pKQ=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/fn/fna3d/package.nix
+++ b/pkgs/by-name/fn/fna3d/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "FNA-XNA";
     repo = "FNA3D";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-0rRwIbOciPepo+ApvJiK5IyhMdq/4jsMlCSv0UeDETs=";
   };

--- a/pkgs/by-name/fo/foxotron/package.nix
+++ b/pkgs/by-name/fo/foxotron/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Gargaj";
     repo = "Foxotron";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-OnZWoiQ5ASKQV73/W6nl17B2ANwqCy/PlybHbNwrOyQ=";
   };

--- a/pkgs/by-name/fr/freebayes/package.nix
+++ b/pkgs/by-name/fr/freebayes/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     name = "freebayes-${version}-src";
     owner = "ekg";
     repo = "freebayes";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "035nriknjqq8gvil81vvsmvqwi35v80q8h1cw24vd1gdyn1x7bys";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -62,7 +62,7 @@ freecad-utils.makeCustomizable (
     src = fetchFromGitHub {
       owner = "FreeCAD";
       repo = "FreeCAD";
-      rev = finalAttrs.version;
+      tag = finalAttrs.version;
       hash = "sha256-VFTNawXxu2ofjj2Frg4OfVhiMKFywBhm7lZunP85ZEQ=";
       fetchSubmodules = true;
     };

--- a/pkgs/by-name/fu/fulcio/package.nix
+++ b/pkgs/by-name/fu/fulcio/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "sigstore";
     repo = "fulcio";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-UVUVT4RvNHvzIwV6azu2h1O9lnNu0PQnnkj4wbrY8BA=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.

--- a/pkgs/by-name/ge/gebaar-libinput/package.nix
+++ b/pkgs/by-name/ge/gebaar-libinput/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Coffee2CodeNL";
     repo = "gebaar-libinput";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "1kqcgwkia1p195xr082838dvj1gqif9d63i8a52jb0lc32zzizh6";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ge/gerbolyze/package.nix
+++ b/pkgs/by-name/ge/gerbolyze/package.nix
@@ -12,7 +12,7 @@ let
   src = fetchFromGitHub {
     owner = "jaseg";
     repo = "gerbolyze";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-bisLln3Y239HuJt0MkrCU+6vLLbEDxfTjEJMkcbE/wE=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/gf/gfxreconstruct/package.nix
+++ b/pkgs/by-name/gf/gfxreconstruct/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "LunarG";
     repo = "gfxreconstruct";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-MuCdJoBFxKwDCOCltlU3oBS9elFS6F251dHjHcIb4Jg=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/gi/gimx/package.nix
+++ b/pkgs/by-name/gi/gimx/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "matlo";
     repo = "GIMX";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-BcFLdQgEAi6Sxyb5/P9YAIkmeXNZXrKcOa/6g817xQg=";
   };

--- a/pkgs/by-name/gi/git-get/package.nix
+++ b/pkgs/by-name/gi/git-get/package.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "grdl";
     repo = "git-get";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-v98Ff7io7j1LLzciHNWJBU3LcdSr+lhwYrvON7QjyCI=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.

--- a/pkgs/by-name/gi/gitqlient/package.nix
+++ b/pkgs/by-name/gi/gitqlient/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "francescmm";
     repo = "gitqlient";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-gfWky5KTSj+5FC++QIVTJbrDOYi/dirTzs6LvTnO74A=";
   };

--- a/pkgs/by-name/gl/glslls/package.nix
+++ b/pkgs/by-name/gl/glslls/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "svenstaro";
     repo = "glsl-language-server";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-wi1QiqaWRh1DmIhwmu94lL/4uuMv6DnB+whM61Jg1Zs=";
   };

--- a/pkgs/by-name/gl/glslviewer/package.nix
+++ b/pkgs/by-name/gl/glslviewer/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "patriciogonzalezvivo";
     repo = "glslViewer";
     fetchSubmodules = true;
-    rev = version;
+    tag = version;
     hash = "sha256-Ve3wmX5+kABCu8IRe4ySrwsBJm47g1zvMqDbqrpQl88=";
   };
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnustep-libobjc/package.nix
+++ b/pkgs/by-name/gn/gnustep-libobjc/package.nix
@@ -13,7 +13,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "gnustep";
     repo = "libobjc2";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-+NP214bbisk7dCFAHaxnhNOfC/0bZLp8Dd2A9F2vK+s=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/go/gossa/package.nix
+++ b/pkgs/by-name/go/gossa/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "pldubouilh";
     repo = "gossa";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-FGlUj0BJ8KeCfvdN9+NG4rqtaUIxgpqQ+09Ie1/TpAQ=";
   };

--- a/pkgs/by-name/gr/grandorgue/package.nix
+++ b/pkgs/by-name/gr/grandorgue/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "GrandOrgue";
     repo = "grandorgue";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-9H7YpTtv9Y36Nc0WCyRy/ohpOQ3WVUd9gMahnGhANRc=";
   };

--- a/pkgs/by-name/gr/grenedalf/package.nix
+++ b/pkgs/by-name/gr/grenedalf/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "lczech";
     repo = "grenedalf";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-DJ7nZjOvYFQlN/L+S2QcMVvH/M9Dhla4VXl2nxc22m4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/gr/grpc-tools/package.nix
+++ b/pkgs/by-name/gr/grpc-tools/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "grpc";
     repo = "grpc-node";
-    rev = "grpc-tools@${version}";
+    tag = "grpc-tools@${version}";
     hash = "sha256-708lBIGW5+vvSTrZHl/kc+ck7JKNXElrghIGDrMSyx8=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/gr/grpc/package.nix
+++ b/pkgs/by-name/gr/grpc/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "grpc";
     repo = "grpc";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-VAr+f+xqZfrP4XfCnZ9KxVTO6pHQe9gB2DgaQuen840=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/gx/gxplugins-lv2/package.nix
+++ b/pkgs/by-name/gx/gxplugins-lv2/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "brummer10";
     repo = "GxPlugins.lv2";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-NvmFoOAQtAnKrZgzG1Shy1HuJEWgjJloQEx6jw59hag=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/he/helio-workstation/package.nix
+++ b/pkgs/by-name/he/helio-workstation/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "helio-fm";
     repo = "helio-workstation";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-JzJA9Y710upgzvsgPEV9QzpRUTYI0i2yi6thnUAcrL0=";
   };

--- a/pkgs/by-name/ic/ictree/package.nix
+++ b/pkgs/by-name/ic/ictree/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "NikitaIvanovV";
     repo = "ictree";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-77Wo6jN8VUGTXBuGL0a9kvSIixdyEQoxqqNsHq9jcWw=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/il/illum/package.nix
+++ b/pkgs/by-name/il/illum/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "jmesmon";
     repo = "illum";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "S4lUBeRnZlRUpIxFdN/bh979xvdS7roF6/6Dk0ZUrnM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/im/imagelol/package.nix
+++ b/pkgs/by-name/im/imagelol/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "MCRedstoner2004";
     repo = "imagelol";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "0978zdrfj41jsqm78afyyd1l64iki9nwjvhd8ynii1b553nn4dmd";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/in/inferno/package.nix
+++ b/pkgs/by-name/in/inferno/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "jonhoo";
     repo = "inferno";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-D72rkTnUgLJRHFEDoUwQDLQJAPGyqmxhf6hmNJGUl+U=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/iq/iqtree/package.nix
+++ b/pkgs/by-name/iq/iqtree/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "iqtree";
     repo = "iqtree2";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-8d5zqZIevv3bnq7z7Iyo/x8i445y1RAFtRMeK8s/ieQ=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/it/itgmania/package.nix
+++ b/pkgs/by-name/it/itgmania/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "itgmania";
     repo = "itgmania";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-C9qVUZdRnKbQgfgbXnzT+lI2+FEXBaMQv/U6UF5wyzo=";
   };

--- a/pkgs/by-name/je/jetbrains-runner/package.nix
+++ b/pkgs/by-name/je/jetbrains-runner/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "alex1701c";
     repo = "JetBrainsRunner";
-    rev = version;
+    tag = version;
     hash = "sha256-fzGwwvBgvUVU6Ra66KrIAqRjWWR6pWYbWVkOk2tDwkc=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ju/junction/package.nix
+++ b/pkgs/by-name/ju/junction/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sonnyp";
     repo = "junction";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-gnFig8C46x73gAUl9VVx3Y3hrhEVeP/DvaYHYuv9RTg=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/kd/kdigger/package.nix
+++ b/pkgs/by-name/kd/kdigger/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "quarkslab";
     repo = "kdigger";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-hpLhtTENtOBQjm+CZRAcx1BG9831JUFIsLL57wZIrso=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.

--- a/pkgs/by-name/kl/klystrack/package.nix
+++ b/pkgs/by-name/kl/klystrack/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "kometbomb";
     repo = "klystrack";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     sha256 = "1h99sm2ddaq483hhk2s3z4bjbgn0d2h7qna7l7qq98wvhqix8iyz";
   };

--- a/pkgs/by-name/ld/ldacbt/package.nix
+++ b/pkgs/by-name/ld/ldacbt/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     repo = "ldacBT";
     owner = "ehfive";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "09dalysx4fgrgpfdm9a51x6slnf4iik1sqba4xjgabpvq91bnb63";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ld/ldc/package.nix
+++ b/pkgs/by-name/ld/ldc/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ldc-developers";
     repo = "ldc";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-6LcpY3LSFK4KgEiGrFp/LONu5Vr+/+vI04wEEpF3s+s=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -30,7 +30,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "eclipse";
     repo = "lemminx";
-    rev = version;
+    tag = version;
     hash = "sha256-a+9RN1265fsmYAUMuUTxA+VqJv7xPlzuc8HqoZwmR4M=";
     # Lemminx reads this git information at runtime from a git.properties
     # file on the classpath

--- a/pkgs/by-name/le/leptosfmt/package.nix
+++ b/pkgs/by-name/le/leptosfmt/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "bram209";
     repo = "leptosfmt";
-    rev = version;
+    tag = version;
     hash = "sha256-+trLQFU8oP45xHQ3DsEESQzQX2WpvQcfpgGC9o5ITcY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/li/libbladeRF/package.nix
+++ b/pkgs/by-name/li/libbladeRF/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Nuand";
     repo = "bladeRF";
-    rev = "libbladeRF_v${version}";
+    tag = "libbladeRF_v${version}";
     hash = "sha256-H40w5YKp6M3QLrsPhILEnJiWutCYLtbgC4a63sV397Q=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/li/libcaption/package.nix
+++ b/pkgs/by-name/li/libcaption/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "szatmary";
     repo = "libcaption";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-OBtxoFJF0cxC+kfSK8TIKIdLkmCh5WOJlI0fejnisJo=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/li/libcgroup/package.nix
+++ b/pkgs/by-name/li/libcgroup/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "libcgroup";
     repo = "libcgroup";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-kWW9ID/eYZH0O/Ge8pf3Cso4yu644R5EiQFYfZMcizs=";
   };

--- a/pkgs/by-name/li/libff/package.nix
+++ b/pkgs/by-name/li/libff/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "scipr-lab";
     repo = "libff";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "0dczi829497vqlmn6n4fgi89bc2h9f13gx30av5z2h6ikik7crgn";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/li/libime/package.nix
+++ b/pkgs/by-name/li/libime/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "fcitx";
     repo = "libime";
-    rev = version;
+    tag = version;
     hash = "sha256-liVJEBUYcVYjjJCMW68xXbEHKQpAgTLCPm2yIdWG3IQ=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/li/libjxl/package.nix
+++ b/pkgs/by-name/li/libjxl/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "libjxl";
     repo = "libjxl";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-ORwhKOp5Nog366UkLbuWpjz/6sJhxUO6+SkoJGH+3fE=";
     # There are various submodules in `third_party/`.
     fetchSubmodules = true;

--- a/pkgs/by-name/li/libnitrokey/package.nix
+++ b/pkgs/by-name/li/libnitrokey/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "libnitrokey";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-4PEZ31QyVOmdhpKqTN8fwcHoLuu+w+OJ3fZeqwlE+io=";
     # On OSX, libnitrokey depends on a custom version of hidapi in a submodule.
     # Monitor https://github.com/Nitrokey/libnitrokey/issues/140 to see if we

--- a/pkgs/by-name/li/libredwg/package.nix
+++ b/pkgs/by-name/li/libredwg/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "LibreDWG";
     repo = "libredwg";
-    rev = version;
+    tag = version;
     hash = "sha256-FlBHwNsqVSBE8dTDewoKkCbs8Jd/4d69MPpEFzg6Ruc=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/li/libresprite/package.nix
+++ b/pkgs/by-name/li/libresprite/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "LibreSprite";
     repo = "LibreSprite";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-jXjrA859hR46Cp5qi6Z1C+hLWCUR7yGlASOGlTveeW8=";
   };

--- a/pkgs/by-name/li/librum/package.nix
+++ b/pkgs/by-name/li/librum/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Librum-Reader";
     repo = "Librum";
-    rev = "v.${version}";
+    tag = "v.${version}";
     fetchSubmodules = true;
     hash = "sha256-Iwcbcz8LrznFP8rfW6mg9p7klAtTx4daFxylTeFKrH0=";
   };

--- a/pkgs/by-name/li/libsidplayfp/package.nix
+++ b/pkgs/by-name/li/libsidplayfp/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "libsidplayfp";
     repo = "libsidplayfp";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-rK7Il8WE4AJbn7GKn21fXr1o+DDdyOjfJ0saeqcZ5Pg=";
   };

--- a/pkgs/by-name/li/libstaden-read/package.nix
+++ b/pkgs/by-name/li/libstaden-read/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jkbonfield";
     repo = "io_lib";
-    rev = "io_lib-" + builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version;
+    tag = "io_lib-" + builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-X96gFrefH2NAp4+fvVLXHP9FbF04gQOWLm/tAFJPgR8=";
   };

--- a/pkgs/by-name/li/libsurvive/package.nix
+++ b/pkgs/by-name/li/libsurvive/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cntools";
     repo = "libsurvive";
-    rev = "v${version}";
+    tag = "v${version}";
     # Fixes 'Unknown CMake command "cnkalman_generate_code"'
     fetchSubmodules = true;
     hash = "sha256-NcxdTKra+YkLt/iu9+1QCeQZLV3/qlhma2Ns/+ZYVsk=";

--- a/pkgs/by-name/li/libtorrent-rasterbar-2_0_x/package.nix
+++ b/pkgs/by-name/li/libtorrent-rasterbar-2_0_x/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "arvidn";
     repo = "libtorrent";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-iph42iFEwP+lCWNPiOJJOejISFF6iwkGLY9Qg8J4tyo=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/li/linuxwave/package.nix
+++ b/pkgs/by-name/li/linuxwave/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "orhun";
     repo = "linuxwave";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-OuD5U/T3GuCQrzdhx01NXPSXD7pUAvLnNsznttJogz8=";
   };

--- a/pkgs/by-name/li/litmus/package.nix
+++ b/pkgs/by-name/li/litmus/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "notroj";
     repo = "litmus";
-    rev = version;
+    tag = version;
     # Required for neon m4 macros, bundled neon not used
     fetchSubmodules = true;
     hash = "sha256-jWz0cnytgn7px3vvB9/ilWBNALQiW5/QvgguM27I3yQ=";

--- a/pkgs/by-name/lo/logiops/package.nix
+++ b/pkgs/by-name/lo/logiops/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (oldAttrs: {
   src = fetchFromGitHub {
     owner = "PixlOne";
     repo = "logiops";
-    rev = "v${oldAttrs.version}";
+    tag = "v${oldAttrs.version}";
     hash = "sha256-GAnlPqjIFGyOWwYFs7gth2m9ITc1jyiaW0sWwQ2zFOs=";
     # In v0.3.0, the `ipcgull` submodule was added as a dependency
     # https://github.com/PixlOne/logiops/releases/tag/v0.3.0

--- a/pkgs/by-name/lo/loksh/package.nix
+++ b/pkgs/by-name/lo/loksh/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "dimkr";
     repo = "loksh";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-BxQ7SZwRP9PlD2MV7DqG7tQ2lqzlkTwmaKwbgC7NYrc=";
   };

--- a/pkgs/by-name/lu/lune/package.nix
+++ b/pkgs/by-name/lu/lune/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "filiptibell";
     repo = "lune";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Kk3ZIF+kQzsg/ApUm12bbWlIthj5cpVefAqEGhgxb3w=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ma/makeself/package.nix
+++ b/pkgs/by-name/ma/makeself/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "megastep";
     repo = "makeself";
-    rev = "release-${version}";
+    tag = "release-${version}";
     fetchSubmodules = true;
     hash = "sha256-15lUtErGsbXF2Gn0f0rvA18mMuVMmkKrGO2poeYZU9g=";
   };

--- a/pkgs/by-name/ma/mamba/package.nix
+++ b/pkgs/by-name/ma/mamba/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "brummer10";
     repo = "Mamba";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-S1+nGnB1LHIUgYves0qtWh+QXYKjtKWICpOo38b3zbY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ma/manifest-tool/package.nix
+++ b/pkgs/by-name/ma/manifest-tool/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "estesp";
     repo = "manifest-tool";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-tEUsqrJGRhyirI8TEgG6r9crHX58webHO5v7JLLRQ30=";
     leaveDotGit = true;
     postFetch = ''

--- a/pkgs/by-name/ma/mariadb-galera/package.nix
+++ b/pkgs/by-name/ma/mariadb-galera/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "codership";
     repo = "galera";
-    rev = "release_${version}";
+    tag = "release_${version}";
     hash = "sha256-v7zwhXfW9K1wvV951Utt/rUbSIMiRZB1rWfeK1VJzN4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ma/marker/package.nix
+++ b/pkgs/by-name/ma/marker/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "fabiocolacio";
     repo = "Marker";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-HhDhigQ6Aqo8R57Yrf1i69sM0feABB9El5R5OpzOyB0=";
   };

--- a/pkgs/by-name/ma/master_me/package.nix
+++ b/pkgs/by-name/ma/master_me/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "trummerschlunk";
     repo = "master_me";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-eesMXxRcCgzhSQ+WUqM00EuKYhFxysjH+RWKHKGYzUM=";
   };

--- a/pkgs/by-name/ma/material-design-icons/package.nix
+++ b/pkgs/by-name/ma/material-design-icons/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Templarian";
     repo = "MaterialDesign-Webfont";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-7t3i3nPJZ/tRslLBfY+9kXH8TR145GC2hPFYJeMHRL8=";
     sparseCheckout = [ "fonts" ];
   };

--- a/pkgs/by-name/me/megaglest/package.nix
+++ b/pkgs/by-name/me/megaglest/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "MegaGlest";
     repo = "megaglest-source";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     sha256 = "0fb58a706nic14ss89zrigphvdiwy5s9dwvhscvvgrfvjpahpcws";
   };

--- a/pkgs/by-name/mi/micropython/package.nix
+++ b/pkgs/by-name/mi/micropython/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "micropython";
     repo = "micropython";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-yH5omiYs07ZKECI+DAnpYq4T+r2O/RuGdtN+dhYxePc=";
     fetchSubmodules = true;
 

--- a/pkgs/by-name/mi/minia/package.nix
+++ b/pkgs/by-name/mi/minia/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "GATB";
     repo = "minia";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "0bmfrywixaaql898l0ixsfkhxjf2hb08ssnqzlzacfizxdp46siq";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ml/mlt/package.nix
+++ b/pkgs/by-name/ml/mlt/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "mlt";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-z1bW+hcVeMeibC1PUS5XNpbkNB+75YLoOWZC2zuDol4=";
     # The submodule contains glaxnimate code, since MLT uses internally some functions defined in glaxnimate.
     # Since glaxnimate is not available as a library upstream, we cannot remove for now this dependency on

--- a/pkgs/by-name/mm/mmex/package.nix
+++ b/pkgs/by-name/mm/mmex/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "moneymanagerex";
     repo = "moneymanagerex";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-gpDwfRKXgp6hEpitflVIAIOU/k3Fx6hKKhyzQvLlog8=";
   };

--- a/pkgs/by-name/mm/mmv/package.nix
+++ b/pkgs/by-name/mm/mmv/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rrthomas";
     repo = "mmv";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-h+hdrIQz+7jKdMdJtWhBbZgvmNTIOr7Q38nhfAWC+G4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/mo/moonlight-embedded/package.nix
+++ b/pkgs/by-name/mo/moonlight-embedded/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "moonlight-stream";
     repo = "moonlight-embedded";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Jc706BjIT3rS9zwntNOdgszP4CHuX+qxvPvWeU68Amg=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/mo/moonlight-qt/package.nix
+++ b/pkgs/by-name/mo/moonlight-qt/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "moonlight-stream";
     repo = "moonlight-qt";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-rWVNpfRDLrWsqELPFquA6rW6/AfWV+6DNLUCPqIhle0=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/mo/mountpoint-s3/package.nix
+++ b/pkgs/by-name/mo/mountpoint-s3/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "mountpoint-s3";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-uV0umUoJkYgmjWjv8GMnk5TRRbCCJS1ut3VV1HvkaAw=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/mo/mozc/package.nix
+++ b/pkgs/by-name/mo/mozc/package.nix
@@ -24,7 +24,7 @@ buildBazelPackage rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "mozc";
-    rev = version;
+    tag = version;
     hash = "sha256-w0bjoMmq8gL7DSehEG7cKqp5e4kNOXnCYLW31Zl9FRs=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ms/mscp/package.nix
+++ b/pkgs/by-name/ms/mscp/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "upa";
     repo = "mscp";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-5lX0b3JfjmQh/HlESRMNxqCe2qFRAEZoazysoy252dY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/mu/museum/package.nix
+++ b/pkgs/by-name/mu/museum/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
     owner = "ente-io";
     repo = "ente";
     sparseCheckout = [ "server" ];
-    rev = "photos-v${version}";
+    tag = "photos-v${version}";
     hash = "sha256-801wTTxruhZc18+TAPSYrBRtCPNZXwSKs2Hkvc/6BjM=";
   };
 

--- a/pkgs/by-name/mu/mustache-go/package.nix
+++ b/pkgs/by-name/mu/mustache-go/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "cbroglie";
     repo = "mustache";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-A7LIkidhpFmhIjiDu9KdmSIdqFNsV3N8J2QEo7yT+DE=";
   };

--- a/pkgs/by-name/na/nasc/package.nix
+++ b/pkgs/by-name/na/nasc/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "parnold-x";
     repo = "nasc";
-    rev = version;
+    tag = version;
     sha256 = "02b9a59a9fzsb6nn3ycwwbcbv04qfzm6x7csq2addpzx5wak6dd8";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ne/neural-amp-modeler-lv2/package.nix
+++ b/pkgs/by-name/ne/neural-amp-modeler-lv2/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "mikeoliphant";
     repo = "neural-amp-modeler-lv2";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-5BOZOocZWWSWawXJFMAgM0NR0s0CbkzDVr6fnvZMvd0=";
   };

--- a/pkgs/by-name/ne/neuron/package.nix
+++ b/pkgs/by-name/ne/neuron/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "neuronsimulator";
     repo = "nrn";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-dmpx0Wud0IhdFvvTJuW/w1Uq6vFYaNal9n27LAqV1Qc=";
   };

--- a/pkgs/by-name/ni/ninjas2/package.nix
+++ b/pkgs/by-name/ni/ninjas2/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "clearly-broken-software";
     repo = "ninjas2";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "1kwp6pmnfar2ip9693gprfbcfscklgri1k1ycimxzlqr61nkd2k9";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ni/nitrokey-fido2-firmware/package.nix
+++ b/pkgs/by-name/ni/nitrokey-fido2-firmware/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nitrokey-fido2-firmware";
-    rev = "${version}.nitrokey";
+    tag = "${version}.nitrokey";
     hash = "sha256-7AsnxRf8mdybI6Mup2mV01U09r5C/oUX6fG2ymkkOOo=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ni/nitrokey-pro-firmware/package.nix
+++ b/pkgs/by-name/ni/nitrokey-pro-firmware/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nitrokey-pro-firmware";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-q+kbEOLA05xR6weAWDA1hx4fVsaN9UNKiOXGxPRfXuI=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ni/nitrokey-start-firmware/package.nix
+++ b/pkgs/by-name/ni/nitrokey-start-firmware/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nitrokey-start-firmware";
-    rev = "RTM.${finalAttrs.version}";
+    tag = "RTM.${finalAttrs.version}";
     hash = "sha256-POW1d/fgOyYa7127FSTCtHGyMWYzKW0qqA1WUyvNc3w=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/no/noisetorch/package.nix
+++ b/pkgs/by-name/no/noisetorch/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "noisetorch";
     repo = "NoiseTorch";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-gOPSMPH99Upi/30OnAdwSb7SaMV0i/uHB051cclfz6A=";
   };

--- a/pkgs/by-name/no/notes/package.nix
+++ b/pkgs/by-name/no/notes/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nuttyartist";
     repo = "notes";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ceZ37torgnxZJybacjnNG+kNAU/I2Ki7ZZ7Tzn4pIas=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/no/noto-fonts-cjk-sans/package.nix
+++ b/pkgs/by-name/no/noto-fonts-cjk-sans/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "notofonts";
     repo = "noto-cjk";
-    rev = "Sans${version}";
+    tag = "Sans${version}";
     hash = "sha256-i3ZKoSy2SVs46IViha+Sg8atH4n3ywgrunHPLtVT4Pk=";
     sparseCheckout = [
       "Sans/OTC"

--- a/pkgs/by-name/no/noto-fonts-cjk-serif/package.nix
+++ b/pkgs/by-name/no/noto-fonts-cjk-serif/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "notofonts";
     repo = "noto-cjk";
-    rev = "Serif${version}";
+    tag = "Serif${version}";
     hash = "sha256-Bwuu64TAnOnqUgLlBsUw/jnv9emngqFBmVn6zEqySlc=";
     sparseCheckout = [
       "Serif/OTC"

--- a/pkgs/by-name/od/odin2/package.nix
+++ b/pkgs/by-name/od/odin2/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "TheWaveWarden";
     repo = "odin2";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-N96Nb7G6hqfh8DyMtHbttl/fRZUkS8f2KfPSqeMAhHY=";
   };

--- a/pkgs/by-name/op/openboardview/package.nix
+++ b/pkgs/by-name/op/openboardview/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "OpenBoardView";
     repo = "OpenBoardView";
-    rev = version;
+    tag = version;
     hash = "sha256-sKDDOPpCagk7rBRlMlZhx+RYYbtoLzJsrnL8qKZMKW8=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/op/opencl-clhpp/package.nix
+++ b/pkgs/by-name/op/opencl-clhpp/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "OpenCL-CLHPP";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     sha256 = "sha256-3RVZJIt03pRmjrPa9q6h6uqFCuTnxvEqjUGUmdwybbY=";
   };

--- a/pkgs/by-name/op/openmsx/package.nix
+++ b/pkgs/by-name/op/openmsx/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "openMSX";
     repo = "openMSX";
-    rev = "RELEASE_${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
+    tag = "RELEASE_${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-iY+oZ7fHZnnEGunM4kOxOGH2Biqj2PfdLhbT8J4mYrA=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/op/openrocket/package.nix
+++ b/pkgs/by-name/op/openrocket/package.nix
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "openrocket";
     repo = "openrocket";
-    rev = "release-${finalAttrs.version}";
+    tag = "release-${finalAttrs.version}";
     hash = "sha256-Dg/v72N9cDG9Ko5JIcZxGxh+ClRDgf5Jq5DvQyCiYOs=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/op/openseachest/package.nix
+++ b/pkgs/by-name/op/openseachest/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Seagate";
     repo = "openSeaChest";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-kd2JRtqnxfYRJcr1yKSB0LZAR96j2WW4tR1iRTvVANs=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/or/orocos-kdl/package.nix
+++ b/pkgs/by-name/or/orocos-kdl/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "orocos";
     repo = "orocos_kinematics_dynamics";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "15ky7vw461005axx96d0f4zxdnb9dxl3h082igyd68sbdb8r1419";
     # Needed to build Python bindings
     fetchSubmodules = true;

--- a/pkgs/by-name/or/orogene/package.nix
+++ b/pkgs/by-name/or/orogene/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "orogene";
     repo = "orogene";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-GMWrlvZZ2xlcvcRG3u8jS8KiewHpyX0brNe4pmCpHbM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/os/osqp/package.nix
+++ b/pkgs/by-name/os/osqp/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "oxfordcontrol";
     repo = "osqp";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-enkK5EFyAeLaUnHNYS3oq43HsHY5IuSLgsYP0k/GW8c=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/os/ossia-score/package.nix
+++ b/pkgs/by-name/os/ossia-score/package.nix
@@ -49,7 +49,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ossia";
     repo = "score";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-khVWoHsxezQjU6O+OX7t1zuzLJpIVTim1rMswD7TaQU=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ow/owamp/package.nix
+++ b/pkgs/by-name/ow/owamp/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "perfsonar";
     repo = "owamp";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "5o85XSn84nOvNjIzlaZ2R6/TSHpKbWLXTO0FmqWsNMU=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/p1/p11-kit/package.nix
+++ b/pkgs/by-name/p1/p11-kit/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "p11-glue";
     repo = "p11-kit";
-    rev = version;
+    tag = version;
     hash = "sha256-2xDUvXGsF8x42uezgnvOXLVUdNNHcaE042HDDEJeplc=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/pa/pam_rssh/package.nix
+++ b/pkgs/by-name/pa/pam_rssh/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "z4yx";
     repo = "pam_rssh";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-VxbaxqyIAwmjjbgfTajqwPQC3bp7g/JNVNx9yy/3tus=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/pd/pdfcpu/package.nix
+++ b/pkgs/by-name/pd/pdfcpu/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "pdfcpu";
     repo = "pdfcpu";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-HTqaFl/ug/4sdchZBD4VQiXbD1L0/DVf2efZ3BV/vx4=";
     # Apparently upstream requires that the compiled executable will know the
     # commit hash and the date of the commit. This information is also presented

--- a/pkgs/by-name/pd/pdfslicer/package.nix
+++ b/pkgs/by-name/pd/pdfslicer/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "junrrein";
     repo = "pdfslicer";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     sha256 = "0sja0ddd9c8wjjpzk2ag8q1lxpj09adgmhd7wnsylincqnj2jyls";
   };

--- a/pkgs/by-name/pe/penguin-subtitle-player/package.nix
+++ b/pkgs/by-name/pe/penguin-subtitle-player/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "carsonip";
     repo = "Penguin-Subtitle-Player";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-AhdShg/eWqF44W1r+KmcHzbGKF2TNSD/wPKj+x4oQkM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/pi/picom/package.nix
+++ b/pkgs/by-name/pi/picom/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "yshui";
     repo = "picom";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-H8IbzzrzF1c63MXbw5mqoll3H+vgcSVpijrlSDNkc+o=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/pk/pkcs11-provider/package.nix
+++ b/pkgs/by-name/pk/pkcs11-provider/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "latchset";
     repo = "pkcs11-provider";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-Q9dmzYDBco+LLVWdORFTjRyk0RX8qhmZ1m+Kgfeyr04=";
   };

--- a/pkgs/by-name/pm/pmix/package.nix
+++ b/pkgs/by-name/pm/pmix/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     repo = "openpmix";
     owner = "openpmix";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qj/exBi1siCHY1QqNY+ad6n3XI4JZuwnM93Vp+rj1AQ=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/pn/pngquant/package.nix
+++ b/pkgs/by-name/pn/pngquant/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "kornelski";
     repo = "pngquant";
-    rev = version;
+    tag = version;
     hash = "sha256-u2zEp9Llo+c/+1QGW4V4r40KQn/ATHCTEsrpy7bRf/I=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/po/pokeget-rs/package.nix
+++ b/pkgs/by-name/po/pokeget-rs/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "talwat";
     repo = "pokeget-rs";
-    rev = version;
+    tag = version;
     hash = "sha256-EtEmaA0ukLoK0vaX+s3d8xodB3pUwSb1EyeyMBF0+rc=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/po/polybar/package.nix
+++ b/pkgs/by-name/po/polybar/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "polybar";
     repo = "polybar";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-5PYKl6Hi4EYEmUBwkV0rLiwxNqIyR5jwm495YnNs0gI=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/po/polylux2pdfpc/package.nix
+++ b/pkgs/by-name/po/polylux2pdfpc/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "polylux-typ";
     repo = "polylux";
-    rev = "v${version}";
+    tag = "v${version}";
     sparseCheckout = [ dirname ];
     hash = "sha256-41FgRejonvVTmE89WGm0Cqumm8lb6kkfxtkWV74UKJA=";
   };

--- a/pkgs/by-name/po/ponyc/package.nix
+++ b/pkgs/by-name/po/ponyc/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (rec {
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
-    rev = version;
+    tag = version;
     hash = "sha256-4gDv8UWTk0RWVNC4PU70YKSK9fIMbWBsQbHboVls2BA=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/po/poptracker/package.nix
+++ b/pkgs/by-name/po/poptracker/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "black-sliver";
     repo = "PopTracker";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-DFJfuDOzcVdiXLv5EzO5TL3UJLCZPM1bTZharp2ww5U=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/pr/pragtical/package.nix
+++ b/pkgs/by-name/pr/pragtical/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pragtical";
     repo = "pragtical";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
 
     # also fetch required git submodules

--- a/pkgs/by-name/pr/prime-server/package.nix
+++ b/pkgs/by-name/pr/prime-server/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "kevinkreiser";
     repo = "prime_server";
-    rev = version;
+    tag = version;
     sha256 = "0izmmvi3pvidhlrgfpg4ccblrw6fil3ddxg5cfxsz4qbh399x83w";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/pr/process-compose/package.nix
+++ b/pkgs/by-name/pr/process-compose/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "F1bonacc1";
     repo = "process-compose";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-qv/fVfuQD7Nan5Nn1RkwXoGZuPYSRWQaojEn6MCF9BQ=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.

--- a/pkgs/by-name/pr/proteus/package.nix
+++ b/pkgs/by-name/pr/proteus/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "GuitarML";
     repo = "Proteus";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-WhJh+Sx64JYxQQ1LXpDUwXeodFU1EZ0TmMhn+6w0hQg=";
   };

--- a/pkgs/by-name/pr/prrte/package.nix
+++ b/pkgs/by-name/pr/prrte/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "openpmix";
     repo = "prrte";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-4JEh4N/38k0Xgp0CqnFipaEZlJBQr8nyxoncyz0/7yo=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/pv/pvsneslib/package.nix
+++ b/pkgs/by-name/pv/pvsneslib/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "alekmaul";
     repo = "pvsneslib";
-    rev = version;
+    tag = version;
     hash = "sha256-Cl4+WvjKbq5IPqf7ivVYwBYwDDWWHGNeq4nWXPxsUHw=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/qc/qcm/package.nix
+++ b/pkgs/by-name/qc/qcm/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "hypengw";
     repo = "Qcm";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-41GsG+NKCMw+LuRUf31ilRso/SkKYVV3IrMSviOZdWs=";
   };

--- a/pkgs/by-name/qg/qgrep/package.nix
+++ b/pkgs/by-name/qg/qgrep/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zeux";
     repo = "qgrep";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-TeXOzfb1Nu6hz9l6dXGZY+xboscPapKm0Z264hv1Aww=";
   };

--- a/pkgs/by-name/qg/qgroundcontrol/package.nix
+++ b/pkgs/by-name/qg/qgroundcontrol/package.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mavlink";
     repo = "qgroundcontrol";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-wjrfwE97J+UzBPIARQ6cPadN6xIdqR8i+ZKbtiDproM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/qu/quadrafuzz/package.nix
+++ b/pkgs/by-name/qu/quadrafuzz/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "jpcima";
     repo = "quadrafuzz";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "1kjsf7il9krihwlrq08gk2xvil4b4q5zd87nnm103hby2w7ws7z1";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ra/rapidyaml/package.nix
+++ b/pkgs/by-name/ra/rapidyaml/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "biojppm";
     repo = "rapidyaml";
     fetchSubmodules = true;
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-+ENfflVjeesX14m0G71HdeSIECopZV4J2JL9+c+nbXE=";
   };
 

--- a/pkgs/by-name/rb/rbdoom-3-bfg/package.nix
+++ b/pkgs/by-name/rb/rbdoom-3-bfg/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "RobertBeckebans";
     repo = "rbdoom-3-bfg";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-9BZEFO+e5IG6hv9+QI9OJecQ84rLTWBDz4k0GU6SeDE=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/re/revive/package.nix
+++ b/pkgs/by-name/re/revive/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "mgechev";
     repo = "revive";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-89BlSc2tgxAJUGZM951fF+0H+SOsl0+xz/G18neRZxI=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.

--- a/pkgs/by-name/rh/rhvoice/package.nix
+++ b/pkgs/by-name/rh/rhvoice/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "RHVoice";
     repo = "RHVoice";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-4l4S4MUnVGN/El1BBuZvzPPcavUefjMyBk1hk0ux7zo=";
   };

--- a/pkgs/by-name/ri/ricochet-refresh/package.nix
+++ b/pkgs/by-name/ri/ricochet-refresh/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "blueprint-freespeech";
     repo = "ricochet-refresh";
-    rev = "v${finalAttrs.version}-release";
+    tag = "v${finalAttrs.version}-release";
     fetchSubmodules = true;
     hash = "sha256-/IT3K3PL2fNl4P7xzItVnI8xJx5MmKxhw3ZEX9rN7j4=";
   };

--- a/pkgs/by-name/ri/rictydiminished-with-firacode/package.nix
+++ b/pkgs/by-name/ri/rictydiminished-with-firacode/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "hakatashi";
     repo = "RictyDiminished-with-FiraCode";
-    rev = version;
+    tag = version;
     hash = "sha256-twh3yLAM4MUjWzSDNmo8gNIRf01hieXeOS334sNdFk4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/rm/rmw/package.nix
+++ b/pkgs/by-name/rm/rmw/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "theimpossibleastronaut";
     repo = "rmw";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-rfJdJHSkusZj/PN74KgV5i36YC0YRZmIfRdvkUNoKEM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ro/rofi-file-browser/package.nix
+++ b/pkgs/by-name/ro/rofi-file-browser/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "marvinkreis";
     repo = "rofi-file-browser-extended";
-    rev = version;
+    tag = version;
     hash = "sha256-UEFv0skFzWhgFkmz1h8uV1ygW977zNq1Dw8VAawqUgw=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/rp/rpiboot/package.nix
+++ b/pkgs/by-name/rp/rpiboot/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "usbboot";
-    rev = version;
+    tag = version;
     hash = "sha256-WccnaIUF5M080M4vg5NzBCLpLVcE7ts/oJJE8CLRi8A=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/rt/rtags/package.nix
+++ b/pkgs/by-name/rt/rtags/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "andersbakken";
     repo = "rtags";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-EJ5pC53S36Uu7lM6KuLvLN6MAyrQW/Yk5kPqZNS5m8c=";
     fetchSubmodules = true;
     # unicode file names lead to different checksums on HFS+ vs. other

--- a/pkgs/by-name/ru/rubyfmt/package.nix
+++ b/pkgs/by-name/ru/rubyfmt/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "fables-tales";
     repo = "rubyfmt";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-IIHPU6iwFwQ5cOAtOULpMSjexFtTelSd/LGLuazdmUo=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ru/rustdesk-server/package.nix
+++ b/pkgs/by-name/ru/rustdesk-server/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "rustdesk";
     repo = "rustdesk-server";
-    rev = version;
+    tag = version;
     hash = "sha256-5LRMey1cxmjLg1s9RtVwgPjHjwYLSQHa6Tyv7r/XEQs=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sa/sambamba/package.nix
+++ b/pkgs/by-name/sa/sambamba/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "biod";
     repo = "sambamba";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-3O9bHGpMuCgdR2Wm7Dv1VUjMT1QTn8K1hdwgjvwhFDw=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/se/securefs/package.nix
+++ b/pkgs/by-name/se/securefs/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "netheril96";
     repo = "securefs";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-7xjGuN7jcLgfGkaBoSj+WsBpM806PPGzeBs7DnI+fwc=";
   };

--- a/pkgs/by-name/se/serial-studio/package.nix
+++ b/pkgs/by-name/se/serial-studio/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Serial-Studio";
     repo = "Serial-Studio";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-q3RWy3HRs5NG0skFb7PSv8jK5pI5rtbccP8j38l8kjM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sh/shadered/package.nix
+++ b/pkgs/by-name/sh/shadered/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "dfranx";
     repo = "SHADERed";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     sha256 = "0drf8wwx0gcmi22jq2yyjy7ppxynfq172wqakchscm313j248fjr";
   };

--- a/pkgs/by-name/sh/shim-unsigned/package.nix
+++ b/pkgs/by-name/sh/shim-unsigned/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rhboot";
     repo = "shim";
-    rev = version;
+    tag = version;
     hash = "sha256-KFpt//A4/T0FRBSPuTKQH/mEIqLVEiE+Lpvuq7ec6eo=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sh/shisho/package.nix
+++ b/pkgs/by-name/sh/shisho/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "flatt-security";
     repo = "shisho";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-G7sHaDq+F5lXNaF1sSLUecdjZbCejJE79P4AQifKdFY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sh/show-midi/package.nix
+++ b/pkgs/by-name/sh/show-midi/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "gbevin";
     repo = "ShowMIDI";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-jANrFZqJZZMTGyNa0sIthoQzaDMdLzpGZqHfxNw8hDg=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/si/singular/package.nix
+++ b/pkgs/by-name/si/singular/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
     # if a release is tagged (which sometimes does not happen), it will
     # be in the format below.
-    rev = "Release-${lib.replaceStrings [ "." ] [ "-" ] version}";
+    tag = "Release-${lib.replaceStrings [ "." ] [ "-" ] version}";
     hash = "sha256-vrRIirWQLbbe1l07AqqHK/StWo0egKuivdKT5R8Rx58=";
 
     # the repository's .gitattributes file contains the lines "/Tst/

--- a/pkgs/by-name/sn/snes9x/package.nix
+++ b/pkgs/by-name/sn/snes9x/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "snes9xgit";
     repo = "snes9x";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-INMVyB3alwmsApO7ToAaUWgh7jlg2MeLxqHCEnUO88U=";
   };

--- a/pkgs/by-name/so/sonobus/package.nix
+++ b/pkgs/by-name/so/sonobus/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "sonosaurus";
     repo = "sonobus";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-NOdmHFKrV7lb8XbeG5GdLKYZ0c/vcz3fcqYj9JvE+/Q=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/so/sony-headphones-client/package.nix
+++ b/pkgs/by-name/so/sony-headphones-client/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Plutoberth";
     repo = "SonyHeadphonesClient";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-vhI97KheKzr87exCh4xNN7NDefcagdMu1tWSt67vLiU=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sp/space-station-14-launcher/package.nix
+++ b/pkgs/by-name/sp/space-station-14-launcher/package.nix
@@ -49,7 +49,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "space-wizards";
     repo = "SS14.Launcher";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Es+DBwWh2QxCev+Aepi8ItTXSYIgNgb05zdScOBZNJs=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sp/spdk/package.nix
+++ b/pkgs/by-name/sp/spdk/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "spdk";
     repo = "spdk";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-27mbIycenOk51PLQrAfU1cZcjiWddNtxoyC6Q9wxqFg=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sp/spicy-parser-generator/package.nix
+++ b/pkgs/by-name/sp/spicy-parser-generator/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zeek";
     repo = "spicy";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-+F7P8D70vN85pYyTOSMXgf1yWgPJHPpvP38rOyKTJ/A=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sq/sqlcheck/package.nix
+++ b/pkgs/by-name/sq/sqlcheck/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "jarulraj";
     repo = "sqlcheck";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-rGqCtEO2K+OT44nYU93mF1bJ07id+ixPkRSC8DcO6rY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/st/starboard/package.nix
+++ b/pkgs/by-name/st/starboard/package.nix
@@ -16,7 +16,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "aquasecurity";
     repo = "starboard";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-yQ4ABzN8EvD5qs0yjTaihM145K79LglprC2nlqAw0XU=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.

--- a/pkgs/by-name/st/stellar-core/package.nix
+++ b/pkgs/by-name/st/stellar-core/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "stellar";
     repo = "stellar-core";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-lxBn/T01Tsa7tid3mRJUigUwv9d3BAPZhV9Mp1lywBU=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/st/sticky-notes/package.nix
+++ b/pkgs/by-name/st/sticky-notes/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "vixalien";
     repo = "sticky";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-82Yxw8NSw82rxhuAgsdN2lCiQ/hli4tQiU6jCgGyp4U=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/st/stochas/package.nix
+++ b/pkgs/by-name/st/stochas/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "surge-synthesizer";
     repo = "stochas";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Gp49cWvUkwz4xAq5sA1nUO+amRC39iWeUemQJyv6hTs=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/su/sumo/package.nix
+++ b/pkgs/by-name/su/sumo/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "eclipse";
     repo = "sumo";
-    rev = "v${lib.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "v${lib.replaceStrings [ "." ] [ "_" ] version}";
     hash = "sha256-yXXOCvlHAzGmNQeXyWQtmq1UdkQ6qt4L9noUii/voP4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/su/surge-XT/package.nix
+++ b/pkgs/by-name/su/surge-XT/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "surge-synthesizer";
     repo = "surge";
-    rev = "release_xt_${version}";
+    tag = "release_xt_${version}";
     fetchSubmodules = true;
     hash = "sha256-4b0H3ZioiXFc4KCeQReobwQZJBl6Ep2/8JlRIwvq/hQ=";
   };

--- a/pkgs/by-name/su/sus-compiler/package.nix
+++ b/pkgs/by-name/su/sus-compiler/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "pc2";
     repo = "sus-compiler";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-dQef5TiOV33lnNl7XKl7TlCY0E2sEclehWOmy2uvISY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sv/svaba/package.nix
+++ b/pkgs/by-name/sv/svaba/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "walaj";
     repo = "svaba";
-    rev = version;
+    tag = version;
     sha256 = "1vv5mc9z5d22kgdy7mm27ya5aahnqgkcrskdr2405058ikk9g8kp";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/sy/symfony-cli/package.nix
+++ b/pkgs/by-name/sy/symfony-cli/package.nix
@@ -17,7 +17,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "symfony-cli";
     repo = "symfony-cli";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xl8pKfAgaeEjtITMpp6urwPndIBXxSyYEcX0PpVK8nc=";
     leaveDotGit = true;
     postFetch = ''

--- a/pkgs/by-name/sy/syslogng/package.nix
+++ b/pkgs/by-name/sy/syslogng/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "syslog-ng";
     repo = "syslog-ng";
-    rev = "syslog-ng-${finalAttrs.version}";
+    tag = "syslog-ng-${finalAttrs.version}";
     hash = "sha256-/hLrUwJhA0jesOl7gmWHfTVO2M7IG8QNPRzc/TIGTH4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ta/taisei/package.nix
+++ b/pkgs/by-name/ta/taisei/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "taisei-project";
     repo = "taisei";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-rThLz8o6IYhIBUc0b1sAQi2aF28btajcM1ScTv+qn6c=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ta/tamatool/package.nix
+++ b/pkgs/by-name/ta/tamatool/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jcrona";
     repo = "tamatool";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-VDmpIBuMWg3TwfCf9J6/bi/DaWip6ESAQWvGh2SH+A8=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ta/tangram/package.nix
+++ b/pkgs/by-name/ta/tangram/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sonnyp";
     repo = "Tangram";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-OtQN8Iigu92iKa7CAaslIpbS0bqJ9Vus++inrgV/eeM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ta/tarantool/package.nix
+++ b/pkgs/by-name/ta/tarantool/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tarantool";
     repo = "tarantool";
-    rev = version;
+    tag = version;
     hash = "sha256-yCRU5IxC6gNS+O2KYtKWjFk35EHkBnnzWy5UnyuB9f4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ta/taskwarrior2/package.nix
+++ b/pkgs/by-name/ta/taskwarrior2/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "GothenburgBitFactory";
     repo = "taskwarrior";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-0YveqiylXJi4cdDCfnPtwCVOJbQrZYsxnXES+9B4Yfw=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/tc/tcpflow/package.nix
+++ b/pkgs/by-name/tc/tcpflow/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "simsong";
     repo = "tcpflow";
-    rev = "tcpflow-${version}";
+    tag = "tcpflow-${version}";
     sha256 = "0vbm097jhi5n8pg08ia1yhzc225zv9948blb76f4br739l9l22vq";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/te/tempo/package.nix
+++ b/pkgs/by-name/te/tempo/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "tempo";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-RzDOx2ZyA0ZntFD1ryfipsgPsxVmsdOusZ37RCnQQnM=";
   };

--- a/pkgs/by-name/te/tev/package.nix
+++ b/pkgs/by-name/te/tev/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Tom94";
     repo = "tev";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-ke1T5nOrDoJilpfshAIAFWw/640Gm5OaxZ+ZakCevTs=";
   };

--- a/pkgs/by-name/th/themix-gui/package.nix
+++ b/pkgs/by-name/th/themix-gui/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "themix-project";
     repo = "themix-gui";
-    rev = version;
+    tag = version;
     hash = "sha256-xFtwNx1c7Atb+9yorZhs/uVkkoxbZiELJ0SZ88L7KMs=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ti/timewarrior/package.nix
+++ b/pkgs/by-name/ti/timewarrior/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "GothenburgBitFactory";
     repo = "timewarrior";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-6WZ5k9cxWe+eS9me700ITq0rKEiIuDhTtmuzhOnUM4k=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ti/tinyfecvpn/package.nix
+++ b/pkgs/by-name/ti/tinyfecvpn/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "wangyu-";
     repo = "tinyfecvpn";
-    rev = version;
+    tag = version;
     hash = "sha256-g4dduREH64TDK3Y2PKc5RZiISW4h2ALRh8vQK7jvCZU=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ti/tinygo/package.nix
+++ b/pkgs/by-name/ti/tinygo/package.nix
@@ -39,7 +39,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "tinygo-org";
     repo = "tinygo";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-I/9JXjt6aF/80Mh3iRgUYXv4l+m3XIpmKsIBviOuWCo=";
     fetchSubmodules = true;
     # The public hydra server on `hydra.nixos.org` is configured with

--- a/pkgs/by-name/tl/tlock/package.nix
+++ b/pkgs/by-name/tl/tlock/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "eklairs";
     repo = "tlock";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-O6erxzanSO5BjMnSSmn89w9SA+xyHhp0SSDkCk5hp8Y=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/tr/tracebox/package.nix
+++ b/pkgs/by-name/tr/tracebox/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "tracebox";
     repo = "tracebox";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-1KBJ4uXa1XpzEw23IjndZg+aGJXk3PVw8LYKAvxbxCA=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/tr/trackma/package.nix
+++ b/pkgs/by-name/tr/trackma/package.nix
@@ -38,7 +38,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "z411";
     repo = "trackma";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "Hov9qdVabu1k3SIoUmvcRtSK8TcETqGPXI2RqN/bei4=";
     fetchSubmodules = true; # for anime-relations submodule
   };

--- a/pkgs/by-name/tr/transmission_3/package.nix
+++ b/pkgs/by-name/tr/transmission_3/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "transmission";
     repo = "transmission";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-n4iEDt9AstDZPZXN47p13brNLbNWS3BTB+A4UuoEjzE=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/tr/trezord/package.nix
+++ b/pkgs/by-name/tr/trezord/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "trezor";
     repo = "trezord-go";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-3I6NOzDMhzRyVSOURl7TjJ1Z0P0RcKrSs5rNaZ0Ho9M=";
   };

--- a/pkgs/by-name/tv/tvm/package.nix
+++ b/pkgs/by-name/tv/tvm/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "apache";
     repo = "incubator-tvm";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-/5IpOraFTgg6sQ1TLHoepq/C8VHKg5BXKrNMBSyYajA=";
   };

--- a/pkgs/by-name/um/umpire/package.nix
+++ b/pkgs/by-name/um/umpire/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "LLNL";
     repo = "umpire";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-MHvJRXAMV64GxGgCJjQPlaNyxVjBvyQXogbla9UMFL8=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/un/unvanquished/package.nix
+++ b/pkgs/by-name/un/unvanquished/package.nix
@@ -40,7 +40,7 @@ let
   src = fetchFromGitHub {
     owner = "Unvanquished";
     repo = "Unvanquished";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-wOFSPPEu7AGsEcqHG7xFWzFlYZRWAIvvfTj5FLZ3HFc=";
   };

--- a/pkgs/by-name/ur/ursadb/package.nix
+++ b/pkgs/by-name/ur/ursadb/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "CERT-Polska";
     repo = "ursadb";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-UVfOImngYPB8UBQHzxwJM+dT3DWiT+7V+QGfUggjazI=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ut/utf8cpp/package.nix
+++ b/pkgs/by-name/ut/utf8cpp/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nemtrif";
     repo = "utfcpp";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-e8qH4eygLnQw7B8x+HN+vH8cr8fkxnTFz+PKtFJ8dGE=";
   };

--- a/pkgs/by-name/ut/utox/package.nix
+++ b/pkgs/by-name/ut/utox/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "uTox";
     repo = "uTox";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-DxnolxUTn+CL6TbZHKLHOUMTHhtTSWufzzOTRpKjOwc=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "vcpkg";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-ZJu3dFsKc7L2THgGXNtBszXUbEEoM3bnLxtf5x5UPTM=";
     leaveDotGit = true;
     postFetch = ''

--- a/pkgs/by-name/vi/violet/package.nix
+++ b/pkgs/by-name/vi/violet/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "paullouisageneau";
     repo = "violet";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-OBrEydVqhbxJZED8mUjV605kvtbXPqb35X1XeNBNvjg=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/vn/vnote/package.nix
+++ b/pkgs/by-name/vn/vnote/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "vnotex";
     repo = "vnote";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-40k0wSqRdwlUqrbb9mDK0dqsSEqCfbNLt+cUKeky+do=";
   };

--- a/pkgs/by-name/vo/volk/package.nix
+++ b/pkgs/by-name/vo/volk/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "gnuradio";
     repo = "volk";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-R1FT5sbl0fAAl6YIX5aD5CiQ/AjZkCSDPPQPiuy4WBY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/vo/volk_2/package.nix
+++ b/pkgs/by-name/vo/volk_2/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "gnuradio";
     repo = "volk";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-XvX6emv30bSB29EFm6aC+j8NGOxWqHCNv0Hxtdrq/jc=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/wa/wabt/package.nix
+++ b/pkgs/by-name/wa/wabt/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "wabt";
-    rev = version;
+    tag = version;
     hash = "sha256-Ejr+FxaYRDI01apHhKTs11iwcv72a8ZxyPmVetEvadU=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/wa/wasm-tools/package.nix
+++ b/pkgs/by-name/wa/wasm-tools/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = "wasm-tools";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-SrWmoDSz2/qSiex46CeDIgarjgGRp2KOThGP4YjglZY=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/wi/wiliwili/package.nix
+++ b/pkgs/by-name/wi/wiliwili/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "xfangfang";
     repo = "wiliwili";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-37DQafP+PFjrfNXJt88oK0ghqQEVQjDdVbYsf1tHAN4=";
   };

--- a/pkgs/by-name/wi/wineasio/package.nix
+++ b/pkgs/by-name/wi/wineasio/package.nix
@@ -15,7 +15,7 @@ multiStdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "wineasio";
     repo = "wineasio";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-d5BGJAkaM5XZXyqm6K/UzFE4sD6QVHHGnLi1bcHxiaM=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/wo/wolf-shaper/package.nix
+++ b/pkgs/by-name/wo/wolf-shaper/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "wolf-plugins";
     repo = "wolf-shaper";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-4oi1wnex6eNRHUWXZHnvrmqp4veFuPJqD0YuOhDepg4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/wx/wxGTK31/package.nix
+++ b/pkgs/by-name/wx/wxGTK31/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "wxWidgets";
     repo = "wxWidgets";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-9qYPatpTT28H+fz77o7/Y3YVmiK0OCsiQT5QAYe93M0=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/wx/wxformbuilder/package.nix
+++ b/pkgs/by-name/wx/wxformbuilder/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "wxFormBuilder";
     repo = "wxFormBuilder";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     leaveDotGit = true;
     postFetch = ''

--- a/pkgs/by-name/x4/x42-avldrums/package.nix
+++ b/pkgs/by-name/x4/x42-avldrums/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "x42";
     repo = "avldrums.lv2";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-AZKHjzgw0TtLHh4TF+yOUSa+GlNVwyHCpJWAZikXTy4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/xe/xemu/package.nix
+++ b/pkgs/by-name/xe/xemu/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "xemu-project";
     repo = "xemu";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-lTZ5j5ULh4GFW4zlQy4l7e4zr8TEIvenGNC59O6G0Wg=";
   };

--- a/pkgs/by-name/xg/xgboost/package.nix
+++ b/pkgs/by-name/xg/xgboost/package.nix
@@ -53,7 +53,7 @@ effectiveStdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "dmlc";
     repo = pnameBase;
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
     hash = "sha256-8mj8uw7bbwhRaL0JZf9L9//a+Re2AwbL0e7Oiw/BqIA=";
   };

--- a/pkgs/by-name/xk/xkb-switch-i3/package.nix
+++ b/pkgs/by-name/xk/xkb-switch-i3/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Zebradil";
     repo = "xkb-switch-i3";
-    rev = version;
+    tag = version;
     hash = "sha256-5d1DdRtz0QCWISSsWQt9xgTOekYUCkhfMsjG+/kyQK4=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/xp/xpano/package.nix
+++ b/pkgs/by-name/xp/xpano/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "krupkat";
     repo = "xpano";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "sha256-f2qoBpZ5lPBocPas8KMsY5bSYL20gO+ZHLz2R66qSig=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/xs/xstow/package.nix
+++ b/pkgs/by-name/xs/xstow/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "majorkingleo";
     repo = "xstow";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-c89+thw5N3Cgl1Ww+W7c3YsyhNJMLlreedvdWJFY3WY=";
   };

--- a/pkgs/by-name/xt/xtuner/package.nix
+++ b/pkgs/by-name/xt/xtuner/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "brummer10";
     repo = "XTuner";
-    rev = "v${version}";
+    tag = "v${version}";
     sha256 = "1i5chfnf3hcivwzni9z6cn9pb68qmwsx8bf4z7d29a5vig8kbhrv";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/za/zam-plugins/package.nix
+++ b/pkgs/by-name/za/zam-plugins/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zamaudio";
     repo = "zam-plugins";
-    rev = version;
+    tag = version;
     hash = "sha256-pjnhDavKnyQjPF4nUO+j1J+Qtw8yIYMY9A5zBMb4zFU=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/zi/zimfw/package.nix
+++ b/pkgs/by-name/zi/zimfw/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zimfw";
     repo = "zimfw";
-    rev = "v${version}";
+    tag = "v${version}";
     ## zim only needs this one file to be installed.
     sparseCheckout = [ "zimfw.zsh" ];
     hash = "sha256-qQViaQOpLp8F4zvJETbNp0lxpdVhM1Meg7WcMKkjJRQ=";

--- a/pkgs/by-name/zl/zls/package.nix
+++ b/pkgs/by-name/zl/zls/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "zigtools";
     repo = "zls";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-A5Mn+mfIefOsX+eNBRHrDVkqFDVrD3iXDNsUL4TPhKo=";
   };

--- a/pkgs/by-name/zo/zoneminder/package.nix
+++ b/pkgs/by-name/zo/zoneminder/package.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ZoneMinder";
     repo = "zoneminder";
-    rev = version;
+    tag = version;
     hash = "sha256-0mpT3qjF8zlcsd6OlNIvrabDsz+oJPPy9Vn2TQSuHAI=";
     fetchSubmodules = true;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
```python
#!/usr/bin/env python3
import os
import re
import subprocess
from pathlib import Path
from concurrent.futures import ThreadPoolExecutor
import requests

github_token = os.getenv('GITHUB_TOKEN')
if not github_token:
    raise RuntimeError("GITHUB_TOKEN is required")

headers = {
    'Authorization': f'token {github_token}',
    'Accept': 'application/vnd.github.v3+json'
}

BLOCK_START = re.compile(r"src\s*=\s*fetchFromGitHub\s*{")
REV_LINE = re.compile(r"(?P<indent>\s*)rev\s*=\s*(?P<value>.+?;)")
URL_RE = re.compile(r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)\.git")


def find_package_files(root):
    return list(Path(root).joinpath('pkgs', 'by-name').rglob('package.nix'))


def github_tag_exists(owner, repo, tag):
    url = f'https://api.github.com/repos/{owner}/{repo}/git/refs/tags/{tag}'
    return requests.get(url, headers=headers).status_code == 200


def eval_nix(pkg, attr, cwd):
    try:
        return subprocess.check_output(
            ['nix', 'eval', '--raw', '-f', '.', f'{pkg}.src.{attr}'],
            cwd=cwd, encoding='utf-8'
        ).strip()
    except subprocess.CalledProcessError:
        return None


def process_file(path):
    text = path.read_text(encoding='utf-8')
    lines = text.splitlines()
    new_lines = lines.copy()
    changed = False
    for i, line in enumerate(lines):
        if BLOCK_START.search(line):
            depth = 0
            end = i
            for j in range(i, len(lines)):
                depth += lines[j].count('{') - lines[j].count('}')
                if depth <= 0:
                    end = j
                    break
            for k in range(i, end + 1):
                m = REV_LINE.match(lines[k])
                if m:
                    pkg = path.parent.name
                    url = eval_nix(pkg, 'url', Path.cwd())
                    rev = eval_nix(pkg, 'rev', Path.cwd())
                    if url and rev:
                        u = URL_RE.match(url)
                        if u and github_tag_exists(u.group('owner'), u.group('repo'), rev):
                            new_lines[k] = f"{m.group('indent')}tag = {m.group('value')}"
                            changed = True
                    break
    if changed:
        path.write_text("\n".join(new_lines) + "\n", encoding='utf-8')


def main():
    files = find_package_files(os.getcwd())
    with ThreadPoolExecutor(max_workers=os.cpu_count() * 5) as executor:
        executor.map(process_file, files)

if __name__ == '__main__':
    main()
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
