### PR TITLE
feishin: 0.12.6 -> 0.20.0

### DIFF
--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  electron_36,
+  electron_37,
   typescript,
   nodejs,
   pnpm,
@@ -13,23 +13,23 @@
   ...
 }:
 let
-  electron = electron_36;
+  electron = electron_37;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "feishin";
-  version = "0.19.0";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "jeffvli";
     repo = "feishin";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-2Jry/wulzkS1P4tughDlH5klqNngPNmFuC5Nqe9sakM=";
+    hash = "sha256-+pBN23IKdUVBlfm6Sydg78RYFSfzwX/Sc86FWjB0Nzg=";
   };
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-4cbrK+3nFD2NgoaGoAQdQ0+/07WiUiFUAyJFOsge8X8=";
+    hash = "sha256-toVWebJoh2PB4mWTulEs1iVrzEtnWtbBd6Ga2uTxU8k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -1,97 +1,80 @@
 {
   lib,
   stdenv,
-  buildNpmPackage,
   fetchFromGitHub,
   electron_36,
+  typescript,
+  nodejs,
+  pnpm,
   darwin,
   copyDesktopItems,
   makeDesktopItem,
+  makeWrapper,
+  ...
 }:
 let
+  electron = electron_36;
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "feishin";
-  version = "0.12.6";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "jeffvli";
     repo = "feishin";
-    rev = "v${version}";
-    hash = "sha256-cnlPks/sJdcxHdIppHn8Q8d2tkwVlPMofQxjdAlBreg=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-2Jry/wulzkS1P4tughDlH5klqNngPNmFuC5Nqe9sakM=";
   };
 
-  electron = electron_36;
-in
-buildNpmPackage {
-  inherit pname version;
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 1;
+    hash = "sha256-4cbrK+3nFD2NgoaGoAQdQ0+/07WiUiFUAyJFOsge8X8=";
+  };
 
-  inherit src;
-  npmDepsHash = "sha256-lThh29prT/cHRrp2mEtUW4eeVfCtkk+54EPNUyGHyq8=";
+  nativeBuildInputs = [
+    makeWrapper
+    typescript
+    nodejs
+    pnpm.configHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ copyDesktopItems ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
 
-  npmFlags = [ "--legacy-peer-deps" ];
-  makeCacheWritable = true;
-
-  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-
-  nativeBuildInputs =
-    lib.optionals (stdenv.hostPlatform.isLinux) [ copyDesktopItems ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
   postPatch = ''
-    # release/app dependencies are installed on preConfigure
-    substituteInPlace package.json \
-      --replace-fail "electron-builder install-app-deps &&" ""
-
     # Don't check for updates.
-    substituteInPlace src/main/main.ts \
+    substituteInPlace src/main/index.ts \
       --replace-fail "autoUpdater.checkForUpdatesAndNotify();" ""
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     # https://github.com/electron/electron/issues/31121
-    substituteInPlace src/main/main.ts \
+    substituteInPlace src/main/index.ts \
       --replace-fail "process.resourcesPath" "'$out/share/feishin/resources'"
   '';
 
-  preConfigure =
-    let
-      releaseAppDeps = buildNpmPackage {
-        pname = "${pname}-release-app";
-        inherit version;
+  postBuild = ''
+    pnpm run build
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # electron-builder appears to build directly on top of Electron.app, by overwriting the files in the bundle.
+    cp -r ${electron.dist}/Electron.app ./
+    find ./Electron.app -name 'Info.plist' | xargs -d '\n' chmod +rw
 
-        src = "${src}/release/app";
-        npmDepsHash = "sha256-kEe5HH/oslH8vtAcJuWTOLc0ZQPxlDVMS4U0RpD8enE=";
-
-        npmFlags = [ "--ignore-scripts" ];
-        dontNpmBuild = true;
-
-        env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-      };
-      releaseNodeModules = "${releaseAppDeps}/lib/node_modules/feishin/node_modules";
-    in
-    ''
-      for release_module_path in "${releaseNodeModules}"/*; do
-        rm -rf node_modules/"$(basename "$release_module_path")"
-        ln -s "$release_module_path" node_modules/
-      done
-    '';
-
-  postBuild =
-    lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # electron-builder appears to build directly on top of Electron.app, by overwriting the files in the bundle.
-      cp -r ${electron.dist}/Electron.app ./
-      find ./Electron.app -name 'Info.plist' | xargs -d '\n' chmod +rw
-
-      # Disable code signing during build on macOS.
-      # https://github.com/electron-userland/electron-builder/blob/fa6fc16/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
-      export CSC_IDENTITY_AUTO_DISCOVERY=false
-      sed -i "/afterSign/d" package.json
-    ''
-    + ''
-      npm exec electron-builder -- \
-        --dir \
-        -c.electronDist=${if stdenv.hostPlatform.isDarwin then "./" else electron.dist} \
-        -c.electronVersion=${electron.version} \
-        -c.npmRebuild=false
-    '';
+    # Disable code signing during build on macOS.
+    # https://github.com/electron-userland/electron-builder/blob/fa6fc16/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
+    export CSC_IDENTITY_AUTO_DISCOVERY=false
+    sed -i "/afterSign/d" package.json
+  ''
+  + ''
+    ./node_modules/.bin/electron-builder \
+    --publish always --linux \
+    --dir \
+      -c.electronDist=${if stdenv.hostPlatform.isDarwin then "./" else electron.dist} \
+      -c.electronVersion=${electron.version} \
+      -c.npmRebuild=false
+  '';
 
   installPhase = ''
     runHook preInstall
@@ -103,9 +86,14 @@ buildNpmPackage {
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p $out/share/feishin
-    pushd release/build/*/
-    cp -r locales resources{,.pak} $out/share/feishin
-    popd
+    cp -r dist/linux-unpacked/locales dist/linux-unpacked/resources dist/linux-unpacked/resources.pak $out/share/feishin
+
+    for size in 32 64 128 256 512 1024; do
+      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+      ln -s \
+        $out/share/feishin/resources/assets/icons/"$size"x"$size".png \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/feishin.png
+    done
 
     # Code relies on checking app.isPackaged, which returns false if the executable is electron.
     # Set ELECTRON_FORCE_IS_PACKAGED=1.
@@ -115,13 +103,6 @@ buildNpmPackage {
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --set ELECTRON_FORCE_IS_PACKAGED=1 \
       --inherit-argv0
-
-    for size in 32 64 128 256 512 1024; do
-      mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-      ln -s \
-        $out/share/feishin/resources/assets/icons/"$size"x"$size".png \
-        $out/share/icons/hicolor/"$size"x"$size"/apps/feishin.png
-    done
   ''
   + ''
     runHook postInstall
@@ -145,7 +126,7 @@ buildNpmPackage {
   meta = {
     description = "Full-featured Subsonic/Jellyfin compatible desktop music player";
     homepage = "https://github.com/jeffvli/feishin";
-    changelog = "https://github.com/jeffvli/feishin/releases/tag/v${version}";
+    changelog = "https://github.com/jeffvli/feishin/releases/tag/v${finalAttrs.version}";
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
@@ -155,4 +136,4 @@ buildNpmPackage {
       jlbribeiro
     ];
   };
-}
+})


### PR DESCRIPTION
Feishin have switched to start using pnpm instead of npm. Updated the nix package accordingly. This will bring us from version `0.12.6` to version `0.18.0` which is the latest release of Feishin. 

https://github.com/jeffvli/feishin/releases

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
