### PR TITLE
maintainers: drop dan4ik605743

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5562,12 +5562,6 @@
     matrix = "@dan:matrix.org";
     name = "Daniel Theriault";
   };
-  dan4ik605743 = {
-    email = "6057430gu@gmail.com";
-    github = "dan4ik605743";
-    githubId = 86075850;
-    name = "Danil Danevich";
-  };
   danbst = {
     email = "abcz2.uprola@gmail.com";
     github = "danbst";

--- a/pkgs/applications/misc/cubocore-packages/coreaction/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreaction/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "coreaction";
     homepage = "https://gitlab.com/cubocore/coreapps/coreaction";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corearchiver/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corearchiver/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corearchiver";
     homepage = "https://gitlab.com/cubocore/coreapps/corearchiver";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corefm/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corefm/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corefm";
     homepage = "https://gitlab.com/cubocore/coreapps/corefm";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/coregarage/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coregarage/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "coregarage";
     homepage = "https://gitlab.com/cubocore/coreapps/coregarage";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corehunt/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corehunt/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corehunt";
     homepage = "https://gitlab.com/cubocore/coreapps/corehunt";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/coreimage/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreimage/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "coreimage";
     homepage = "https://gitlab.com/cubocore/coreapps/coreimage";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/coreinfo/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreinfo/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "coreinfo";
     homepage = "https://gitlab.com/cubocore/coreapps/coreinfo";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corekeyboard/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corekeyboard/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corekeyboard";
     homepage = "https://gitlab.com/cubocore/coreapps/corekeyboard";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corepad/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corepad/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corepad";
     homepage = "https://gitlab.com/cubocore/coreapps/corepad";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corepaint/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corepaint/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corepaint";
     homepage = "https://gitlab.com/cubocore/coreapps/corepaint";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corepdf/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corepdf/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corepdf";
     homepage = "https://gitlab.com/cubocore/coreapps/corepdf";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corepins/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corepins/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corepins";
     homepage = "https://gitlab.com/cubocore/coreapps/corepins";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corerenamer/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corerenamer/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corerenamer";
     homepage = "https://gitlab.com/cubocore/coreapps/corerenamer";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/coreshot/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreshot/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "coreshot";
     homepage = "https://gitlab.com/cubocore/coreapps/coreshot";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corestats/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corestats/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corestats";
     homepage = "https://gitlab.com/cubocore/coreapps/corestats";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/corestuff/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/corestuff/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "corestuff";
     homepage = "https://gitlab.com/cubocore/coreapps/corestuff";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
     # Address boundary error
     broken = true;

--- a/pkgs/applications/misc/cubocore-packages/coreterminal/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreterminal/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "coreterminal";
     homepage = "https://gitlab.com/cubocore/coreapps/coreterminal";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/coretime/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coretime/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "coretime";
     homepage = "https://gitlab.com/cubocore/coreapps/coretime";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/coretoppings/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coretoppings/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "shareIT";
     homepage = "https://gitlab.com/cubocore/coreapps/coretoppings";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/coreuniverse/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/coreuniverse/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "coreuniverse";
     homepage = "https://gitlab.com/cubocore/coreapps/coreuniverse";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/libcprime/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/libcprime/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library for bookmarking, saving recent activites, managing settings of C-Suite";
     homepage = "https://gitlab.com/cubocore/libcprime";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/misc/cubocore-packages/libcsys/default.nix
+++ b/pkgs/applications/misc/cubocore-packages/libcsys/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library for managing drive and getting system resource information in real time";
     homepage = "https://gitlab.com/cubocore/libcsys";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/applications/window-managers/i3/lock-blur.nix
+++ b/pkgs/applications/window-managers/i3/lock-blur.nix
@@ -34,7 +34,7 @@ i3lock-color.overrideAttrs (oldAttrs: rec {
     description = "Improved screenlocker based upon XCB and PAM with background blurring filter";
     homepage = "https://github.com/karulont/i3lock-blur/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ dan4ik605743 ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.all;
     broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/i3lock-blur.x86_64-darwin
   };

--- a/pkgs/by-name/af/afetch/package.nix
+++ b/pkgs/by-name/af/afetch/package.nix
@@ -24,7 +24,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/13-CF/afetch";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
-      dan4ik605743
       jk
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gi/github-desktop/package.nix
+++ b/pkgs/by-name/gi/github-desktop/package.nix
@@ -100,7 +100,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://desktop.github.com/";
     license = lib.licenses.mit;
     mainProgram = "github-desktop";
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/li/libarchive-qt/package.nix
+++ b/pkgs/by-name/li/libarchive-qt/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "archiver";
     homepage = "https://gitlab.com/marcusbritanicus/libarchive-qt";
     license = lib.licenses.lgpl3Plus;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ta/tagutil/package.nix
+++ b/pkgs/by-name/ta/tagutil/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     description = "Scriptable music files tags tool and editor";
     homepage = "https://github.com/kaworu/tagutil";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ dan4ik605743 ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
     mainProgram = "tagutil";
   };

--- a/pkgs/by-name/to/tonelib-gfx/package.nix
+++ b/pkgs/by-name/to/tonelib-gfx/package.nix
@@ -69,7 +69,6 @@ stdenv.mkDerivation rec {
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
     maintainers = with maintainers; [
-      dan4ik605743
       husjon
       orivej
     ];

--- a/pkgs/by-name/to/tonelib-jam/package.nix
+++ b/pkgs/by-name/to/tonelib-jam/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     homepage = "https://tonelib.net/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "ToneLib-Jam";
   };

--- a/pkgs/by-name/to/tonelib-metal/package.nix
+++ b/pkgs/by-name/to/tonelib-metal/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     homepage = "https://tonelib.net";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ dan4ik605743 ];
+    maintainers = with lib.maintainers; [ ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "ToneLib-Metal";
   };

--- a/pkgs/by-name/to/tonelib-zoom/package.nix
+++ b/pkgs/by-name/to/tonelib-zoom/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     homepage = "https://tonelib.net/";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ dan4ik605743 ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "ToneLib-Zoom";
   };

--- a/pkgs/by-name/vk/vk-cli/package.nix
+++ b/pkgs/by-name/vk/vk-cli/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/vk-cli/vk";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.asl20;
-    maintainers = with maintainers; [ dan4ik605743 ];
+    maintainers = with maintainers; [ ];
     platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
Tagging @dan4ik605743 to provide a week to respond per policy

They are sole maintainer for several packages, but have not participated in nixpkgs since August 2023 (nor contributed since even earlier). Proposing removal as maintainer to reflect the de facto unmaintained nature of their packages that continue to see new issues filed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
