### PR TITLE
jetbrains-jdk: add missing runtime dependency.

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -19,6 +19,7 @@
   libXrender,
   libX11,
   libXext,
+  libxkbcommon,
   libxcb,
   nss,
   nspr,
@@ -140,6 +141,7 @@ jdk.overrideAttrs (oldAttrs: rec {
         libXrender
         libX11
         libXext
+        libxkbcommon
         libxcb
         nss
         nspr


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add missing dependency according to: https://github.com/JetBrains/JetBrainsRuntime/blob/da1ad417adde9b6766e2f3777004d55f52a0ed32/.github/README.md?plain=1#L164

This prevents Intellij idea from crashing when `-Dawt.toolkit.name=WLToolkit` is set.

Stack trace:

```
-----
JRE: 21.0.6+6-nixos amd64 (JetBrains s.r.o.)
/nix/store/gl7nsv9a75wzji9g0fd1yc1mbi8pvpln-jetbrains-jdk-jcef-21.0.6-b895.109/lib/openjdk

-----
Also, a UI exception occurred in an attempt to show the above message:
java.lang.NoClassDefFoundError: Could not initialize class sun.awt.wl.WLToolkit
        at java.desktop/sun.awt.PlatformGraphicsInfo.createToolkit(PlatformGraphicsInfo.java:75)
        at java.desktop/java.awt.Toolkit.getDefaultToolkit(Toolkit.java:595)
        at java.desktop/javax.swing.ImageIcon.<init>(ImageIcon.java:213)
        at java.desktop/javax.swing.ImageIcon.<init>(ImageIcon.java:232)
        at com.intellij.platform.ide.bootstrap.StartupErrorReporter.showError(StartupErrorReporter.java:138)
        at com.intellij.platform.ide.bootstrap.StartupErrorReporter.showError(StartupErrorReporter.java:99)
        at com.intellij.idea.Main.mainImpl(Main.kt:86)
        at com.intellij.idea.Main.main(Main.kt:47)
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: No such file or directory (libxkbcommon.so) [in thread "DefaultDispatcher-worker-7"]
        at java.desktop/sun.awt.wl.WLKeyboard.initialize(Native Method)
        at java.desktop/sun.awt.wl.WLKeyboard.<init>(WLKeyboard.java:37)
        at java.desktop/sun.awt.wl.WLToolkit.<clinit>(WLToolkit.java:167)
        at java.desktop/sun.awt.PlatformGraphicsInfo.createToolkit(PlatformGraphicsInfo.java:75)
        at java.desktop/java.awt.Toolkit.getDefaultToolkit(Toolkit.java:595)
        at com.intellij.platform.ide.bootstrap.UiKt$initAwtToolkit$2.invokeSuspend(ui.kt:139)
        at com.intellij.platform.ide.bootstrap.UiKt$initAwtToolkit$2.invoke(ui.kt)
        at com.intellij.platform.ide.bootstrap.UiKt$initAwtToolkit$2.invoke(ui.kt)
        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
        at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:163)
        at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
        at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span(tracer.kt:56)
        at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span$default(tracer.kt:48)
        at com.intellij.platform.ide.bootstrap.UiKt.initAwtToolkit(ui.kt:138)
        at com.intellij.platform.ide.bootstrap.UiKt.access$initAwtToolkit(ui.kt:1)
        at com.intellij.platform.ide.bootstrap.UiKt$scheduleInitAwtToolkit$task$1$1.invokeSuspend(ui.kt:121)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:608)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:873)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:763)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:750)

```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
