### PR TITLE
tev: 1.29 -> 2.5.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26253,6 +26253,12 @@
     githubId = 74688871;
     name = "Tochukwu Ahanonu";
   };
+  tom94 = {
+    email = "nix@94.me";
+    github = "Tom94";
+    githubId = 4923655;
+    name = "Thomas Müller";
+  };
   tomahna = {
     email = "kevin.rauscher@tomahna.fr";
     github = "Tomahna";

--- a/pkgs/by-name/te/tev/package.nix
+++ b/pkgs/by-name/te/tev/package.nix
@@ -1,81 +1,91 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
   cmake,
-  wrapGAppsHook3,
-  libX11,
-  libzip,
-  glfw,
-  libpng,
+  darwin,
+  dbus,
+  fetchFromGitHub,
+  lcms2,
+  libGL,
+  libffi,
+  libxkbcommon,
+  nasm,
+  perl,
+  pkg-config,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
   xorg,
-  zenity,
 }:
 
 stdenv.mkDerivation rec {
   pname = "tev";
-  version = "1.29";
+  version = "2.5.2";
 
   src = fetchFromGitHub {
     owner = "Tom94";
     repo = "tev";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-ke1T5nOrDoJilpfshAIAFWw/640Gm5OaxZ+ZakCevTs=";
+    hash = "sha256-S4VE33wMima6GeGPmZOU6ub5V/ZWoVYqAIizh9BJHGo=";
   };
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux (
+    let
+      waylandLibPath = "${lib.getLib wayland}/lib";
+    in
+    ''
+      substituteInPlace ./dependencies/nanogui/ext/glfw/src/wl_init.c \
+        --replace-fail "libwayland-client.so" "${waylandLibPath}/libwayland-client.so" \
+        --replace-fail "libwayland-cursor.so" "${waylandLibPath}/libwayland-cursor.so" \
+        --replace-fail "libwayland-egl.so" "${waylandLibPath}/libwayland-egl.so" \
+        --replace-fail "libxkbcommon.so" "${lib.getLib libxkbcommon}/lib/libxkbcommon.so"
+    ''
+  );
 
   nativeBuildInputs = [
     cmake
-    wrapGAppsHook3
+    nasm
+    perl
+    pkg-config
   ];
-  buildInputs = [
-    libX11
-    libzip
-    glfw
-    libpng
-  ]
-  ++ (with xorg; [
-    libXrandr
-    libXinerama
-    libXcursor
-    libXi
-    libXxf86vm
-    libXext
-  ]);
 
-  dontWrapGApps = true; # We also need zenity (see below)
+  buildInputs = [
+    lcms2
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    dbus
+    libffi
+    libGL
+    libxkbcommon
+    wayland
+    wayland-protocols
+    wayland-scanner
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXinerama
+    xorg.libXrandr
+  ];
 
   cmakeFlags = [
-    "-DTEV_DEPLOY=1" # Only relevant not to append "dev" to the version
+    "-DTEV_DEPLOY=1"
   ];
 
-  postInstall = ''
-    wrapProgram $out/bin/tev \
-      "''${gappsWrapperArgs[@]}" \
-      --prefix PATH ":" "${zenity}/bin"
-  '';
-
-  env.CXXFLAGS = "-include cstdint";
-
   meta = {
-    description = "High dynamic range (HDR) image comparison tool";
+    description = "High dynamic range (HDR) image viewer for people who care about colors";
     mainProgram = "tev";
     longDescription = ''
-      A high dynamic range (HDR) image comparison tool for graphics people. tev
-      allows viewing images through various tonemapping operators and inspecting
-      the values of individual pixels. Often, it is important to find exact
-      differences between pairs of images. For this purpose, tev allows rapidly
-      switching between opened images and visualizing various error metrics (L1,
-      L2, and relative versions thereof). To avoid clutter, opened images and
-      their layers can be filtered by keywords.
-      While the predominantly supported file format is OpenEXR certain other
-      types of images can also be loaded.
+      High dynamic range (HDR) image viewer for people who care about colors. It is
+      - Lightning fast: starts up instantly, loads hundreds of images in seconds.
+      - Accurate: understands color profiles and displays HDR.
+      - Versatile: supports many formats, histograms, pixel peeping, tonemaps, etc.
     '';
-    inherit (src.meta) homepage;
     changelog = "https://github.com/Tom94/tev/releases/tag/v${version}";
-    license = lib.licenses.bsd3;
+    homepage = "https://github.com/Tom94/tev";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ tom94 ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin; # needs apple frameworks + SDK fix? see #205247
-    maintainers = [ ];
   };
 }


### PR DESCRIPTION
Updated [tev](https://github.com/tom94/tev) from version 1.29 to version 2.5.2

Upstream changelogs:
- https://github.com/Tom94/tev/releases/tag/v2.0
- https://github.com/Tom94/tev/releases/tag/v2.1
- https://github.com/Tom94/tev/releases/tag/v2.2
- https://github.com/Tom94/tev/releases/tag/v2.3
- https://github.com/Tom94/tev/releases/tag/v2.3.2
- https://github.com/Tom94/tev/releases/tag/v2.4.0
- https://github.com/Tom94/tev/releases/tag/v2.4.1
- https://github.com/Tom94/tev/releases/tag/v2.5.0
- https://github.com/Tom94/tev/releases/tag/v2.5.1
- https://github.com/Tom94/tev/releases/tag/v2.5.2

Other changes to `tev/package.nix` in this PR:
- Unbroke nix-darwin.
- Updated metadata. Most notably, the license changed from BSD 3-Clause to GPLv3 with the major version bump of 1.X to 2.X.
- Upstream recently added Wayland support, so added necessary dependencies.
- Removed several annoying dependencies and requirement to wrap app.

Also added myself as the maintainer of this package. I'm the author of tev and am happy to commit to updating the nixos and nix-darwin package in sync with future releases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
