### PR TITLE
comma: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/by-name/co/comma/package.nix
+++ b/pkgs/by-name/co/comma/package.nix
@@ -3,37 +3,51 @@
   fetchFromGitHub,
   fzy,
   lib,
-  makeBinaryWrapper,
   nix-index-unwrapped,
+  nix,
   rustPlatform,
   testers,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "comma";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "comma";
     rev = "v${version}";
-    hash = "sha256-mhSX2yx+/xDwCtLVb+aSFFxP2TOJek/ZX/28khvetwE=";
+    hash = "sha256-JogC9NIS71GyimpqmX2/dhBX1IucK395iWZVVabZxiE=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-6BsRgxcUtVuN1gp3VVXkNQzqb9hD5rWWctieJvFdyrQ=";
+  cargoHash = "sha256-Cd4WaOG+OkCM4Q1K9qVzMYOjSi9U8W82JypqUN20x9w=";
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
+  postPatch = ''
+    substituteInPlace ./src/main.rs \
+      --replace-fail '"nix-locate"' '"${lib.getExe' nix-index-unwrapped "nix-locate"}"' \
+      --replace-fail '"nix"' '"${lib.getExe nix}"' \
+      --replace-fail '"nix-env"' '"${lib.getExe' nix "nix-env"}"' \
+      --replace-fail '"fzy"' '"${lib.getExe fzy}"'
+  '';
 
   postInstall = ''
-    wrapProgram $out/bin/comma \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          fzy
-          nix-index-unwrapped
-        ]
-      }
     ln -s $out/bin/comma $out/bin/,
+
+    mkdir -p $out/etc/profile.d
+    mkdir -p $out/etc/nushell
+    mkdir -p $out/etc/fish/functions
+
+    cp $src/etc/comma-command-not-found.sh $out/etc/profile.d
+    cp $src/etc/comma-command-not-found.nu $out/etc/nushell
+    cp $src/etc/comma-command-not-found.fish $out/etc/fish/functions
+
+    patchShebangs $out/etc/profile.d/comma-command-not-found.sh
+    substituteInPlace \
+      "$out/etc/profile.d/comma-command-not-found.sh" \
+      "$out/etc/nushell/comma-command-not-found.nu" \
+      "$out/etc/fish/functions/comma-command-not-found.fish" \
+      --replace-fail "comma --ask" "$out/bin/comma --ask"
   '';
 
   passthru.tests = {


### PR DESCRIPTION
Diff: https://www.github.com/nix-community/comma/compare/v2.2.0...v2.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
