### PR TITLE
flang: init at 20.x

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -553,6 +553,13 @@
     githubId = 124545;
     name = "Anthony Cowley";
   };
+  acture = {
+    email = "acturea@gmail.com";
+    github = "Acture";
+    githubId = 11632382;
+    name = "Acture";
+    keys = [ { fingerprint = "30D9 BFA9 6998 4393 37B1  08EC B0FE 879A 0504 3C80"; } ];
+  };
   acuteaangle = {
     name = "Summer Tea";
     email = "zestypurple@protonmail.com";

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -488,6 +488,11 @@ let
         {
           libclc = callPackage ./libclc { };
         }
+    // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "20") {
+      flang = callPackage ./flang {
+        mlir = tools.mlir;
+      };
+    }
   );
 
   libraries = lib.makeExtensible (

--- a/pkgs/development/compilers/llvm/common/flang/default.nix
+++ b/pkgs/development/compilers/llvm/common/flang/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  llvm_meta,
+  monorepoSrc,
+  release_version,
+  runCommand,
+  cmake,
+  libxml2,
+  libllvm,
+  ninja,
+  libffi,
+  libclang,
+  stdenv,
+  clang,
+  mlir,
+  version,
+  python3,
+  buildLlvmTools,
+  devExtraCmakeFlags ? [ ],
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "flang";
+  inherit version;
+
+  src = runCommand "flang-src-${version}" { inherit (monorepoSrc) passthru; } ''
+    mkdir -p "$out"
+    cp -r ${monorepoSrc}/${finalAttrs.pname} "$out"
+    cp -r ${monorepoSrc}/cmake "$out"
+    cp -r ${monorepoSrc}/llvm "$out"
+    cp -r ${monorepoSrc}/clang "$out"
+    cp -r ${monorepoSrc}/mlir "$out"
+    cp -r ${monorepoSrc}/third-party "$out"
+    chmod -R +w $out/llvm
+  '';
+
+  patches = [
+    ./dummy_target_19+.patch
+  ];
+  patchFlags = [ "-p2" ];
+
+  sourceRoot = "${finalAttrs.src.name}/flang";
+
+  buildInputs = [
+    libffi
+    libxml2
+    libllvm
+    libclang
+    mlir
+  ];
+  nativeBuildInputs = [
+    cmake
+    clang
+    ninja
+    python3
+    libllvm.dev
+    mlir.dev
+  ];
+  preConfigure = ''
+    ls -l ${libllvm.dev}/lib/cmake/llvm/LLVMConfig.cmake
+    ls -l ${libclang.dev}/lib/cmake/clang/ClangConfig.cmake
+    ls -l ${mlir.dev}/lib/cmake/mlir/MLIRConfig.cmake
+  '';
+  cmakeFlags = [
+    (lib.cmakeBool "CMAKE_VERBOSE_MAKEFILE" true)
+    (lib.cmakeFeature "LLVM_DIR" "${libllvm.dev}/lib/cmake/llvm")
+    (lib.cmakeFeature "LLVM_TOOLS_BINARY_DIR" "${buildLlvmTools.tblgen}/bin/")
+    (lib.cmakeFeature "LLVM_EXTERNAL_LIT" "${buildLlvmTools.tblgen}/bin/llvm-lit")
+    (lib.cmakeFeature "CLANG_DIR" "${libclang.dev}/lib/cmake/clang")
+    (lib.cmakeFeature "MLIR_DIR" "${mlir.dev}/lib/cmake/mlir")
+    (lib.cmakeFeature "MLIR_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/mlir-tblgen")
+    (lib.cmakeFeature "MLIR_TABLEGEN_TARGET" "MLIR-TBLGen")
+    (lib.cmakeBool "LLVM_BUILD_EXAMPLES" false)
+    (lib.cmakeBool "LLVM_ENABLE_PLUGINS" false)
+    (lib.cmakeBool "FLANG_STANDALONE_BUILD" true)
+    (lib.cmakeBool "LLVM_INCLUDE_EXAMPLES" false)
+    (lib.cmakeBool "FLANG_INCLUDE_TESTS" false)
+
+  ]
+  ++ devExtraCmakeFlags;
+
+  postUnpack = ''
+    chmod -R u+w -- $sourceRoot/..
+  '';
+
+  outputs = [ "out" ];
+  requiredSystemFeatures = [ "big-parallel" ];
+  meta = llvm_meta // {
+    homepage = "https://flang.llvm.org/";
+    description = "LLVM-based Fortran frontend";
+    license = lib.licenses.ncsa;
+    mainProgram = "flang";
+    maintainers = with lib.maintainers; [ acture ];
+  };
+})

