### PR TITLE
go-jsonschema: init at 0.20.0

### DIFF
--- a/pkgs/by-name/go/go-jsonschema/package.nix
+++ b/pkgs/by-name/go/go-jsonschema/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "go-jsonschema";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "omissis";
+    repo = "go-jsonschema";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e1eL5Blf9l4cSR7Tg740eTFza3ViJEiwLaoUsUZzQu4=";
+  };
+
+  vendorHash = "sha256-vHtigJ2YNFFWGxv6/pGwmmGE0Fn+2S7NguyrhVME7ak=";
+
+  ldflags = [
+    "-X main.version=v${finalAttrs.version}"
+    "-s"
+    "-w"
+  ];
+
+  env.GOWORK = "off";
+
+  # Tests are in a nested Go module which makes things difficult.
+  preBuild = ''
+    rm -rf tests
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A tool to generate Go data types from JSON Schema definitions.";
+    homepage = "https://github.com/omissis/go-jsonschema";
+    changelog = "https://github.com/omissis/go-jsonschema/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      shellhazard
+    ];
+    mainProgram = "go-jsonschema";
+  };
+})


### PR DESCRIPTION
> go-jsonschema is a tool to generate Go data types from [JSON Schema](http://json-schema.org/) definitions. 
>
> This tool generates Go data types and structs that corresponds to definitions in the schema, along with unmarshalling code that validates the input JSON according to the schema's validation rules.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
