### PR TITLE
stac-validator: 3.6.0 → 3.10.0

### DIFF
--- a/pkgs/by-name/st/stac-validator/package.nix
+++ b/pkgs/by-name/st/stac-validator/package.nix
@@ -6,7 +6,7 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "stac-validator";
-  version = "3.6.0";
+  version = "3.10.0";
   pyproject = true;
   disabled = python3Packages.pythonOlder "3.8";
 
@@ -14,7 +14,7 @@ python3Packages.buildPythonPackage rec {
     owner = "stac-utils";
     repo = "stac-validator";
     tag = "v${version}";
-    hash = "sha256-j29Bo8n+/85fzJtif0eWYxDP86k9n4Osl9/piWmTxSs=";
+    hash = "sha256-diaiF2wJyS/1DuUwPkdMyqpMfvKWvTnRo2H4O7FxYBM=";
   };
 
   build-system = [ python3Packages.setuptools ];
@@ -26,6 +26,7 @@ python3Packages.buildPythonPackage rec {
   dependencies = with python3Packages; [
     click
     jsonschema
+    pyyaml
     requests
   ];
 


### PR DESCRIPTION
https://github.com/stac-utils/stac-validator/blob/v3.10.0/CHANGELOG.md

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
