### PR TITLE
python3Packages.mkdocs-git-authors-plugin: 0.9.2 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/mkdocs-git-authors-plugin/default.nix
+++ b/pkgs/development/python-modules/mkdocs-git-authors-plugin/default.nix
@@ -2,32 +2,40 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
+  setuptools,
   mkdocs,
+  gitMinimal,
 }:
 
 buildPythonPackage rec {
   pname = "mkdocs-git-authors-plugin";
-  version = "0.9.2";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.8";
+  version = "0.10.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "timvink";
     repo = "mkdocs-git-authors-plugin";
     tag = "v${version}";
-    hash = "sha256-2ITro34lZ+tz7ev7Yuh1wJjsSNik6VUTt3dupIajmLU=";
+    hash = "sha256-Uy1XgSJchA7hkc9i4hE8Ws4OWY5GRzvfnhKkZvxT2d0=";
   };
 
-  propagatedBuildInputs = [ mkdocs ];
+  postPatch = ''
+    substituteInPlace src/mkdocs_git_authors_plugin/git/command.py \
+      --replace-fail 'args = ["git"]' 'args = ["${gitMinimal}/bin/git"]'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [ mkdocs ];
 
   pythonImportsCheck = [ "mkdocs_git_authors_plugin" ];
 
-  meta = with lib; {
+  meta = {
     description = "Lightweight MkDocs plugin to display git authors of a markdown page";
     homepage = "https://github.com/timvink/mkdocs-git-authors-plugin";
-    license = licenses.mit;
-    maintainers = with maintainers; [ totoroot ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ totoroot ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
