### PR TITLE
venator: init at 1.0.4

### DIFF
--- a/pkgs/by-name/ve/venator/package.nix
+++ b/pkgs/by-name/ve/venator/package.nix
@@ -1,0 +1,73 @@
+{
+  cargo-tauri,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  glib-networking,
+  lib,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "venator";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "kmdreko";
+    repo = "venator";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qjSB/XAxB/VbO4m9Gg/XP9332WaSm/d/ejSTrHRchHg=";
+  };
+
+  cargoRoot = "venator-app";
+  buildAndTestSubdir = "venator-app";
+  # NOTE: don't put npmRoot here because it will break the build with "Found
+  # version mismatched Tauri packages".
+  #
+  # Nasty workaround to `npmRoot` not working. I don't know man...
+  postPatch = ''
+    cp ${finalAttrs.src}/venator-app/package.json .
+    cp ${finalAttrs.src}/venator-app/package-lock.json .
+    cp ${finalAttrs.src}/Cargo.lock venator-app/
+  '';
+
+  cargoHash = "sha256-OLtWDJuK9fXbpjUfidLP2nKdD49cWmqWI92bhV29054=";
+
+  npmDeps = fetchNpmDeps {
+    src = "${finalAttrs.src}/venator-app";
+    hash = "sha256-DnpqX+B0s2d5GwftPh2rpBvUuZpzG+i4+jdgcaB7fIg=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    webkitgtk_4_1
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Desktop app for viewing logs and traces from OpenTelemetry and the Rust tracing ecosystem";
+    homepage = "https://github.com/kmdreko/venator";
+    license = lib.licenses.mit;
+    mainProgram = "venator";
+    maintainers = [
+      lib.maintainers.frankp
+      lib.maintainers._9999years
+    ];
+  };
+})


### PR DESCRIPTION
[Venator](https://github.com/kmdreko/venator) is a application for recording, viewing, and filtering logs and spans from programs instrumented with the Rust tracing crate or using [OpenTelemetry](https://opentelemetry.io/). It is purpose-built for rapid local development.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
