### PR TITLE
wine: move gettext to nativeBuildInputs

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -13,6 +13,7 @@
   bison,
   flex,
   fontforge,
+  gettext,
   makeWrapper,
   pkg-config,
   nixosTests,
@@ -92,16 +93,19 @@ stdenv.mkDerivation (
     # Fixes "Compiler cannot create executables" building wineWow with mingwSupport
     strictDeps = true;
 
-    nativeBuildInputs = [
-      bison
-      flex
-      fontforge
-      makeWrapper
-      pkg-config
-    ]
-    ++ lib.optionals supportFlags.mingwSupport (
-      mingwGccs ++ lib.optional stdenv.hostPlatform.isDarwin setupHookDarwin
-    );
+    nativeBuildInputs =
+      with supportFlags;
+      [
+        bison
+        flex
+        fontforge
+        makeWrapper
+        pkg-config
+      ]
+      ++ lib.optional gettextSupport gettext
+      ++ lib.optionals mingwSupport (
+        mingwGccs ++ lib.optional stdenv.hostPlatform.isDarwin setupHookDarwin
+      );
 
     buildInputs = toBuildInputs pkgArches (
       with supportFlags;
@@ -115,7 +119,6 @@ stdenv.mkDerivation (
         ++ lib.optional stdenv.hostPlatform.isLinux pkgs.libcap
         ++ lib.optional stdenv.hostPlatform.isDarwin pkgs.libinotify-kqueue
         ++ lib.optional cupsSupport pkgs.cups
-        ++ lib.optional gettextSupport pkgs.gettext
         ++ lib.optional dbusSupport pkgs.dbus
         ++ lib.optional cairoSupport pkgs.cairo
         ++ lib.optional odbcSupport pkgs.unixODBC


### PR DESCRIPTION
Resolves #428236. Closes #428239.  
According to [a message on the Wine mailing list](https://list.winehq.org/pipermail/wine-devel/2012-October/097651.html), Wine requires `gettext` as a build dependency rather than at runtime. Therefore, I removed gettext from `buildInputs` instead of keeping it there. 
More discussions can be found in issue #428239.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
