### PR TITLE
immich: 1.135.3 -> 1.136.0

### DIFF
--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -218,7 +218,16 @@ buildNpmPackage' {
     imagemagick
     libraw
     libheif
-    vips' # Required for sharp
+    # https://github.com/Automattic/node-canvas/blob/master/Readme.md#compiling
+    cairo
+    giflib
+    libjpeg
+    libpng
+    librsvg
+    pango
+    pixman
+    # Required for sharp
+    vips'
   ];
 
   # Required because vips tries to write to the cache dir

--- a/pkgs/by-name/im/immich/sources.json
+++ b/pkgs/by-name/im/immich/sources.json
@@ -1,26 +1,26 @@
 {
-  "version": "1.135.3",
-  "hash": "sha256-CIYuDAWd0OH7jwV4XKIJDVlk1D/tYlDVW5V4uEDCwEE=",
+  "version": "1.136.0",
+  "hash": "sha256-IMog1lvitT1fNKlT4pv/5Qlg/2JNkBNZrBu65NRAgJ0=",
   "components": {
     "cli": {
-      "npmDepsHash": "sha256-43W9yKr1XuTLUi3RuZNR8CjcHIyhHaSl+azZKqDWBx0=",
-      "version": "2.2.72"
+      "npmDepsHash": "sha256-+cMBzlvnSAwlutVm1F0Sa2LEAP6ppOvI9XjDb40xWW4=",
+      "version": "2.2.73"
     },
     "server": {
-      "npmDepsHash": "sha256-Z5vRpSau9nxrlXe7QuxYhqpVkloVIz12o0hXKAl8Y6o=",
-      "version": "1.135.3"
+      "npmDepsHash": "sha256-kVmoxOd7ErLmLKBkanb8IOUJ3ccpzUHBkaLgnvli0Uw=",
+      "version": "1.136.0"
     },
     "web": {
-      "npmDepsHash": "sha256-M5TNLBJPl/9rue651XyyV5ZnPakq0wPgTmS7XhSbf0A=",
-      "version": "1.135.3"
+      "npmDepsHash": "sha256-CxQQbqIhqhWqtlV4BWQDPkg0tm3wPXC6BcCFb/6mM+o=",
+      "version": "1.136.0"
     },
     "open-api/typescript-sdk": {
-      "npmDepsHash": "sha256-HOQMbbLzxkw5U2MHJFGKiquvfFYdwCEjHhXWwrhCmng=",
-      "version": "1.135.3"
+      "npmDepsHash": "sha256-z9W3YGqoUV90TXoyEnR069pLvirzDAisgQZdaJEOlSg=",
+      "version": "1.136.0"
     },
     "geonames": {
-      "timestamp": "20250620153832",
-      "hash": "sha256-OJSQFjaYm1TVyA0JL7DiHy/dbhRd5HYoTPqIoPnBLss="
+      "timestamp": "20250725064853",
+      "hash": "sha256-UzP8JapHTCpk5/6X5usLLXQUfqEOUgkq76CTIBZoz08="
     }
   }
 }


### PR DESCRIPTION
`canvas` was added as a dependency to server/package.json in https://github.com/immich-app/immich/commit/db0415bbcc7512e99013a6c310b64f51fd34a711

I am not sure if this was intentional as `canvas` is not ever imported in the server package. Perhaps we can raise a bug for this.

https://github.com/immich-app/immich/releases/tag/v1.136.0

Note that the breaking change shouldn't affect NixOS users, as `IMMICH_MEDIA_LOCATION` is set to an absolute path by default.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
