### PR TITLE
ktextaddons: migrate to by-name

### DIFF
--- a/pkgs/by-name/kt/ktextaddons/package.nix
+++ b/pkgs/by-name/kt/ktextaddons/package.nix
@@ -1,30 +1,28 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchurl,
   cmake,
-  extra-cmake-modules,
-  karchive,
-  kconfigwidgets,
-  kcoreaddons,
-  ki18n,
-  kxmlgui,
-  qtkeychain,
+  libsForQt5,
 }:
-mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ktextaddons";
   version = "1.3.2";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${pname}-${version}.tar.xz";
+    url = "mirror://kde/stable/ktextaddons/ktextaddons-${finalAttrs.version}.tar.xz";
     hash = "sha256-mB7Hh2Ljrg8D2GxDyHCa1s6CVmg5DDkhwafEqtSqUeM=";
   };
 
   nativeBuildInputs = [
     cmake
+  ]
+  ++ (with libsForQt5; [
     extra-cmake-modules
-  ];
-  buildInputs = [
+    wrapQtAppsHook
+  ]);
+
+  buildInputs = with libsForQt5; [
     karchive
     kconfigwidgets
     kcoreaddons
@@ -33,10 +31,10 @@ mkDerivation rec {
     qtkeychain
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Various text handling addons for KDE applications";
     homepage = "https://invent.kde.org/libraries/ktextaddons/";
-    license = licenses.gpl2Plus;
-    maintainers = [ ];
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8459,8 +8459,6 @@ with pkgs;
   };
   libkrb5 = krb5; # TODO(de11n) Try to make krb5 reuse libkrb5 as a dependency
 
-  ktextaddons = libsForQt5.callPackage ../development/libraries/ktextaddons { };
-
   l-smash = callPackage ../development/libraries/l-smash {
     stdenv = gccStdenv;
   };


### PR DESCRIPTION
Migrate ktextaddons to by-name
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
