### PR TITLE
xapp-thumbnailers: init at 1.2.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25973,6 +25973,11 @@
     name = "Chinmay D. Pai";
     keys = [ { fingerprint = "7F3E EEAA EE66 93CC 8782  042A 7550 7BE2 56F4 0CED"; } ];
   };
+  thunze = {
+    name = "Tom Hunze";
+    github = "thunze";
+    githubId = 22795263;
+  };
   tiagolobocastro = {
     email = "tiagolobocastro@gmail.com";
     github = "tiagolobocastro";

--- a/pkgs/by-name/xa/xapp-thumbnailers/meson.patch
+++ b/pkgs/by-name/xa/xapp-thumbnailers/meson.patch
@@ -1,0 +1,14 @@
+diff --git a/meson.build b/meson.build
+index d0887d1..277cfb7 100644
+--- a/meson.build
++++ b/meson.build
+@@ -4,8 +4,8 @@ project_url = 'https://github.com/linuxmint/xapp-thumbnailers'
+ version = meson.project_version()
+
+ install_subdir(
+-    'files',
+-    install_dir: '/',
++    'files/usr',
++    install_dir: '',
+     strip_directory: true,
+ )

--- a/pkgs/by-name/xa/xapp-thumbnailers/package.nix
+++ b/pkgs/by-name/xa/xapp-thumbnailers/package.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  wrapGAppsNoGuiHook,
+  gobject-introspection,
+  meson,
+  ninja,
+  gdk-pixbuf,
+  xapp,
+
+  dcraw,
+  gimp,
+  libjxl,
+  squashfsTools,
+
+  # Exclude "raw" for now because dcraw is vulnerable.
+  enabledThumbnailers ? [
+    "aiff"
+    "appimage"
+    "epub"
+    "gimp"
+    "jxl"
+    "mp3"
+    "ora"
+    "vorbiscomment"
+  ],
+
+  # passthru.updateScript
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "xapp-thumbnailers";
+  version = "1.2.8";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "xapp-thumbnailers";
+    tag = version;
+    hash = "sha256-MX2TvtuOmqi8cpA/K8pSEPScUOXEmz++t7Xb/eDdb9c=";
+  };
+
+  patches = [ ./meson.patch ];
+
+  postPatch =
+    let
+      enabledThumbnailerFilenames = map (format: "xapp-${format}-thumbnailer") enabledThumbnailers;
+    in
+    ''
+      for path in files/usr/bin/xapp-*-thumbnailer; do
+        filename=$(basename "$path");
+        if [[ ! " ${lib.concatStringsSep " " enabledThumbnailerFilenames} " =~ " $filename " ]]; then
+          rm "files/usr/bin/$filename"
+          rm "files/usr/share/thumbnailers/$filename.thumbnailer"
+        fi
+      done
+
+      # Make thumbnailer binaries executable (because not all of them are), use absolute paths in thumbnailer files
+      for format in ${lib.concatStringsSep " " enabledThumbnailers}; do
+        chmod +x files/usr/bin/xapp-$format-thumbnailer
+        substituteInPlace files/usr/share/thumbnailers/xapp-$format-thumbnailer.thumbnailer \
+          --replace-fail "TryExec=xapp-$format-thumbnailer" "TryExec=${placeholder "out"}/bin/xapp-$format-thumbnailer" \
+          --replace-fail "Exec=xapp-$format-thumbnailer" "Exec=${placeholder "out"}/bin/xapp-$format-thumbnailer"
+      done
+    '';
+
+  nativeBuildInputs = [
+    wrapGAppsNoGuiHook
+    gobject-introspection
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    gdk-pixbuf
+    xapp
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      pillow
+      pygobject3
+    ]
+    ++ lib.optional (builtins.elem "aiff" enabledThumbnailers) mutagen
+    ++ lib.optional (builtins.elem "appimage" enabledThumbnailers) pyelftools
+    ++ lib.optional (builtins.elem "mp3" enabledThumbnailers) eyed3
+    ++ lib.optional (builtins.elem "vorbiscomment" enabledThumbnailers) mutagen;
+
+  # Let the Python wrapper add `gappsWrapperArgs` to avoid two layers of wrapping.
+  dontWrapGApps = true;
+
+  preFixup =
+    let
+      runtimeBinPackages =
+        lib.optional (builtins.elem "appimage" enabledThumbnailers) squashfsTools
+        ++ lib.optional (builtins.elem "gimp" enabledThumbnailers) gimp
+        ++ lib.optional (builtins.elem "jxl" enabledThumbnailers) libjxl
+        ++ lib.optional (builtins.elem "raw" enabledThumbnailers) dcraw;
+    in
+    ''
+      makeWrapperArgs+=(
+        "''${gappsWrapperArgs[@]}" \
+        --prefix PATH : '${lib.makeBinPath runtimeBinPackages}'
+      )
+    '';
+
+  pythonImportsCheck = [ "XappThumbnailers" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Thumbnailers for GTK desktop environments";
+    homepage = "https://github.com/linuxmint/xapp-thumbnailers";
+    changelog = "https://github.com/linuxmint/xapp-thumbnailers/blob/${src.tag}/debian/changelog";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ thunze ];
+    inherit (xapp.meta) platforms;
+  };
+}


### PR DESCRIPTION
This PR adds [xapp-thumbnailers](https://github.com/linuxmint/xapp-thumbnailers), a collection of thumbnail generators for GTK-based desktop environments that supports a variety of file types.

The `enabledThumbnailers` argument allows selecting which thumbnailers to include, with the default being “all except the RAW thumbnailer”. I excluded the RAW thumbnailer from the default list of thumbnailers for now because it requires `dcraw`, which is currently marked as vulnerable in nixpkgs.

The thumbnailer binaries can be tested on files of the respective formats using variations of the following command:

```bash
xapp-<format>-thumbnailer -i <input_file> -o <output_file> -s <size>
```

I found ffmpeg to be particularly useful when testing different audio formats.

I also tested a subset of the thumbnailers directly in [Nautilus](https://apps.gnome.org/Nautilus/). If you test any of the thumbnailers in a file manager, make sure to clear your thumbnail cache first.

@donovanglover You requested this package in #269256 a while ago, so maybe this is of interest to you.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
