### PR TITLE
tracy: 0.11.1 -> 0.12.2

### DIFF
--- a/pkgs/by-name/tr/tracy/cpm-dependencies.nix
+++ b/pkgs/by-name/tr/tracy/cpm-dependencies.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  fetchFromGitLab,
+  runCommand,
+}:
+let
+  # List of all the dependencies that get fetched via CPM during the configure phase
+  # This was obtained by repeatedly running `nix build` and looking for
+  # messages like these in the logs:
+  # CPM: Adding package zstd@1.5.7 (v1.5.7 to /build/source/cpm_source_cache/zstd/dfd2e0b6e613dcf44911302708e636a8aee527d2)
+  #
+  # If we pass git into nativeBuildDependencies and disable the no git patch, then the build logs also tell us
+  # the repository that CPM tries to download the sources from
+  cpmDeps = [
+    {
+      name = "zstd";
+      src = fetchFromGitHub {
+        owner = "facebook";
+        repo = "zstd";
+        rev = "v1.5.7";
+        hash = "sha256-tNFWIT9ydfozB8dWcmTMuZLCQmQudTFJIkSr0aG7S44=";
+      };
+    }
+    {
+      name = "imgui";
+      src = fetchFromGitHub {
+        owner = "ocornut";
+        repo = "imgui";
+        rev = "v1.91.9b-docking";
+        hash = "sha256-mQOJ6jCN+7VopgZ61yzaCnt4R1QLrW7+47xxMhFRHLQ=";
+      };
+    }
+    {
+      name = "nfd";
+      src = fetchFromGitHub {
+        owner = "btzy";
+        repo = "nativefiledialog-extended";
+        rev = "v1.2.1";
+        hash = "sha256-GwT42lMZAAKSJpUJE6MYOpSLKUD5o9nSe9lcsoeXgJY=";
+      };
+    }
+    {
+      name = "ppqsort";
+      src = fetchFromGitHub {
+        owner = "GabTux";
+        repo = "PPQSort";
+        rev = "v1.0.5";
+        hash = "sha256-EMZVI/uyzwX5637/rdZuMZoql5FTrsx0ESJMdLVDmfk=";
+      };
+    }
+    {
+      name = "capstone";
+      src = fetchFromGitHub {
+        owner = "capstone-engine";
+        repo = "capstone";
+        rev = "6.0.0-Alpha1";
+        hash = "sha256-oKRu3P1inWueEMIpL0uI2ayCMHZ9FIVotil4sqwLqH4=";
+      };
+    }
+    {
+      name = "packageproject.cmake";
+      # Transitive from PPQSort
+      src = fetchFromGitHub {
+        owner = "TheLartians";
+        repo = "PackageProject.cmake";
+        rev = "v1.11.1";
+        hash = "sha256-E7WZSYDlss5bidbiWL1uX41Oh6JxBRtfhYsFU19kzIw=";
+      };
+    }
+    {
+      name = "wayland-protocols";
+      src = fetchFromGitLab {
+        owner = "wayland";
+        repo = "wayland-protocols";
+        rev = "1.37";
+        domain = "gitlab.freedesktop.org";
+        hash = "sha256-ryyv1RZqpwev1UoXRlV8P1ujJUz4m3sR89iEPaLYSZ4=";
+      };
+    }
+  ];
+
+  # Weird CPM Dep where ppqsort uses cpm to manage cpm itself
+  cpmDep = fetchurl {
+    url = "https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.7/CPM.cmake";
+    hash = "sha256-g+XrcbK7uLHyrTjxlQKHoFdiTjhcI49gh/lM38RK+cU=";
+  };
+  # Combine all the dependencies into the cpm source cache, that gets copied into the build directory
+in
+runCommand "cpm-source-cache" { } (
+  ''
+    mkdir -p $out/cpm
+    cp --no-preserve=mode -r ${cpmDep} $out/cpm/CPM_0.38.7.cmake
+  ''
+  + (lib.strings.concatMapStringsSep "\n" (dep: ''
+    mkdir -p $out/${dep.name}/NIX_ORIGIN_HASH_STUB
+    cp --no-preserve=mode -r ${dep.src}/. $out/${dep.name}/NIX_ORIGIN_HASH_STUB
+  '') cpmDeps)
+)

--- a/pkgs/by-name/tr/tracy/cpm-no-hash.patch
+++ b/pkgs/by-name/tr/tracy/cpm-no-hash.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/CPM.cmake b/cmake/CPM.cmake
+index c1c05320..91fb3417 100644
+--- a/cmake/CPM.cmake
++++ b/cmake/CPM.cmake
+@@ -778,11 +778,9 @@ function(CPMAddPackage)
+       # Application set a custom unique directory name
+       set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${CPM_ARGS_CUSTOM_CACHE_KEY})
+     elseif(CPM_USE_NAMED_CACHE_DIRECTORIES)
+-      string(SHA1 origin_hash "${origin_parameters};NEW_CACHE_STRUCTURE_TAG")
+-      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash}/${CPM_ARGS_NAME})
++      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/NIX_ORIGIN_HASH_STUB/${CPM_ARGS_NAME})
+     else()
+-      string(SHA1 origin_hash "${origin_parameters}")
+-      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash})
++      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/NIX_ORIGIN_HASH_STUB)
+     endif()
+     # Expand `download_directory` relative path. This is important because EXISTS doesn't work for
+     # relative paths.

--- a/pkgs/by-name/tr/tracy/no-git.patch
+++ b/pkgs/by-name/tr/tracy/no-git.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/CPM.cmake b/cmake/CPM.cmake
+index c1c05320..6a551481 100644
+--- a/cmake/CPM.cmake
++++ b/cmake/CPM.cmake
+@@ -405,8 +405,6 @@ endfunction()
+ # Check that the working directory for a git repo is clean
+ function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
+ 
+-  find_package(Git REQUIRED)
+-
+   if(NOT GIT_EXECUTABLE)
+     # No git executable, assume directory is clean
+     set(${isClean}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates the tracy profiler to [version 0.12.2](https://github.com/wolfpld/tracy/releases)

Resolves #417177
Supersedes #417618

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of some binary files (usually in `./result/bin/`) (tracy, tracy-capture, tracy-csvexport)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other contributing documentation in corresponding paths.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
