### PR TITLE
[25.05] gnome-notes: Use webkit2gtk-4.1

### DIFF
--- a/pkgs/by-name/gn/gnome-notes/package.nix
+++ b/pkgs/by-name/gn/gnome-notes/package.nix
@@ -19,7 +19,7 @@
   libuuid,
   curl,
   libhandy,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
   gnome,
   adwaita-icon-theme,
   libxml2,
@@ -42,6 +42,13 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/gnome-notes/-/commit/994af76ce5144062d55d141129bf6bf5fab002ee.patch";
       hash = "sha256-z7dPOLZzaqvdqUIDy6+V3dKossRbG0EDjBu2oJCF6b4=";
+    })
+
+    # build: Depend on webkit2gtk-4.1
+    # https://gitlab.gnome.org/GNOME/gnome-notes/-/merge_requests/200
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-notes/-/commit/0791507873c96d0463cd0c83108415541f854edd.patch";
+      hash = "sha256-TwCi9sDudeiOjrH2VevAynxvy/WTmwB2HrWqhviPg8o=";
     })
   ];
 
@@ -71,7 +78,7 @@ stdenv.mkDerivation rec {
     libuuid
     curl
     libhandy
-    webkitgtk_4_0
+    webkitgtk_4_1
     tinysparql
     gnome-online-accounts
     gsettings-desktop-schemas


### PR DESCRIPTION
(cherry picked from [#428043](https://github.com/NixOS/nixpkgs/pull/428043))


Otherwise this crashes at startup `libsoup-ERROR **: 21:52:03.046: libsoup3 symbols detected. Using libsoup2 and libsoup3 in the same process is not supported.`.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

