### PR TITLE
jerryscript: init at 3.0.0

### DIFF
--- a/pkgs/by-name/je/jerryscript/package.nix
+++ b/pkgs/by-name/je/jerryscript/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  python3,
+  validatePkgConfig,
+  versionCheckHook,
+  testers,
+  nix-update-script,
+
+  enableCmdline ? !stdenv.hostPlatform.isNone,
+  enableMath ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jerryscript";
+  version = "3.0.0";
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "jerryscript-project";
+    repo = "jerryscript";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Evu4qLlwg3Sf9w/ojtZMNxGJEtopHgKnwqlpf115zD4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "JERRY_CMDLINE" enableCmdline)
+    (lib.cmakeBool "JERRY_MATH" enableMath)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  nativeCheckInputs = [
+    python3
+  ];
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    pushd ../
+    python3 tools/run-tests.py --unittests
+    popd
+
+    runHook postCheck
+  '';
+
+  # Uses a custom lib variable that ignores what nixpkgs's cmake setupHook specifies.
+  postInstall = ''
+    mkdir -p "$lib/lib"
+    mv "$out/lib/"*.so "$lib/lib"
+  '';
+
+  nativeInstallCheckInputs = [
+    validatePkgConfig
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  postInstallCheck = ''
+    echo 'print("Hello" + " " + "World!")' | \
+    "$out/bin/jerry" - | \
+    cmp - <(echo "Hello World!")
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Lightweight JavaScript engine for resource-constrained devices";
+    homepage = "https://jerryscript.net/";
+    downloadPage = "https://github.com/jerryscript-project/jerryscript/";
+    changelog = "https://github.com/jerryscript-project/jerryscript/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "jerry";
+    pkgConfigModules = [
+      "libjerry-core"
+      "libjerry-ext"
+      "libjerry-port"
+    ];
+    maintainers = with lib.maintainers; [ RossSmyth ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
