### PR TITLE
cc-wrapper: don't set -fno-omit-frame-pointer on s390/s390x

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -810,9 +810,13 @@ stdenvNoCC.mkDerivation {
     # Do not prevent omission of framepointers on x86 32bit due to the small
     # number of general purpose registers. Keeping EBP available provides
     # non-trivial performance benefits.
+    # Also skip s390/s390x as it fails to build glibc and causes
+    # performance regressions:
+    #   https://bugs.launchpad.net/ubuntu-z-systems/+bug/2064538
+    #   https://github.com/NixOS/nixpkgs/issues/428260
     + (
       let
-        enable_fp = !targetPlatform.isx86_32;
+        enable_fp = !targetPlatform.isx86_32 && !targetPlatform.isS390;
         enable_leaf_fp =
           enable_fp
           && (


### PR DESCRIPTION
Without the change both `s390` and `s390x` `glibc` builds fail as https://hydra.nixos.org/build/303208799:

    In file included from ../sysdeps/s390/utf16-utf32-z9.c:501,
                     from ../sysdeps/s390/multiarch/utf16-utf32-z9.c:20:
    ../iconv/loop.c: In function '__from_utf16_loop_vx_cu':
    ../iconv/loop.c:274:1: error: %r11 cannot be used in 'asm' here
      274 | }
          | ^

Disable the `-fno-omit-frame-pointer` for now.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
