### PR TITLE
git-spice: format

### DIFF
--- a/pkgs/by-name/gi/git-spice/package.nix
+++ b/pkgs/by-name/gi/git-spice/package.nix
@@ -37,21 +37,20 @@ buildGo124Module rec {
 
   __darwinAllowLocalNetworking = true;
 
-  preCheck =
-    ''
-      # timeout on both aarch64-darwin and x86_64-linux
-      rm testdata/script/issue725_pre_push_hook_worktree.txt
+  preCheck = ''
+    # timeout on both aarch64-darwin and x86_64-linux
+    rm testdata/script/issue725_pre_push_hook_worktree.txt
 
-      # failing on both aarch64-darwin and x86_64-linux
-      # TODO: check if this still fails after next release
-      rm testdata/script/branch_restack_conflict_no_edit.txt
-    ''
+    # failing on both aarch64-darwin and x86_64-linux
+    # TODO: check if this still fails after next release
+    rm testdata/script/branch_restack_conflict_no_edit.txt
+  ''
 
-    + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
-      # timeout
-      rm testdata/script/branch_submit_remote_prompt.txt
-      rm testdata/script/branch_submit_multiple_pr_templates.txt
-    '';
+  + lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
+    # timeout
+    rm testdata/script/branch_submit_remote_prompt.txt
+    rm testdata/script/branch_submit_multiple_pr_templates.txt
+  '';
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd gs \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

cc @vinnymeller

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
