### PR TITLE
xenia-canary: 0-unstable-2025-07-07 -> 0-unstable-2025-07-27

### DIFF
--- a/pkgs/by-name/xe/xenia-canary/package.nix
+++ b/pkgs/by-name/xe/xenia-canary/package.nix
@@ -19,14 +19,14 @@
 }:
 llvmPackages_20.stdenv.mkDerivation {
   pname = "xenia-canary";
-  version = "0-unstable-2025-07-07";
+  version = "0-unstable-2025-07-27";
 
   src = fetchFromGitHub {
     owner = "xenia-canary";
     repo = "xenia-canary";
     fetchSubmodules = true;
-    rev = "0aeac841b8354806f1c455402edb0815dfe9729e";
-    hash = "sha256-KgFwQSXj5s5WuFboFyKqQRHrzH3ENatqWp0WeHEJgRg=";
+    rev = "c3e4a93c0a59281cb53c6991c2c4b67e224a37d8";
+    hash = "sha256-p4XZwmehboq7CZnVO4J+QzyTNIjvJEplBfVPPvzVepw=";
   };
 
   dontConfigure = true;
@@ -42,6 +42,11 @@ llvmPackages_20.stdenv.mkDerivation {
     libuuid
   ];
 
+  postPatch = ''
+    substituteInPlace premake5.lua \
+      --replace-fail "cdialect(\"C17\")" ""
+  ''; # Prevent build failure
+
   NIX_CFLAGS_COMPILE = [
     "-Wno-error=unused-result"
   ];
@@ -55,7 +60,7 @@ llvmPackages_20.stdenv.mkDerivation {
   buildPhase = ''
     runHook preBuild
     python3 xenia-build setup
-    python3 xenia-build build --config=release -j $NIX_BUILD_CORES
+    python3 xenia-build build --config=release
     runHook postBuild
   '';
 
@@ -89,7 +94,7 @@ llvmPackages_20.stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
   meta = {
     description = "Xbox 360 Emulator Research Project";


### PR DESCRIPTION
https://github.com/xenia-canary/xenia-canary/pull/679
https://github.com/xenia-canary/xenia-canary/pull/678
https://github.com/xenia-canary/xenia-canary/pull/676
https://github.com/xenia-canary/xenia-canary/pull/674
https://github.com/xenia-canary/xenia-canary/pull/673
https://github.com/xenia-canary/xenia-canary/pull/671
https://github.com/xenia-canary/xenia-canary/pull/670
https://github.com/xenia-canary/xenia-canary/pull/668

New fixes to build failure (deletion of cdialect("C17")), and add hardcodeZeroVersion to unstableGitUpdater due to incompatible tagging.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
