### PR TITLE
[Backport release-25.05] comma: Backport updates

### DIFF
--- a/pkgs/by-name/co/comma/package.nix
+++ b/pkgs/by-name/co/comma/package.nix
@@ -3,37 +3,51 @@
   fetchFromGitHub,
   fzy,
   lib,
-  makeBinaryWrapper,
   nix-index-unwrapped,
+  nix,
   rustPlatform,
   testers,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "comma";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "comma";
     rev = "v${version}";
-    hash = "sha256-mhSX2yx+/xDwCtLVb+aSFFxP2TOJek/ZX/28khvetwE=";
+    hash = "sha256-JogC9NIS71GyimpqmX2/dhBX1IucK395iWZVVabZxiE=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-6BsRgxcUtVuN1gp3VVXkNQzqb9hD5rWWctieJvFdyrQ=";
+  cargoHash = "sha256-Cd4WaOG+OkCM4Q1K9qVzMYOjSi9U8W82JypqUN20x9w=";
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
+  postPatch = ''
+    substituteInPlace ./src/main.rs \
+      --replace-fail '"nix-locate"' '"${lib.getExe' nix-index-unwrapped "nix-locate"}"' \
+      --replace-fail '"nix"' '"${lib.getExe nix}"' \
+      --replace-fail '"nix-env"' '"${lib.getExe' nix "nix-env"}"' \
+      --replace-fail '"fzy"' '"${lib.getExe fzy}"'
+  '';
 
   postInstall = ''
-    wrapProgram $out/bin/comma \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          fzy
-          nix-index-unwrapped
-        ]
-      }
     ln -s $out/bin/comma $out/bin/,
+
+    mkdir -p $out/etc/profile.d
+    mkdir -p $out/etc/nushell
+    mkdir -p $out/etc/fish/functions
+
+    cp $src/etc/comma-command-not-found.sh $out/etc/profile.d
+    cp $src/etc/comma-command-not-found.nu $out/etc/nushell
+    cp $src/etc/comma-command-not-found.fish $out/etc/fish/functions
+
+    patchShebangs $out/etc/profile.d/comma-command-not-found.sh
+    substituteInPlace \
+      "$out/etc/profile.d/comma-command-not-found.sh" \
+      "$out/etc/nushell/comma-command-not-found.nu" \
+      "$out/etc/fish/functions/comma-command-not-found.fish" \
+      --replace-fail "comma --ask" "$out/bin/comma --ask"
   '';
 
   passthru.tests = {

--- a/pkgs/by-name/co/comma/package.nix
+++ b/pkgs/by-name/co/comma/package.nix
@@ -11,17 +11,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "comma";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "comma";
     rev = "v${version}";
-    hash = "sha256-Q9s3z/FqkEqCQyvYhH07qlITGGlA8quZcYsK3lO8M8g=";
+    hash = "sha256-mhSX2yx+/xDwCtLVb+aSFFxP2TOJek/ZX/28khvetwE=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-yNx0Sc2JnEfndBBPxaeNMWsdWpB9fAUqXUPVNR+NOrM=";
+  cargoHash = "sha256-6BsRgxcUtVuN1gp3VVXkNQzqb9hD5rWWctieJvFdyrQ=";
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 

--- a/pkgs/by-name/co/comma/package.nix
+++ b/pkgs/by-name/co/comma/package.nix
@@ -11,17 +11,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "comma";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "comma";
     rev = "v${version}";
-    hash = "sha256-EP1UGmoPXeyJY1mk3c4DNF6/HkjqlwKf5ZLhjNa1WMo=";
+    hash = "sha256-Q9s3z/FqkEqCQyvYhH07qlITGGlA8quZcYsK3lO8M8g=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-GEHvS4hDBKqSquRmGZ9LMIFsX8MGqOqPZVf0aAzMmmI=";
+  cargoHash = "sha256-yNx0Sc2JnEfndBBPxaeNMWsdWpB9fAUqXUPVNR+NOrM=";
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 

--- a/pkgs/by-name/co/comma/package.nix
+++ b/pkgs/by-name/co/comma/package.nix
@@ -11,17 +11,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "comma";
-  version = "1.9.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "comma";
     rev = "v${version}";
-    hash = "sha256-XXe0SSdH2JZLx0o+vHDtdlDRtVn7nouIngipbXhmhiQ=";
+    hash = "sha256-EP1UGmoPXeyJY1mk3c4DNF6/HkjqlwKf5ZLhjNa1WMo=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-vNXczPhCfoXHy5IT/ybuKEQ7I08eJJdP+6+iXfwWjdU=";
+  cargoHash = "sha256-GEHvS4hDBKqSquRmGZ9LMIFsX8MGqOqPZVf0aAzMmmI=";
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 

--- a/pkgs/by-name/co/comma/package.nix
+++ b/pkgs/by-name/co/comma/package.nix
@@ -31,6 +31,10 @@ rustPlatform.buildRustPackage rec {
       --replace-fail '"fzy"' '"${lib.getExe fzy}"'
   '';
 
+  patches = [
+    ./rustverfix.patch
+  ];
+
   postInstall = ''
     ln -s $out/bin/comma $out/bin/,
 

--- a/pkgs/by-name/co/comma/rustverfix.patch
+++ b/pkgs/by-name/co/comma/rustverfix.patch
@@ -1,0 +1,14 @@
+diff --git a/src/main.rs b/src/main.rs
+index cdd04a0..413139a 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -214,7 +214,7 @@ fn run_command_from_cache(
+ 
+ fn confirmer(run_cmd: &Command) -> bool {
+     loop {
+-        print!("Run '{}'? [Y/n]: ", run_cmd.get_program().display());
++        print!("Run '{}'? [Y/n]: ", run_cmd.get_program().to_string_lossy());
+         io::stdout().flush().unwrap();
+ 
+         let mut input = String::new();
+


### PR DESCRIPTION
Diff: https://www.github.com/nix-community/comma/compare/v1.9.0...v2.0.0
(cherry picked from commit 26b511e)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
