### PR TITLE
lunasvg, plutosvg, plutovg: Add module testers and cmake config options

### DIFF
--- a/pkgs/by-name/lu/lunasvg/package.nix
+++ b/pkgs/by-name/lu/lunasvg/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   plutovg,
+  testers,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "lunasvg";
@@ -26,13 +27,26 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "USE_SYSTEM_PLUTOVG" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     # the cmake package does not handle absolute CMAKE_INSTALL_INCLUDEDIR correctly
     # (setting it to an absolute path causes include files to go to $out/$out/include,
     #  because the absolute path is interpreted with root at $out).
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DCMAKE_INSTALL_LIBDIR=lib"
-
   ];
+
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+    cmake-config = testers.hasCmakeConfigModules {
+      package = finalAttrs.finalPackage;
+      buildInputs = [ plutovg ];
+      moduleNames = [ "lunasvg" ];
+      versionCheck = true;
+    };
+  };
 
   meta = {
     homepage = "https://github.com/sammycage/lunasvg";
@@ -41,5 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.eymeric ];
     platforms = lib.platforms.all;
+    pkgConfigModules = [ "lunasvg" ];
   };
 })

--- a/pkgs/by-name/pl/plutovg/package.nix
+++ b/pkgs/by-name/pl/plutovg/package.nix
@@ -3,6 +3,8 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  testers,
+  fontFaceCache ? true,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "plutovg";
@@ -16,6 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "PLUTOVG_DISABLE_FONT_FACE_CACHE_LOAD" (!fontFaceCache))
     # the cmake package does not handle absolute CMAKE_INSTALL_INCLUDEDIR correctly
     # (setting it to an absolute path causes include files to go to $out/$out/include,
     #  because the absolute path is interpreted with root at $out).
@@ -27,11 +31,24 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
   ];
 
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+    cmake-config = testers.hasCmakeConfigModules {
+      package = finalAttrs.finalPackage;
+      moduleNames = [ "plutovg" ];
+      versionCheck = true;
+    };
+  };
+
   meta = {
     homepage = "https://github.com/sammycage/plutovg/";
     changelog = "https://github.com/sammycage/plutovg/releases/tag/v${finalAttrs.version}";
     description = "Tiny 2D vector graphics library in C";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.eymeric ];
+    pkgConfigModules = [ "plutovg" ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Add meta.pkgConfigModules attributes to each package
2. Add hasPkgConfigModules and hasCmakeConfigModules passthru testers to each package
3. Add BUILD_SHARED_LIBS option to each package
4. Add other cmake options to relevant pacakges

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
