### PR TITLE
tg: 0.19.0 → 0.22.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tg/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tg/default.nix
@@ -2,49 +2,50 @@
   lib,
   buildPythonApplication,
   fetchFromGitHub,
+  poetry-core,
   pythonOlder,
-  fetchpatch,
   stdenv,
   libnotify,
+  mailcap-fix,
   python-telegram,
 }:
 
 buildPythonApplication rec {
   pname = "tg";
-  version = "0.19.0";
-  format = "setuptools";
-  disabled = pythonOlder "3.8";
+  version = "0.22.0";
+  pyproject = true;
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "paul-nameless";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-apHd26XnOz5nak+Kz8PJPsonQfTWDyPz7Mi/tWf7zwM=";
+    repo = "tg";
+    tag = "v${version}";
+    hash = "sha256-qzqYkksocR86QFmP75ZE93kMSVmdel+OTxPgt9uZHLI=";
   };
 
-  patches = [
-    # Fix sending messages
-    # https://github.com/paul-nameless/tg/pull/306
-    (fetchpatch {
-      url = "https://github.com/mindtheegab/tg/commit/13e2b266989d2d757a394b0fb8cb7fd6ccc2b70c.patch";
-      hash = "sha256-Wja6xBOlPuACzhbT8Yl3F8qSh3Kd9G1lnr9VarbPrfM=";
-    })
-  ];
-
-  # Fix notifications on platforms other than darwin by providing notify-send
-  postPatch = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "poetry-core>=1.0.0,<2.0.0" "poetry-core"
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    # Fix notifications on platforms other than darwin by providing notify-send
     sed -i 's|^NOTIFY_CMD = .*|NOTIFY_CMD = "${libnotify}/bin/notify-send {title} {message} -i {icon_path}"|' tg/config.py
   '';
 
-  propagatedBuildInputs = [ python-telegram ];
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    mailcap-fix
+    python-telegram
+  ];
 
   doCheck = false; # No tests
 
-  meta = with lib; {
+  meta = {
     description = "Terminal client for telegram";
     mainProgram = "tg";
     homepage = "https://github.com/paul-nameless/tg";
-    license = licenses.unlicense;
-    maintainers = with maintainers; [ sikmir ];
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ sikmir ];
   };
 }

--- a/pkgs/by-name/tg/tg/package.nix
+++ b/pkgs/by-name/tg/tg/package.nix
@@ -1,20 +1,16 @@
 {
   lib,
-  buildPythonApplication,
   fetchFromGitHub,
-  poetry-core,
-  pythonOlder,
+  python3Packages,
   stdenv,
   libnotify,
-  mailcap-fix,
-  python-telegram,
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "tg";
   version = "0.22.0";
   pyproject = true;
-  disabled = pythonOlder "3.9";
+  disabled = python3Packages.pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "paul-nameless";
@@ -32,9 +28,9 @@ buildPythonApplication rec {
     sed -i 's|^NOTIFY_CMD = .*|NOTIFY_CMD = "${libnotify}/bin/notify-send {title} {message} -i {icon_path}"|' tg/config.py
   '';
 
-  build-system = [ poetry-core ];
+  build-system = [ python3Packages.poetry-core ];
 
-  dependencies = [
+  dependencies = with python3Packages; [
     mailcap-fix
     python-telegram
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13861,8 +13861,6 @@ with pkgs;
         stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_19.stdenv else stdenv;
       };
 
-  tg = python3Packages.callPackage ../applications/networking/instant-messengers/telegram/tg { };
-
   termdown = python3Packages.callPackage ../applications/misc/termdown { };
 
   terminaltexteffects = with python3Packages; toPythonApplication terminaltexteffects;


### PR DESCRIPTION
* https://github.com/paul-nameless/tg/releases/tag/v0.22.0
* https://github.com/paul-nameless/tg/releases/tag/v0.21.0 (Mitigation for https://github.com/advisories/GHSA-wvcr-2gc8-63gg)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
