### PR TITLE
rkik: init at 0.5.0

### DIFF
--- a/pkgs/by-name/rk/rkik/package.nix
+++ b/pkgs/by-name/rk/rkik/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rkik";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "aguacero7";
+    repo = "rkik";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MVNqc0IHFZTi3Vz1OeKeRrKbk4kcM3GvfTPajs+FHew=";
+  };
+
+  cargoHash = "sha256-CuFQFHN9O/bnZ32sQoj4aduLECpKmBXfJt5n0IH/5Tc=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-line tool for querying NTP servers and comparing clock offsets";
+    longDescription = ''
+      Most systems rely on a daemon (like chronyd or ntpd) to
+      synchronize time. But what if you just want to inspect the
+      current offset between your system clock and one or more NTP
+      servers — without root, without sync, and without installing
+      anything heavyweight?
+
+      RKIK is a Rust-based CLI tool designed for stateless and passive
+      NTP inspection, just as dig or ping are for DNS and ICMP.
+    '';
+    homepage = "https://github.com/aguacero7/rkik";
+    changelog = "https://github.com/aguacero7/rkik/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "rkik";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- ~~Nixpkgs Release Notes~~
  - [ ] ~~Package update: when the change is major or breaking.~~
- ~~NixOS Release Notes~~
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc