### PR TITLE
alsa-plugins: provide precise licence information

### DIFF
--- a/pkgs/by-name/al/alsa-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-plugins/package.nix
@@ -39,7 +39,13 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Various plugins for ALSA";
     homepage = "http://alsa-project.org/";
-    license = lib.licenses.lgpl21;
+
+    license = with lib.licenses; [
+      lgpl21Plus
+      lgpl2Plus # maemo plugin
+      gpl2Plus # attributes.m4 & usb_stream.h
+    ];
+
     maintainers = [ lib.maintainers.marcweber ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
The code is licenced under LGPL 2.1 or later with the following exceptions:

- The [maemo plugin](https://github.com/alsa-project/alsa-plugins/tree/master/maemo) is licenced under the older LGPL 2 (or later), and
- [`m4/attributes.m4`](https://github.com/alsa-project/alsa-plugins/blob/master/m4/attributes.m4) and [`usb_stream/usb_stream.h`](https://github.com/alsa-project/alsa-plugins/blob/master/usb_stream/usb_stream.h) are marked as being GPL 2 or later.

I assume that in most jurisdiction the inclusion of a single GPL‐licenced header would not be sufficient to make the whole package or even just the usb_stream plugin a derivative work, but I am not a lawyer and think that it is best to expose precise licence information.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
