### PR TITLE
pkgs/waydroid-script: init

### DIFF
--- a/pkgs/by-name/wa/waydroid-script/package.nix
+++ b/pkgs/by-name/wa/waydroid-script/package.nix
@@ -1,0 +1,56 @@
+{
+  python3,
+  waydroid,
+
+  fetchFromGitHub,
+  stdenv,
+  lib,
+  makeWrapper,
+}:
+stdenv.mkDerivation rec {
+  pname = "waydroid-script";
+  version = "0-unstable-2025-07-13";
+
+  buildInputs = [
+    (python3.withPackages (
+      ps:
+      (with ps; [
+        tqdm
+        requests
+        inquirerpy
+      ])
+    ))
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  src = fetchFromGitHub {
+    owner = "casualsnek";
+    repo = "waydroid_script";
+    rev = "3e344b360f64f4a417c4f5e9a3b1aae3da9fdfb9";
+    hash = "sha256-l4L11Ilz3Y2lmKceg0+ZROPADgqhOwxzR/8V+ffyTjY=";
+  };
+
+  postPatch = ''
+    substituteInPlace tools/container.py --replace-fail ' run(["waydroid",' ' run(["${lib.getExe waydroid}",'
+    patchShebangs main.py
+  '';
+
+  installPhase = ''
+    mkdir -p $out/libexec
+    cp -r . $out/libexec/waydroid_script
+    mkdir -p $out/bin
+    ln -s $out/libexec/waydroid_script/main.py $out/bin/${pname}
+  '';
+
+  meta = {
+    description = "Script to add GApps and other stuff to Waydroid";
+    homepage = "https://github.com/casualsnek/waydroid_script";
+    mainProgram = "waydroid-script";
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ hustlerone ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds waydroid-script into nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
