### PR TITLE
kanban-bash: init at 0-unstable-2025-09-16

### DIFF
--- a/pkgs/by-name/ka/kanban-bash/fix-sed-i.patch
+++ b/pkgs/by-name/ka/kanban-bash/fix-sed-i.patch
@@ -1,0 +1,50 @@
+commit 51300c99f84b94114ce4dbaf1ab6531aeef0cde8
+Author: phanirithvij <phanirithvij2000@gmail.com>
+Date:   Thu Sep 18 11:56:20 2025 +0530
+
+    ignore patching sed -i; we use gnused on darwin
+
+    This reverts commit b0b6563c109ae12b94bfe4441eeb5e8ce1c8b5ce.
+
+diff --git a/kanban b/kanban
+index 0900aeb..02b4d28 100755
+--- a/kanban
++++ b/kanban
+@@ -67,8 +67,6 @@ COL1="\033[37;1m"
+ COL2="\033[91;1m"
+ COL3="\033[91;5m"
+ TMP=$(mktemp -t kanban.XXXXXXXX)
+-IS_MAC=0
+-[[ "$(uname)" =~ Darwin ]] && IS_MAC=1
+ [[ ! -n $TERM ]] && TERM=vt100
+ locale | grep -q "UTF-8" && UTF8=1
+ [[ -n $PLAIN ]] && unset UTF8
+@@ -111,11 +109,6 @@ maximum_todo[DOING]=5
+ # usage: fb put <x> <y> <string>
+ put() { printf "\x1B["$2";"$1"f$3" "$4"; }
+
+-sedi(){
+-  test $IS_MAC = 0 && sed -i "$@"
+-  test $IS_MAC = 1 && sed -i '' "$@"
+-}
+-
+ strtoline() {
+     str="$1"
+     char="$2"
+@@ -316,7 +309,7 @@ update_item_status(){
+     newitem="${newitem/$status/$2}"
+     newitem="${newitem/$flags/$newflags}"
+     newitem="${newitem/$dates/$newdates}"
+-    sedi "s|$item|$newitem|g" "$KANBANFILE" 
++    sed -i "s|$item|$newitem|g" "$KANBANFILE"
+     echo "$status -> $2"
+   fi
+ }
+@@ -334,7 +327,7 @@ update_item(){
+ #
+ '"$item" > $TMP.update
+   ${EDITOR} $TMP.update
+-  sedi "s|$item|$(cat $TMP.update | tail -n1)|g" "$KANBANFILE" 
++  sed -i "s|$item|$(cat $TMP.update | tail -n1)|g" "$KANBANFILE"
+   echo "updated item $1"
+ }

--- a/pkgs/by-name/ka/kanban-bash/package.nix
+++ b/pkgs/by-name/ka/kanban-bash/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  bash,
+  gawk,
+  which,
+  gnused,
+  gnugrep,
+  ncurses,
+  coreutils,
+  unixtools,
+  resholve,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installShellFiles,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "kanban.bash";
+  version = "0-unstable-2025-09-16";
+  src = fetchFromGitHub {
+    owner = "coderofsalvation";
+    repo = "kanban.bash";
+    rev = "b0b6563c109ae12b94bfe4441eeb5e8ce1c8b5ce";
+    hash = "sha256-5uwLm5L40YrCCGIXfRLJTS2GpSuXMEJeEnd2aVbnbo4=";
+  };
+  patches = [
+    # remove references to sed -i '' and use gnused on macos
+    ./fix-sed-i.patch
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+  buildPhase = ''
+    runHook preBuild
+    mkdir -p $out/bin
+    mv kanban $out/bin
+    exe=$out/bin/kanban
+    # remove deps check and replace stray tput in a string
+    substituteInPlace $exe \
+      --replace-fail "$(grep "deps=" $exe)" "" \
+      --replace-fail "$(grep "for dep in" $exe)" "" \
+      --replace-fail "tput sgr0" "${ncurses}/bin/tput sgr0"
+    ${resholve.phraseSolution "kanban" {
+      scripts = [ "bin/kanban" ];
+      interpreter = "${bash}/bin/bash";
+      keep = {
+        "$EDITOR" = true;
+        source = [ "$FILE_CONF" ];
+      };
+      inputs = [
+        which
+        gawk
+        gnused
+        gnugrep
+        ncurses # tput
+        unixtools.column
+        unixtools.locale
+        unixtools.more
+        coreutils
+      ];
+    }}
+    installShellCompletion --cmd kanban \
+      --name kanban.bash --bash kanban.completion
+    runHook postBuild
+  '';
+
+  # from .travis.yml, the complete test suite
+  installCheckPhase = ''
+    runHook preInstallCheck
+    (
+      cd test
+      export PLAIN=1 NOCOLOR=1 EDITOR=vi
+      cp $out/bin/kanban $TMP/kanban
+      remove="| "${unixtools.more}/bin/more
+      substituteInPlace $TMP/kanban --replace-fail "$remove" ""
+      for test in test-*; do
+        substituteInPlace $test \
+          --replace-quiet '../../kanban' $TMP/kanban \
+          --replace-fail '../kanban' $TMP/kanban
+        echo $test && bash ./$test &>/dev/null
+      done
+    )
+    runHook postInstallCheck
+  '';
+  nativeInstallCheckInputs = [ writableTmpDirAsHomeHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Commandline ascii kanban board for minimalist productivity hackers";
+    homepage = "https://github.com/coderofsalvation/kanban.bash";
+    mainProgram = "kanban";
+    maintainers = with lib.maintainers; [
+      coderofsalvation
+      phanirithvij
+    ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.gpl3Plus;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
