### PR TITLE
quasar: init at 0-unstable-2024-12-23

### DIFF
--- a/pkgs/by-name/qu/quasar/package.nix
+++ b/pkgs/by-name/qu/quasar/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  alsa-lib,
+  xorg,
+  libGL,
+  freetype,
+  ninja,
+  python3,
+  pkg-config,
+  jack1,
+}:
+
+stdenv.mkDerivation {
+  pname = "quasar";
+  version = "0-unstable-2024-12-23";
+
+  src = fetchFromGitHub {
+    owner = "DarkRTA";
+    repo = "quasar";
+    rev = "11e24bb569ef914e1a9641323a2b9edd5b0b3e95";
+    hash = "sha256-nNGaNFUIZp+rP6K6fbg+HnWpev5M44K47MGapTAyvPE=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    ninja
+    python3
+    pkg-config
+  ];
+
+  buildInputs = [
+    freetype
+    alsa-lib
+    libGL
+    xorg.libX11
+    xorg.libXinerama
+    xorg.libXext
+    xorg.libXcursor
+    jack1
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    for f in lv2 vst2 vst3 standalone; do
+      python build-scripts/configure.py $f
+      mv build.ninja $f.ninja
+    done
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    for f in lv2 vst2 vst3 standalone; do
+      ninja -f $f.ninja
+    done
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    pushd out
+      install -Dm755 Quasar $out/bin/Quasar
+      install -Dm644 Quasar.vst2.so $out/lib/vst/Quasar.so
+
+      mkdir -p $out/lib/lv2
+      cp -r Quasar.lv2 $out/lib/lv2/Quasar.lv2
+
+      mkdir -p $out/lib/vst3
+      cp -r Quasar.vst3 $out/lib/vst3/Quasar.vst3
+    popd
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Linux-focused fork of Matt Tytel's Vital, a spectral warping wavetable synthesizer";
+    homepage = "https://github.com/DarkRTA/quasar";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ mrtnvgr ];
+    mainProgram = "Quasar";
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
