### PR TITLE
lib, mkDerivation: Document overriding functions

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -166,7 +166,16 @@ rec {
         overrideWith = newArgs: origArgs // (if isFunction newArgs then newArgs origArgs else newArgs);
 
         # Re-call the function but with different arguments
-        overrideArgs = mirrorArgs (newArgs: makeOverridable f (overrideWith newArgs));
+        overrideArgs = mirrorArgs (
+          /**
+            Change the arguments with which a certain function is called.
+
+            In some cases, you may find a list of possible attributes to pass in this function's `__functionArgs` attribute, but it will not be complete for an original function like `args@{foo, ...}: ...`, which accepts arbitrary attributes.
+
+            This function was provided by `lib.makeOverridable`.
+          */
+          newArgs: makeOverridable f (overrideWith newArgs)
+        );
         # Change the result of the function call by applying g to it
         overrideResult = g: makeOverridable (mirrorArgs (args: g (f args))) origArgs;
       in
@@ -176,6 +185,16 @@ rec {
           override = overrideArgs;
           overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
           ${if result ? overrideAttrs then "overrideAttrs" else null} =
+            /**
+              Override the attributes that were passed to `mkDerivation` in order to generate this derivation.
+
+              This function is provided by `lib.makeOverridable`, and indirectly by `callPackage` among others, in order to make the combination of `override` and `overrideAttrs` work.
+              Specifically, it re-adds the `override` attribute to the result of `overrideAttrs`.
+
+              The real implementation of `overrideAttrs` is provided by `stdenv.mkDerivation`.
+            */
+            # NOTE: part of the above documentation had to be duplicated in `mkDerivation`'s `overrideAttrs`.
+            #       design/tech debt issue: https://github.com/NixOS/nixpkgs/issues/273815
             fdrv: overrideResult (x: x.overrideAttrs fdrv);
         }
       else if isFunction result then

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -84,6 +84,10 @@ let
       args = rattrs (args // { inherit finalPackage overrideAttrs; });
       #              ^^^^
 
+      /**
+        Override the attributes that were passed to `mkDerivation` in order to generate this derivation.
+      */
+      # NOTE: the above documentation had to be duplicated in `lib/customisation.nix`: `makeOverridable`.
       overrideAttrs =
         f0:
         let


### PR DESCRIPTION
These doc comments are mainly for consumption in the repl.

```
nix-repl> :doc hello.override
Function defined at /home/user/src/nixpkgs-master/lib/customisation.nix:177:11

    Change the arguments with which a certain function is called.

    In some cases, you may find a list of possible attributes to pass in this function's __functionArgs attribute, but it will not be complete for an original function like args@{foo,
    ...}: ..., which accepts arbitrary attributes.

    This function was provided by lib.makeOverridable.

nix-repl> :doc hello.overrideAttrs
Function overrideAttrs
    … defined at /home/user/src/nixpkgs-master/lib/customisation.nix:198:13

    Override the attributes that were passed to mkDerivation in order to generate this derivation.

    This function is provided by lib.makeOverridable, and indirectly by callPackage among others, in order to make the combination of override and overrideAttrs work. Specifically, it
    re-adds the override attribute to the result of overrideAttrs.

    The real implementation of overrideAttrs is provided by stdenv.mkDerivation.

nix-repl> :doc (stdenv.mkDerivation { name = "foo"; }).overrideAttrs
Function overrideAttrs
    … defined at /home/user/src/nixpkgs-master/pkgs/stdenv/generic/make-derivation.nix:92:9

    Override the attributes that were passed to mkDerivation in order to generate this derivation.

```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
