### PR TITLE
zsign: init at 0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19337,6 +19337,12 @@
     githubId = 821972;
     name = "Parth Mehrotra";
   };
+  pascalj = {
+    email = "nix@pascalj.de";
+    github = "pascalj";
+    githubId = 330168;
+    name = "Pascal Jungblut";
+  };
   paschoal = {
     email = "paschoal@gmail.com";
     github = "paschoal";

--- a/pkgs/by-name/zs/zsign/package.nix
+++ b/pkgs/by-name/zs/zsign/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  openssl,
+  pkg-config,
+  minizip,
+  zlib,
+  versionCheckHook,
+}:
+let
+  platformName = if stdenv.hostPlatform.isLinux then "linux" else "macos";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zsign";
+  version = "0.7";
+
+  src = fetchFromGitHub {
+    owner = "zhlynn";
+    repo = "zsign";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CAG9ewROyIGN5VOZbs0X1W88HdZ3H1sxaRJ7JpDbw3o=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/build/${platformName}";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    openssl
+    minizip
+    zlib
+  ];
+
+  makeFlags = [
+    "BINDIR=bin/"
+    "CXX=${stdenv.cc.targetPrefix}c++"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin/
+    cp bin/zsign $out/bin/
+
+    runHook postInstall
+  '';
+
+  enableParallelBuilding = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Cross-platform codesign alternative for iOS 12+";
+    homepage = "https://github.com/zhlynn/zsign";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pascalj ];
+    mainProgram = "zsign";
+    platforms = with lib.platforms; darwin ++ linux;
+  };
+})


### PR DESCRIPTION
>  It might be the quickest cross-platform codesign alternative for iOS 12+, supporting macOS, Linux, Windows, and more features. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
