### PR TITLE
[Backport release-25.05] nixos/vector: add graceful shutdown limit option; nixos/vector: add option to disable the configuration validation 

### DIFF
--- a/nixos/modules/services/logging/vector.nix
+++ b/nixos/modules/services/logging/vector.nix
@@ -22,6 +22,15 @@ in
       '';
     };
 
+    gracefulShutdownLimitSecs = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 60;
+      description = ''
+        Set the duration in seconds to wait for graceful shutdown after SIGINT or SIGTERM are received.
+        After the duration has passed, Vector will force shutdown.
+      '';
+    };
+
     settings = lib.mkOption {
       type = (pkgs.formats.json { }).type;
       default = { };
@@ -56,7 +65,7 @@ in
               '';
         in
         {
-          ExecStart = "${lib.getExe cfg.package} --config ${validateConfig conf}";
+          ExecStart = "${lib.getExe cfg.package} --config ${validateConfig conf} --graceful-shutdown-limit-secs ${builtins.toString cfg.gracefulShutdownLimitSecs}";
           DynamicUser = true;
           Restart = "always";
           StateDirectory = "vector";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual Backport of [#414311](https://github.com/NixOS/nixpkgs/pull/414311) and [#425119](https://github.com/NixOS/nixpkgs/pull/425119). 

CC @adamcstephens 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
