### PR TITLE
eduvpn-daemon: init at 3.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15097,6 +15097,11 @@
     github = "M0NsTeRRR";
     githubId = 37785089;
   };
+  m0ustach3 = {
+    name = "M0ustach3";
+    github = "M0ustach3";
+    githubId = 37956764;
+  };
   m1cr0man = {
     email = "lucas+nix@m1cr0man.com";
     github = "m1cr0man";

--- a/pkgs/by-name/ed/eduvpn-daemon/package.nix
+++ b/pkgs/by-name/ed/eduvpn-daemon/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitea,
+  nix-update-script,
+}:
+
+buildGoModule rec {
+  pname = "eduvpn-daemon";
+  version = "3.3.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "eduVPN";
+    repo = "vpn-daemon";
+    tag = version;
+    hash = "sha256-tRdXc5sP8yInRMn6HFUf17ABIV1/mhugCH++TxuLcBw=";
+  };
+
+  vendorHash = "sha256-KcLwKZFg9e6eLFoYFiE7DpPN7wQa5wNl8+5B3MDe8S4=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "OpenVPN & WireGuard Management Daemon";
+    homepage = "https://${src.domain}/${src.owner}/${src.repo}";
+    license = lib.licenses.mit;
+    changelog = "https://${src.domain}/${src.owner}/${src.repo}/src/tag/${version}/CHANGES.md";
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      m0ustach3
+    ];
+    mainProgram = "vpn-daemon";
+  };
+}


### PR DESCRIPTION
Resolves #379153 

Not sure if this is still relevant, as the issue is from a few months ago, but hey there you go

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
