### PR TITLE
nixos/cloudflared-service: Add support for token based tunnels

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3637,6 +3637,12 @@
     github = "bmwalters";
     githubId = 4380777;
   };
+  bn = {
+    github = "bn-c";
+    githubId = 149229524;
+    name = "Bach Nguyen";
+    email = "root.bachnc@gmail.com";
+  };
   bnlrnz = {
     github = "bnlrnz";
     githubId = 11310385;

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -211,6 +211,20 @@ in
                 '';
               };
 
+              token = lib.mkOption {
+                type = with lib.types; nullOr str;
+                default = null;
+                description = ''
+                  Cloudflare tunnel token to use instead of a configuration file.
+                  If set, the tunnel will be run using `cloudflared tunnel run --token <token>`.
+                  This option is mutually exclusive with the config file-based approach
+                  (which requires `credentialsFile`).
+                  Note: Using a token bypasses locally defined ingress rules and uses
+                  rules configured via the Cloudflare dashboard.
+                '';
+                example = "eyJhIj...zUzZg==";
+              };
+
               warp-routing = {
                 enabled = lib.mkOption {
                   type = with lib.types; nullOr bool;
@@ -315,6 +329,11 @@ in
           };
           default = "http_status:404";
         };
+        # Example for token-based
+        "my-token-tunnel" = {
+          token = "eyJhIj...zUzZg==";
+          # No credentialsFile, default, or ingress needed here
+        };
       };
     };
   };
@@ -333,6 +352,8 @@ in
     systemd.services = lib.mapAttrs' (
       name: tunnel:
       let
+        isTokenBased = tunnel.token != null;
+
         filterConfig = lib.attrsets.filterAttrsRecursive (
           _: v:
           !builtins.elem v [
@@ -348,7 +369,7 @@ in
         ingressesSet = filterIngressSet tunnel.ingress;
         ingressesStr = filterIngressStr tunnel.ingress;
 
-        fullConfig = filterConfig {
+        fullConfig = lib.mkIf (!isTokenBased) (filterConfig {
           tunnel = name;
           credentials-file = "/run/credentials/cloudflared-tunnel-${name}.service/credentials.json";
           warp-routing = filterConfig tunnel.warp-routing;
@@ -366,7 +387,7 @@ in
               service = lib.getAttr key ingressesStr;
             }) (lib.attrNames ingressesStr))
             ++ [ { service = tunnel.default; } ];
-        };
+        });
 
         mkConfigFile = pkgs.writeText "cloudflared.yml" (builtins.toJSON fullConfig);
         certFile = if (tunnel.certificateFile != null) then tunnel.certificateFile else cfg.certificateFile;
@@ -384,12 +405,18 @@ in
         serviceConfig = {
           RuntimeDirectory = "cloudflared-tunnel-${name}";
           RuntimeDirectoryMode = "0400";
-          LoadCredential = [
-            "credentials.json:${tunnel.credentialsFile}"
-          ]
-          ++ (lib.optional (certFile != null) "cert.pem:${certFile}");
+          LoadCredential = lib.mkIf (!isTokenBased) (
+            [
+              "credentials.json:${tunnel.credentialsFile}"
+            ]
+            ++ (lib.optional (certFile != null) "cert.pem:${certFile}")
+          );
 
-          ExecStart = "${cfg.package}/bin/cloudflared tunnel --config=${mkConfigFile} --no-autoupdate run";
+          ExecStart =
+            if isTokenBased then
+              "${cfg.package}/bin/cloudflared tunnel run --token ${lib.escapeShellArg tunnel.token}"
+            else
+              "${cfg.package}/bin/cloudflared tunnel --config=${mkConfigFile} --no-autoupdate run";
           Restart = "on-failure";
           DynamicUser = true;
         };
