### PR TITLE
mixtool: init at 0-unstable-2025-07-07

### DIFF
--- a/pkgs/by-name/mi/mixtool/package.nix
+++ b/pkgs/by-name/mi/mixtool/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mixtool";
+  version = "0-unstable-2025-07-07";
+
+  src = fetchFromGitHub {
+    owner = "monitoring-mixins";
+    repo = "mixtool";
+    rev = "1abe34c3187d53b795d0474535b476bc9b7500c3";
+    hash = "sha256-RRoz5Kp/IGkUD6XVK70+k4L05rYqhkqh6LpopihyEd8=";
+  };
+
+  vendorHash = "sha256-o9HNcq7XHXH/s6UthYADsktGh9NjgC1rVPbGP11Cfc0=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Helper for easily working with jsonnet mixins";
+    homepage = "https://github.com/monitoring-mixins/mixtool";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ arikgrahl ];
+    mainProgram = "mixtool";
+  };
+})


### PR DESCRIPTION
Helper for easily working with jsonnet mixins as used in [Grafana's Jsonnet Libraries](https://github.com/grafana/jsonnet-libs).

https://github.com/monitoring-mixins/mixtool

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
