### PR TITLE
[Backport release-25.05] tailscale: disable flaky tests; misc. cleanup

### DIFF
--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -98,6 +98,10 @@ buildGoModule {
 
     # several tests hang
     rm tsnet/tsnet_test.go
+
+    # new test, probably missing import
+    # reported: https://github.com/tailscale/tailscale/issues/16051
+    rm tsnet/packet_filter_test.go
   '';
 
   checkFlags =

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -140,6 +140,10 @@ buildGoModule {
 
         # flaky: https://github.com/tailscale/tailscale/issues/11762
         "TestTwoDevicePing"
+
+        # timeout 10m
+        "TestTaildropIntegration"
+        "TestTaildropIntegration_Fresh"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # syscall default route interface en0 differs from netstat

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -4,7 +4,6 @@
 
   buildGoModule,
   fetchFromGitHub,
-  fetchpatch,
 
   makeWrapper,
   installShellFiles,

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -137,6 +137,9 @@ buildGoModule {
 
         # flaky: https://github.com/tailscale/tailscale/issues/7030
         "TestConcurrent"
+
+        # flaky: https://github.com/tailscale/tailscale/issues/11762
+        "TestTwoDevicePing"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # syscall default route interface en0 differs from netstat

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -95,12 +95,10 @@ buildGoModule {
     # want but also limits the tests
     unset subPackages
 
-    # several tests hang
-    rm tsnet/tsnet_test.go
-
-    # new test, probably missing import
-    # reported: https://github.com/tailscale/tailscale/issues/16051
-    rm tsnet/packet_filter_test.go
+    # several tests hang, but keeping the file for tsnet/packet_filter_test.go
+    # packet_filter_test issue: https://github.com/tailscale/tailscale/issues/16051
+    substituteInPlace tsnet/tsnet_test.go \
+      --replace-fail 'func Test' 'func skippedTest'
   '';
 
   checkFlags =
@@ -147,6 +145,9 @@ buildGoModule {
         # timeout 10m
         "TestTaildropIntegration"
         "TestTaildropIntegration_Fresh"
+
+        # context deadline exceeded
+        "TestPacketFilterFromNetmap"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # syscall default route interface en0 differs from netstat

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -148,6 +148,9 @@ buildGoModule {
 
         # context deadline exceeded
         "TestPacketFilterFromNetmap"
+
+        # flaky: https://github.com/tailscale/tailscale/issues/15348
+        "TestSafeFuncHappyPath"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # syscall default route interface en0 differs from netstat


### PR DESCRIPTION
Manual backport of #407380 4b78b9bee5031af00396643018feb2d2b9045c31 a296d255d98fcac8de4353027b84f3b6ba09650e 25122135e6c5976ee41c0d560c125a618ee53d6d 69984d594fc4d175fd0cf0762f98801dc598b99d #412623 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
