### PR TITLE
alsa-ucm-conf: 1.2.12 -> 1.2.14

### DIFF
--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "alsa-ucm-conf";
-  version = "1.2.12";
+  version = "1.2.14";
 
   src = fetchurl {
     url = "mirror://alsa/lib/alsa-ucm-conf-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-Fo58BUm3v4mRCS+iv7kDYx33edxMQ+6PQnf8t3LYwDU=";
+    hash = "sha256-MumAn1ktkrl4qhAy41KTwzuNDx7Edfk3Aiw+6aMGnCE=";
   };
 
   dontBuild = true;
@@ -25,20 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "/bin/rm" "${coreutils}/bin/rm" \
       --replace-fail "/bin/mkdir" "${coreutils}/bin/mkdir"
 
-    files=(
-        "ucm2/HDA/HDA.conf"
-        "ucm2/codecs/rt715/init.conf"
-        "ucm2/codecs/rt715-sdca/init.conf"
-        "ucm2/Intel/cht-bsw-rt5672/cht-bsw-rt5672.conf"
-        "ucm2/Intel/bytcr-rt5640/bytcr-rt5640.conf"
-    )
-
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
-    for file in "''${files[@]}"; do
-        substituteInPlace "$file" \
-            --replace-fail '/sbin/modprobe' '${kmod}/bin/modprobe'
-    done
+    substituteInPlace ucm2/common/ctl/led.conf \
+        --replace-fail '/sbin/modprobe' '${kmod}/bin/modprobe'
   ''
   + ''
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Newer alsa-ucm-conf versions bring support for more x1e80100-based qcom devices.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