--- a/pkgs/development/compilers/llvm/common/flang/dummy_target_19+.patch
+++ b/pkgs/development/compilers/llvm/common/flang/dummy_target_19+.patch
@@ -1,0 +1,27 @@
+diff --git a/flang/CMakeLists.txt b/flang/CMakeLists.txt
+index 070c39eb6e9a..168c97524943 100644
+--- a/flang/CMakeLists.txt
++++ b/flang/CMakeLists.txt
+@@ -1,6 +1,22 @@
+ cmake_minimum_required(VERSION 3.20.0)
+ set(LLVM_SUBPROJECT_TITLE "Flang")
+ 
++# Patch: define dummy mlir-tblgen target for TableGen.cmake
++if(DEFINED MLIR_TABLEGEN_EXE AND NOT TARGET mlir-tblgen)
++  add_executable(mlir-tblgen IMPORTED GLOBAL)
++  set_target_properties(mlir-tblgen PROPERTIES
++    IMPORTED_LOCATION "${MLIR_TABLEGEN_EXE}"
++  )
++endif()
++
++if(DEFINED MLIR_TABLEGEN_EXE AND NOT TARGET MLIR-TBLGen)
++  add_executable(MLIR-TBLGen IMPORTED GLOBAL)
++  set_target_properties(MLIR-TBLGen PROPERTIES
++    IMPORTED_LOCATION "${MLIR_TABLEGEN_EXE}"
++  )
++endif()
++
++
+ if(NOT DEFINED LLVM_COMMON_CMAKE_UTILS)
+   set(LLVM_COMMON_CMAKE_UTILS ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
+ endif()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5680,6 +5680,7 @@ with pkgs;
 
   mlir_16 = llvmPackages_16.mlir;
   mlir_17 = llvmPackages_17.mlir;
+  flang = llvmPackages_20.flang;
 
   libclc = llvmPackages.libclc;
   libllvm = llvmPackages.libllvm;
@@ -5717,6 +5718,7 @@ with pkgs;
       lldb_20 = llvmPackages_20.lldb;
       llvm_20 = llvmPackages_20.llvm;
       bolt_20 = llvmPackages_20.bolt;
+      flang_20 = llvmPackages_20.flang;
 
       llvmPackages_21 = llvmPackagesSet."21";
       clang_21 = llvmPackages_21.clang;
@@ -5724,6 +5726,7 @@ with pkgs;
       lldb_21 = llvmPackages_21.lldb;
       llvm_21 = llvmPackages_21.llvm;
       bolt_21 = llvmPackages_21.bolt;
+      flang_21 = llvmPackages_21.flang;
 
       mkLLVMPackages = llvmPackagesSet.mkPackage;
     })
@@ -5750,12 +5753,14 @@ with pkgs;
     lldb_20
     llvm_20
     bolt_20
+    flang_20
     llvmPackages_21
     clang_21
     lld_21
     lldb_21
     llvm_21
     bolt_21
+    flang_21
     mkLLVMPackages
     ;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds a standalone flang package build based on LLVM 19.1.7. It enables building flang out-of-tree by:
	•	Adding flang/default.nix and wiring it into llvmPackages.
	•	Patching the top-level CMakeLists.txt to declare dummy mlir-tblgen/MLIR-TBLGen targets, necessary for TableGen support in a standalone build.
	•	Wiring in CMake flags to explicitly provide MLIR_TABLEGEN_EXE and related variables.
	•	Registering flang in all-packages.nix.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
