### PR TITLE
buildRustCrate: add a way to compile integration tests using CARGO_BIN_EXE_<name>

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -23,6 +23,7 @@
   verbose,
   colors,
   buildTests,
+  testedCrate,
   codegenUnits,
 }:
 
@@ -88,6 +89,13 @@ in
   fi
 
 
+  ${lib.optionalString (testedCrate != null) ''
+    for exe in ${testedCrate}/bin/*; do
+      # if $exe contains a dash we cannot use export
+      # hence the indirection through EXTRA_ENV
+      EXTRA_ENV+=("CARGO_BIN_EXE_$(basename $exe)=$exe")
+    done
+  ''}
 
   ${lib.optionalString (lib.length crateBin > 0) (
     lib.concatMapStringsSep "\n" (

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -196,10 +196,13 @@ lib.makeOverridable
       # Example: [ "-Z debuginfo=2" ]
       # Default: []
       extraRustcOptsForBuildRs,
-      # Whether to enable building tests.
-      # Use true to enable.
+      # if True, executables running tests are built instead of the actual
+      # binaries/libararies.
       # Default: false
       buildTests,
+      # if buildTests is true, test executables may need to reference the
+      # actual executables to be tested
+      testedCrate,
       # Passed to stdenv.mkDerivation.
       preUnpack,
       # Passed to stdenv.mkDerivation.
@@ -249,6 +252,7 @@ lib.makeOverridable
         "buildTests"
         "codegenUnits"
         "links"
+        "testedCrate"
       ];
       extraDerivationAttrs = builtins.removeAttrs crate processedAttrs;
       nativeBuildInputs_ = nativeBuildInputs;
@@ -291,6 +295,7 @@ lib.makeOverridable
           preInstall
           postInstall
           buildTests
+          testedCrate
           ;
 
         src = crate.src or (fetchCrate { inherit (crate) crateName version sha256; });
@@ -433,6 +438,7 @@ lib.makeOverridable
             colors
             extraRustcOpts
             buildTests
+            testedCrate
             codegenUnits
             ;
         };
@@ -492,4 +498,5 @@ lib.makeOverridable
     buildDependencies = crate_.buildDependencies or [ ];
     crateRenames = crate_.crateRenames or { };
     buildTests = crate_.buildTests or false;
+    testedCrate = crate_.testedCrate or null;
   }

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -1,3 +1,5 @@
+declare -a EXTRA_ENV
+
 echo_build_heading() {
   if (( $# == 1 )); then
     echo_colored "Building $1"
@@ -10,7 +12,7 @@ build_lib() {
   lib_src=$1
   echo_build_heading $lib_src ${libName}
 
-  noisily rustc \
+  noisily env "${EXTRA_ENV[@]}" rustc \
     --crate-name $CRATE_NAME \
     $lib_src \
     --out-dir target/lib \
@@ -41,7 +43,7 @@ build_bin() {
     main_file=$2
   fi
   echo_build_heading $@
-  noisily rustc \
+  noisily env "${EXTRA_ENV[@]}" rustc \
     --crate-name $crate_name_ \
     $main_file \
     --crate-type bin \

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -90,8 +90,17 @@ let
   mkTest =
     crateArgs:
     let
-      crate = mkHostCrate (builtins.removeAttrs crateArgs [ "expectedTestOutput" ]);
+      untestedcrate = mkHostCrate (
+        builtins.removeAttrs (crateArgs // { buildTests = false; }) [ "expectedTestOutput" ]
+      );
       hasTests = crateArgs.buildTests or false;
+      crate =
+        if hasTests then
+          mkHostCrate (
+            builtins.removeAttrs (crateArgs // { testedCrate = untestedcrate; }) [ "expectedTestOutput" ]
+          )
+        else
+          untestedcrate;
       expectedTestOutputs = crateArgs.expectedTestOutputs or null;
       binaries = map (v: lib.escapeShellArg v.name) (crateArgs.crateBin or [ ]);
       isLib = crateArgs ? libName || crateArgs ? libPath;
@@ -133,8 +142,9 @@ let
           ''
         else if stdenv.hostPlatform == stdenv.buildPlatform then
           ''
+            echo testing ${crate}
             for file in ${crate}/tests/*; do
-              $file 2>&1 >> $out
+              $file 2>&1 | tee -a $out
             done
             set -e
             ${lib.concatMapStringsSep "\n" (
@@ -406,6 +416,39 @@ rec {
             "test src_main ... ok"
             "test tests_foo ... ok"
             "test tests_bar ... ok"
+          ];
+        };
+        rustBinTestsEnvVar = {
+          src = symlinkJoin {
+            name = "rustBinTestsEnvVar";
+            paths = [
+              (mkFile "src/main.rs" "pub fn main() { std::process::exit(32); }")
+              (mkFile "src/bin/exe.rs" "pub fn main() { std::process::exit(33); }")
+              (mkFile "src/bin/exe-with-dash.rs" "pub fn main() { std::process::exit(34); }")
+              (mkFile "tests/foo.rs" ''
+                #[test]
+                fn test_main() {
+                  let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_rustBinTestsEnvVar"));
+                  assert_eq!(cmd.status().unwrap().code().unwrap(), 32);
+                }
+                #[test]
+                fn test_exe() {
+                  let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_exe"));
+                  assert_eq!(cmd.status().unwrap().code().unwrap(), 33);
+                }
+                #[test]
+                fn test_exe_with_dash() {
+                  let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_exe-with-dash"));
+                  assert_eq!(cmd.status().unwrap().code().unwrap(), 34);
+                }
+              '')
+            ];
+          };
+          buildTests = true;
+          expectedTestOutputs = [
+            "test test_main ... ok"
+            "test test_exe ... ok"
+            "test test_exe_with_dash ... ok"
           ];
         };
         rustBinTestsSubdirCombined = {


### PR DESCRIPTION
when *compiling* integration tests, cargo exports the following variable:
CARGO_BIN_EXE_<name> — The absolute path to a binary target’s executable. This is only set when building an integration test or benchmark. This may be used with the env macro to find the executable to run for testing purposes. The <name> is the name of the binary target, exactly as-is. For example, CARGO_BIN_EXE_my-program for a binary named my-program. Binaries are automatically built when the test is built, unless the binary has required features that are not enabled.

(excerpt of the documentation)

so buildRustCrate in buildTests mode must take as argument the crate built in normal mode, so that it may point to it.


companion crate2nix change: https://github.com/nix-community/crate2nix/pull/398

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
