### PR TITLE
Revert "coin3d: 4.0.3 -> 4.0.4"

### DIFF
--- a/pkgs/by-name/co/coin3d/package.nix
+++ b/pkgs/by-name/co/coin3d/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "coin";
-  version = "4.0.4";
+  version = "4.0.3";
 
   src = fetchFromGitHub {
     owner = "coin3d";
     repo = "coin";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Zk9tlGMbNhfHKv+Z5VFWr1g3wNuPFzof+7vsLAlOBC4=";
+    hash = "sha256-dUFmcUOdNc3ZFtr+Hnh3Q3OY/JA/WxmiRJiU2RFSSus=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#420051

This change needs to be reverted as FreeCAD now crashes when creating and opening files, as well as when changing some settings, making the program unusable (https://github.com/FreeCAD/FreeCAD/issues/22695).