### PR TITLE
plater: migrate to by-name

### DIFF
--- a/pkgs/by-name/pl/plater/package.nix
+++ b/pkgs/by-name/pl/plater/package.nix
@@ -1,38 +1,37 @@
 {
-  mkDerivation,
+  stdenv,
   cmake,
   fetchFromGitHub,
   lib,
   libGLU,
   makeDesktopItem,
-  qtbase,
-  wrapQtAppsHook,
+  qt5,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "plater";
-  version = "2020-07-30";
+  version = "1.0.0-unstable-2025-03-24";
 
   src = fetchFromGitHub {
     owner = "Rhoban";
     repo = "Plater";
-    rev = "f8de6d038f95a9edebfcfe142c8e9783697d5b47";
-    sha256 = "0r20mbzd16zv1aiadjqdy7z6sp09rr6lgfxhvir4ll3cpakkynr4";
+    rev = "6c4f924504979095b1b45cf8fd81b1e38f0f8642";
+    hash = "sha256-+iL5Gl7k4lPikRwkyhaXSEcFYmhXV4ubAvP3iTBXDO8=";
   };
 
   nativeBuildInputs = [
     cmake
-    wrapQtAppsHook
+    qt5.wrapQtAppsHook
   ];
   buildInputs = [
     libGLU
-    qtbase
+    qt5.qtbase
   ];
 
   desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
+    name = "plater";
+    exec = "plater";
+    icon = "plater";
     desktopName = "Ideamaker";
     genericName = meta.description;
     categories = [
@@ -47,11 +46,11 @@ mkDerivation rec {
     cp $src/gui/img/plater.png $out/share/pixmaps/${pname}.png
   '';
 
-  meta = with lib; {
+  meta = {
     description = "3D-printer parts placer and plate generator";
     homepage = "https://github.com/Rhoban/Plater";
-    maintainers = with maintainers; [ lovesegfault ];
-    platforms = platforms.linux;
-    license = licenses.cc-by-nc-30;
+    maintainers = with lib.maintainers; [ lovesegfault ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.cc-by-nc-30;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13340,8 +13340,6 @@ with pkgs;
 
   pineapple-pictures = qt6Packages.callPackage ../applications/graphics/pineapple-pictures { };
 
-  plater = libsForQt5.callPackage ../applications/misc/plater { };
-
   plexamp = callPackage ../applications/audio/plexamp { };
 
   plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };


### PR DESCRIPTION
upgrade plater and migrate to by-name
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
