### PR TITLE
darwin.libffi: backport automake-1.18 fix

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/libffi/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libffi/package.nix
@@ -27,6 +27,8 @@ mkAppleDerivation (finalAttrs: {
     ./patches/llvm-18-compatibility.patch
     # Fix a memory leak when using the trampoline dylib. See https://github.com/libffi/libffi/pull/621#discussion_r955298301.
     ./patches/fix-tramponline-memory-leak.patch
+    # Fix automake-18.18 compatibility, https://github.com/libffi/libffi/issues/853#issuecomment-2909994482
+    ./patches/automake-1.18.patch
   ];
 
   # Make sure libffi is using the trampolines dylib in this package not the system one.

--- a/pkgs/os-specific/darwin/apple-source-releases/libffi/patches/automake-1.18.patch
+++ b/pkgs/os-specific/darwin/apple-source-releases/libffi/patches/automake-1.18.patch
@@ -1,0 +1,14 @@
+The hunk is used from https://github.com/libffi/libffi/issues/853#issuecomment-2909994482
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -4,6 +4,10 @@ AUTOMAKE_OPTIONS = foreign subdir-objects
+ 
+ ACLOCAL_AMFLAGS = -I m4
+ 
++# Alias required by AX_ENABLE_BUILDDIR / config-ml
++.PHONY: all-configured
++all-configured: all
++
+ SUBDIRS = include testsuite man
+ if BUILD_DOCS
+ ## This hack is needed because it doesn't seem possible to make a


### PR DESCRIPTION
Attempt to fix build failure reported at https://github.com/NixOS/nixpkgs/pull/340373#issuecomment-3122173611.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
