### PR TITLE
fcitx5: fix svg loading

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/with-addons.nix
+++ b/pkgs/tools/inputmethods/fcitx5/with-addons.nix
@@ -8,6 +8,7 @@
   libsForQt5,
   qt6Packages,
   fcitx5-gtk,
+  librsvg,
   addons ? [ ],
 }:
 
@@ -25,10 +26,15 @@ symlinkJoin {
   ]
   ++ addons;
 
+  buildInputs = [
+    librsvg
+  ];
+
   nativeBuildInputs = [ makeBinaryWrapper ];
 
   postBuild = ''
     wrapProgram $out/bin/fcitx5 \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --prefix FCITX_ADDON_DIRS : "$out/lib/fcitx5" \
       --suffix XDG_DATA_DIRS : "$out/share" \
       --suffix PATH : "$out/bin" \


### PR DESCRIPTION
I noticed that fcitx5 doesn't load SVGs without the `GDK_PIXBUF_MODULE_FILE` environment variable, it breaks stuff like the highlight image. Thie variable is not loaded when running in a [systemd service for example](https://github.com/nix-community/home-manager/blob/master/modules/i18n/input-method/fcitx5.nix#L259). After looking at other implementations for this fix I decided to add the `librsvg` library to `buildInputs` as it [exports the variable](https://github.com/NixOS/nixpkgs/blob/master/doc/hooks/gdk-pixbuf.section.md) and set the `GDK_PIXBUF_MODULE_FILE` variable for the wrapper.

## Things done

- Added `librsvg` to `buildInputs` of `fcitx5-with-addons`.
- Set `GDK_PIXBUF_MODULE_FILE` variable for the wrapper.

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