@@ -404,6 +431,7 @@ in
 
   meta.maintainers = with lib.maintainers; [
     bbigras
+    bn
     anpin
   ];
 }

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -203,7 +203,8 @@ in
               inherit certificateFile originRequest;
 
               credentialsFile = lib.mkOption {
-                type = lib.types.path;
+                type = with lib.types; nullOr path;
+                default = null;
                 description = ''
                   Credential file.
 
@@ -223,6 +224,20 @@ in
                   rules configured via the Cloudflare dashboard.
                 '';
                 example = "eyJhIj...zUzZg==";
+              };
+
+              tokenFile = lib.mkOption {
+                type = with lib.types; nullOr path;
+                default = null;
+                description = ''
+                  Cloudflare tunnel tokenFile to use instead of a configuration file.
+                  If set, the tunnel will be run using `cloudflared tunnel run --token-file <tokenFile>`.
+                  This option is mutually exclusive with the config file-based approach
+                  (which requires `credentialsFile`).
+                  Note: Using a tokenFile bypasses locally defined ingress rules and uses
+                  rules configured via the Cloudflare dashboard.
+                '';
+                example = "/path/to/my/token_file";
               };
 
               warp-routing = {
@@ -262,6 +277,7 @@ in
                   See `service`.
                 '';
                 example = "http_status:404";
+                default = "http_status:404";
               };
 
               ingress = lib.mkOption {
@@ -339,6 +355,24 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.mapAttrsToList (
+      name: tunnel:
+      if tunnel.token != null then
+        "[cloudflared-service | ${name}] Tunnel is using raw token value, which is world-readable!"
+      else
+        ""
+    ) cfg.tunnels;
+
+    assertions = lib.mapAttrsToList (name: tunnel: {
+      assertion =
+        (lib.count (x: !builtins.isNull x) [
+          tunnel.token
+          tunnel.tokenFile
+          tunnel.credentialsFile
+        ]) <= 1;
+      message = "[cloudflared-service | ${name}] You must specify AT MOST ONE of 'token', 'tokenFile', or 'credentialsFile'.";
+    }) cfg.tunnels;
+
     systemd.targets = lib.mapAttrs' (
       name: tunnel:
       lib.nameValuePair "cloudflared-tunnel-${name}" {
@@ -352,8 +386,6 @@ in
     systemd.services = lib.mapAttrs' (
       name: tunnel:
       let
-        isTokenBased = tunnel.token != null;
-
         filterConfig = lib.attrsets.filterAttrsRecursive (
           _: v:
           !builtins.elem v [
@@ -369,7 +401,7 @@ in
         ingressesSet = filterIngressSet tunnel.ingress;
         ingressesStr = filterIngressStr tunnel.ingress;
 
-        fullConfig = lib.mkIf (!isTokenBased) (filterConfig {
+        fullConfig = filterConfig {
           tunnel = name;
           credentials-file = "/run/credentials/cloudflared-tunnel-${name}.service/credentials.json";
           warp-routing = filterConfig tunnel.warp-routing;
@@ -387,7 +419,7 @@ in
               service = lib.getAttr key ingressesStr;
             }) (lib.attrNames ingressesStr))
             ++ [ { service = tunnel.default; } ];
-        });
+        };
 
         mkConfigFile = pkgs.writeText "cloudflared.yml" (builtins.toJSON fullConfig);
         certFile = if (tunnel.certificateFile != null) then tunnel.certificateFile else cfg.certificateFile;
@@ -405,16 +437,15 @@ in
         serviceConfig = {
           RuntimeDirectory = "cloudflared-tunnel-${name}";
           RuntimeDirectoryMode = "0400";
-          LoadCredential = lib.mkIf (!isTokenBased) (
-            [
-              "credentials.json:${tunnel.credentialsFile}"
-            ]
-            ++ (lib.optional (certFile != null) "cert.pem:${certFile}")
-          );
+          LoadCredential = [
+            (lib.optional (tunnel.credentialsFile != null) ("credentials.json:${tunnel.credentialsFile}"))
+          ] ++ (lib.optional (certFile != null) "cert.pem:${certFile}");
 
           ExecStart =
-            if isTokenBased then
+            if tunnel.token != null then
               "${cfg.package}/bin/cloudflared tunnel run --token ${lib.escapeShellArg tunnel.token}"
+            else if tunnel.tokenFile != null then
+              "${cfg.package}/bin/cloudflared tunnel run --token-file ${lib.escapeShellArg tunnel.token}"
             else
               "${cfg.package}/bin/cloudflared tunnel --config=${mkConfigFile} --no-autoupdate run";
           Restart = "on-failure";

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -347,7 +347,7 @@ in
         after = [ "cloudflared-tunnel-${name}.service" ];
         unitConfig.StopWhenUnneeded = true;
       }
-    ) config.services.cloudflared.tunnels;
+    ) cfg.tunnels;
 
     systemd.services = lib.mapAttrs' (
       name: tunnel:
@@ -426,7 +426,7 @@ in
           TUNNEL_EDGE_IP_VERSION = tunnel.edgeIPVersion;
         };
       }
-    ) config.services.cloudflared.tunnels;
+    ) cfg.tunnels;
   };
 
   meta.maintainers = with lib.maintainers; [


### PR DESCRIPTION
Supersedes  #404337

I made the service load the token file with LoadCredential and I have also added an environmentFile option that can be used to set [tunnel run parameters](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/cloudflared-parameters/run-parameters), such as TUNNEL_TOKEN.

CC from previous PR @bn-c @LoCrealloc @anpin @marcusramberg
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
