### PR TITLE
python3Packages.beanquery: 0.1.0-unstable-2025-01-10 -> 0.2.0, fava: 1.30.1 -> 1.30.5

### DIFF
--- a/pkgs/by-name/fa/fava/dont-compile-frontend.patch
+++ b/pkgs/by-name/fa/fava/dont-compile-frontend.patch
@@ -1,0 +1,11 @@
+--- a/_build_backend.py
++++ b/_build_backend.py
+@@ -87,7 +87,7 @@
+ 
+ def _build_fava() -> None:
+     """Run the build steps for Fava."""
+-    _compile_frontend()
++    # _compile_frontend()
+     _compile_translations()
+ 
+ 

--- a/pkgs/by-name/fa/fava/package.nix
+++ b/pkgs/by-name/fa/fava/package.nix
@@ -90,6 +90,7 @@ python3Packages.buildPythonApplication {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       bhipple
+      prince213
       sigmanificient
     ];
   };

--- a/pkgs/by-name/fa/fava/package.nix
+++ b/pkgs/by-name/fa/fava/package.nix
@@ -2,16 +2,17 @@
   lib,
   python3Packages,
   fetchPypi,
+  stdenv,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "fava";
-  version = "1.30.1";
+  version = "1.30.5";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-69Wx9/H7nLDPZP9LOUnDJngY9YTCcr+oQ0E6+xeIWPE=";
+    hash = "sha256-pfnRNhAcyuYFHqPBF0qCrK7w1PJiMOdYXCGj+xXi6uQ=";
   };
 
   postPatch = ''
@@ -39,6 +40,12 @@ python3Packages.buildPythonApplication rec {
   ];
 
   nativeCheckInputs = [ python3Packages.pytestCheckHook ];
+
+  # tests/test_cli.py
+  __darwinAllowLocalNetworking = true;
+
+  # flaky, fails only on ci
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test_core_watcher.py" ];
 
   env = {
     # Disable some tests when building with beancount2

--- a/pkgs/development/python-modules/beanquery/default.nix
+++ b/pkgs/development/python-modules/beanquery/default.nix
@@ -9,18 +9,16 @@
   setuptools,
   tatsu-lts,
 }:
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "beanquery";
-  version = "0.1.0-unstable-2025-01-10";
+  version = "0.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "beancount";
     repo = "beanquery";
-    # Pinned at commit where tatsu dependency replaced with tatsu-lts
-    # Later snapsot versions break fava build due to API changes at beanquery/shell.py
-    rev = "e77a67996a54eef2e9d77b6352c74a40164e281d";
-    hash = "sha256-XYfKAscm55lY4YjIGTQ6RMFnCPWemfszpheGQ9qjMiM=";
+    tag = "v${version}";
+    hash = "sha256-O7+WCF7s50G14oNTvJAOTvgSoNR9fWcn/m1jv7RHmK8=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates beanquery and fava to the latest released version.  Also add myself to maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
