### PR TITLE
nixos/wireguard: fix misleading preShutdown/postShutdown option examples

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -101,7 +101,7 @@ let
         };
 
         preShutdown = mkOption {
-          example = literalExpression ''"''${pkgs.iproute2}/bin/ip netns del foo"'';
+          example = literalExpression ''"''${pkgs.wireguard-tools}/bin/wg show all transfer"'';
           default = "";
           type = with types; coercedTo (listOf str) (concatStringsSep "\n") lines;
           description = ''
@@ -110,7 +110,7 @@ let
         };
 
         postShutdown = mkOption {
-          example = literalExpression ''"''${pkgs.openresolv}/bin/resolvconf -d wg0"'';
+          example = literalExpression ''"''${pkgs.iproute2}/bin/ip netns del foo"'';
           default = "";
           type = with types; coercedTo (listOf str) (concatStringsSep "\n") lines;
           description = "Commands called after shutting down the interface.";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The namespace is still used after the `preShutdown` script, so using this example in practice will result in an error during service shutdown. As `resolvconf -d wg0` is redundant if the interface has already been removed, I put the namespace deletion where it belongs. I couldn't find a good example for using `preShutdown`. Displaying some ugly transfer stats was the best I could come up with.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
