### PR TITLE
dsremote: init at 0-unstable-2025-07-07

### DIFF
--- a/pkgs/by-name/ds/dsremote/package.nix
+++ b/pkgs/by-name/ds/dsremote/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  libsForQt5,
+}:
+stdenv.mkDerivation {
+  pname = "dsremote";
+  version = "0-unstable-2025-07-07";
+
+  src = fetchFromGitLab {
+    owner = "Teuniz";
+    repo = "DSRemote";
+    rev = "b290debcfecd4fecf2069fb958bd43fe9e5ce5e1";
+    hash = "sha256-7a13T8MwIFDhrXe7xqB84D6MwfTYs1gJj6VWs4JbzEM=";
+  };
+
+  nativeBuildInputs = [
+    libsForQt5.qmake
+    libsForQt5.qt5.wrapQtAppsHook
+    libsForQt5.qt5.qtbase
+  ];
+
+  hardeningDisable = [ "fortify" ];
+
+  postPatch = ''
+    substituteInPlace dsremote.pro \
+      --replace-fail "/usr/" "$out/" \
+      --replace-fail "/etc/" "$out/etc/"
+  '';
+
+  meta = {
+    description = "Rigol DS1000Z remote control and waveform viewer";
+    homepage = "https://www.teuniz.net/DSRemote";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ mksafavi ];
+    mainProgram = "dsremote";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
DSRemote is a desktop app for controlling Rigol oscilloscopes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
