### PR TITLE
epson-inkjet-printer-workforce-840-series: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9965,6 +9965,12 @@
     githubId = 665472;
     matrix = "@hehongbo:matrix.org";
   };
+  heichro = {
+    github = "heichro";
+    githubId = 76887148;
+    keys = [ { fingerprint = "BBA7 9E8E 17FE 9C3F BFEA  61E8 30D0 186F 4E19 7E48"; } ];
+    name = "heichro";
+  };
   heijligen = {
     email = "src@posteo.de";
     github = "heijligen";

--- a/pkgs/by-name/ep/epson-inkjet-printer-workforce-840-series/eps_raster_print-cast.patch
+++ b/pkgs/by-name/ep/epson-inkjet-printer-workforce-840-series/eps_raster_print-cast.patch
@@ -1,0 +1,21 @@
+diff --git a/src/raster_to_epson.c b/src/raster_to_epson.c
+index 6e621c8..a5ca797 100644
+--- a/src/raster_to_epson.c
++++ b/src/raster_to_epson.c
+@@ -438,14 +438,14 @@ static int print_page (void)
+ 					break;
+ 				}
+ 
+-				if (eps_raster_print(raster_h, image_raw, pageRegion.bytesPerLine, pageRegion.width, &nraster)) {
++				if (eps_raster_print(raster_h, image_raw, pageRegion.bytesPerLine, pageRegion.width, (int *) &nraster)) {
+ 					error  = 1;
+ 					break;
+ 				}
+ 			}
+ 
+ 			// flushing page
+-			eps_raster_print(raster_h, NULL, 0, 0, &nraster);
++			eps_raster_print(raster_h, NULL, 0, 0, (int *) &nraster);
+ 
+ 			bAbort = (error) ? TRUE : FALSE;
+ 			if (epcgEndPage (bAbort)) {

--- a/pkgs/by-name/ep/epson-inkjet-printer-workforce-840-series/include-raster-helper.patch
+++ b/pkgs/by-name/ep/epson-inkjet-printer-workforce-840-series/include-raster-helper.patch
@@ -1,0 +1,23 @@
+diff --git a/src/pagemanager/pagemanager.c b/src/pagemanager/pagemanager.c
+index 029e6d3..2881585 100644
+--- a/src/pagemanager/pagemanager.c
++++ b/src/pagemanager/pagemanager.c
+@@ -23,6 +23,7 @@
+ #include "debuglog.h"
+ #include "memory.h"
+ #include "raster.h"
++#include "raster-helper.h"
+ #include "pagemanager.h"
+
+ extern int JobCanceled;
+diff --git a/src/raster_to_epson.c b/src/raster_to_epson.c
+index 6e621c8..6eea77c 100644
+--- a/src/raster_to_epson.c
++++ b/src/raster_to_epson.c
+@@ -36,6 +36,7 @@
+ #include "raster.h"
+ #include "memory.h"
+ #include "raster_to_epson.h"
++#include "raster-helper.h"
+ #include "pagemanager.h"
+ #include "filter_option.h"

--- a/pkgs/by-name/ep/epson-inkjet-printer-workforce-840-series/package.nix
+++ b/pkgs/by-name/ep/epson-inkjet-printer-workforce-840-series/package.nix
@@ -1,0 +1,131 @@
+{
+  autoreconfHook,
+  cups,
+  libjpeg,
+  rpmextract,
+  fetchurl,
+  lib,
+  stdenv,
+}:
+
+let
+  srcdirs = {
+    filter = "epson-inkjet-printer-filter-1.0.0";
+    driver = "epson-inkjet-printer-workforce-840-series-1.0.0";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "epson-inkjet-printer-workforce-840-series";
+  version = "1.0.0";
+
+  # The Epson may be unreliable, and it has been since sometime in
+  # 2024. Non-browser requests using commands like fetchurl receive a
+  # 403 error, an access denied response -- last checked on
+  # 2025-08-21.
+  #
+  # Therefore, an archive.org link has been added as a fallback
+  # option just in case.
+  src = fetchurl {
+    # NOTE: Don't forget to update the webarchive link too!
+    urls = [
+      "https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-workforce-840-series-${finalAttrs.version}-1lsb3.2.src.rpm"
+      "https://web.archive.org/web/https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-workforce-840-series-${finalAttrs.version}-1lsb3.2.src.rpm"
+    ];
+    hash = "sha256-rTYnEmgzqR/wOZYYIe2rO9x2cX8s2qDyTuRaTjzJjbg=";
+  };
+  sourceRoot = srcdirs.filter;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    rpmextract
+  ];
+  buildInputs = [
+    cups
+    libjpeg
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    rpmextract "$src"
+    for i in ${lib.concatStringsSep " " (builtins.attrValues srcdirs)}; do
+        tar xvf "$i".tar.gz
+    done
+
+    runHook postUnpack
+  '';
+
+  # Both patches fix errors that occur when building with GCC 14.
+  #
+  # eps_raster_print-cast.patch fixes 'error: passing argument 5 of
+  # ‘eps_raster_print’ from incompatible pointer type' in file
+  # raster_to_epson.c
+  #
+  # include-raster-helper.patch fixes 'error: implicit declaration of
+  # function' in files pagemanager.c and raster_to_epson.c
+  patches = [
+    ./eps_raster_print-cast.patch
+    ./include-raster-helper.patch
+  ];
+
+  installPhase =
+    let
+      filterdir = "$out/lib/cups/filter";
+      docdir = "$out/share/doc/epson-inkjet-printer-workforce-840-series";
+      ppddir = "$out/share/cups/model/epson-inkjet-printer-workforce-840-series";
+      libdir =
+        if stdenv.hostPlatform.isx86_64 then
+          "lib64"
+        else
+          throw "Platforms other than x86_64-linux are not (yet) supported.";
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p "$out" "${docdir}" "${filterdir}" "${ppddir}"
+      cp src/epson_inkjet_printer_filter "${filterdir}"
+
+      cp AUTHORS COPYING COPYING.EPSON COPYING.LIB "${docdir}"
+
+      cd ../${srcdirs.driver}
+      cp Manual.txt README "${docdir}"
+      for ppd in ppds/*; do
+          substituteInPlace "$ppd" --replace-fail '/opt/epson-inkjet-printer-workforce-840-series/cups/lib' "$out/lib/cups"
+          gzip -c "$ppd" > "${ppddir}/''${ppd#*/}"
+      done
+      cp -r resource watermark ${libdir} "$out"
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Proprietary CUPS drivers for Epson inkjet printers";
+    longDescription = ''
+      This software is a filter program used with the Common UNIX Printing
+      System (CUPS) under Linux. It supplies high quality printing with
+      Seiko Epson Color Ink Jet Printers.
+
+      This printer driver is supporting the following printers.
+
+      Epson Stylus Office BX925
+      Epson WorkForce 840
+
+      To use the driver adjust your configuration.nix file:
+      ```nix
+      {
+        services.printing = {
+          enable = true;
+          drivers = [ pkgs.epson-inkjet-printer-workforce-840-series ];
+        };
+      }
+      ```
+    '';
+    downloadPage = "http://download.ebz.epson.net/dsc/du/02/DriverDownloadInfo.do?LG2=EN&CN2=&DSCMI=16839&DSCCHK=3d7bc6bdfca08006abfb859fb1967183156a7252";
+    license = with lib.licenses; [
+      lgpl21
+      epson
+    ];
+    maintainers = with lib.maintainers; [ heichro ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Proprietary CUPS drivers for Epson inkjet printers. This printer driver is supporting the following printers:
- Epson Stylus Office BX925
- Epson WorkForce 840

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
