### PR TITLE
tailscale: 1.84.3 -> 1.86.2

### DIFF
--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -23,7 +23,7 @@
 }:
 
 let
-  version = "1.84.3";
+  version = "1.86.2";
 in
 buildGoModule {
   pname = "tailscale";
@@ -37,11 +37,11 @@ buildGoModule {
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "tailscale";
-    rev = "v${version}";
-    hash = "sha256-0HvUNpyi6xzS3PtbgMvh6bLRhV77CZRrVSKGMr7JtbE=";
+    tag = "v${version}";
+    hash = "sha256-hozfvKkvTeaabN1tYl0NlEpjfD4sZQe9Z+agdoXFHNE=";
   };
 
-  vendorHash = "sha256-QBYCMOWQOBCt+69NtJtluhTZIOiBWcQ78M9Gbki6bN0=";
+  vendorHash = "sha256-4QTSspHLYJfzlontQ7msXyOB5gzq7ZwSvWmKuYY5klA=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -63,8 +63,7 @@ buildGoModule {
   ];
 
   excludedPackages = [
-    # exlude integration tests which fail to work
-    # and require additional tooling
+    # Exclude integration tests which fail to work and require additional tooling
     "tstest/integration"
   ];
 
@@ -79,8 +78,7 @@ buildGoModule {
     "ts_include_cli"
   ];
 
-  # remove vendored tooling to ensure it's not used
-  # also avoids some unnecessary tests
+  # Remove vendored tooling to ensure it's not used; also avoids some unnecessary tests
   preBuild = ''
     rm -rf ./tool
   '';
@@ -151,6 +149,12 @@ buildGoModule {
 
         # flaky: https://github.com/tailscale/tailscale/issues/15348
         "TestSafeFuncHappyPath"
+
+        # Requires `go` to be installed with the `go tool` system which we don't use
+        "TestGoVersion"
+
+        # Fails because we vendor dependencies
+        "TestLicenseHeaders"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # syscall default route interface en0 differs from netstat
@@ -165,6 +169,11 @@ buildGoModule {
 
         # Fails only on Darwin, succeeds on other tested platforms.
         "TestOnTailnetDefaultAutoUpdate"
+
+        # Fails due to UNIX domain socket path limits in the Nix build environment.
+        # Likely we could do something to make the paths shorter.
+        "TestProtocolQEMU"
+        "TestProtocolUnixDgram"
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];


### PR DESCRIPTION
https://tailscale.com/changelog#2025-07-29

Closes #428437

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
