### PR TITLE
phira-mp: init at 0.1.0-unstable-2025-06-10

### DIFF
--- a/pkgs/by-name/ph/phira-mp/package.nix
+++ b/pkgs/by-name/ph/phira-mp/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "phira-mp";
+  # 0.1.0 does not build because the time crate is too old and is incompatible with Rust 1.80.0 or later.
+  version = "0.1.0-unstable-2025-06-10";
+
+  src = fetchFromGitHub {
+    owner = "TeamFlos";
+    repo = "phira-mp";
+    rev = "30b481117af8d17cbfcca88de460e4a407a4cb67";
+    hash = "sha256-oKQbym627+7ghD7LRI0PaYWzqIm8PinjmUgqlkvDKRA=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  cargoHash = "sha256-fkGB9qgOxroOjfQMwXfJqSVWB1S7T+ndYVYEmGrqtIs=";
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "Multiplayer server for the rhythm game Phira";
+    homepage = "https://github.com/TeamFlos/phira-mp";
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    license = lib.licenses.unfree; # https://github.com/TeamFlos/phira-mp/issues/7
+    platforms = lib.platforms.unix;
+    mainProgram = "phira-mp-server";
+  };
+
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
