### PR TITLE
[Backport release-25.05] slimevr: 0.15.0 -> 0.16.0

### DIFF
--- a/pkgs/by-name/sl/slimevr-server/deps.json
+++ b/pkgs/by-name/sl/slimevr-server/deps.json
@@ -20,10 +20,10 @@
    "jar": "sha256-At4T7JOk5Ary/jGDErygVFkglIQ37CdG98idweqySAQ=",
    "pom": "sha256-aEgGw0Vfw3gG0B4RCADfpb1wmQBtXY4c0jwryNaS3yY="
   },
-  "loucass003#EspflashKotlin/v0.10.0": {
-   "jar": "sha256-ORIPUdeqSAhXBuXmPkmyZ6gS8EFnwYkvUtgXFttKIwU=",
-   "module": "sha256-6IMNElGmZLIg/qqVYFdFoHxZIK+YYsT4rBTzyM86FW8=",
-   "pom": "sha256-4ni1oElb85tIe9C0diwh20pgxVUA0c8PX1JZhgomdgo="
+  "loucass003#EspflashKotlin/v0.11.0": {
+   "jar": "sha256-JjFP8WfEvQA8QfKwSQ3EL+LcihGOEsEobFnCfLz/wK8=",
+   "module": "sha256-M9dHPREom7PongBx9lIIJYNAxh3ed9nCcFsqjSfa2ng=",
+   "pom": "sha256-5dGKuzEH67lOmuyc2CJdxWhWyS7tZVMFTvaKw+IBZT8="
   }
  },
  "https://oss.sonatype.org/content/repositories/snapshots": {
@@ -595,15 +595,15 @@
    "module": "sha256-tJZEwfTNkvRk844MXEwqFJp7s+0VsyrJCO5XypCHfqg=",
    "pom": "sha256-qRWJAaDp8uNB+jtHPwK7mOIC+gkY1Fxo3/n602z+X2Y="
   },
-  "com/melloware#jintellitype/1.5.0": {
-   "jar": "sha256-jf+mMUTxKiDf70/Zm9OeyQSxS0TPR8CeGOy3G4Hze1g=",
-   "pom": "sha256-e1E2mFo87oyeK/FQR1K/++7WyQwTCLsrX5//sNwBvao="
+  "com/melloware#jintellitype/1.5.6": {
+   "jar": "sha256-Ocg8asI4sopzRAiIhBYr+MmY3z5ipGteBtq0y08Q+1s=",
+   "pom": "sha256-oHvWfANoBK+t3hnGbtlCSQdjxnRqSTdlQB0LxPlY40s="
   },
   "com/melloware/jintellitype/maven-metadata": {
    "xml": {
     "groupId": "com.melloware",
-    "lastUpdated": "20250413134243",
-    "release": "1.5.0"
+    "lastUpdated": "20250523184542",
+    "release": "1.5.6"
    }
   },
   "com/typesafe#config/1.4.3": {

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -21,13 +21,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "slimevr";
-  version = "0.15.0";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "SlimeVR";
     repo = "SlimeVR-Server";
     rev = "v${version}";
-    hash = "sha256-Sc51fGUXc9FCTO7wVy9hkZiOe0RYefVasp+jCeWl844=";
+    hash = "sha256-ZYL+aBrADbzSXnhFzxNk8xRrY0WHmHCtVaC6VfXfLJw=";
     # solarxr
     fetchSubmodules = true;
   };
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
     pname = "${pname}-pnpm-deps";
     inherit version src;
     fetcherVersion = 1;
-    hash = "sha256-xCID9JOFEswsTbE5Dh6ZAkhhyy4eMuqkme54IdWfcks=";
+    hash = "sha256-lh5IKdBXuH9GZFUTrzaQFDWCEYj0UJhKwCdPmsiwfCs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Manual backport of #422175 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.