### PR TITLE
tattoy: init at 0.1.8

### DIFF
--- a/pkgs/by-name/ta/tattoy/package.nix
+++ b/pkgs/by-name/ta/tattoy/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  libxcb,
+  dbus,
+  bash,
+  procps,
+  nano,
+  watch,
+}:
+
+rustPlatform.buildRustPackage (attrs: {
+  pname = "tattoy";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "tattoy-org";
+    repo = "tattoy";
+    tag = "tattoy-v${attrs.version}";
+    hash = "sha256-44rXygZVbwwC/jOB69iHydsjYr/WeVU4Eky3BPqJzyc=";
+  };
+
+  cargoHash = "sha256-DJyml8J9XXKD2t1dQz+OrVDFcq6PLMoDlhiLo86D3CM=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+    libxcb
+  ];
+
+  nativeCheckInputs = [
+    bash
+    nano
+    procps
+    watch
+  ];
+
+  checkFlags = [
+    # e2e tests currently fail
+    # see https://github.com/tattoy-org/tattoy/pull/104/files for discussion
+    # re-enable after PR merged
+    "--skip e2e"
+    "--skip gpu"
+  ];
+
+  useNextest = true;
+
+  meta = {
+    description = "Text-based compositor for modern terminals";
+    homepage = "https://github.com/tattoy-org/tattoy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      DieracDelta
+    ];
+    mainProgram = "tattoy";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Packaged tattoy. Note that the tests don't pass. I didn't look into why. The main executable builds and runs properly for me on ghostty.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
