### PR TITLE
[25.05] tomcat9: 9.0.106 -> 9.0.107, tomcat10: 10.1.42 -> 10.1.43, tomcat11: 11.0.8 -> 11.0.9

### DIFF
--- a/pkgs/servers/http/tomcat/default.nix
+++ b/pkgs/servers/http/tomcat/default.nix
@@ -65,8 +65,8 @@ in
   };
 
   tomcat10 = common {
-    version = "10.1.42";
-    hash = "sha256-m29iOmn6DMhQElyJVXPuZX9+5WYIl2uiapZEsF5J/ac=";
+    version = "10.1.43";
+    hash = "sha256-hZ0Vx/DgjlQ6klv4RyjuIWbHELFKYvvJvn9Y8XqpZ10=";
   };
 
   tomcat11 = common {

--- a/pkgs/servers/http/tomcat/default.nix
+++ b/pkgs/servers/http/tomcat/default.nix
@@ -60,8 +60,8 @@ let
 in
 {
   tomcat9 = common {
-    version = "9.0.106";
-    hash = "sha256-EBMxGWDLyIvm2H75RsaF4WBSoNnRp24109GsQZG44n0=";
+    version = "9.0.107";
+    hash = "sha256-08qgrQpltJMafTrsok5VQc90O6X6nlGr2ls6MdC0hX0=";
   };
 
   tomcat10 = common {

--- a/pkgs/servers/http/tomcat/default.nix
+++ b/pkgs/servers/http/tomcat/default.nix
@@ -70,7 +70,7 @@ in
   };
 
   tomcat11 = common {
-    version = "11.0.8";
-    hash = "sha256-BGT3ORiCetG5hdhwpehW1ldfEJ0MrWEKSho9sPqadXI=";
+    version = "11.0.9";
+    hash = "sha256-YsVio60p26PqBPWK4x6/yGXPISAzUWP88PwD1CbtOoc=";
   };
 }


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-4j3c-42xv-3f84, https://github.com/advisories/GHSA-wr62-c79q-cv37 and https://github.com/advisories/GHSA-25xr-qj8w-c4vf.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
