### PR TITLE
github-desktop: 3.4.13 -> 3.5.7, package from source, add dtomvan as a maintainer

### DIFF
--- a/pkgs/by-name/gi/github-desktop/package.nix
+++ b/pkgs/by-name/gi/github-desktop/package.nix
@@ -27,17 +27,19 @@
 
 let
   inherit (stdenv.hostPlatform.node) arch platform;
+  cacheRootHash = "sha256-mR5geiPPAv+oK1efT3pMfnUT1keOxB8Ge1yiq4hLtj0=";
+  cacheAppHash = "sha256-y8brlXwBur2RqJD8xlpA9ivg09xIDBuAtolhyzYkRx4=";
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "github-desktop";
-  version = "3.4.13";
+  version = "3.5.7";
 
   src = fetchFromGitHub {
     owner = "desktop";
     repo = "desktop";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-srXX49sXJnxa/7GQzP1pdJ77qeZbK1Ge8OPfrq3s5m8=";
+    hash = "sha256-H6FPMp+Y3PmRtuaOVX+8Yd3a5JA+zvLeGeLp99X1+y0=";
     fetchSubmodules = true;
     postCheckout = "git -C $out rev-parse HEAD > $out/.gitrev";
   };
@@ -75,13 +77,13 @@ stdenv.mkDerivation (finalAttrs: {
   cacheRoot = fetchYarnDeps {
     name = "${finalAttrs.pname}-cache-root";
     yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-PhjMY4bAt+Prx8tmgGCZ7fhAyKhOUudrJO9K8yr7F18=";
+    hash = cacheRootHash;
   };
 
   cacheApp = fetchYarnDeps {
     name = "${finalAttrs.pname}-cache-app";
     yarnLock = finalAttrs.src + "/app/yarn.lock";
-    hash = "sha256-eW3G4saTbjRUexgg+n0z4EU1YtAgvSoW+uU0rNZZ1l0=";
+    hash = cacheAppHash;
   };
 
   dontYarnInstallDeps = true;
@@ -100,9 +102,26 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath [ git-lfs ]}
 
 
-    for native in fs-admin keytar desktop-trampoline windows-argv-parser; do
-      yarn --offline --cwd app/node_modules/$native build
+    # exception: printenvz needs `node-gyp` configure first for some reason
+    pushd node_modules/printenvz
+    node node_modules/.bin/node-gyp configure
+    popd
+
+    declare -a natives=(
+      app/node_modules/fs-admin
+      app/node_modules/keytar
+      app/node_modules/desktop-trampoline
+      app/node_modules/windows-argv-parser
+      node_modules/printenvz
+    )
+    for native in "''${natives[@]}"; do
+      yarn --offline --cwd $native build
     done
+
+    # exception: desktop-trampoline doesn't include `node-gyp rebuild` in its build script anymore
+    pushd app/node_modules/desktop-trampoline
+    node-gyp rebuild
+    popd
 
     yarn compile:script
 

--- a/pkgs/by-name/gi/github-desktop/package.nix
+++ b/pkgs/by-name/gi/github-desktop/package.nix
@@ -1,108 +1,171 @@
 {
-  stdenvNoCC,
   lib,
-  fetchurl,
-  autoPatchelfHook,
-  buildPackages,
+  stdenv,
+  copyDesktopItems,
+  desktopToDarwinBundle,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  makeBinaryWrapper,
+  makeDesktopItem,
+  yarnBuildHook,
+  yarnConfigHook,
+
+  electron,
+  git,
+  git-lfs,
+  node-gyp,
+  nodejs,
+  pkg-config,
+  python3,
+  typescript,
+  zip,
+
   gnome-keyring,
   libsecret,
-  git,
   curl,
-  nss,
-  nspr,
-  libxdamage,
-  libx11,
-  libdrm,
-  alsa-lib,
-  cups,
-  libgbm,
-  systemdLibs,
-  openssl,
-  libglvnd,
 }:
 
 let
-  rcversion = "1";
+  inherit (stdenv.hostPlatform.node) arch platform;
 in
-stdenvNoCC.mkDerivation (finalAttrs: {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "github-desktop";
   version = "3.4.13";
 
-  src =
-    let
-      urls = {
-        "x86_64-linux" = {
-          url = "https://github.com/shiftkey/desktop/releases/download/release-${finalAttrs.version}-linux${rcversion}/GitHubDesktop-linux-amd64-${finalAttrs.version}-linux${rcversion}.deb";
-          hash = "sha256-i1V3dhx5AMrCiWtfvB2I9a6ki2zncUNyYr4qZqs42Yc=";
-        };
-        "aarch64-linux" = {
-          url = "https://github.com/shiftkey/desktop/releases/download/release-${finalAttrs.version}-linux${rcversion}/GitHubDesktop-linux-arm64-${finalAttrs.version}-linux${rcversion}.deb";
-          hash = "sha256-SN4qtEI4q/AAgfUaBiM5eWyCK5Kr77CrTHsIAmvEceU=";
-        };
-      };
-    in
-    fetchurl
-      urls."${stdenvNoCC.hostPlatform.system}"
-        or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+  src = fetchFromGitHub {
+    owner = "desktop";
+    repo = "desktop";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-srXX49sXJnxa/7GQzP1pdJ77qeZbK1Ge8OPfrq3s5m8=";
+    fetchSubmodules = true;
+    postCheckout = "git -C $out rev-parse HEAD > $out/.gitrev";
+  };
 
-  nativeBuildInputs = [
-    autoPatchelfHook
-    # override doesn't preserve splicing https://github.com/NixOS/nixpkgs/issues/132651
-    # Has to use `makeShellWrapper` from `buildPackages` even though `makeShellWrapper` from the inputs is spliced because `propagatedBuildInputs` would pick the wrong one because of a different offset.
-    (buildPackages.wrapGAppsHook3.override { makeWrapper = buildPackages.makeShellWrapper; })
-  ];
+  yarnBuildScript = "build:prod";
 
   buildInputs = [
     gnome-keyring
-    libxdamage
-    libx11
     libsecret
-    git
     curl
-    nss
-    nspr
-    libdrm
-    alsa-lib
-    cups
-    libgbm
-    openssl
   ];
 
-  unpackPhase = ''
-    runHook preUnpack
-    mkdir -p $TMP/github-desktop $out/{opt,bin}
-    cp $src $TMP/github-desktop.deb
-    ar vx github-desktop.deb
-    tar --no-overwrite-dir -xvf data.tar.xz -C $TMP/github-desktop/
-    runHook postUnpack
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeBinaryWrapper
+    yarnBuildHook
+    yarnConfigHook
+
+    git
+    nodejs
+    node-gyp
+    pkg-config
+    python3
+    # desktop-notifications build doesn't pick up tsc from node_modules for some reason
+    typescript
+    zip
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    npm_config_nodedir = electron.headers;
+  };
+
+  cacheRoot = fetchYarnDeps {
+    name = "${finalAttrs.pname}-cache-root";
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-PhjMY4bAt+Prx8tmgGCZ7fhAyKhOUudrJO9K8yr7F18=";
+  };
+
+  cacheApp = fetchYarnDeps {
+    name = "${finalAttrs.pname}-cache-app";
+    yarnLock = finalAttrs.src + "/app/yarn.lock";
+    hash = "sha256-eW3G4saTbjRUexgg+n0z4EU1YtAgvSoW+uU0rNZZ1l0=";
+  };
+
+  dontYarnInstallDeps = true;
+
+  postConfigure = ''
+    yarnOfflineCache="$cacheRoot" runHook yarnConfigHook
+
+    pushd app
+    yarnOfflineCache="$cacheApp" runHook yarnConfigHook
+    popd
+
+    yarn --cwd app/node_modules/desktop-notifications run install
+
+    # use git from nixpkgs instead of an automatically downloaded one by dugite
+    makeWrapper ${lib.getExe git} app/node_modules/dugite/git/bin/git \
+      --prefix PATH : ${lib.makeBinPath [ git-lfs ]}
+
+
+    for native in fs-admin keytar desktop-trampoline windows-argv-parser; do
+      yarn --offline --cwd app/node_modules/$native build
+    done
+
+    yarn compile:script
+
+    touch electron
+    zip -0Xqr electron-v${electron.version}-${platform}-${arch}.zip electron
+    rm electron
+
+    substituteInPlace script/build.ts \
+      --replace-fail "return packager({" "return packager({electronZipDir:\"$(pwd)\",electronVersion: \"${electron.version}\","
   '';
+
+  preBuild = ''
+    export CIRCLE_SHA1="$(cat .gitrev)"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "github-desktop";
+      desktopName = "GitHub Desktop";
+      comment = "Focus on what matters instead of fighting with Git";
+      exec = "github-desktop %u";
+      icon = "github-desktop";
+      mimeTypes = [
+        "x-scheme-handler/x-github-client"
+        "x-scheme-handler/x-github-desktop-auth"
+        "x-scheme-handler/x-github-desktop-dev-auth"
+      ];
+      terminal = false;
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
-    cp -R $TMP/github-desktop/usr/share $out/
-    cp -R $TMP/github-desktop/usr/lib/github-desktop/* $out/opt/
-    ln -sf $out/opt/github-desktop $out/bin/github-desktop
+
+    mkdir -p $out/share/github-desktop
+
+    # transpose [name][size] into [size][name]
+    for icon in app/static/logos/*.png; do
+      size="$(basename "$icon" .png)"
+      install -Dm444 "$icon" -T "$out/share/icons/hicolor/$size/github-desktop.png"
+    done
+
+    cp -r dist/*/resources $out/share/github-desktop
+
+    makeWrapper ${lib.getExe electron} $out/bin/github-desktop \
+      --add-flag $out/share/github-desktop/resources/app \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --inherit-argv0
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    ln -s $out/share/github-desktop/resources/app/static/icon-logo.png $out/share/icons/hicolor/512x512/apps/github-desktop.png
+
     runHook postInstall
   '';
 
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true}}"
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libglvnd ]}
-    )
-  '';
-
-  runtimeDependencies = [
-    systemdLibs
-  ];
-
   meta = {
     description = "GUI for managing Git and GitHub";
-    homepage = "https://desktop.github.com/";
+    homepage = "https://desktop.github.com";
+    changelog = "https://desktop.github.com/release-notes";
+    downloadPage = "https://desktop.github.com/download";
     license = lib.licenses.mit;
     mainProgram = "github-desktop";
     maintainers = with lib.maintainers; [ dtomvan ];
-    platforms = lib.platforms.linux;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    inherit (electron.meta) platforms;
   };
 })

