### PR TITLE
haskellPackages.llvm-ffi: 20.0 -> 21.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -37,8 +37,6 @@ default-package-overrides:
   - hsc3 < 0.21
   # 2024-12-31: last version that's compatible with GHC < 9.9
   - htree < 0.2.0.0
-  # 2025-07-10: use latest released version of LLVM
-  - llvm-ffi == 20.*
   # 2025-06-11: last version that supports pandoc == 3.6.* which is prescribed by LTS 23
   - pandoc-crossref < 0.3.20
 # keep-sorted end

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -508,19 +508,24 @@ builtins.intersectAttrs super {
   # LLVM input that llvm-ffi declares.
   llvm-ffi =
     let
-      matchingLlvmVersion = lib.strings.toInt (lib.versions.major super.llvm-ffi.version);
-      nextLlvmVersion = matchingLlvmVersion + 1;
+      chosenLlvmVersion = 20;
+      nextLlvmAttr = "llvmPackages_${toString (chosenLlvmVersion + 1)}";
+      shouldUpgrade =
+        pkgs ? ${nextLlvmAttr} && (lib.strings.match ".+rc.+" pkgs.${nextLlvmAttr}.llvm.version) == null;
     in
-    lib.warnIf (pkgs ? "llvmPackages_${toString nextLlvmVersion}")
-      # This package can be updated by changing the version constraint in
-      # configuration-hackage2nix/main.yaml and regenerating the haskellPackages set.
-      "haskellPackages.llvm-ffi: LLVM ${toString nextLlvmVersion} is available in Nixpkgs, consider updating."
-      addBuildDepends
+    lib.warnIf shouldUpgrade
+      "haskellPackages.llvm-ffi: ${nextLlvmAttr} is available in Nixpkgs, consider updating."
+      lib.pipe
+      super.llvm-ffi
       [
-        pkgs."llvmPackages_${toString matchingLlvmVersion}".llvm.lib
-        pkgs."llvmPackages_${toString matchingLlvmVersion}".llvm.dev
-      ]
-      super.llvm-ffi;
+        # ATTN: There is no matching flag for the latest supported LLVM version,
+        # so you may need to remove this when updating chosenLlvmVersion
+        (enableCabalFlag "LLVM${toString chosenLlvmVersion}00")
+        (addBuildDepends [
+          pkgs."llvmPackages_${toString chosenLlvmVersion}".llvm.lib
+          pkgs."llvmPackages_${toString chosenLlvmVersion}".llvm.dev
+        ])
+      ];
 
   # Needs help finding LLVM.
   spaceprobe = addBuildTool self.buildHaskellPackages.llvmPackages.llvm super.spaceprobe;


### PR DESCRIPTION
We keep using LLVM 20, though, since LLVM 21 is still just a release candidate on our branch and llvm-ffi doesn't yet supported a released LLVM 21, just the git version. We can use the older version by passing a specific cabal flag.

The evaluation warning reminding us to upgrade now also checks whether LLVM is a release candidate before triggering.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
