### PR TITLE
gnutls: patch security issues from 3.8.10

### DIFF
--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   zlib,
   libtasn1,
   nettle,
@@ -82,7 +83,45 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./nix-ssl-cert-file.patch
-  ];
+  ]
+  ++ (
+    let
+      fp =
+        name: commit: sha256:
+        fetchpatch {
+          name = "${name}.patch";
+          url = "https://gitlab.com/gnutls/gnutls/-/commit/${commit}.diff";
+          hash = "sha256-${sha256}";
+          excludes = [
+            "NEWS"
+            ".gitignore"
+            "tests/cert-tests/*"
+            "tests/Makefile.am"
+          ];
+        };
+    in
+    [
+      # This list is almost all of git log 3.8.10^..3.8.10
+      (fp "CVE-2025-32989" "8e5ca951257202089246fa37e93a99d210ee5ca2"
+        "I3q8+WyFohVrnWkQn1v2kUfc1NCIrAK/pceIhyddJ7w="
+      )
+      (fp "oss-fuzz-42513990" "208c6478d5c20b9d8a9f0a293e3808aa16ee091f"
+        "Dw3ib8wgw9dxneG8Iv19agxAytfr4JcuHrwxXyGdW7Q="
+      )
+      (fp "oss-fuzz-42536706" "61c0505634a6faacf9fa0723843408aa0d3fb90a"
+        "0la9GZhP2ol7KmKzi/sk9hslC8YcUe8cFJCqYqx44bY="
+      )
+      (fp "CVE-2025-32988" "608829769cbc247679ffe98841109fc73875e573"
+        "Tr0vatliZ0OuMc6KFSHacTwLRYteI54SR7/RtUD5Cb0="
+      )
+      (fp "CVE-2025-32990" "408bed40c36a4cc98f0c94a818f682810f731f32"
+        "Bpt1HcaIdcpqaeDvwZfNq73X1eNisI0Avu18ach7wdY="
+      )
+      (fp "CVE-2025-6395" "23135619773e6ec087ff2abc65405bd4d5676bad"
+        "xBk8bi2memjhFO0mgvTKid695YHRkHDiYXm48Uzqp8E="
+      )
+    ]
+  );
 
   # Skip some tests:
   #  - pkg-config: building against the result won't work before installing (3.5.11)


### PR DESCRIPTION
Mentioned in
https://lists.gnupg.org/pipermail/gnutls-help/2025-July/004883.html

Given the non-trivial changes e.g. in kTLS, I thought it might be preferable to just pick the security/important fixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
