### PR TITLE
nixos/doc/rl-2511: Distinguish core incompatibilities

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -21,6 +21,13 @@
 - `space-orbit` package has been removed due to lack of upstream maintenance. Debian upstream stopped tracking it in 2011.
 - `command-not-found` package is now disabled by default; it works only for nix-channels based systems, and requires setup for it to work.
 
+- The `no-broken-symlink` build hook now also fails builds whose output derivation contains links to $TMPDIR (typically /build, which contains the build directory).
+
+- `gitversion` was updated to 6.3.0, which includes a number of breaking changes, old configurations may need updating or they will cause the tool to fail to run.
+  See the [6.0.0 release notes for GitVersion](https://github.com/GitTools/GitVersion/releases/tag/6.0.0) for details on the breaking changes, [the documentation on the configuration format](https://gitversion.net/docs/reference/configuration) for the new configuration specification, and [the documentation on version variables](https://gitversion.net/docs/reference/variables) for what is now supported.
+
+- `renovate` was updated to v41. See the upstream release notes for [v40](https://github.com/renovatebot/renovate/releases/tag/40.0.0) and [v41](https://github.com/renovatebot/renovate/releases/tag/41.0.0) for breaking changes.
+
 - Derivations setting both `separateDebugInfo` and one of `allowedReferences`, `allowedRequistes`, `disallowedReferences` or `disallowedRequisites` must now set `__structuredAttrs` to `true`. The effect of reference whitelisting or blacklisting will be disabled on the `debug` output created by `separateDebugInfo`.
 
 - `victoriametrics` no longer contains VictoriaLogs components. These have been separated into the new package `victorialogs`.

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -78,8 +78,9 @@
 
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
-Core incompatibilities that may affect any user:
+NixOS is bundled with Nixpkgs, which has its own release notes and breaking changes.
 
+Core incompatibilities that may affect any user:
 
 - The Perl implementation of the `switch-to-configuration` program is removed. All switchable systems now use the Rust rewrite. Any prior usage of `system.switch.enableNg` must now be removed. If you have any outstanding issues with the new implementation, please open an issue on GitHub.
 
@@ -87,9 +88,7 @@ Incompatibilities in modules:
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the appropriate category instead. -->
 
-<!-- FIXME: move Nixpkgs changes to Nixpkgs release notes -->
-
-- The `no-broken-symlink` build hook now also fails builds whose output derivation contains links to $TMPDIR (typically /build, which contains the build directory).
+<!-- NOTE: put Nixpkgs changes in the Nixpkgs release notes; not this file but <nixpkgs>/doc/release-notes/rl-2511.md.  -->
 
 - The `services.polipo` module has been removed as `polipo` is unmaintained and archived upstream.
 
@@ -111,11 +110,6 @@ Incompatibilities in modules:
 - `netbox-manage` script created by the `netbox` module no longer uses `sudo -u netbox` internally. It can be run as root and will change it's user to `netbox` using `runuser`
 
 - `services.dwm-status.extraConfig` was replaced by [RFC0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-compliant [](#opt-services.dwm-status.settings), which is used to generate the config file. `services.dwm-status.order` is now moved to [](#opt-services.dwm-status.settings.order), as it's a part of the config file.
-
-- `gitversion` was updated to 6.3.0, which includes a number of breaking changes, old configurations may need updating or they will cause the tool to fail to run.
-  See the [6.0.0 release notes for GitVersion](https://github.com/GitTools/GitVersion/releases/tag/6.0.0) for details on the breaking changes, [the documentation on the configuration format](https://gitversion.net/docs/reference/configuration) for the new configuration specification, and [the documentation on version variables](https://gitversion.net/docs/reference/variables) for what is now supported.
-
-- `renovate` was updated to v41. See the upstream release notes for [v40](https://github.com/renovatebot/renovate/releases/tag/40.0.0) and [v41](https://github.com/renovatebot/renovate/releases/tag/41.0.0) for breaking changes.
 
 - The `boot.readOnlyNixStore` has been removed. Control over bind mount options on `/nix/store` is now offered by the `boot.nixStoreMountOpts` option.
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -78,9 +78,16 @@
 
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
-<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+Core incompatibilities that may affect any user:
+
 
 - The Perl implementation of the `switch-to-configuration` program is removed. All switchable systems now use the Rust rewrite. Any prior usage of `system.switch.enableNg` must now be removed. If you have any outstanding issues with the new implementation, please open an issue on GitHub.
+
+Incompatibilities in modules:
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the appropriate category instead. -->
+
+<!-- FIXME: move Nixpkgs changes to Nixpkgs release notes -->
 
 - The `no-broken-symlink` build hook now also fails builds whose output derivation contains links to $TMPDIR (typically /build, which contains the build directory).
 


### PR DESCRIPTION
- Originally written for #428328 

Core is of course ill-defined, but I believe it would be beneficial to call attention to "core" changes that may affect anyone.
The rest can then be skimmed by readers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
