### PR TITLE
webfontkitgenerator: 1.2.0 -> 1.3.0

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -37,6 +37,10 @@
 
 - `tooling-language-server` has been renamed to `deputy` (both the package and binary), following the rename of the upstream project.
 
+- `webfontkitgenerator` has been renamed to `webfont-bundler`, following the rename of the upstream project.
+  The binary name remains `webfontkitgenerator`.
+  The `webfontkitgenerator` package is an alias to `webfont-bundler`.
+
 - `lima` package now only includes the guest agent for the host's architecture by default. If your guest VM's architecture differs from your Lima host's, you'll need to enable the `lima-additional-guestagents` package by setting `withAdditionalGuestAgents = true` when overriding lima with this input.
 
 - `vmware-horizon-client` was renamed to `omnissa-horizon-client`, following [VMware's sale of their end-user business to Omnissa](https://www.omnissa.com/insights/introducing-omnissa-the-former-vmware-end-user-computing-business/). The binary has been renamed from `vmware-view` to `horizon-client`.

--- a/pkgs/by-name/we/webfont-bundler/package.nix
+++ b/pkgs/by-name/we/webfont-bundler/package.nix
@@ -21,7 +21,7 @@
   wrapGAppsHook4,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  pname = "webfont-kit-generator";
+  pname = "webfont-bundler";
   version = "1.3.0";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/we/webfontkitgenerator/package.nix
+++ b/pkgs/by-name/we/webfontkitgenerator/package.nix
@@ -22,13 +22,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "webfont-kit-generator";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "rafaelmardojai";
     repo = "webfont-kit-generator";
-    rev = finalAttrs.version;
-    hash = "sha256-ZfyF1Didce88/HaLeMNTw0nGzj3EZnC7V9OzsN21L40=";
+    tag = finalAttrs.version;
+    hash = "sha256-5TFsUSY6pJc/OwOklw5YocrleL9nzxKMVS1Bt6LPI/Q=";
   };
 
   nativeBuildInputs = [
@@ -69,9 +69,11 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = with lib; {
-    description = "Webfont Kit Generator is a simple utility that allows you to generate woff, woff2 and the necessary CSS boilerplate from non-web font formats (otf & ttf)";
+    description = "Create @font-face kits easily";
+    longDescription = "Webfont Bundler is a simple utility that allows you to generate woff, woff2 and the necessary CSS boilerplate from non-web font formats (otf and ttf).";
+    changelog = "https://github.com/rafaelmardojai/webfont-kit-generator/releases/tag/${finalAttrs.version}";
     mainProgram = "webfontkitgenerator";
-    homepage = "https://apps.gnome.org/app/com.rafaelmardojai.WebfontKitGenerator";
+    homepage = "https://apps.gnome.org/WebfontKitGenerator/";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ benediktbroich ];
     teams = [ teams.gnome-circle ];

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2139,6 +2139,7 @@ mapAliases {
   ''; # Add 2023-07-29
   waypoint = throw "waypoint has been removed from nixpkgs as the upstream project was archived"; # Added 2024-04-24
   wcurl = throw "'wcurl' has been removed due to being bundled with 'curl'"; # Added 2025-07-04
+  webfontkitgenerator = webfont-bundler; # Added 2025-07-27
   webkitgtk = throw "'webkitgtk' attribute has been removed from nixpkgs, use attribute with ABI version set explicitly"; # Added 2025-06-11
   webmetro = throw "'webmetro' has been removed due to lack of upstream maintenance"; # Added 2025-01-25
   wg-bond = throw "'wg-bond' has been removed due to lack of upstream maintenance"; # Added 2025-01-25


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* [Changelog](https://github.com/rafaelmardojai/webfont-kit-generator/releases/tag/1.3.0)
* [Diff](https://github.com/rafaelmardojai/webfont-kit-generator/compare/1.2.0...1.3.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