--- a/pkgs/by-name/gi/github-desktop/package.nix
+++ b/pkgs/by-name/gi/github-desktop/package.nix
@@ -101,7 +101,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://desktop.github.com/";
     license = lib.licenses.mit;
     mainProgram = "github-desktop";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ dtomvan ];
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };

--- a/pkgs/by-name/gi/github-desktop/package.nix
+++ b/pkgs/by-name/gi/github-desktop/package.nix
@@ -23,6 +23,9 @@
   gnome-keyring,
   libsecret,
   curl,
+
+  _experimental-update-script-combinators,
+  nix-update-script,
 }:
 
 let
@@ -176,6 +179,20 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    inherit (finalAttrs) cacheRoot cacheApp;
+    updateScript = _experimental-update-script-combinators.sequence [
+      (nix-update-script {
+        extraArgs = [
+          "--version-regex"
+          ''^release-(\d\.\d\.\d)$''
+        ];
+      })
+      # TODO: in the future, use `nix-update --custom-dep`.
+      ./update-yarn-caches.sh
+    ];
+  };
 
   meta = {
     description = "GUI for managing Git and GitHub";

--- a/pkgs/by-name/gi/github-desktop/update-yarn-caches.sh
+++ b/pkgs/by-name/gi/github-desktop/update-yarn-caches.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix gnused common-updater-scripts
+
+set -euxo pipefail
+
+cd "$(dirname $0)"
+
+setKV() {
+  sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" package.nix
+}
+
+for cache in cacheApp cacheRoot; do
+  hashKey="${cache}Hash"
+  setKV "$hashKey" sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
+  pushd ../../../..
+  set +e
+  newHash="$(nix-build --no-out-link -A github-desktop.$cache 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')"
+  set -e
+  popd
+
+  if [ -z "$newHash" ]; then
+    echo Failed to update hash for $cache
+    exit 1
+  fi
+  setKV "$hashKey" "$newHash"
+done


### PR DESCRIPTION
In response to https://github.com/NixOS/nixpkgs/pull/428716

Otherwise `github-desktop` would have no maintainers...

Now I'm debating whether or not this is a good change to make, because:
- It's implementation turned out very hacky
- ~~darwin might not work anymore on this (but as usual I cannot test that so I'd need some help from someone who can test this stuff)~~ welp, I guess `meta.platforms` has always only been linux. Then at least it's not a regression. Would be nice if I could get some help with writing the darwin wrapper so it also works there... 

So if the "package from source" part gets blocked for some reason I'd be happy to just update the binary package and move on...

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
