### PR TITLE
elixir-ls: fix elixir executable in path

### DIFF
--- a/pkgs/development/beam-modules/elixir-ls/launch.sh.patch
+++ b/pkgs/development/beam-modules/elixir-ls/launch.sh.patch
@@ -1,5 +1,5 @@
 diff --git c/scripts/launch.sh w/scripts/launch.sh
-index 21afbb1e..6b61f0b4 100755
+index 21afbb1e..8bc5c382 100755
 --- c/scripts/launch.sh
 +++ w/scripts/launch.sh
 @@ -1,125 +1,4 @@
@@ -129,7 +129,7 @@ index 21afbb1e..6b61f0b4 100755
  
  # In case that people want to tweak the path, which Elixir to use, or
  # whatever prior to launching the language server or the debug adapter, we
-@@ -138,29 +17,18 @@ fi
+@@ -138,29 +17,22 @@ fi
  # script so we can correctly configure the Erlang library path to
  # include the local .ez files, and then do what we were asked to do.
  
@@ -165,5 +165,9 @@ index 21afbb1e..6b61f0b4 100755
 +# ensure elixir stdlib can be found
 +ELX_STDLIB_PATH=${ELX_STDLIB_PATH:-@elixir@/lib/elixir}
 +export ELX_STDLIB_PATH
++
++# ensure our elixir is in the path
++PATH="@elixir@/bin:$PATH"
++export PATH
 +
 +source "$SCRIPTPATH/exec.bash"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

If I keep breaking it, I keep having to fix it. This fixes breakage from #427805 

```
Install complete
/nix/store/cqs84kfdnibkgcwv29xyqqxy2znqmqzz-elixir-ls-0.28.1/scripts/../scripts/exec.bash: line 8: exec: elixir: not found
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
