### PR TITLE
[Backport release-25.05] amazon-q-cli: 1.12.1 -> 1.13.1; add darwin to supported platforms

### DIFF
--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -7,20 +7,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "amazon-q-cli";
-  version = "1.12.6";
+  version = "1.12.7";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "amazon-q-developer-cli-autocomplete";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IjM9eFoFfy/WV6lPJB1mnRZYoXLIiVozjzmnXEnU2MA=";
+    hash = "sha256-K9OwA7qEv+yPYL4vv/ZhDK2mhW/jYmGFLEQ9oX2pjUE=";
   };
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-XZX8EisHQ1vqbrV8VnXrah3o1h3iKCxzPsKk6Z+aKzU=";
+  cargoHash = "sha256-C8uc9/g70fBpEeSagNcSfv/KHpW2zJdRvWe2bpTzHRU=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -7,20 +7,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "amazon-q-cli";
-  version = "1.12.7";
+  version = "1.13.1";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "amazon-q-developer-cli-autocomplete";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-K9OwA7qEv+yPYL4vv/ZhDK2mhW/jYmGFLEQ9oX2pjUE=";
+    hash = "sha256-YQNBgOS94laEBhht8eeT8ZgtfXjjAMCeAI22z9SjpGs=";
   };
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-C8uc9/g70fBpEeSagNcSfv/KHpW2zJdRvWe2bpTzHRU=";
+  cargoHash = "sha256-VPJuuUzrtFpZjFog4WENI3eTw9IUNZw3mt5IYHW7MuE=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -7,20 +7,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "amazon-q-cli";
-  version = "1.12.1";
+  version = "1.12.2";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "amazon-q-developer-cli-autocomplete";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oY2hDOsws2WVQPKEFhGNPHITo26p/UZ5XzvRX7DoMyc=";
+    hash = "sha256-TIKG1nzpmjiHE+EjTJR+/GklQNJQeUzmDXaPEiRT80Y=";
   };
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-xriK88OY6W1cOZVgiUPBIuItVHwEyFNq5Ywh367K6CU=";
+  cargoHash = "sha256-lJbHPqQ3eybo03oZY2VyKlsxcTdbdrc8q8AjV+IahEY=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -7,20 +7,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "amazon-q-cli";
-  version = "1.12.2";
+  version = "1.12.4";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "amazon-q-developer-cli-autocomplete";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TIKG1nzpmjiHE+EjTJR+/GklQNJQeUzmDXaPEiRT80Y=";
+    hash = "sha256-juZuqZkBsIHhLOCZk+QpTaO1BsHj2RZyCvkvc0G5KbU=";
   };
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-lJbHPqQ3eybo03oZY2VyKlsxcTdbdrc8q8AjV+IahEY=";
+  cargoHash = "sha256-BT3LNOkRf4gfBy5SwuAnMoJVF9PmwiLsS5phdtEgIrs=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -7,20 +7,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "amazon-q-cli";
-  version = "1.12.4";
+  version = "1.12.6";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "amazon-q-developer-cli-autocomplete";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-juZuqZkBsIHhLOCZk+QpTaO1BsHj2RZyCvkvc0G5KbU=";
+    hash = "sha256-IjM9eFoFfy/WV6lPJB1mnRZYoXLIiVozjzmnXEnU2MA=";
   };
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-BT3LNOkRf4gfBy5SwuAnMoJVF9PmwiLsS5phdtEgIrs=";
+  cargoHash = "sha256-XZX8EisHQ1vqbrV8VnXrah3o1h3iKCxzPsKk6Z+aKzU=";
 
   cargoBuildFlags = [
     "-p"

--- a/pkgs/by-name/am/amazon-q-cli/package.nix
+++ b/pkgs/by-name/am/amazon-q-cli/package.nix
@@ -16,6 +16,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-oY2hDOsws2WVQPKEFhGNPHITo26p/UZ5XzvRX7DoMyc=";
   };
 
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ];
+
   cargoHash = "sha256-xriK88OY6W1cOZVgiUPBIuItVHwEyFNq5Ywh367K6CU=";
 
   cargoBuildFlags = [
@@ -55,6 +59,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=init_lint_zsh_pre_zprofile"
     "--skip=init_lint_zsh_pre_zshrc"
     "--skip=telemetry::cognito::test::pools"
+    "--skip=auth::pkce::tests::test_pkce_flow_with_state_mismatch_throws_err"
+    "--skip=auth::pkce::tests::test_pkce_flow_completes_successfully"
+    "--skip=auth::pkce::tests::test_pkce_flow_with_authorization_redirect_error"
+    "--skip=auth::pkce::tests::test_pkce_flow_with_timeout"
+    "--skip=request::tests::request_test"
   ];
 
   doInstallCheck = true;
@@ -71,6 +80,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ];
     mainProgram = "amazon-q";
     maintainers = [ lib.maintainers.jamesward ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
Manual backport of #420097 #421370 #424255 #426667 #428894 #431214 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
