### PR TITLE
nixos/immich: add support for VectorChord

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -605,6 +605,12 @@
   "module-services-suwayomi-server-extra-config": [
     "index.html#module-services-suwayomi-server-extra-config"
   ],
+  "module-services-immich": [
+    "index.html#module-services-immich"
+  ],
+  "module-services-immich-vectorchord-migration": [
+    "index.html#module-services-immich-vectorchord-migration"
+  ],
   "module-services-paisa": [
     "index.html#module-services-paisa"
   ],

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -198,7 +198,7 @@
 
 - `services.ntpd-rs` now performs configuration validation.
 
-- Immich now has support for [VectorChord](https://github.com/tensorchord/VectorChord) when using the PostgreSQL configuration provided by `services.immich.database.enable`, which replaces `pgvecto-rs`. VectorChord support can be toggled with the option `services.immich.database.enableVectorChord`.
+- Immich now has support for [VectorChord](https://github.com/tensorchord/VectorChord) when using the PostgreSQL configuration provided by `services.immich.database.enable`, which replaces `pgvecto-rs`. VectorChord support can be toggled with the option `services.immich.database.enableVectorChord`. Additionally, `pgvecto-rs` support is now disabled from NixOS 25.11 onwards using the option `services.immich.database.enableVectors`. This option will be removed fully in the future once Immich drops support for `pgvecto-rs` fully.
 
 - `services.postsrsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.postsrsd.configurePostfix](#opt-services.postsrsd.configurePostfix) option.
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -198,7 +198,7 @@
 
 - `services.ntpd-rs` now performs configuration validation.
 
-- Immich now has support for [VectorChord](https://github.com/tensorchord/VectorChord) when using the PostgreSQL configuration provided by `services.immich.database.enable`, which replaces `pgvecto-rs`. VectorChord support can be toggled with the option `services.immich.database.enableVectorChord`. Additionally, `pgvecto-rs` support is now disabled from NixOS 25.11 onwards using the option `services.immich.database.enableVectors`. This option will be removed fully in the future once Immich drops support for `pgvecto-rs` fully.
+- Immich now has support for [VectorChord](https://github.com/tensorchord/VectorChord) when using the PostgreSQL configuration provided by `services.immich.database.enable`, which replaces `pgvecto-rs`. VectorChord support can be toggled with the option `services.immich.database.enableVectorChord`. Additionally, `pgvecto-rs` support is now disabled from NixOS 25.11 onwards using the option `services.immich.database.enableVectors`. This option will be removed fully in the future once Immich drops support for `pgvecto-rs` fully. See [Immich migration instructions](#module-services-immich-vectorchord-migration)
 
 - `services.postsrsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.postsrsd.configurePostfix](#opt-services.postsrsd.configurePostfix) option.
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -198,6 +198,8 @@
 
 - `services.ntpd-rs` now performs configuration validation.
 
+- Immich now has support for [VectorChord](https://github.com/tensorchord/VectorChord) when using the PostgreSQL configuration provided by `services.immich.database.enable`, which replaces `pgvecto-rs`. VectorChord support can be toggled with the option `services.immich.database.enableVectorChord`.
+
 - `services.postsrsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.postsrsd.configurePostfix](#opt-services.postsrsd.configurePostfix) option.
 
 - `services.pfix-srsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.pfix-srsd.configurePostfix](#opt-services.pfix-srsd.configurePostfix) option.

--- a/nixos/modules/services/web-apps/immich.md
+++ b/nixos/modules/services/web-apps/immich.md
@@ -1,0 +1,32 @@
+# Immich {#module-services-immich}
+
+[Immich](https://immich.app/) is a self-hosted photo and video management
+solution, similar to SaaS offerings like Google Photos.
+
+## Migrating from `pgvecto-rs` to VectorChord (pre-25.11 installations) {#module-services-immich-vectorchord-migration}
+
+Immich instances that were setup before 25.11 (as in
+`system.stateVersion = 25.11;`) will be automatically migrated to VectorChord.
+Note that this migration is not reversible, so database dumps should be created
+if desired.
+
+See [Immich documentation][vectorchord-migration-docs] for more details about
+the automatic migration.
+
+After a successful migration, `pgvecto-rs` should be removed from the database
+installation, unless other applications depend on it.
+
+1. Make sure VectorChord is enabled ([](#opt-services.immich.database.enableVectorChord)) and Immich has completed the migration. Refer to the [Immich documentation][vectorchord-migration-docs] for details.
+2. Run the following two statements in the PostgreSQL database using a superuser role in Immich's database.
+
+    ```sql
+    DROP EXTENSION vectors;
+    DROP SCHEMA vectors;
+    ```
+
+    - You may use the following command to run these statements against the database: `sudo -u postgres psql immich` (Replace `immich` with the value of [](#opt-services.immich.database.name))
+
+3. Disable `pgvecto-rs` by setting [](#opt-services.immich.database.enableVectors) to `false`.
+4. Rebuild and switch.
+
+[vectorchord-migration-docs]: https://immich.app/docs/administration/postgres-standalone/#migrating-to-vectorchord

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -335,7 +335,8 @@ in
 
     systemd.services.immich-server = {
       description = "Immich backend server (Self-hosted photo and video backup solution)";
-      after = [ "network.target" ];
+      requires = lib.mkIf cfg.database.enable [ "postgresql.target" ];
+      after = [ "network.target" ] ++ lib.optionals cfg.database.enable [ "postgresql.target" ];
       wantedBy = [ "multi-user.target" ];
       inherit (cfg) environment;
       path = [
@@ -362,7 +363,8 @@ in
 
     systemd.services.immich-machine-learning = mkIf cfg.machine-learning.enable {
       description = "immich machine learning";
-      after = [ "network.target" ];
+      requires = lib.mkIf cfg.database.enable [ "postgresql.target" ];
+      after = [ "network.target" ] ++ lib.optionals cfg.database.enable [ "postgresql.target" ];
       wantedBy = [ "multi-user.target" ];
       inherit (cfg.machine-learning) environment;
       serviceConfig = commonServiceConfig // {

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -436,5 +436,8 @@ in
     };
     users.groups = mkIf (cfg.group == "immich") { immich = { }; };
   };
-  meta.maintainers = with lib.maintainers; [ jvanbruegge ];
+  meta = {
+    maintainers = with lib.maintainers; [ jvanbruegge ];
+    doc = ./immich.md;
+  };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -741,6 +741,7 @@ in
   ifm = runTest ./ifm.nix;
   iftop = runTest ./iftop.nix;
   immich = runTest ./web-apps/immich.nix;
+  immich-vectorchord-migration = runTest ./web-apps/immich-vectorchord-migration.nix;
   immich-public-proxy = runTest ./web-apps/immich-public-proxy.nix;
   incron = runTest ./incron.nix;
   incus = pkgs.recurseIntoAttrs (

--- a/nixos/tests/web-apps/immich-vectorchord-migration.nix
+++ b/nixos/tests/web-apps/immich-vectorchord-migration.nix
@@ -1,0 +1,71 @@
+{ ... }:
+{
+  name = "immich-vectorchord-migration";
+
+  nodes.machine =
+    { lib, pkgs, ... }:
+    {
+      # These tests need a little more juice
+      virtualisation = {
+        cores = 2;
+        memorySize = 2048;
+        diskSize = 4096;
+      };
+
+      environment.systemPackages = with pkgs; [ immich-cli ];
+
+      services.immich = {
+        enable = true;
+        environment.IMMICH_LOG_LEVEL = "verbose";
+        # Simulate an existing setup
+        database.enableVectorChord = lib.mkDefault false;
+        database.enableVectors = lib.mkDefault true;
+      };
+
+      # TODO: Remove when PostgreSQL 17 is supported.
+      services.postgresql.package = pkgs.postgresql_16;
+
+      specialisation."immich-vectorchord-enabled".configuration = {
+        services.immich.database.enableVectorChord = true;
+      };
+
+      specialisation."immich-vectorchord-only".configuration = {
+        services.immich.database = {
+          enableVectorChord = true;
+          enableVectors = false;
+        };
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      specBase = "${nodes.machine.system.build.toplevel}/specialisation";
+      vectorchordEnabled = "${specBase}/immich-vectorchord-enabled";
+      vectorchordOnly = "${specBase}/immich-vectorchord-only";
+    in
+    ''
+      def psql(command: str):
+        machine.succeed(f"sudo -u postgres psql -d ${nodes.machine.services.immich.database.name} -c '{command}'")
+
+      def immich_works():
+        machine.wait_for_unit("immich-server.service")
+
+        machine.wait_for_open_port(2283) # Server
+        machine.wait_for_open_port(3003) # Machine learning
+        machine.succeed("curl --fail http://localhost:2283/")
+
+      immich_works()
+
+      machine.succeed("${vectorchordEnabled}/bin/switch-to-configuration test")
+
+      immich_works()
+
+      psql("DROP EXTENSION vectors;")
+      psql("DROP SCHEMA vectors;")
+
+      machine.succeed("${vectorchordOnly}/bin/switch-to-configuration test")
+
+      immich_works()
+    '';
+}

--- a/nixos/tests/web-apps/immich.nix
+++ b/nixos/tests/web-apps/immich.nix
@@ -18,9 +18,6 @@
         enable = true;
         environment.IMMICH_LOG_LEVEL = "verbose";
       };
-
-      # TODO: Remove when PostgreSQL 17 is supported.
-      services.postgresql.package = pkgs.postgresql_16;
     };
 
   testScript = ''

--- a/pkgs/by-name/im/immich/package.nix
+++ b/pkgs/by-name/im/immich/package.nix
@@ -273,7 +273,7 @@ buildNpmPackage' {
 
   passthru = {
     tests = {
-      inherit (nixosTests) immich;
+      inherit (nixosTests) immich immich-vectorchord-migration;
     };
 
     machine-learning = immich-machine-learning;


### PR DESCRIPTION
This PR adds enable options for VectorChord and pgvecto.rs respectively. The latter is only enabled by default for `system.stateVersion` <= 25.11.

Once Immich drops support for pgvecto.rs, we can remove the option and ask users to migrate (i.e. remove the extension and schema).

I have added a test that tranistions from pgvecto.rs only -> pgvecto.rs + VectorChord (automatic migration by Immich) -> VectorChord only

This has not been tested in a real world setup yet!

## TODO

- [x] Write release notes
- [x] Write migration instructions (in short: drop extension and schema, disable option)
- [x] Add assertion that either VectorChord and/or pgvecto-rs has to be enabled.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
