### PR TITLE
merchant: init at 1.0.4

### DIFF
--- a/pkgs/by-name/me/merchant/package.nix
+++ b/pkgs/by-name/me/merchant/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "merchant";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "samgqroberts";
+    repo = "merchant";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JY8+rwY533oanFgDKFaTByX9MkZwSV9Mkwc2LMjUv7k=";
+  };
+
+  cargoHash = "sha256-2GUFwuTmNsHwuGwnL7+b6DzlXDEtNht07rD7kAd3vaQ=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Clone of the classic terminal UI game Drug Wars";
+    longDescription = ''
+      A clone of the classic terminal UI game Drug Wars, but now set
+      on a merchant ship in the 18th century.
+    '';
+    homepage = "https://github.com/samgqroberts/merchant";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "merchant";
+  };
+})


### PR DESCRIPTION
A clone of the classic terminal UI game Drug Wars, but now set on a merchant ship in the 18th century.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- ~~Nixpkgs Release Notes~~
  - [ ] ~~Package update: when the change is major or breaking.~~
- ~~NixOS Release Notes~~
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
