### PR TITLE
python3Packages.mkdocs-build-plantuml: init at 1.11.0

### DIFF
--- a/pkgs/development/python-modules/mkdocs-build-plantuml/default.nix
+++ b/pkgs/development/python-modules/mkdocs-build-plantuml/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pkgs, # Only for pkgs.plantuml,
+  setuptools,
+  httplib2,
+}:
+
+buildPythonPackage rec {
+  pname = "mkdocs-build-plantuml";
+  version = "1.11.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "christo-ph";
+    repo = "mkdocs_build_plantuml";
+    tag = version;
+    hash = "sha256-cbyxvWBIV+v81m+xGZZsUypkM1uuj4ADMUrAYlc/XBI=";
+  };
+
+  # There's only one substitution, no patch is needed.
+  postPatch = ''
+    substituteInPlace mkdocs_build_plantuml_plugin/plantuml.py \
+      --replace-fail '/usr/local/bin/plantuml' '${lib.getExe pkgs.plantuml}'
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    httplib2
+  ];
+
+  pythonImportsCheck = [ "mkdocs_build_plantuml_plugin" ];
+
+  # No tests available
+  doCheck = false;
+
+  meta = {
+    description = "MkDocs plugin to help generate your plantuml images locally or remotely as files (NOT inline)";
+    homepage = "https://github.com/christo-ph/mkdocs_build_plantuml";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9273,6 +9273,8 @@ self: super: with self; {
 
   mkdocs-backlinks = callPackage ../development/python-modules/mkdocs-backlinks { };
 
+  mkdocs-build-plantuml = callPackage ../development/python-modules/mkdocs-build-plantuml { };
+
   mkdocs-drawio-exporter = callPackage ../development/python-modules/mkdocs-drawio-exporter { };
 
   mkdocs-drawio-file = callPackage ../development/python-modules/mkdocs-drawio-file { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
