### PR TITLE
alsa-firmware: clean up & provide update script

### DIFF
--- a/pkgs/by-name/al/alsa-firmware/package.nix
+++ b/pkgs/by-name/al/alsa-firmware/package.nix
@@ -47,11 +47,11 @@ stdenv.mkDerivation (finalAttrs: {
     rm -rf $out/bin
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "http://www.alsa-project.org/";
     description = "Soundcard firmwares from the alsa project";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ l-as ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ l-as ];
   };
 })

--- a/pkgs/by-name/al/alsa-firmware/package.nix
+++ b/pkgs/by-name/al/alsa-firmware/package.nix
@@ -7,12 +7,12 @@
   fetchpatch,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "alsa-firmware";
   version = "1.2.4";
 
   src = fetchurl {
-    url = "mirror://alsa/firmware/alsa-firmware-${version}.tar.bz2";
+    url = "mirror://alsa/firmware/alsa-firmware-${finalAttrs.version}.tar.bz2";
     hash = "sha256-tnttfQi8/CR+9v8KuIqZwYgwWjz1euLf0LzZpbNs1bs=";
   };
 
@@ -54,4 +54,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ l-as ];
   };
-}
+})

--- a/pkgs/by-name/al/alsa-firmware/package.nix
+++ b/pkgs/by-name/al/alsa-firmware/package.nix
@@ -5,6 +5,7 @@
   autoreconfHook,
   fetchurl,
   fetchpatch,
+  directoryListingUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -46,6 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
     # remove empty dir
     rm -rf $out/bin
   '';
+
+  passthru.updateScript = directoryListingUpdater {
+    url = "https://alsa-project.org/files/pub/firmware/";
+  };
 
   meta = {
     homepage = "http://www.alsa-project.org/";


### PR DESCRIPTION
- Provide update script,
- use `finalAttrs` pattern instead of `rec`, and
- remove use of `with lib;`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
