### PR TITLE
yaziPlugins: update on 2025-07-24

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/chmod/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/chmod/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "chmod.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-06-26";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "7c174cc0ae1e07876218868e5e0917308201c081";
+    hash = "sha256-RE93ZNlG6CRGZz7YByXtO0mifduh6MMGls6J9IYwaFA=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/git/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/git/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "git.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-07-05";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "cbc4450a6c238114362e3c2fbca355166c2a2202";
+    hash = "sha256-otD7zmm/Juh68D2czRhtU7CZFIaMgADxuo8p68cS7fk=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/glow/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/glow/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "glow.yazi";
-  version = "0-unstable-2025-04-15";
+  version = "0-unstable-2025-06-13";
 
   src = fetchFromGitHub {
     owner = "Reledia";
     repo = "glow.yazi";
-    rev = "2da96e3ffd9cd9d4dd53e0b2636f83ff69fe9af0";
-    hash = "sha256-4krck4U/KWmnl32HWRsblYW/biuqzDPysrEn76buRck=";
+    rev = "bd3eaa58c065eaf216a8d22d64c62d8e0e9277e9";
+    hash = "sha256-mzW/ut/LTEriZiWF8YMRXG9hZ70OOC0irl5xObTNO40=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/jump-to-char/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/jump-to-char/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "jump-to-char.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-06-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
+    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/lsar/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/lsar/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "lsar.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-06-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
+    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mactag.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-07-02";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "e5f00e2716fd177b0ca0d313f1a6e64f01c12760";
+    hash = "sha256-DLcmzCmITybWrYuBpTyswtoGUimpagkyeVUWmbKjarY=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.5.31-unstable-2025-06-05";
+  version = "25.5.31-unstable-2025-07-19";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "a7d1aa69a1a107e64540c17f19ac94be1366769f";
-    hash = "sha256-HUD8Sv1C4gzZRvSEIYqcmm+A0mBYDuwZHCNH26kipS0=";
+    rev = "f89605ce7ca33181ee6770e641d80ec4673093e0";
+    hash = "sha256-NloChkZWKo9JL636d+G7vgEY/HX24udngYftw/Ydzk4=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mime-ext/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mime-ext.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-06-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
+    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mount/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mount/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mount.yazi";
-  version = "25.5.28-unstable-2025-06-11";
+  version = "25.5.31-unstable-2025-07-02";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "c1d638374c76655896c06e9bc91cdb39857b7f15";
-    hash = "sha256-cj2RjeW4/9ZRCd/H4PxrIQWW9kSOxtdi72f+8o13aPI=";
+    rev = "e5f00e2716fd177b0ca0d313f1a6e64f01c12760";
+    hash = "sha256-DLcmzCmITybWrYuBpTyswtoGUimpagkyeVUWmbKjarY=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "ouch.yazi";
-  version = "0-unstable-2025-06-10";
+  version = "0-unstable-2025-07-13";
 
   src = fetchFromGitHub {
     owner = "ndtoan96";
     repo = "ouch.yazi";
-    rev = "1ee69a56da3c4b90ec8716dd9dd6b82e7a944614";
-    hash = "sha256-4KZeDkMXlhUV0Zh+VGBtz9kFPGOWCexYVuKUSCN463o=";
+    rev = "0742fffea5229271164016bf96fb599d861972db";
+    hash = "sha256-C0wG8NQ+zjAMfd+J39Uvs3K4U6e3Qpo1yLPm2xcsAaI=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/piper/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/piper/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "piper.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-06-21";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "f9b3f8876eaa74d8b76e5b8356aca7e6a81c0fb7";
-    hash = "sha256-EoIrbyC7WgRzrEtvso2Sr6HnNW91c5E+RZGqnjEi6Zo=";
+    rev = "3d1efb706924112daed986a4eef634e408bad65e";
+    hash = "sha256-GgEg1A5sxaH7hR1CUOO9WV21kH8B2YUGAtOapcWLP7Y=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/projects/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/projects/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "projects.yazi";
-  version = "0-unstable-2025-06-03";
+  version = "0-unstable-2025-06-19";
 
   src = fetchFromGitHub {
     owner = "MasouShizuka";
     repo = "projects.yazi";
-    rev = "7037dd5eee184ccb7725bdc9f7ea6faa188420d5";
-    hash = "sha256-Lc0MeiAuPgJTq4ojNw9hwxqPJ74S4ymn4uPTkxGeZGc=";
+    rev = "a5e33db284ab580de7b549e472bba13a5ba7c7b9";
+    hash = "sha256-4VD1OlzGgyeB1jRgPpI4aWnOCHNZQ9vhh40cbU80Les=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/relative-motions/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/relative-motions/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "relative-motions.yazi";
-  version = "25.5.28-unstable-2025-06-05";
+  version = "25.5.28-unstable-2025-07-09";
 
   src = fetchFromGitHub {
     owner = "dedukun";
     repo = "relative-motions.yazi";
-    rev = "2e3b6172e6226e0db96aea12d09dea2d2e443fea";
-    hash = "sha256-v0e06ieBKNmt9DATdL7R4AyVFa9DlNBwpfME3LHozLA=";
+    rev = "a603d9ea924dfc0610bcf9d3129e7cba605d4501";
+    hash = "sha256-9i6x/VxGOA3bB3FPieB7mQ1zGaMK5wnMhYqsq4CvaM4=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/restore/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/restore/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "restore.yazi";
-  version = "25.5.31-unstable-2025-06-05";
+  version = "25.5.31-unstable-2025-07-11";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "restore.yazi";
-    rev = "b7c33766e0bc4bbbb99e8e934be90e3beb881d29";
-    hash = "sha256-qtthY7eySqXoA3TARubZF0SsYkkLEgkjdtPUxR5ro0I=";
+    rev = "84f1921806c49b7b20af26cbe57cb4fd286142e2";
+    hash = "sha256-pEQZ/2Z4XVYlfzqtCz51bIgE9KzkDF/qyX8vThhlWGI=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-enter/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-enter/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-enter.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-06-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
+    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-filter/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-filter/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-filter.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-07-23";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "de53d90cb2740f84ae595f93d0c4c23f8618a9e4";
+    hash = "sha256-ixZKOtLOwLHLeSoEkk07TB3N57DXoVEyImR3qzGUzxQ=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/smart-paste/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/smart-paste/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "smart-paste.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-06-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
+    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/starship/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/starship/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "starship.yazi";
-  version = "25.4.8-unstable-2025-06-01";
+  version = "25.4.8-unstable-2025-07-08";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";
     repo = "starship.yazi";
-    rev = "6a0f3f788971b155cbc7cec47f6f11aebbc148c9";
-    hash = "sha256-q1G0Y4JAuAv8+zckImzbRvozVn489qiYVGFQbdCxC98=";
+    rev = "a63550b2f91f0553cc545fd8081a03810bc41bc0";
+    hash = "sha256-PYeR6fiWDbUMpJbTFSkM57FzmCbsB4W4IXXe25wLncg=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/toggle-pane/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/toggle-pane/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "toggle-pane.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-06-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "a54b96a3f21495ab3659e45d5354bcc8413be15c";
-    hash = "sha256-TtVaWazkk2xnomhJFinElbUsXUKAbDDhLEVq5Ah3nAk=";
+    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
+    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "vcs-files.yazi";
-  version = "25.5.28-unstable-2025-05-28";
+  version = "25.5.31-unstable-2025-06-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d642bfb0822eb0c3c5c891ab0f4b6f897a2083cb";
-    hash = "sha256-WF2b9t0VPGNP3QXgr/GMDFcSh5bsXC7KKd2ICL4WDHo=";
+    rev = "86d28e4fb4f25f36cc501b8cb0badb37a6b14263";
+    hash = "sha256-m/gJTDm0cVkIdcQ1ZJliPqBhNKoCW1FciLkuq7D1mxo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "yatline.yazi";
-  version = "0-unstable-2025-06-11";
+  version = "25.5.31-unstable-2025-06-12";
 
   src = fetchFromGitHub {
     owner = "imsi32";
     repo = "yatline.yazi";
-    rev = "73bce63ffb454ea108a96f316e2a8c2e16a35262";
-    hash = "sha256-pIaqnxEGKiWvtFZJm0e7GSbbIc2qaTCB+czHLcVuVzY=";
+    rev = "88bd1c58357d472fe7e8daf9904936771fc49795";
+    hash = "sha256-RkQKZQAa5U9eMWk1Q0doueJZiuP4elUJ0dM1XKLSnDo=";
   };
 
   meta = {


### PR DESCRIPTION
Update summary: 23 plugins updated out of 34 checked

Updated plugins:
  - chmod: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-06-26
  - git: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-07-05
  - glow: 0-unstable-2025-04-15 → 0-unstable-2025-06-13
  - jump-to-char: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-06-18
  - lsar: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-06-18
  - mactag: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-07-02
  - mediainfo: 25.5.31-unstable-2025-06-05 → 25.5.31-unstable-2025-07-19
  - mime-ext: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-06-18
  - mount: 25.5.28-unstable-2025-06-11 → 25.5.31-unstable-2025-07-02
  - ouch: 0-unstable-2025-06-10 → 0-unstable-2025-07-13
  - piper: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-06-21
  - projects: 0-unstable-2025-06-03 → 0-unstable-2025-06-19
  - relative-motions: 25.5.28-unstable-2025-06-05 → 25.5.28-unstable-2025-07-09
  - restore: 25.5.31-unstable-2025-06-05 → 25.5.31-unstable-2025-07-11
  - smart-enter: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-06-18
  - smart-filter: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-07-23
  - smart-paste: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-06-18
  - starship: 25.4.8-unstable-2025-06-01 → 25.4.8-unstable-2025-07-08
  - toggle-pane: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-06-18
  - vcs-files: 25.5.28-unstable-2025-05-28 → 25.5.31-unstable-2025-06-18
  - yatline: 0-unstable-2025-06-11 → 25.5.31-unstable-2025-06-12

Failed to update 3 plugins:
  - gitui: Error fetching plugin content: 404 Client Error: Not Found for url:
https://raw.githubusercontent.com/gclarkjr5/gitui.yazi/main/main.lua
  - miller: Error fetching plugin content: 404 Client Error: Not Found for url:
https://raw.githubusercontent.com/Reledia/miller.yazi/main/main.lua
  - wl-clipboard: Error fetching plugin content: 404 Client Error: Not Found for url:
https://raw.githubusercontent.com/grappas/wl-clipboard.yazi/master/main.lua


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
