### PR TITLE
equicord, equibop: updates

### DIFF
--- a/pkgs/by-name/eq/equibop/disable_update_checking.patch
+++ b/pkgs/by-name/eq/equibop/disable_update_checking.patch
@@ -2,15 +2,14 @@ diff --git i/src/main/index.ts w/src/main/index.ts
 index 23ea0d6..1ef465f 100644
 --- i/src/main/index.ts
 +++ w/src/main/index.ts
-@@ -32,7 +32,9 @@ if (process.platform === "linux") {
- if (IS_DEV) {
-     require("source-map-support").install();
- } else {
+@@ -22,7 +22,9 @@ import { isDeckGameMode } from "./utils/steamOS";
+ 
+ if (!IS_DEV) {
 -    autoUpdater.checkForUpdatesAndNotify();
 +    console.log("Update checking is disabled. Skipping...");
 +    // autoUpdater.checkForUpdatesAndNotify();
 +
  }
  
- // Make the Vencord files use our DATA_DIR
+ console.log("Equibop v" + app.getVersion());
 

--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -12,7 +12,7 @@
   pipewire,
   libpulseaudio,
   autoPatchelfHook,
-  pnpm_9,
+  pnpm_10,
   nodejs,
   nix-update-script,
   withTTS ? true,
@@ -23,16 +23,16 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "equibop";
-  version = "2.1.4";
+  version = "2.1.5";
 
   src = fetchFromGitHub {
     owner = "Equicord";
     repo = "Equibop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-y5q3shwmMjXlMaLWfxjN164uM8hSbWymsHIIJxM82Nk=";
+    hash = "sha256-uod94pP261Alq+dby+/diiLT0KFjXswVapwXYAAAkbs=";
   };
 
-  pnpmDeps = pnpm_9.fetchDeps {
+  pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs)
       pname
       version
@@ -40,12 +40,12 @@ stdenv.mkDerivation (finalAttrs: {
       patches
       ;
     fetcherVersion = 1;
-    hash = "sha256-laTyxRh54x3iopGVgoFtcgaV7R6IKux1O/+tzGEy0Fg=";
+    hash = "sha256-0UNScJAdpcMOcBHGGG+SeGQon89qLXTCNmaxEswNFBI=";
   };
 
   nativeBuildInputs = [
     nodejs
-    pnpm_9.configHook
+    pnpm_10.configHook
     # XXX: Equibop *does not* ship venmic as a prebuilt node module. The package
     # seems to build with or without this hook, but I (NotAShelf) don't have the
     # time to test the consequences of removing this hook. Please open a pull

--- a/pkgs/by-name/eq/equibop/use_system_equicord.patch
+++ b/pkgs/by-name/eq/equibop/use_system_equicord.patch
@@ -2,13 +2,13 @@ diff --git i/src/main/constants.ts w/src/main/constants.ts
 index afb171f..c6a014e 100644
 --- i/src/main/constants.ts
 +++ w/src/main/constants.ts
-@@ -47,10 +47,7 @@ export const VENCORD_THEMES_DIR = join(DATA_DIR, "themes");
+@@ -30,10 +30,7 @@ export const VENCORD_THEMES_DIR = join(DATA_DIR, "themes");
  
  // needs to be inline require because of circular dependency
  // as otherwise "DATA_DIR" (which is used by ./settings) will be uninitialised
 -export const VENCORD_DIR = (() => {
 -    const { State } = require("./settings") as typeof import("./settings");
--    return State.store.vencordDir ? join(State.store.vencordDir, "equibop") : join(SESSION_DATA_DIR, "equicord.asar");
+-    return State.store.equicordDir ? join(State.store.equicordDir, "equibop") : join(SESSION_DATA_DIR, "equicord.asar");
 -})();
 +export const VENCORD_DIR = "@equicord@";
  

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -14,19 +14,19 @@ stdenv.mkDerivation (finalAttrs: {
   # the Equicord repository. Dates as tags (and automatic releases) were the compromise
   # we came to with upstream. Please do not change the version schema (e.g., to semver)
   # unless upstream changes the tag schema from dates.
-  version = "2025-04-17";
+  version = "2025-07-25";
 
   src = fetchFromGitHub {
     owner = "Equicord";
     repo = "Equicord";
     tag = "${finalAttrs.version}";
-    hash = "sha256-pAuNqPrQBeL2qPIoIvyBl1PrUBz81TrBd5RT15Iuuus=";
+    hash = "sha256-6p7lfdRaxQusqZf86a1qclal2E0LusYYT1y3BPkOSKY=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-fjfzBy1Z7AUKA53yjjCQ6yasHc5QMaOBtXtXA5fNK5s=";
+    hash = "sha256-LXbr/qh1QZXQ/Na5180Im2WW8KbWU78Oo0O12SiNMWg=";
   };
 
   nativeBuildInputs = [
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "^\d{4}-\d{2}-\d{2}$"
+      "^(\\d{4}-\\d{2}-\\d{2})$"
     ];
   };
 


### PR DESCRIPTION
## Things done

fixes #428182 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
