### PR TITLE
linux-rpi: fix eval on darwin

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -43,12 +43,12 @@ lib.overrideDerivation
       extraMeta =
         if (rpiVersion < 3) then
           {
-            platforms = with lib.platforms; arm;
+            platforms = with lib.platforms; lib.intersectLists arm linux;
             hydraPlatforms = [ ];
           }
         else
           {
-            platforms = with lib.platforms; arm ++ aarch64;
+            platforms = with lib.platforms; lib.intersectLists (arm ++ aarch64) linux;
             hydraPlatforms = [ "aarch64-linux" ];
           };
       ignoreConfigErrors = true;


### PR DESCRIPTION
`meta.platforms` should only contain Linux platforms.

Fixes https://github.com/NixOS/nixpkgs/pull/427219#issuecomment-3113024199.

Hopefully this is enough and there are no other eval failures hiding for us.

Closes #427877.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
