### PR TITLE
nixos/systemd: run0: enable setLoginUid, disable pamMount

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -838,7 +838,11 @@ in
     # error that we’re trying to avoid can’t possibly happen if polkit isn’t enabled. When polkit isn’t
     # enabled, run0 will fail before it even tries to run the command.
     security.pam.services = mkIf config.security.polkit.enable {
-      systemd-run0 = { };
+      systemd-run0 = {
+        # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
+        setLoginUid = true;
+        pamMount = false;
+      };
     };
   };
 


### PR DESCRIPTION
This brings our `run0` in line with the upstream defaults: https://github.com/systemd/systemd/blob/bcc73cafdbd9c3947c53e4cff3498f8a73e56d9d/src/run/systemd-run0.in

While working on `auditd`, i noticed differences in how `run0` behaves in regard to `/proc/$pid/sessionid` and `/proc/$pid/loginuid`. Particularly, both files were set to `4294967295`, the magic value denoting `unset`.

While the manual page says elevators such as sudo should not set the loginuid, run0 is a bit of a special case: The unit spawned by it is not child of the running user session, and as such there is no id to inherit.

`systemd` upstream uses `pam_loginuid`, and for consistency we should too. Especially because it prevents a whole lot of pain when working with `auditd`.

As to pam mounts:
On nixos we enable those if they are globally enabled. Upstream does not. Considering the password entered into polkit is usually not the user password of the account which will own the unit, pam mount will fail for any partition which requires a password. Thus it makes sense to also disable pam mounts for our run0, it prevents unnecessary unexpected pain.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
