### PR TITLE
build-support/php: avoid code duplication in variables expansion

### DIFF
--- a/pkgs/build-support/php/builders/v2/hooks/composer-vendor-hook.sh
+++ b/pkgs/build-support/php/builders/v2/hooks/composer-vendor-hook.sh
@@ -5,6 +5,14 @@ source @phpScriptUtils@
 
 declare -g out
 declare -g composerLock
+declare -g composerNoDev
+declare -g composerNoPlugins
+declare -g composerNoScripts
+
+declare -ga composerFlags=()
+[[ -n "$composerNoDev" ]] && composerFlags+=(--no-dev)
+[[ -n "$composerNoPlugins" ]] && composerFlags+=(--no-plugins)
+[[ -n "$composerNoScripts" ]] && composerFlags+=(--no-scripts)
 
 preConfigureHooks+=(composerVendorConfigureHook)
 preBuildHooks+=(composerVendorBuildHook)
@@ -32,9 +40,7 @@ composerVendorConfigureHook() {
       --no-interaction \
       --no-progress \
       --optimize-autoloader \
-      ${composerNoDev:+--no-dev} \
-      ${composerNoPlugins:+--no-plugins} \
-      ${composerNoScripts:+--no-scripts} \
+      "${composerFlags[@]}" \
       update
 
     if [[ -f "composer.lock" ]]; then
@@ -76,9 +82,7 @@ composerVendorBuildHook() {
     --no-interaction \
     --no-progress \
     --optimize-autoloader \
-    ${composerNoDev:+--no-dev} \
-    ${composerNoPlugins:+--no-plugins} \
-    ${composerNoScripts:+--no-scripts} \
+    "${composerFlags[@]}" \
     install
 
   echo "Finished composerVendorBuildHook"


### PR DESCRIPTION
Continuation of https://github.com/NixOS/nixpkgs/pull/428443

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
