### PR TITLE
immersed: 10.6.0 -> 10.9.0

### DIFF
--- a/pkgs/by-name/im/immersed/package.nix
+++ b/pkgs/by-name/im/immersed/package.nix
@@ -7,20 +7,20 @@
 }:
 let
   pname = "immersed";
-  version = "10.6.0";
+  version = "10.9.0";
 
   sources = lib.mapAttrs (_: fetchurl) (rec {
     x86_64-linux = {
-      url = "https://web.archive.org/web/20241229041449/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
-      hash = "sha256-u07QpGXEXbp7ApZgerq36x+4Wxsz08YAruIVnZeS0ck=";
+      url = "https://web.archive.org/web/20250725134919if_/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
+      hash = "sha256-plGcvZRpV+nhQ4FoYiIuLmyOg/SHJ8ZjT4Fh6UyH9W0=";
     };
     aarch64-linux = {
-      url = "https://web.archive.org/web/20241229041902/https://static.immersed.com/dl/Immersed-aarch64.AppImage";
+      url = "https://web.archive.org/web/20250725135029if_/https://static.immersed.com/dl/Immersed-aarch64.AppImage";
       hash = "sha256-3BokV30y6QRjE94K7JQ6iIuQw1t+h3BKZY+nEFGTVHI=";
     };
     x86_64-darwin = {
-      url = "https://web.archive.org/web/20241229041652/https://static.immersed.com/dl/Immersed.dmg";
-      hash = "sha256-Sgfm0giVR1dDIFIDpNmGmXLXLRgpMXrVxD/oyPc+Lq0=";
+      url = "https://web.archive.org/web/20250725135025if_/https://static.immersed.com/dl/Immersed.dmg";
+      hash = "sha256-lmSkatB75Bztm19aCC50qrd/NV+HQX9nBMOTxIguaqI=";
     };
     aarch64-darwin = x86_64-darwin;
   });

--- a/pkgs/by-name/im/immersed/package.nix
+++ b/pkgs/by-name/im/immersed/package.nix
@@ -9,7 +9,7 @@ let
   pname = "immersed";
   version = "10.6.0";
 
-  sources = rec {
+  sources = lib.mapAttrs (_: fetchurl) (rec {
     x86_64-linux = {
       url = "https://web.archive.org/web/20241229041449/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
       hash = "sha256-u07QpGXEXbp7ApZgerq36x+4Wxsz08YAruIVnZeS0ck=";
@@ -23,9 +23,9 @@ let
       hash = "sha256-Sgfm0giVR1dDIFIDpNmGmXLXLRgpMXrVxD/oyPc+Lq0=";
     };
     aarch64-darwin = x86_64-darwin;
-  };
+  });
 
-  src = fetchurl (sources.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}"));
+  src = sources.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
 
   meta = with lib; {
     description = "VR coworking platform";
@@ -40,21 +40,29 @@ let
   };
 
 in
-if stdenv.hostPlatform.isDarwin then
-  callPackage ./darwin.nix {
-    inherit
-      pname
-      version
-      src
-      meta
-      ;
-  }
-else
-  callPackage ./linux.nix {
-    inherit
-      pname
-      version
-      src
-      meta
-      ;
-  }
+
+(
+  if stdenv.hostPlatform.isDarwin then
+    callPackage ./darwin.nix {
+      inherit
+        pname
+        version
+        src
+        meta
+        ;
+    }
+  else
+    callPackage ./linux.nix {
+      inherit
+        pname
+        version
+        src
+        meta
+        ;
+    }
+)
+// {
+  passthru = {
+    inherit sources;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Known bug: does not launch on COSMIC (`listener function for opcode 2 of wl_output is NULL`; almost certainly some fhsenv or vendored dependency bug). Use `XDG_SESSION_TYPE=x11` to fix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
