### PR TITLE
flux-local: init at 7.7.0

### DIFF
--- a/pkgs/by-name/fl/flux-local/package.nix
+++ b/pkgs/by-name/fl/flux-local/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  kustomize,
+  fluxcd,
+  kubernetes-helm,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "flux-local";
+  version = "7.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "allenporter";
+    repo = "flux-local";
+    tag = version;
+    hash = "sha256-/Lt0bl16GxmnWCQMf10ev/xjcDHi2b04uHy//Yz0zaY=";
+    leaveDotGit = true; # Diff tests require exact git history to function.
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    aiofiles
+    nest-asyncio
+    gitpython
+    pyyaml
+    mashumaro
+    pytest # Used by `flux-local test` command, not just a test dependency.
+    pytest-asyncio
+    oras
+    python-slugify
+  ];
+
+  buildInputs = [
+    kustomize
+    fluxcd
+    kubernetes-helm
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    syrupy
+  ];
+
+  postPatch = ''
+    substituteInPlace flux_local/kustomize.py \
+      --replace-fail 'KUSTOMIZE_BIN = "kustomize"' 'KUSTOMIZE_BIN = "${kustomize}/bin/kustomize"' \
+      --replace-fail 'FLUX_BIN = "flux"' 'FLUX_BIN = "${fluxcd}/bin/flux"'
+    substituteInPlace flux_local/helm.py \
+      --replace-fail 'HELM_BIN = "helm"' 'HELM_BIN = "${kubernetes-helm}/bin/helm"'
+    substituteInPlace tests/tool/__init__.py \
+      --replace-fail 'FLUX_LOCAL_BIN = "flux-local"' "FLUX_LOCAL_BIN = \"$out/bin/flux-local\""
+  '';
+
+  doCheck = true;
+
+  # Do not treat syrupy out-of-date snapshots as an error.
+  pytestFlags = [ "--snapshot-warn-unused" ];
+
+  disabledTests = [
+    # Requires network to pull OCI containers.
+    "test_oci_repository[oci_repo_dir0-release_dir0]"
+    "test_test_hr[cluster]"
+    "test_test_hr[cluster2]"
+    "test_test_hr[cluster3]"
+    "test_test_hr[cluster9]"
+    "test_template[helm_repo_dir0-release_dir0]"
+    # Auto-generated test-data relying on relative paths we patched to /nix/store paths.
+    # Serialization format is hard to patch, so these tests are skipped instead.
+    "test_internal_commands"
+  ];
+
+  meta = {
+    changelog = "https://github.com/pytest-dev/pytest/releases/tag/${version}";
+    description = "Set of tools and libraries for managing a local flux gitops repository";
+    homepage = "https://github.com/allenporter/flux-local";
+    mainProgram = "flux-local";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      soupglasses
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
