### PR TITLE
various: Don't depend on libsoup2

### DIFF
--- a/pkgs/by-name/gn/gnome-notes/package.nix
+++ b/pkgs/by-name/gn/gnome-notes/package.nix
@@ -19,7 +19,7 @@
   libuuid,
   curl,
   libhandy,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
   gnome,
   adwaita-icon-theme,
   libxml2,
@@ -42,6 +42,13 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/gnome-notes/-/commit/994af76ce5144062d55d141129bf6bf5fab002ee.patch";
       hash = "sha256-z7dPOLZzaqvdqUIDy6+V3dKossRbG0EDjBu2oJCF6b4=";
+    })
+
+    # build: Depend on webkit2gtk-4.1
+    # https://gitlab.gnome.org/GNOME/gnome-notes/-/merge_requests/200
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-notes/-/commit/0791507873c96d0463cd0c83108415541f854edd.patch";
+      hash = "sha256-TwCi9sDudeiOjrH2VevAynxvy/WTmwB2HrWqhviPg8o=";
     })
   ];
 
@@ -71,7 +78,7 @@ stdenv.mkDerivation rec {
     libuuid
     curl
     libhandy
-    webkitgtk_4_0
+    webkitgtk_4_1
     tinysparql
     gnome-online-accounts
     gsettings-desktop-schemas

--- a/pkgs/by-name/gt/gthumb/package.nix
+++ b/pkgs/by-name/gt/gthumb/package.nix
@@ -13,17 +13,13 @@
   libtiff,
   gst_all_1,
   libraw,
-  libsoup_2_4,
-  libsecret,
   glib,
   gtk3,
   gsettings-desktop-schemas,
-  libchamplain,
   libjxl,
   librsvg,
   libwebp,
   libX11,
-  json-glib,
   lcms2,
   bison,
   flex,
@@ -33,8 +29,6 @@
   python3,
   desktop-file-utils,
   itstool,
-  withWebservices ? true,
-  webkitgtk_4_0,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -70,26 +64,23 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-bad
     gst_all_1.gst-plugins-ugly
     gtk3
-    json-glib
     lcms2
-    libchamplain
     libheif
     libjpeg
     libjxl
     libraw
     librsvg
-    libsecret
-    libsoup_2_4
     libtiff
     libwebp
     libX11
-  ]
-  ++ lib.optional withWebservices webkitgtk_4_0;
+  ];
 
   mesonFlags = [
-    "-Dlibchamplain=true"
     "-Dlibjxl=true"
-    (lib.mesonBool "webservices" withWebservices)
+    # Depends on libsoup2.
+    # https://gitlab.gnome.org/GNOME/gthumb/-/issues/244
+    "-Dlibchamplain=false"
+    "-Dwebservices=false"
   ];
 
   postPatch = ''
@@ -119,6 +110,9 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "gthumb";
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.mimame ];
+    maintainers = with maintainers; [
+      bobby285271
+      mimame
+    ];
   };
 })

--- a/pkgs/by-name/sh/shotwell/package.nix
+++ b/pkgs/by-name/sh/shotwell/package.nix
@@ -24,7 +24,6 @@
   gcr,
   libgee,
   gexiv2,
-  librest,
   gettext,
   desktop-file-utils,
   gdk-pixbuf,
@@ -81,7 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
     glib-networking
     gdk-pixbuf
     librsvg
-    librest
     gcr
     adwaita-icon-theme
     libsecret

--- a/pkgs/by-name/ti/timezonemap/package.nix
+++ b/pkgs/by-name/ti/timezonemap/package.nix
@@ -10,7 +10,7 @@
   file,
   gobject-introspection,
   json-glib,
-  libsoup_2_4,
+  libsoup_3,
 }:
 
 stdenv.mkDerivation {
@@ -30,6 +30,13 @@ stdenv.mkDerivation {
       url = "https://git.launchpad.net/ubuntu/+source/libtimezonemap/plain/debian/patches/timezone-map-Never-try-to-access-to-free-d-or-null-values.patch?id=88f72f724e63df061204f6818c9a1e7d8c003e29";
       sha256 = "sha256-M5eR0uaqpJOeW2Ya1Al+3ZciXukzHpnjJTMVvdO0dPE=";
     })
+
+    # Port to libsoup3
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1068679
+    (fetchpatch {
+      url = "https://git.launchpad.net/ubuntu/+source/libtimezonemap/plain/debian/patches/port-to-libsoup3.patch?id=b8346a99d4abece742bce73780ccf0edfa0b99f0";
+      hash = "sha256-BHLVA3Vcakl9COAiSPo0OyFOUz4ejsxB22gJW/+m7NI=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -42,7 +49,7 @@ stdenv.mkDerivation {
     gtk3
     glib
     json-glib
-    libsoup_2_4
+    libsoup_3
   ];
 
   configureFlags = [

--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -8,7 +8,7 @@
   glib,
   gst_all_1,
   gtk3,
-  gupnp,
+  gupnp_1_6,
   imagemagick,
   mate-desktop,
   wrapGAppsHook3,
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
     gtk3
-    gupnp
+    gupnp_1_6
     imagemagick
     mate-desktop
   ];


### PR DESCRIPTION
cc  #427813


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

