### PR TITLE
nix_2_3: drop and raise minver to 2.18

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -128,8 +128,7 @@ rec {
   parse = pkgs.lib.recurseIntoAttrs {
     latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };
     lix = pkgs.callPackage ./parse.nix { nix = pkgs.lix; };
-    # TODO: Raise nixVersions.minimum to 2.24 and flip back to it.
-    minimum = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.nix_2_24; };
+    nix_2_24 = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.nix_2_24; };
   };
   shell = import ../shell.nix { inherit nixpkgs system; };
   tarball = import ../pkgs/top-level/make-tarball.nix {

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -17,13 +17,7 @@ let
     else
       nixpkgs;
 
-  pkgs = import nixpkgs' {
-    inherit system;
-    config = {
-      permittedInsecurePackages = [ "nix-2.3.18" ];
-    };
-    overlays = [ ];
-  };
+  pkgs = import nixpkgs' { inherit system; };
 
   fmt =
     let

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -14,6 +14,10 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `nixVersions.nix_2_3` has been dropped because it was insecure and unmaintained.
+
+- The minimum version of Nix required to evaluate Nixpkgs has been raised from 2.3 to 2.18.
+
 - The `offrss` package was removed due to lack of upstream maintenance since 2012. It's recommended for users to migrate to another RSS reader
 
 - `base16-builder` node package has been removed due to lack of upstream maintenance.

--- a/lib/minver.nix
+++ b/lib/minver.nix
@@ -1,2 +1,2 @@
 # Expose the minimum required version for evaluating Nixpkgs
-"2.3.17"
+"2.18"

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -16,7 +16,7 @@
   pkgsBB ? pkgs.pkgsBuildBuild,
   nix ? pkgs-nixVersions.stable,
   nixVersions ? [
-    pkgs-nixVersions.minimum
+    pkgs-nixVersions.nix_2_24
     nix
     pkgs-nixVersions.latest
   ],

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -2,16 +2,9 @@
   # The pkgs used for dependencies for the testing itself
   # Don't test properties of pkgs.lib, but rather the lib in the parent directory
   system ? builtins.currentSystem,
