### PR TITLE
tic-80: add support for darwin

### DIFF
--- a/pkgs/by-name/ti/tic-80/package.nix
+++ b/pkgs/by-name/ti/tic-80/package.nix
@@ -73,6 +73,15 @@ stdenv.mkDerivation {
       "BUILD_WITH_ALL"
     ]);
 
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p "$out"/Applications/TIC-80.app/Contents/{MacOS,Resources}
+    cp bin/tic80 "$out"/Applications/TIC-80.app/Contents/MacOS/tic80
+    cp macosx/tic80.plist "$out"/Applications/TIC-80.app/Contents/Info.plist
+    cp macosx/tic80.icns "$out"/Applications/TIC-80.app/Contents/Resources/tic80.icns
+    mkdir -p "$out"/bin
+    ln -s "$out"/Applications/TIC-80.app/Contents/MacOS/tic80 "$out"/bin/tic80
+  '';
+
   nativeBuildInputs = [
     cmake
     curl
@@ -109,7 +118,7 @@ stdenv.mkDerivation {
     '';
     homepage = "https://github.com/nesbox/TIC-80";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     mainProgram = "tic80";
     maintainers = with maintainers; [ blinry ];
   };


### PR DESCRIPTION
Already built 'successfully' with `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1`, but the default CMake `installPhase` didn't do anything on macOS, so it just resulted in an empty directory.

Bundle creation commands are based on [the ones in the README][], but without the wrapper script since the extra args don't seem to be needed.

[the ones in the README]: https://github.com/nesbox/TIC-80#mac


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
