### PR TITLE
debian-devscripts: 2.25.15 -> 2.25.16

### DIFF
--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -18,6 +18,7 @@
   pkg-config,
   bash-completion,
   help2man,
+  nix-update-script,
   sendmailPath ? "/run/wrappers/bin/sendmail",
 }:
 
@@ -29,14 +30,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "debian-devscripts";
-  version = "2.25.15";
+  version = "2.25.16";
 
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
     owner = "debian";
     repo = "devscripts";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-s2QSfJyHsFr1eiia/yFj3jsS5k38xNewEe/g5PFpqag=";
+    hash = "sha256-cbaG7yNZt+205fa6HGEjLOjLsW3HloLQHvcGGjmnXDM=";
   };
 
   patches = [
@@ -51,10 +52,13 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace scripts/debrebuild.pl \
       --replace-fail "/usr/bin/perl" "${perlPackages.perl}/bin/perl"
     patchShebangs scripts
+  ''
+  +
     # Remove man7 target to avoid missing *.7 file error
-    substituteInPlace doc/Makefile \
-      --replace-fail " install_man7" ""
-  '';
+    ''
+      substituteInPlace doc/Makefile \
+        --replace-fail " install_man7" ""
+    '';
 
   nativeBuildInputs = [
     makeWrapper
@@ -95,11 +99,11 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$tgtpy"
     export PYTHONPATH="$PYTHONPATH''${PYTHONPATH:+:}$tgtpy"
     find lib po4a scripts -type f -exec sed -r \
-      -e "s@/usr/bin/gpg(2|)@${gnupg}/bin/gpg@g" \
+      -e "s@/usr/bin/gpg(2|)@${lib.getExe' gnupg "gpg"}@g" \
       -e "s@/usr/(s|)bin/sendmail@${sendmailPath}@g" \
-      -e "s@/usr/bin/diff@${diffutils}/bin/diff@g" \
-      -e "s@/usr/bin/gpgv(2|)@${gnupg}/bin/gpgv@g" \
-      -e "s@(command -v|/usr/bin/)curl@${curl.bin}/bin/curl@g" \
+      -e "s@/usr/bin/diff@${lib.getExe' diffutils "diff"}@g" \
+      -e "s@/usr/bin/gpgv(2|)@${lib.getExe' gnupg "gpgv"}@g" \
+      -e "s@(command -v|/usr/bin/)curl@${lib.getExe curl}@g" \
       -e "s@sensible-editor@${sensible-editor}@g" \
       -e "s@(^|\W)/bin/bash@\1${stdenv.shell}@g" \
       -i {} +
@@ -130,6 +134,8 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s debchange $out/bin/dch
     ln -s pts-subscribe $out/bin/pts-unsubscribe
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Debian package maintenance scripts";


### PR DESCRIPTION
Diff: https://salsa.debian.org/debian/devscripts/-/compare/refs/tags/v2.25.15...v2.25.16


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
