### PR TITLE
shapr3d: init at 5.910.0.9193

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .nixos-test-history
 .vscode/
 .helix/
+.zed/
 outputs/
 result-*
 result

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15086,6 +15086,12 @@
     matrix = "@sananatheskenana:matrix.org";
     name = "sanana the skenana";
   };
+  m-saghir = {
+    email = "m@saghir.ca";
+    name = "Muhammad Saghir";
+    github = "m-saghir";
+    githubId = 139656372;
+  };
   m00wl = {
     name = "Moritz Lumme";
     email = "moritz.lumme@gmail.com";

--- a/pkgs/by-name/sh/shapr3d/package.nix
+++ b/pkgs/by-name/sh/shapr3d/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  undmg,
+}:
+let
+  inherit (stdenv.hostPlatform) system;
+  unsupported = throw "Shapr3D doesn't support ${system}";
+  identifier = "5.910.0.9193";
+  url =
+    {
+      aarch64-darwin = fetchurl {
+        url = "https://download.shapr3d.com/mac/Shapr3D-${identifier}.dmg";
+        hash = "sha256-aCxANPRSe/biEZVL2fHOHt1h7b2vMDwafuaU9NHoy5Q=";
+      };
+    }
+    .${system} or unsupported;
+in
+stdenv.mkDerivation {
+  pname = "shapr3d";
+  version = identifier;
+  src = url;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = "Shapr3D.app";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications/Shapr3D.app
+    cp -R . $out/Applications/Shapr3D.app
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://www.shapr3d.com";
+    description = "modeling software geared towards Apple devices";
+    license = lib.licenses.unfree;
+    platforms = [ "aarch64-darwin" ];
+    maintainers = with lib.maintainers; [
+      m-saghir
+    ];
+    changelog = "https://support.shapr3d.com/hc/en-us/articles/7770045712540-Shapr3D-release-updates";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Wrapped [Shapr3D](https://www.shapr3d.com/) for Nixpkgs — a 3D modeling application for Apple devices.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
