### PR TITLE
test-driver: add Testinfra support

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -34,6 +34,7 @@ python3Packages.buildPythonApplication {
       ptpython
       ipython
       remote-pdb
+      pytest-testinfra
     ]
     ++ extraPythonPackages python3Packages;
 

--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -25,6 +25,8 @@ from test_driver.logger import AbstractLogger
 from .ocr import perform_ocr_on_screenshot, perform_ocr_variants_on_screenshot
 from .qmp import QMPSession
 
+import testinfra  # type: ignore
+
 CHAR_TO_KEY = {
     "A": "shift-a",
     "N": "shift-n",
@@ -193,6 +195,27 @@ class StartCommand:
         )
 
 
+class TestInfraBackendNix(testinfra.backend.base.BaseBackend):
+    NAME = "Nix"
+
+    def __init__(self, host: testinfra.host.Host, *args: Any, **kwargs: Any):
+        super().__init__(host.name, **kwargs)
+        self._host = host
+
+    def run(
+        self, command: str, *args: str, **kwargs: Any
+    ) -> testinfra.backend.base.CommandResult:
+        cmd = self.get_command(command, *args)
+        rc, output = self._host.execute(cmd)
+        return testinfra.backend.base.CommandResult(
+            backend=self,
+            exit_status=rc,
+            command=cmd,
+            _stdout=output,
+            _stderr="",
+        )
+
+
 class NixStartScript(StartCommand):
     """A start script from nixos/modules/virtualiation/qemu-vm.nix
     that also satisfies the requirement of the BaseStartCommand.
@@ -213,7 +236,7 @@ class NixStartScript(StartCommand):
         return name
 
 
-class Machine:
+class Machine(testinfra.host.Host):
     """A handle to the machine with this name, that also knows how to manage
     the machine lifecycle with the help of a start script / command."""
 
@@ -285,6 +308,8 @@ class Machine:
 
         self.booted = False
         self.connected = False
+
+        testinfra.host.Host.__init__(self, backend=TestInfraBackendNix(self))
 
     def is_up(self) -> bool:
         return self.booted and self.connected

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -175,6 +175,7 @@ in
           [[ 143 = $(cat $failed/testBuildFailure.exit) ]]
           touch $out
         '';
+    testinfra = runTest ./nixos-test-driver/testinfra.nix;
   };
 
   # NixOS vm tests and non-vm unit tests

--- a/nixos/tests/nixos-test-driver/testinfra.nix
+++ b/nixos/tests/nixos-test-driver/testinfra.nix
@@ -1,0 +1,26 @@
+{
+  name = "Test that testinfra works";
+
+  nodes = {
+    machine = ({ pkgs, ... }: { });
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    assert machine.user('root').exists
+
+    passwd = machine.file("/etc/passwd")
+    assert passwd.exists
+    assert passwd.is_file
+
+    cmd = machine.run("echo hello")
+    assert cmd.rc == 0
+    assert cmd.stdout.strip() == 'hello'
+
+    service = machine.service("multi-user.target")
+    assert service.exists
+    assert service.systemd_properties['Before'] == "shutdown.target", "Before property is not set correctly"
+  '';
+}


### PR DESCRIPTION
Extend nixos test Machine to support Testinfra tests


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
