### PR TITLE
nixos/drupal: config extend

### DIFF
--- a/nixos/modules/services/web-apps/drupal.nix
+++ b/nixos/modules/services/web-apps/drupal.nix
@@ -58,6 +58,35 @@ let
       '';
     });
 
+  drupalSettings =
+    hostName: cfg:
+    pkgs.writeTextFile {
+      name = "settings.nixos-${hostName}.php";
+      text = ''
+        <?php
+
+          // NixOS automatically generated settings
+          $settings['file_private_path'] = '${cfg.privateFilesDir}';
+          $settings['config_sync_directory'] = '${cfg.configSyncDir}';
+
+          // Extra config
+          ${cfg.extraConfig}
+      '';
+      checkPhase = "${pkgs.php}/bin/php --syntax-check $target";
+    };
+
+  appendSettings =
+    hostName:
+    pkgs.writeTextFile {
+      name = "append-drupal-settings-${hostName}";
+      text = ''
+
+        // NixOS settings file import.
+        require dirname(__FILE__) . '/settings.nixos-${hostName}.php';
+
+      '';
+    };
+
   siteOpts =
     {
       options,
@@ -85,6 +114,26 @@ let
           default = "/var/lib/drupal/${name}/private";
           defaultText = "/var/lib/drupal/<name>/private";
           description = "The location of the Drupal private files directory.";
+        };
+
+        configSyncDir = mkOption {
+          type = types.path;
+          default = "/var/lib/drupal/${name}/config/sync";
+          defaultText = "/var/lib/drupal/<name>/config/sync";
+          description = "The location of the Drupal config sync directory.";
+        };
+
+        extraConfig = mkOption {
+          type = types.lines;
+          default = "";
+          description = ''
+            Extra configuration values that you want to insert into settings.php.
+            All configuration must be written as PHP script.
+          '';
+          example = ''
+            $config['user.settings']['anonymous'] = 'Visitor';
+            $settings['entity_update_backup'] = TRUE;
+          '';
         };
 
         stateDir = mkOption {
@@ -308,6 +357,7 @@ in
           "d '${cfg.themesDir}' 0750 ${user} ${webserver.group} - -"
           "Z '${cfg.themesDir}' 0750 ${user} ${webserver.group} - -"
           "d '${cfg.privateFilesDir}' 0750 ${user} ${webserver.group} - -"
+          "d '${cfg.configSyncDir}' 0750 ${user} ${webserver.group} - -"
         ]) eachSite
       );
 
@@ -330,6 +380,8 @@ in
             serviceConfig = {
               Type = "oneshot";
               User = "root";
+              RemainAfterExit = true;
+
               ExecStart = writeShellScript "drupal-state-init-${hostName}" ''
                 set -e
 
@@ -345,22 +397,29 @@ in
                 fi
 
                 settings_file="${cfg.stateDir}/sites/default/settings.php"
-                defaultSettings="${cfg.package}/share/php/drupal/sites/default/default.settings.php"
+                default_settings="${cfg.package}/share/php/drupal/sites/default/default.settings.php"
 
-                if [ ! -f "$settings" ]; then
+                if [ ! -f "$settings_file" ]; then
                   echo "Preparing settings.php for ${hostName}..."
-                  cp "$defaultSettings" "$settings_file"
+                  cp "$default_settings" "$settings_file"
+                  cat < ${appendSettings hostName} >> "$settings_file"
                   chmod 644 "$settings_file"
-
-                  # Append settings to settings file
-                  printf "\n\n// NixOS Automatically Generated Settings\n" >> $settings_file
-                  printf "\$settings['file_private_path'] = '${cfg.privateFilesDir}';" >> $settings_file
                 fi
+
+                # Link the NixOS-managed settings file to the state directory.
+                ln -sf ${drupalSettings hostName cfg} ${cfg.stateDir}/sites/default/settings.nixos-${hostName}.php
 
                 # Set or reset file permissions so that the web user and webserver owns them.
                 chown -R ${user}:${webserver.group} ${cfg.stateDir}
               '';
             };
+
+            # Rerun this service if certain settings were updated
+            reloadTriggers = [
+              cfg.extraConfig
+              cfg.privateFilesDir
+              cfg.configSyncDir
+            ];
           })
         ) eachSite)
 


### PR DESCRIPTION
This MR extends the available config options for Drupal.

There is a new `configSyncDir` setting that allows users to define the location of the config sync dir.

There is also a new `extraConfig` setting that accepts raw PHP code that will be injected into the Drupal `settings.php` file. The settings that users write to both attributes will automatically be available to Drupal.

These changes help bring the Drupal service one step closer to being managed by the nix language and NixOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
