### PR TITLE
python3Packages.webtest-aiohttp: add aiohttp to dependencies

### DIFF
--- a/pkgs/development/python-modules/webtest-aiohttp/default.nix
+++ b/pkgs/development/python-modules/webtest-aiohttp/default.nix
@@ -38,10 +38,12 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  dependencies = [ webtest ];
+  dependencies = [
+    aiohttp
+    webtest
+  ];
 
   nativeCheckInputs = [
-    aiohttp
     pytest-aiohttp
     pytestCheckHook
   ];


### PR DESCRIPTION
Otherwise, this package fails to build with doCheck = false.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `e1391ef11b6b2b59162cca4498c74f54e60a34d5`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 9 packages marked as broken and skipped:</summary>
  <ul>
    <li>python313Packages.swh-export</li>
    <li>python313Packages.swh-export.dist</li>
    <li>python313Packages.swh-objstorage</li>
    <li>python313Packages.swh-objstorage.dist</li>
    <li>python313Packages.swh-scheduler</li>
    <li>python313Packages.swh-scheduler.dist</li>
    <li>python313Packages.swh-storage</li>
    <li>python313Packages.swh-storage.dist</li>
    <li>swh</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 49 packages built:</summary>
  <ul>
    <li>python312Packages.aiohttp-apispec</li>
    <li>python312Packages.aiohttp-apispec.dist</li>
    <li>python312Packages.aiohttp-utils</li>
    <li>python312Packages.aiohttp-utils.dist</li>
    <li>python312Packages.pyipv8</li>
    <li>python312Packages.pyipv8.dist</li>
    <li>python312Packages.swh-auth</li>
    <li>python312Packages.swh-auth.dist</li>
    <li>python312Packages.swh-core</li>
    <li>python312Packages.swh-core.dist</li>
    <li>python312Packages.swh-export</li>
    <li>python312Packages.swh-export.dist</li>
    <li>python312Packages.swh-journal</li>
    <li>python312Packages.swh-journal.dist</li>
    <li>python312Packages.swh-objstorage</li>
    <li>python312Packages.swh-objstorage.dist</li>
    <li>python312Packages.swh-scanner</li>
    <li>python312Packages.swh-scanner.dist</li>
    <li>python312Packages.swh-scheduler</li>
    <li>python312Packages.swh-scheduler.dist</li>
    <li>python312Packages.swh-storage</li>
    <li>python312Packages.swh-storage.dist</li>
    <li>python312Packages.swh-web-client</li>
    <li>python312Packages.swh-web-client.dist</li>
    <li>python312Packages.webargs</li>
    <li>python312Packages.webargs.dist</li>
    <li>python312Packages.webtest-aiohttp</li>
    <li>python312Packages.webtest-aiohttp.dist</li>
    <li>python313Packages.aiohttp-apispec</li>
    <li>python313Packages.aiohttp-apispec.dist</li>
    <li>python313Packages.aiohttp-utils</li>
    <li>python313Packages.aiohttp-utils.dist</li>
    <li>python313Packages.pyipv8</li>
    <li>python313Packages.pyipv8.dist</li>
    <li>python313Packages.swh-auth</li>
    <li>python313Packages.swh-auth.dist</li>
    <li>python313Packages.swh-core</li>
    <li>python313Packages.swh-core.dist</li>
    <li>python313Packages.swh-journal</li>
    <li>python313Packages.swh-journal.dist</li>
    <li>python313Packages.swh-scanner</li>
    <li>python313Packages.swh-scanner.dist</li>
    <li>python313Packages.swh-web-client</li>
    <li>python313Packages.swh-web-client.dist</li>
    <li>python313Packages.webargs</li>
    <li>python313Packages.webargs.dist</li>
    <li>python313Packages.webtest-aiohttp</li>
    <li>python313Packages.webtest-aiohttp.dist</li>
    <li>tribler</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc