### PR TITLE
rawtherapee: fix version information

### DIFF
--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -50,7 +50,15 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    echo "set(HG_VERSION ${version})" > ReleaseInfo.cmake
+    cat <<EOF > ReleaseInfo.cmake
+    set(GIT_DESCRIBE ${version})
+    set(GIT_BRANCH ${version})
+    set(GIT_VERSION ${version})
+    # Missing GIT_COMMIT and GIT_COMMIT_DATE, which are not easy to obtain.
+    set(GIT_COMMITS_SINCE_TAG 0)
+    set(GIT_COMMITS_SINCE_BRANCH 0)
+    set(GIT_VERSION_NUMERIC_BS ${version})
+    EOF
     substituteInPlace tools/osx/Info.plist.in rtgui/config.h.in \
       --replace "/Applications" "${placeholder "out"}/Applications"
   '';


### PR DESCRIPTION
The existing version logic dates to 68a38d6c0fac3 (PR 18368 on September 25, 2016). But rawtherapee switched from hg to git around 2015, so these cmake variables were wrong almost as soon as they were set.

Without this patch, running

    rawtherapee-cli --version

has the output

    RawTherapee, version , command line.

With this patch:

    RawTherapee, version 5.12, command line.

which is significantly better, although personally I'd prefer to also have a git commit ID.