-  pkgs ?
-    import ../.. {
-      inherit system;
-      config = {
-        permittedInsecurePackages = [ "nix-2.3.18" ];
-      };
-    }
-    // {
-      lib = throw "pkgs.lib accessed, but the lib tests should use nixpkgs' lib path directly!";
-    },
+  pkgs ? import ../.. { inherit system; } // {
+    lib = throw "pkgs.lib accessed, but the lib tests should use nixpkgs' lib path directly!";
+  },
   # For testing someone may edit impure.nix to return cross pkgs, use `pkgsBuildBuild` directly so everything here works.
   pkgsBB ? pkgs.pkgsBuildBuild,
   nix ? pkgs-nixVersions.stable,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -121,9 +121,9 @@ python3Packages.buildPythonApplication rec {
         with_nix_stable = nixos-rebuild-ng.override {
           nix = nixVersions.stable;
         };
-        with_nix_2_3 = nixos-rebuild-ng.override {
-          # oldest / minimum supported version in nixpkgs
-          nix = nixVersions.nix_2_3;
+        with_nix_2_24 = nixos-rebuild-ng.override {
+          # oldest supported version in nixpkgs
+          nix = nixVersions.nix_2_24;
         };
         with_lix_latest = nixos-rebuild-ng.override {
           nix = lixPackageSets.latest.lix;

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -233,23 +233,6 @@ lib.makeExtensible (
 
       latest = self.nix_2_30;
 
-      # The minimum Nix version supported by Nixpkgs
-      # Note that some functionality *might* have been backported into this Nix version,
-      # making this package an inaccurate representation of what features are available
-      # in the actual lowest minver.nix *patch* version.
-      minimum =
-        let
-          minver = import ../../../../lib/minver.nix;
-          major = lib.versions.major minver;
-          minor = lib.versions.minor minver;
-          attribute = "nix_${major}_${minor}";
-          nix = self.${attribute};
-        in
-        if !self ? ${attribute} then
-          throw "The minimum supported Nix version is ${minver} (declared in lib/minver.nix), but pkgs.nixVersions.${attribute} does not exist."
-        else
-          nix;
-
       # Read ./README.md before bumping a major release
       stable = addFallbackPathsCheck self.nix_2_28;
     }
@@ -269,6 +252,7 @@ lib.makeExtensible (
         nix_2_27 = throw "nix_2_27 has been removed. use nix_2_28.";
         nix_2_25 = throw "nix_2_25 has been removed. use nix_2_28.";
 
+        minimum = throw "nixVersions.minimum has been removed. Use a specific version instead.";
         unstable = throw "nixVersions.unstable has been removed. use nixVersions.latest or the nix flake.";
       }
     )

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -151,32 +151,6 @@ lib.makeExtensible (
   self:
   (
     {
-      nix_2_3 =
-        (commonAutoconf {
-          version = "2.3.18";
-          hash = "sha256-jBz2Ub65eFYG+aWgSI3AJYvLSghio77fWQiIW1svA9U=";
-          patches = [
-            patch-monitorfdhup
-          ];
-          self_attribute_name = "nix_2_3";
-          knownVulnerabilities = [
-            "CVE-2024-38531"
-            "CVE-2024-47174"
-            "CVE-2025-46415"
-            "CVE-2025-46416"
-            "CVE-2025-52991"
-            "CVE-2025-52992"
-            "CVE-2025-52993"
-          ];
-          maintainers = with lib.maintainers; [ flokli ];
-          teams = [ ];
-        }).overrideAttrs
-          {
-            # https://github.com/NixOS/nix/issues/10222
-            # spurious test/add.sh failures
-            enableParallelChecking = false;
-          };
-
       nix_2_24 = commonAutoconf {
         version = "2.24.15";
         hash = "sha256-GHqFHLxvRID2IEPUwIfRMp8epYQMFcvG9ogLzfWRbPc=";

--- a/pkgs/tools/package-management/nix/update-all.sh
+++ b/pkgs/tools/package-management/nix/update-all.sh
@@ -11,9 +11,6 @@ nix_versions=$(nix eval --impure --json --expr "with import ./. { config.allowAl
 
 for name in $nix_versions; do
     minor_version=${name#nix_*_}
-    if [[ "$name" = "nix_2_3" ]]; then # not maintained by the nix team
-        continue
-    fi
 
     nix-update --override-filename "$SCRIPT_DIR/default.nix" --version-regex "(2\\.${minor_version}\..+)" --build --commit "nixVersions.$name"
 done
@@ -25,9 +22,6 @@ stable_version_trimmed=${stable_version_full%.*}
 
 for name in $nix_versions; do
     minor_version=${name#nix_*_}
-    if [[ "$name" = "nix_2_3" ]]; then # not maintained by the nix team
-        continue
-    fi
     if [[ "$name" = "nix_${stable_version_trimmed//./_}" ]]; then
         curl https://releases.nixos.org/nix/nix-$stable_version_full/fallback-paths.nix > "$NIXPKGS_DIR/nixos/modules/installer/tools/nix-fallback-paths.nix"
         # nix-update will commit the file if it has changed

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1435,7 +1435,7 @@ mapAliases {
   nixFlakes = throw "'nixFlakes' has been renamed to/replaced by 'nixVersions.stable'"; # Converted to throw 2024-10-17
   nixStable = nixVersions.stable; # Added 2022-01-24
   nixUnstable = throw "nixUnstable has been removed. For bleeding edge (Nix master, roughly weekly updated) use nixVersions.git, otherwise use nixVersions.latest."; # Converted to throw 2024-04-22
-  nix_2_3 = nixVersions.nix_2_3;
+  nix_2_3 = throw "'nix_2_3' has been removed, because it was unmaintained and insecure."; # Converted to throw 2025-07-24
   nixfmt-rfc-style =
     if lib.oldestSupportedReleaseIsAtLeast 2511 then
       lib.warnOnInstantiate

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -3,13 +3,7 @@
   officialRelease,
   pkgs ? import nixpkgs.outPath { },
   nix ? pkgs.nix,
-  lib-tests ? import ../../lib/tests/release.nix {
-    pkgs = import nixpkgs.outPath {
-      config = {
-        permittedInsecurePackages = [ "nix-2.3.18" ];
-      };
-    };
-  },
+  lib-tests ? import ../../lib/tests/release.nix { inherit pkgs; },
 }:
 
 pkgs.releaseTools.sourceTarball {

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -113,20 +113,7 @@ let
 
     manual = pkgs.nixpkgs-manual.override { inherit nixpkgs; };
     metrics = import ./metrics.nix { inherit pkgs nixpkgs; };
-    lib-tests = import ../../lib/tests/release.nix {
-      pkgs = import nixpkgs (
-        recursiveUpdate
-          (recursiveUpdate {
-            inherit system;
-            config.allowUnsupportedSystem = true;
-          } nixpkgsArgs)
-          {
-            config.permittedInsecurePackages = nixpkgsArgs.config.permittedInsecurePackages or [ ] ++ [
-              "nix-2.3.18"
-            ];
-          }
-      );
-    };
+    lib-tests = import ../../lib/tests/release.nix { inherit pkgs; };
     pkgs-lib-tests = import ../pkgs-lib/tests { inherit pkgs; };
 
     darwin-tested =


### PR DESCRIPTION
Nix 2.3 was marked insecure in #420974.

In #427437, we updated the pinned nixpkgs for CI at which point we were not able to test Nix 2.3 in CI anymore and had to remove it from the `parse` check.

This brought up https://github.com/NixOS/nixpkgs/pull/427437#issuecomment-3102652854 and https://github.com/NixOS/nixpkgs/pull/427437#issuecomment-3112985078. The same questions asked therein, are still open: What's the plan for Nix 2.3 going forward?

I have neither the ability, nor the intent to backport the patches myself, "removal" is the only suggestion I can practically make, thus this PR.

## Things done

- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
