### PR TITLE
cc2538-bsl: 2.1-unstable-2025-01-14 -> 2.1-unstable-2025-03-28

### DIFF
--- a/pkgs/by-name/cc/cc2538-bsl/do_not_run_git.patch
+++ b/pkgs/by-name/cc/cc2538-bsl/do_not_run_git.patch
@@ -1,0 +1,22 @@
+diff --git a/cc2538_bsl/cc2538_bsl.py b/cc2538_bsl/cc2538_bsl.py
+index b62ea64..f38d872 100755
+--- a/cc2538_bsl/cc2538_bsl.py
++++ b/cc2538_bsl/cc2538_bsl.py
+@@ -1050,16 +1050,7 @@ def parse_page_address_range(device, pg_range):
+ 
+ 
+ def version():
+-    # Get the version using "git describe".
+-    try:
+-        p = Popen(['git', 'describe', '--tags', '--match', '[0-9]*'],
+-                  stdout=PIPE, stderr=PIPE)
+-        p.stderr.close()
+-        line = p.stdout.readlines()[0]
+-        return line.decode('utf-8').strip()
+-    except:
+-        # We're not in a git repo, or git failed, use fixed version string.
+-        return __version__
++    return __version__
+ 
+ 
+ def cli_setup():


### PR DESCRIPTION
`cc2538-bsl` will run `git describe` when executed, so if you do that from a random repository, `cc2538-bsl --version` will return *that* as opposed to the actual version.

This *really* should be fixed upstream but for now we work around it.

Additionally, we need to disable 2 tests but we basically run those manually.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
