### PR TITLE
Switch Livebook from erlang 27 full to erlang 28 minimal

### DIFF
--- a/pkgs/by-name/li/livebook/package.nix
+++ b/pkgs/by-name/li/livebook/package.nix
@@ -1,21 +1,21 @@
 {
   lib,
-  beamPackages,
+  beamMinimal28Packages,
   makeWrapper,
-  rebar3,
-  elixir,
-  erlang,
   fetchFromGitHub,
   nixosTests,
   nix-update-script,
 }:
+let
+  beamPackages = beamMinimal28Packages;
+in
 beamPackages.mixRelease rec {
   pname = "livebook";
   version = "0.16.4";
 
-  inherit elixir;
+  inherit (beamPackages) elixir;
 
-  buildInputs = [ erlang ];
+  buildInputs = [ beamPackages.erlang ];
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -36,11 +36,11 @@ beamPackages.mixRelease rec {
     wrapProgram $out/bin/livebook \
       --prefix PATH : ${
         lib.makeBinPath [
-          elixir
-          erlang
+          beamPackages.elixir
+          beamPackages.erlang
         ]
       } \
-      --set MIX_REBAR3 ${rebar3}/bin/rebar3
+      --set MIX_REBAR3 ${beamPackages.rebar3}/bin/rebar3
   '';
 
   passthru = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR does 3 things:
- Refactor the livebook package to make it clear which Erlang we're using,
- Upgrade Erlang from 27 to 28, and
- Switch Livebook from the full package set to the minimal one.

The main difference, as far as I can tell, is that the minimal set doesn't include wxWidgets or systemd support.  Livebook doesn't use either, so we should be fine.

The change reduces livebook's transitive closure by about 1 GB:

```
$ nix path-info -Sh ./result
/nix/store/ry4ymdckg11ndqsp33r5ilv4lvdcw46l-livebook-0.16.4	  1.3 GiB  
$ nix path-info -Sh ./result
/nix/store/592zg236ca19yyjil044lk18x5rf9188-livebook-0.16.4	221.2 MiB
```

The main benefit for us is that since Livebook has fewer dependencies, hydra will build it faster, so future changes will go through in less time.  We're also less likely to be broken by a change in GTK or something else ridiculous like that.

I tested this by running the passthru tests and using it locally.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
