### PR TITLE
[Backport release-25.05] postfix-tlspol: 1.8.9 -> 1.8.12

### DIFF
--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -8,6 +8,7 @@
 let
   inherit (lib)
     hasPrefix
+    literalExpression
     mkEnableOption
     mkIf
     mkMerge
@@ -92,7 +93,13 @@ in
           dns = {
             address = mkOption {
               type = types.str;
-              default = "127.0.0.1:53";
+              default = if config.networking.resolvconf.useLocalResolver then "127.0.0.1:53" else null;
+              defaultText = literalExpression ''
+                if config.networking.resolvconf.useLocalResolver then
+                  "127.0.0.1:53"
+                else
+                  null
+              '';
               description = ''
                 IP and port to your DNS resolver
 

--- a/nixos/modules/services/mail/postfix-tlspol.nix
+++ b/nixos/modules/services/mail/postfix-tlspol.nix
@@ -24,6 +24,8 @@ let
 in
 
 {
+  meta.maintainers = pkgs.postfix-tlspol.meta.maintainers;
+
   options.services.postfix-tlspol = {
     enable = mkEnableOption "postfix-tlspol";
 

--- a/pkgs/by-name/po/postfix-tlspol/package.nix
+++ b/pkgs/by-name/po/postfix-tlspol/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "postfix-tlspol";
-  version = "1.8.11";
+  version = "1.8.12";
 
   src = fetchFromGitHub {
     owner = "Zuplu";
     repo = "postfix-tlspol";
     tag = "v${version}";
-    hash = "sha256-hQSJ0bp3ghfi5chislf2zuCrvPhhoA0jjChRdGYHcFY=";
+    hash = "sha256-OBGBjbLnyDKz/UK5th1k/gfxHjBGxyWQKgiXuuJNf8Q=";
   };
 
   vendorHash = null;
@@ -28,6 +28,7 @@ buildGoModule rec {
   };
 
   meta = {
+    changelog = "https://github.com/Zuplu/postfix-tlspol/releases/tag/${src.tag}";
     description = "Lightweight MTA-STS + DANE/TLSA resolver and TLS policy server for Postfix, prioritizing DANE.";
     homepage = "https://github.com/Zuplu/postfix-tlspol";
     license = lib.licenses.mit;

--- a/pkgs/by-name/po/postfix-tlspol/package.nix
+++ b/pkgs/by-name/po/postfix-tlspol/package.nix
@@ -32,7 +32,10 @@ buildGoModule rec {
     description = "Lightweight MTA-STS + DANE/TLSA resolver and TLS policy server for Postfix, prioritizing DANE.";
     homepage = "https://github.com/Zuplu/postfix-tlspol";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ valodim ];
+    maintainers = with lib.maintainers; [
+      hexa
+      valodim
+    ];
     mainProgram = "postfix-tlspol";
   };
 }

--- a/pkgs/by-name/po/postfix-tlspol/package.nix
+++ b/pkgs/by-name/po/postfix-tlspol/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "postfix-tlspol";
-  version = "1.8.10";
+  version = "1.8.11";
 
   src = fetchFromGitHub {
     owner = "Zuplu";
     repo = "postfix-tlspol";
     tag = "v${version}";
-    hash = "sha256-UAAjvu/nWF9Q60n+Fojw/a6CsgY6iI5qjKv2nsBuzvo=";
+    hash = "sha256-hQSJ0bp3ghfi5chislf2zuCrvPhhoA0jjChRdGYHcFY=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/po/postfix-tlspol/package.nix
+++ b/pkgs/by-name/po/postfix-tlspol/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "postfix-tlspol";
-  version = "1.8.9";
+  version = "1.8.10";
 
   src = fetchFromGitHub {
     owner = "Zuplu";
     repo = "postfix-tlspol";
     tag = "v${version}";
-    hash = "sha256-SsZyK+DN93o6HgTSAza2ppwHuqoW2strmE/uotuBIAM=";
+    hash = "sha256-UAAjvu/nWF9Q60n+Fojw/a6CsgY6iI5qjKv2nsBuzvo=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
Manual backport of #408788 #414150 #424199 to `release-25.05`.

- [x] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.