### PR TITLE
kdePackages.plasma-bigscreen: init at unstable-2025-07-25

### DIFF
--- a/pkgs/kde/plasma/default.nix
+++ b/pkgs/kde/plasma/default.nix
@@ -40,6 +40,7 @@
   oxygen-sounds = callPackage ./oxygen-sounds { };
   plasma-activities = callPackage ./plasma-activities { };
   plasma-activities-stats = callPackage ./plasma-activities-stats { };
+  plasma-bigscreen = callPackage ./plasma-bigscreen { };
   plasma-browser-integration = callPackage ./plasma-browser-integration { };
   plasma-desktop = callPackage ./plasma-desktop { };
   plasma-dialer = callPackage ./plasma-dialer { };

--- a/pkgs/kde/plasma/plasma-bigscreen/default.nix
+++ b/pkgs/kde/plasma/plasma-bigscreen/default.nix
@@ -1,0 +1,63 @@
+{
+  mkKdeDerivation,
+  lib,
+  fetchgit,
+  pkg-config,
+  ki18n,
+  kdeclarative,
+  kcmutils,
+  knotifications,
+  kio,
+  kwayland,
+  kwindowsystem,
+  plasma-workspace,
+  qtmultimedia,
+}:
+mkKdeDerivation {
+  pname = "plasma-bigscreen";
+  version = "unstable-2025-07-25";
+
+  src = fetchgit {
+    url = "https://invent.kde.org/plasma/plasma-bigscreen.git";
+    rev = "37dcff3aa008256f0c2260fbf66e4382d0391ac4";
+    hash = "sha256-Xzp9OuR5UOPi0NWJIXP4l4ys73vcqOj/iVmcA/bIlDw=";
+  };
+
+  extraNativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    ki18n
+    kdeclarative
+    kcmutils
+    knotifications
+    kio
+    kwayland
+    kwindowsystem
+    plasma-workspace
+    qtmultimedia
+  ];
+
+  postPatch = ''
+    substituteInPlace bin/plasma-bigscreen-wayland.in \
+      --replace @KDE_INSTALL_FULL_LIBEXECDIR@ "${plasma-workspace}/libexec"
+
+    # Plasma version numbers are required to match, but we are building an
+    # unreleased package against a stable Plasma release.
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(PROJECT_VERSION "6.4.80")' 'set(PROJECT_VERSION "${plasma-workspace.version}")'
+  '';
+
+  preFixup = ''
+    wrapQtApp $out/bin/plasma-bigscreen-wayland
+  '';
+
+  passthru.providedSessions = [
+    "plasma-bigscreen-wayland"
+  ];
+
+  meta = {
+    license = lib.licenses.gpl2Plus;
+  };
+}


### PR DESCRIPTION
## Things done

To make this package work on NixOS, enable a regular [Plasma6 installation](https://wiki.nixos.org/wiki/KDE#Installation) and add the following configuration:
```nix
{ pkgs, ... }:
let
  inherit (pkgs.kdePackages.plasma) plasma-bigscreen;
in
  {
    xdg.portal.configPackages = [ plasma-bigscreen ];
    services.displayManager.sessionPackages = [
      plasma-bigscreen
    ];
    environment.systemPackages = [
      plasma-bigscreen
    ];
  }
```

You can then select the Plasma Bigscreen session from your login screen.

Currently broken:
- The session is launched with`dbus-run-session`, causing an incorrect session bus to be used

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
