### PR TITLE
[WIP] nixos/olm: init; nixos/{olm,newt,pangolin,gerbil}: add documentation chapters

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1588,6 +1588,9 @@
   "module-services-web-apps-pihole-web-configuration": [
     "index.html#module-services-web-apps-pihole-web-configuration"
   ],
+  "module-services-newt": [
+    "index.html#module-services-newt"
+  ],
   "ch-profiles": [
     "index.html#ch-profiles"
   ],

--- a/nixos/modules/services/networking/newt.md
+++ b/nixos/modules/services/networking/newt.md
@@ -1,0 +1,38 @@
+# Newt {#module-services-newt}
+
+Newt is a tunneling client for [Pangolin](https://pangolin.net/). It is designed to securely expose private resources as orchestrated by a Pangolin server. It is the client component of the [Pangolin stack](https://docs.pangolin.net/).
+
+It does not use stateful configuration files; the module simply wraps Newt inside a sandboxed systemd service and uses the Newt command-line flags or environment variables to configure a connection to a Pangolin instance. Thus, this module acts as a more robust alternative to the `nix-shell` commands suggested in the Pangolin dashboard.
+
+To set it up, create a file owned by `root` with permissions `700` to store the {env}`NEWT_SECRET` environment variable. This file may contain other environment variables, like {env}`NEWT_ID` or {env}`PANGOLIN_ENDPOINT`. This removes the need for setting the Newt ID and endpoint in your NixOS configuration via the {option}`services.newt.settings` option, and keeps them out of the Nix Store. Below is an example of the environment file's syntax:
+
+```bash
+NEWT_SECRET=nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2
+NEWT_ID=2ix2t8xk22ubpfy
+PANGOLIN_ENDPOINT=https://pangolin.example.test
+```
+
+Those credentials can be found during site generation in the Pangolin dashboard. Once a site is created, these credentials are not shown again. After setting up the environment file, the following can be added to the NixOS configuration:
+
+```nix
+{
+  services.newt = {
+    enable = true;
+    environmentFile = "/var/lib/secrets/newt.env"
+    settings = {
+      log-level = "DEBUG";
+      mtu = 1280;
+      ping-timeout = "10s";
+      # You can also set up the ID, endpoint and secret via the `settings`
+      # option, but this will cause them to be leaked in the Nix Store:
+      # id = "2ix2t8xk22ubpfy";
+      # endpoint = "https://pangolin.example.test";
+      # secret = "nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2";
+    };
+  };
+}
+```
+
+After rebuilding, the `newt.service` systemd unit should be running and connected to the specified Pangolin instance.
+
+See the [upstream documentation](https://docs.pangolin.net/manage/sites/configure-site) for more information on Newt.

--- a/nixos/modules/services/networking/newt.nix
+++ b/nixos/modules/services/networking/newt.nix
@@ -164,5 +164,11 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ jackr ];
+  meta = {
+    doc = ./newt.md;
+    maintainers = with lib.maintainers; [
+      jackr
+      sigmasquadron
+    ];
+  };
 }

--- a/nixos/modules/services/networking/newt.nix
+++ b/nixos/modules/services/networking/newt.nix
@@ -48,17 +48,19 @@ in
         };
         description = "Settings for Newt module, see [Newt CLI docs](https://github.com/fosrl/newt?tab=readme-ov-file#cli-args) for more information.";
       };
-
-      # provide path to file to keep secrets out of the nix store
       environmentFile = lib.mkOption {
         type = with lib.types; nullOr path;
         default = null;
         description = ''
           Path to a file containing sensitive environment variables for Newt. See <https://docs.fossorial.io/Newt/overview#cli-args>
           These will overwrite anything defined in the config.
-          The file should contain environment-variable assignments like:
+
+          The file should contain environment variable assignments similar to the following:
+
+          ```
           NEWT_ID=2ix2t8xk22ubpfy
           NEWT_SECRET=nnisrfsdfc7prqsp9ewo1dvtvci50j5uiqotez00dgap0ii2
+          ```
         '';
       };
     };


### PR DESCRIPTION
Adds some documentation chapters for the Pangolin stack, and improves some option descriptions.

Oh, I guess it also refactor the entire client-side module set and adds the Olm module too.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
