### PR TITLE
pihole-ftl: Fix files.macvendor setting, and download database (fixes #428282)

### DIFF
--- a/nixos/modules/services/networking/pihole-ftl-setup-script.nix
+++ b/nixos/modules/services/networking/pihole-ftl-setup-script.nix
@@ -15,6 +15,7 @@ let
       comment = list.description;
     };
   payloads = map makePayload cfg.lists;
+  macvendorURL = lib.strings.escapeShellArg cfg.macvendorURL;
 in
 ''
   # Can't use -u (unset) because api.sh uses API_URL before it is set
@@ -22,8 +23,10 @@ in
   pihole="${lib.getExe pihole}"
   jq="${lib.getExe pkgs.jq}"
 
+  ${lib.getExe pkgs.curl} --retry 3 --retry-delay 5 "${macvendorURL}" -o "${cfg.settings.files.macvendor}" || echo "Failed to download MAC database from ${macvendorURL}"
+
   # If the database doesn't exist, it needs to be created with gravity.sh
-  if [ ! -f '${cfg.stateDirectory}'/gravity.db ]; then
+  if [ ! -f '${cfg.settings.files.gravity}' ]; then
     $pihole -g
     # Send SIGRTMIN to FTL, which makes it reload the database, opening the newly created one
     ${lib.getExe' pkgs.procps "kill"} -s SIGRTMIN $(systemctl show --property MainPID --value ${config.systemd.services.pihole-ftl.name})

--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -118,6 +118,14 @@ in
       '';
     };
 
+    macvendorURL = mkOption {
+      type = types.str;
+      default = "https://ftl.pi-hole.net/macvendor.db";
+      description = ''
+        URL from which to download the macvendor.db file.
+      '';
+    };
+
     pihole = mkOption {
       type = types.package;
       default = piholeScript;

--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -260,7 +260,7 @@ in
         files = {
           database = "${cfg.stateDirectory}/pihole-FTL.db";
           gravity = "${cfg.stateDirectory}/gravity.db";
-          macvendor = "${cfg.stateDirectory}/gravity.db";
+          macvendor = "${cfg.stateDirectory}/macvendor.db";
           log.ftl = "${cfg.logDirectory}/FTL.log";
           log.dnsmasq = "${cfg.logDirectory}/pihole.log";
           log.webserver = "${cfg.logDirectory}/webserver.log";

--- a/pkgs/by-name/pi/pihole-ftl/package.nix
+++ b/pkgs/by-name/pi/pihole-ftl/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  nixosTests,
   fetchFromGitHub,
   cmake,
   gmp,
@@ -12,7 +13,6 @@
   readline,
   xxd,
   iproute2,
-  ...
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -78,6 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru.settingsTemplate = ./pihole.toml;
+  passthru.tests = nixosTests.pihole-ftl;
 
   meta = {
     description = "Pi-hole FTL engine";

--- a/pkgs/by-name/pi/pihole-web/package.nix
+++ b/pkgs/by-name/pi/pihole-web/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   lib,
+  nixosTests,
   fetchFromGitHub,
   pihole,
   pihole-ftl,
@@ -35,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.tests = nixosTests.pihole-ftl;
 
   meta = {
     description = "Pi-hole web dashboard displaying stats and more";

--- a/pkgs/by-name/pi/pihole/package.nix
+++ b/pkgs/by-name/pi/pihole/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  nixosTests,
   fetchFromGitHub,
   makeBinaryWrapper,
   installShellFiles,
@@ -237,6 +238,8 @@
     platforms = lib.platforms.linux;
     mainProgram = "pihole";
   };
+
+  passthru.tests = nixosTests.pihole-ftl;
 
   passthru = {
     inherit stateDir;


### PR DESCRIPTION
Fix the setting's default value, which accidentally duplicates the gravity.db file path.

This fixes #428282.

Also download the file as done in upstream's installation script

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
