### PR TITLE
headlessDisplayHook: init

### DIFF
--- a/pkgs/by-name/he/headlessDisplayHook/headless-display-hook.sh
+++ b/pkgs/by-name/he/headlessDisplayHook/headless-display-hook.sh
@@ -1,0 +1,10 @@
+appendToVar prePhases setupHeadlessDisplay
+
+setupHeadlessDisplay() {
+  export FONTCONFIG_FILE=@fontconfig_file@
+  export XDG_RUNTIME_DIR=$(mktemp -d)
+  export XDG_CACHE_HOME=$(mktemp -d)
+  export LD_LIBRARY_PATH="@ld_library_path@:${LD_LIBRARY_PATH:-}"
+  Xvfb :99 -screen 0 800x600x24 >/dev/null 2>&1 &
+  export DISPLAY=:99
+}

--- a/pkgs/by-name/he/headlessDisplayHook/package.nix
+++ b/pkgs/by-name/he/headlessDisplayHook/package.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  stdenv,
+  makeSetupHook,
+  xvfb,
+  makeFontsConf,
+  dejavu_fonts,
+  mesa,
+}:
+if stdenv.hostPlatform.isLinux then
+  makeSetupHook {
+    name = "headlessDisplayHook";
+    propagatedBuildInputs = [
+      xvfb
+      mesa.llvmpipeHook
+    ];
+    substitutions = {
+      fontconfig_file = makeFontsConf { fontDirectories = [ dejavu_fonts ]; };
+      ld_library_path = lib.makeLibraryPath [ mesa ];
+    };
+  } ./headless-display-hook.sh
+else
+  null

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -10,7 +10,6 @@
   gdb,
   glib,
   lttng-ust,
-  mesa,
   perl,
   pkg-config,
   python3,
@@ -27,7 +26,7 @@
   suru-icon-theme,
   validatePkgConfig,
   wrapQtAppsHook,
-  xvfb-run,
+  headlessDisplayHook,
 }:
 
 let
@@ -148,8 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
     dbus-test-runner
     dpkg # `dpkg-architecture -qDEB_HOST_ARCH` response decides how tests are run
     gdb
-    mesa.llvmpipeHook # ShapeMaterial needs an OpenGL context: https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/issues/35
-    xvfb-run
+    headlessDisplayHook
   ];
 
   qmakeFlags = [
@@ -178,7 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
     export QT_PLUGIN_PATH=${qtPluginPaths}
     export XDG_DATA_DIRS=${suru-icon-theme}/share
 
-    tests/xvfb.sh make check ''${enableParallelChecking:+-j''${NIX_BUILD_CORES}}
+    make check ''${enableParallelChecking:+-j''${NIX_BUILD_CORES}}
 
     runHook postCheck
   '';


### PR DESCRIPTION
add a headlessDisplayHook doing graphical check.
should fix https://hydra.nixos.org/build/303107238.

related pr: https://github.com/NixOS/nixpkgs/pull/423961

cc @vcunat  @K900 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
