### PR TITLE
lib.types: introduce a `fileset` type

### DIFF
--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -1008,6 +1008,17 @@ in
         };
 
   /**
+    The empty fileset. It can be useful as a default value or as starting accumulator for a folding operation.
+
+    # Type
+
+    ```
+    empty :: FileSet
+    ```
+  */
+  empty = _emptyWithoutBase;
+
+  /**
     Tests whether a given value is a fileset, or can be used in place of a fileset.
 
     # Inputs

--- a/lib/fileset/default.nix
+++ b/lib/fileset/default.nix
@@ -101,6 +101,7 @@ let
 
   inherit (import ./internal.nix { inherit lib; })
     _coerce
+    _coerceResult
     _singleton
     _coerceMany
     _toSourceFilter
@@ -1005,4 +1006,38 @@ in
         {
           submodules = recurseSubmodules;
         };
+
+  /**
+    Tests whether a given value is a fileset, or can be used in place of a fileset.
+
+    # Inputs
+
+    `value`
+
+    : The value to test
+
+    # Type
+
+    ```
+    isFileset :: Any -> Bool
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.fileset.isFileset` usage example
+
+    ```nix
+    isFileset ./.
+    => true
+
+    isFileset (unions [  ])
+    => true
+
+    isFileset 1
+    => false
+    ```
+
+    :::
+  */
+  isFileset = x: (_coerceResult "" x).success;
 }

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -220,6 +220,17 @@ checkConfigError 'A definition for option .* is not of type .path in the Nix sto
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: ".*/store/.links"' config.pathInStore.bad4 ./types.nix
 checkConfigError 'A definition for option .* is not of type .path in the Nix store.. Definition values:\n\s*- In .*: "/foo/bar"' config.pathInStore.bad5 ./types.nix
 
+# types.fileset
+checkConfigOutput '^0$' config.filesetCardinal.ok1 ./fileset.nix
+checkConfigOutput '^1$' config.filesetCardinal.ok2 ./fileset.nix
+checkConfigOutput '^1$' config.filesetCardinal.ok3 ./fileset.nix
+checkConfigOutput '^1$' config.filesetCardinal.ok4 ./fileset.nix
+checkConfigOutput '^0$' config.filesetCardinal.ok5 ./fileset.nix
+checkConfigError 'A definition for option .* is not of type .fileset.. Definition values:\n.*' config.filesetCardinal.err1 ./fileset.nix
+checkConfigError 'A definition for option .* is not of type .fileset.. Definition values:\n.*' config.filesetCardinal.err2 ./fileset.nix
+checkConfigError 'A definition for option .* is not of type .fileset.. Definition values:\n.*' config.filesetCardinal.err3 ./fileset.nix
+checkConfigError 'A definition for option .* is not of type .fileset.. Definition values:\n.*' config.filesetCardinal.err4 ./fileset.nix
+
 # Check boolean option.
 checkConfigOutput '^false$' config.enable ./declare-enable.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./define-enable.nix

--- a/lib/tests/modules/fileset.nix
+++ b/lib/tests/modules/fileset.nix
@@ -1,0 +1,50 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkOption
+    mkIf
+    types
+    mapAttrs
+    length
+    ;
+  inherit (lib.fileset)
+    empty
+    unions
+    toList
+    ;
+in
+
+{
+  options = {
+    fileset = mkOption { type = with types; lazyAttrsOf fileset; };
+
+    ## The following option is only here as a proxy to test `fileset` that does
+    ## not work so well with `modules.sh` because it is not JSONable. It exposes
+    ## the number of elements in the fileset.
+    filesetCardinal = mkOption { default = mapAttrs (_: fs: length (toList fs)) config.fileset; };
+  };
+
+  config = {
+    fileset.ok1 = empty;
+    fileset.ok2 = ./fileset;
+    fileset.ok3 = unions [
+      empty
+      ./fileset
+    ];
+    # fileset.ok4: see imports below
+    fileset.ok5 = mkIf false ./fileset;
+
+    fileset.err1 = 1;
+    fileset.err2 = "foo";
+    fileset.err3 = "./.";
+    fileset.err4 = [ empty ];
+
+  };
+
+  imports = [
+    { fileset.ok4 = ./fileset; }
+    { fileset.ok4 = empty; }
+    { fileset.ok4 = ./fileset; }
+  ];
+}

--- a/lib/tests/modules/fileset/keepme
+++ b/lib/tests/modules/fileset/keepme
@@ -1,0 +1,1 @@
+Do not remove. This file is used by the tests in `../fileset.nix`.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -66,6 +66,11 @@ let
     fixupOptionType
     mergeOptionDecls
     ;
+  inherit (lib.fileset)
+    isFileset
+    unions
+    empty
+    ;
 
   inAttrPosSuffix =
     v: name:
@@ -610,6 +615,15 @@ let
         emptyValue = {
           value = { };
         };
+      };
+
+      fileset = mkOptionType {
+        name = "fileset";
+        description = "fileset";
+        descriptionClass = "noun";
+        check = isFileset;
+        merge = loc: defs: unions (map (x: x.value) defs);
+        emptyValue.value = empty;
       };
 
       # A package is a top-level store path (/nix/store/hash-name). This includes:


### PR DESCRIPTION
During [some work on the Fediversity project](https://git.fediversity.eu/Fediversity/Fediversity/pulls/450), I came with the need for a programmatic FileSet type. I used a bit of an ugly workaround, and this PR is here to introduce a clean alternative.

- Update the `_coerce` internal function to expose a pure variant, `_coerceResult`.
- Expose `isFileset` (using the new `_coerceResult`) and `empty`
- Introduce the “FileSet” type.

IMO, what will deserve most attention is:

- My choice for `isFileset`, namely anything that can be passed to `lib.fileset` functions, not just something with `_type == "fileset'`. I could have called it “filesetable” or something, but this is how “FileSet” is used in the documentation.

- My choices for `check` and `merge`, namely `lib.fileset.isFileset` and `lib.fileset.unions`. This is the first time I contribute to `lib.types`, so I am probably not seeing some interactions they might have.

- Whether we even want that change in nixpkgs or whether we feel it belongs downstream where it is actually used.

Closes https://github.com/NixOS/nixpkgs/issues/266366
Related to https://github.com/NixOS/nixpkgs/issues/266356

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
