### PR TITLE
python3Packages.plantuml-markdown: patch path to local `plantuml`

### DIFF
--- a/pkgs/development/python-modules/plantuml-markdown/default.nix
+++ b/pkgs/development/python-modules/plantuml-markdown/default.nix
@@ -1,6 +1,7 @@
 {
   buildPythonPackage,
   fetchFromGitHub,
+  pkgs, # Only for pkgs.plantuml,
   lib,
   plantuml,
   markdown,
@@ -9,7 +10,6 @@
   runCommand,
   writeText,
   plantuml-markdown,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -17,14 +17,17 @@ buildPythonPackage rec {
   version = "3.11.1";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
-
   src = fetchFromGitHub {
     owner = "mikitex70";
     repo = "plantuml-markdown";
     tag = version;
     hash = "sha256-DgHWqwPsZ5q1XqrfaAiUslKnJdHX4Pzw9lygF3iaxz4=";
   };
+
+  postPatch = ''
+    substituteInPlace plantuml_markdown/plantuml_markdown.py \
+      --replace-fail '"plantuml_cmd": ["plantuml"' '"plantuml_cmd": ["${lib.getExe pkgs.plantuml}"'
+  '';
 
   propagatedBuildInputs = [
     plantuml
@@ -34,6 +37,7 @@ buildPythonPackage rec {
   ];
 
   # The package uses a custom script that downloads a certain version of plantuml for testing.
+  # Missing https://github.com/ezequielramos/http-server-mock which looks unmaintained
   doCheck = false;
 
   pythonImportsCheck = [ "plantuml_markdown" ];
@@ -52,7 +56,7 @@ buildPythonPackage rec {
       ! grep -q "Error" $out
     '';
 
-  meta = with lib; {
+  meta = {
     description = "PlantUML plugin for Python-Markdown";
     longDescription = ''
       This plugin implements a block extension which can be used to specify a PlantUML
@@ -60,7 +64,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/mikitex70/plantuml-markdown";
     changelog = "https://github.com/mikitex70/plantuml-markdown/releases/tag/${src.tag}";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ nikstur ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ nikstur ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
