### PR TITLE
gnucobol: Add missing enclosing end verbatim to texi docs

### DIFF
--- a/pkgs/by-name/gn/gnucobol/fix-verbatim.patch
+++ b/pkgs/by-name/gn/gnucobol/fix-verbatim.patch
@@ -1,0 +1,11 @@
+--- a/doc/cbrunt.tex	2023-07-28 14:20:48.000000000 -0300
++++ b/doc/cbrunt.tex	2025-07-25 13:18:43.553275270 -0300
+@@ -212,5 +212,7 @@
+                    current_date YYYYMMDDHHMMSS+01:00
+
+
++@end verbatim
++
+ @section Call environment
+ @verbatim
+

--- a/pkgs/by-name/gn/gnucobol/package.nix
+++ b/pkgs/by-name/gn/gnucobol/package.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./fix-libxml2-include.patch
+    ./fix-verbatim.patch
   ];
 
   # Skips a broken test


### PR DESCRIPTION
Fixes installation/building-docs error. Related makefile output:

```
gnucobol.texi:2765: no matching `@end verbatim'
gnucobol.texi:2736: Next reference to nonexistent `Appendix J'
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
