### PR TITLE
[Backport release-25.05] mdp: 1.0.15 -> 1.0.18

### DIFF
--- a/pkgs/by-name/md/mdp/package.nix
+++ b/pkgs/by-name/md/mdp/package.nix
@@ -6,14 +6,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.17";
+  version = "1.0.18";
   pname = "mdp";
 
   src = fetchFromGitHub {
     owner = "visit1985";
     repo = "mdp";
     rev = version;
-    sha256 = "sha256-g9+bqMoUpcRL1pcNqaeMR3l5uHuiEpDZj/6YmyOSn7k=";
+    sha256 = "sha256-7ltqnvNzdr+sJiiiCQpp25dzhOrcUCOAgMTt1RIgVTw=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/by-name/md/mdp/package.nix
+++ b/pkgs/by-name/md/mdp/package.nix
@@ -6,14 +6,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.15";
+  version = "1.0.17";
   pname = "mdp";
 
   src = fetchFromGitHub {
     owner = "visit1985";
     repo = "mdp";
     rev = version;
-    sha256 = "1m9a0vvyw2m55cn7zcq011vrjkiaj5a3g5g6f2dpq953gyi7gff9";
+    sha256 = "sha256-g9+bqMoUpcRL1pcNqaeMR3l5uHuiEpDZj/6YmyOSn7k=";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];


### PR DESCRIPTION
Manual backport of #423775 #428576 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.