### PR TITLE
kanshi: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/by-name/ka/kanshi/package.nix
+++ b/pkgs/by-name/ka/kanshi/package.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       balsoft
       danielbarter
+      aleksana
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/ka/kanshi/package.nix
+++ b/pkgs/by-name/ka/kanshi/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromSourcehut,
+  fetchFromGitLab,
   meson,
   ninja,
   pkg-config,
@@ -12,21 +12,24 @@
   libscfg,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kanshi";
-  version = "1.7.0";
+  version = "1.8.0";
 
-  src = fetchFromSourcehut {
-    owner = "~emersion";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "emersion";
     repo = "kanshi";
-    rev = "v${version}";
-    sha256 = "sha256-FDt+F5tWHLsMejlExb5yPh0SlWzuUlK9u54Uy+alrzw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-90FnVtiYR8AEAddIQe9sfgQDMO8OqlQ8fNy/nJsbhKs=";
   };
 
   strictDeps = true;
+
   depsBuildBuild = [
     pkg-config
   ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -34,18 +37,14 @@ stdenv.mkDerivation rec {
     scdoc
     wayland-scanner
   ];
+
   buildInputs = [
     wayland
     libvarlink
     libscfg
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-error=maybe-uninitialized"
-  ];
-
-  meta = with lib; {
-    homepage = "https://sr.ht/~emersion/kanshi";
+  meta = {
     description = "Dynamic display configuration tool";
     longDescription = ''
       kanshi allows you to define output profiles that are automatically enabled
@@ -55,12 +54,14 @@ stdenv.mkDerivation rec {
       kanshi can be used on Wayland compositors supporting the
       wlr-output-management protocol.
     '';
-    license = licenses.mit;
+    homepage = "https://gitlab.freedesktop.org/emersion/kanshi";
+    changelog = "https://gitlab.freedesktop.org/emersion/kanshi/-/tags/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
     mainProgram = "kanshi";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       balsoft
       danielbarter
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Diff: https://gitlab.freedesktop.org/emersion/kanshi/-/compare/v1.7.0...v1.8.0
Changelog: https://gitlab.freedesktop.org/emersion/kanshi/-/tags/v1.8.0
Migration notice: https://git.sr.ht/~emersion/kanshi#kanshi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
