### PR TITLE
nixos/github-runner: use apply to override package

### DIFF
--- a/nixos/modules/services/continuous-integration/github-runner/options.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/options.nix
@@ -26,7 +26,7 @@
     default = { };
     type = lib.types.attrsOf (
       lib.types.submodule (
-        { name, ... }:
+        { name, config, ... }:
         {
           options = {
             enable = lib.mkOption {
@@ -186,7 +186,11 @@
               default = { };
             };
 
-            package = lib.mkPackageOption pkgs "github-runner" { };
+            package = lib.mkPackageOption pkgs "github-runner" { } // {
+              apply =
+                # Support old github-runner versions which don't have the `nodeRuntimes` arg yet.
+                pkg: pkg.override (old: lib.optionalAttrs (old ? nodeRuntimes) { inherit (config) nodeRuntimes; });
+            };
 
             ephemeral = lib.mkOption {
               type = lib.types.bool;

--- a/nixos/modules/services/continuous-integration/github-runner/service.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/service.nix
@@ -41,10 +41,6 @@
         currentConfigTokenFilename = ".current-token";
 
         workDir = if cfg.workDir == null then runtimeDir else cfg.workDir;
-        # Support old github-runner versions which don't have the `nodeRuntimes` arg yet.
-        package = cfg.package.override (
-          old: lib.optionalAttrs (lib.hasAttr "nodeRuntimes" old) { inherit (cfg) nodeRuntimes; }
-        );
       in
       lib.nameValuePair svcName {
         description = "GitHub Actions runner";
@@ -77,7 +73,7 @@
 
         serviceConfig = lib.mkMerge [
           {
-            ExecStart = "${package}/bin/Runner.Listener run --startuptype service";
+            ExecStart = "${cfg.package}/bin/Runner.Listener run --startuptype service";
 
             # Does the following, sequentially:
             # - If the module configuration or the token has changed, purge the state directory,
@@ -196,7 +192,7 @@
                         else
                           args+=(--token "$token")
                         fi
-                        ${package}/bin/Runner.Listener configure "''${args[@]}"
+                        ${cfg.package}/bin/Runner.Listener configure "''${args[@]}"
                         # Move the automatically created _diag dir to the logs dir
                         mkdir -p  "$STATE_DIRECTORY/_diag"
                         cp    -r  "$STATE_DIRECTORY/_diag/." "$LOGS_DIRECTORY/"


### PR DESCRIPTION
These changes allow users to reference the final package


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
