### PR TITLE
duckdb: disable known bad test

### DIFF
--- a/pkgs/by-name/du/duckdb/package.nix
+++ b/pkgs/by-name/du/duckdb/package.nix
@@ -113,6 +113,8 @@ stdenv.mkDerivation (finalAttrs: {
           # fails with incorrect result
           # Upstream issue https://github.com/duckdb/duckdb/issues/14294
           "test/sql/copy/file_size_bytes.test"
+          # https://github.com/duckdb/duckdb/issues/17757#issuecomment-3032080432
+          "test/issues/general/test_17757.test"
         ]
         ++ lib.optionals stdenv.hostPlatform.isAarch64 [
           "test/sql/aggregate/aggregates/test_kurtosis.test"

--- a/pkgs/by-name/du/duckdb/package.nix
+++ b/pkgs/by-name/du/duckdb/package.nix
@@ -136,16 +136,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = ./update.sh;
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/duckdb/duckdb/releases/tag/v${finalAttrs.version}";
     description = "Embeddable SQL OLAP Database Management System";
     homepage = "https://duckdb.org/";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "duckdb";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       costrouc
       cpcloud
     ];
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
1. `test/issues/general/test_17757.test` is [known to be broken](https://github.com/duckdb/duckdb/issues/17757#issuecomment-3032080432). Disabled.
2. Housekeeping: fixed `with lib;`

Mentioned in https://github.com/NixOS/nixpkgs/pull/409698#issuecomment-3092630328

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux **PLEASE CONFIRM FIXED**
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
