### PR TITLE
wdisplays: 1.1.1 -> 1.1.3

### DIFF
--- a/pkgs/by-name/wd/wdisplays/package.nix
+++ b/pkgs/by-name/wd/wdisplays/package.nix
@@ -14,7 +14,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wdisplays";
-  version = "1.1.1";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "artizirk";
+    repo = "wdisplays";
+    tag = finalAttrs.version;
+    hash = "sha256-KabaW2BH4zAS0xWkzCM8YaAnP/hkZL7Wq3EARantRis=";
+  };
 
   nativeBuildInputs = [
     meson
@@ -30,19 +37,12 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
   ];
 
-  src = fetchFromGitHub {
-    owner = "artizirk";
-    repo = "wdisplays";
-    rev = finalAttrs.version;
-    sha256 = "sha256-dtvP930ChiDRT60xq6xBDU6k+zHnkrAkxkKz2FxlzRs=";
-  };
-
-  meta = with lib; {
+  meta = {
     description = "Graphical application for configuring displays in Wayland compositors";
-    homepage = "https://github.com/luispabon/wdisplays";
-    maintainers = with maintainers; [ ma27 ];
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    homepage = "https://github.com/artizirk/wdisplays";
+    maintainers = with lib.maintainers; [ ma27 ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
     mainProgram = "wdisplays";
   };
 })


### PR DESCRIPTION
Tested on Hyprland. Includes two fixes.

Diff: https://github.com/artizirk/wdisplays/compare/1.1.1...1.1.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
