### PR TITLE
gtk{3,4}: get X11 out of the closure on Darwin

### DIFF
--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -15,6 +15,7 @@
   dbus,
   glib,
   dconf,
+  x11Support ? !stdenv.hostPlatform.isDarwin,
   libX11,
   libxml2,
   libXtst,
@@ -52,8 +53,10 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    libX11
     libxml2
+  ]
+  ++ lib.optionals x11Support [
+    libX11
     # at-spi2-core can be build without X support, but due it is a client-side library, GUI-less usage is a very rare case
     libXtst
     libXi
@@ -81,6 +84,7 @@ stdenv.mkDerivation rec {
     # including the entire dbus closure in libraries linked with
     # the at-spi2-core libraries.
     "-Ddbus_daemon=/run/current-system/sw/bin/dbus-daemon"
+    (lib.mesonEnable "x11" x11Support)
   ]
   ++ lib.optionals systemdSupport [
     # Same as the above, but for dbus-broker

--- a/pkgs/by-name/ca/cairo/package.nix
+++ b/pkgs/by-name/ca/cairo/package.nix
@@ -14,7 +14,7 @@
   libpng,
   pixman,
   zlib,
-  x11Support ? !stdenv.hostPlatform.isDarwin || true,
+  x11Support ? !stdenv.hostPlatform.isDarwin,
   libXext,
   libXrender,
   gobjectSupport ? true,

--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -14,7 +14,7 @@
   xmlto,
   autoreconfHook,
   autoconf-archive,
-  x11Support ? (stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isDarwin),
+  x11Support ? !stdenv.hostPlatform.isDarwin,
   xorg,
 }:
 

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -130,15 +130,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs =
-    lib.optionals (x11Support || waylandSupport) [
-      # TODO: Reorder me on `staging`.
-      libxkbcommon
-    ]
-    ++ [
+    [
       (libepoxy.override { inherit x11Support; })
     ]
     ++ lib.optionals (x11Support || waylandSupport) [
       isocodes
+      libxkbcommon
     ]
     ++ lib.optionals trackerSupport [
       tinysparql
@@ -149,6 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
     at-spi2-atk
     atk
     cairo
+    pango
     expat
     fribidi
     gdk-pixbuf
@@ -169,10 +167,6 @@ stdenv.mkDerivation (finalAttrs: {
       libXrender
     ]
   )
-  ++ [
-    # TODO: Reorder me on `staging`.
-    pango
-  ]
   ++ lib.optionals waylandSupport [
     libGL
     wayland

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -20,8 +20,7 @@
   cairo,
   pango,
   gdk-pixbuf,
-  atk,
-  at-spi2-atk,
+  at-spi2-core,
   gobject-introspection,
   buildPackages,
   withIntrospection ?
@@ -143,10 +142,9 @@ stdenv.mkDerivation (finalAttrs: {
   #TODO: colord?
 
   propagatedBuildInputs = [
-    at-spi2-atk
-    atk
-    cairo
-    pango
+    (at-spi2-core.override { inherit x11Support; })
+    (cairo.override { inherit x11Support; })
+    (pango.override { inherit x11Support; })
     expat
     fribidi
     gdk-pixbuf

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -132,9 +132,9 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     [
       (libepoxy.override { inherit x11Support; })
+      isocodes
     ]
     ++ lib.optionals (x11Support || waylandSupport) [
-      isocodes
       libxkbcommon
     ]
     ++ lib.optionals trackerSupport [

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -163,11 +163,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [
     # Required by pkg-config files.
-    cairo
+    (cairo.override { inherit x11Support; })
     gdk-pixbuf
     glib
     graphene
-    pango
+    (pango.override { inherit x11Support; })
   ]
   ++ lib.optionals waylandSupport [
     wayland

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -116,24 +116,24 @@ stdenv.mkDerivation (finalAttrs: {
   ++ finalAttrs.setupHooks;
 
   buildInputs = [
-    libxkbcommon
     libpng
     libtiff
     libjpeg
     (libepoxy.override { inherit x11Support; })
     isocodes
-  ]
-  ++ lib.optionals vulkanSupport [
-    vulkan-headers
-    libdrm
-  ]
-  ++ [
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-bad
     fribidi
     harfbuzz
   ]
-  ++ (with xorg; [
+  ++ lib.optionals vulkanSupport [
+    vulkan-headers
+    libdrm
+  ]
+  ++ lib.optionals (x11Support || waylandSupport) [
+    libxkbcommon
+  ]
+  ++ lib.optionals x11Support (with xorg; [
     libICE
     libSM
     libXcursor


### PR DESCRIPTION
GTK 4 still pulls in `libX11` through GraphViz through GStreamer, but meh.

I haven’t tested whether this breaks `waylandSupport && !x11Support`, which I fear I may have broken on `staging-next` already. cc @LordGrimmauld who I think uses that configuration.

cc @jtojnar did you ever decide whether to split up `at-spi2-core` again? If it’s not happening at this point, maybe you want to do the alias migration mentioned in `all-packges.nix`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
