### PR TITLE
nixos/meshcentral: support defining secret values

### DIFF
--- a/nixos/modules/services/admin/meshcentral.nix
+++ b/nixos/modules/services/admin/meshcentral.nix
@@ -2,12 +2,12 @@
   config,
   pkgs,
   lib,
+  utils,
   ...
 }:
 let
   cfg = config.services.meshcentral;
   configFormat = pkgs.formats.json { };
-  configFile = configFormat.generate "meshcentral-config.json" cfg.settings;
 in
 with lib;
 {
@@ -22,6 +22,10 @@ with lib;
         - [simple sample configuration](https://github.com/Ylianst/MeshCentral/blob/master/sample-config.json)
         - [complex sample configuration](https://github.com/Ylianst/MeshCentral/blob/master/sample-config-advanced.json)
         - [Old homepage with documentation link](https://www.meshcommander.com/meshcentral2)
+
+        Options containing secret data should be set to an attribute set
+        containing the attribute `_secret` - a string pointing to a file
+        containing the value the option should be set to.
       '';
       type = types.submodule {
         freeformType = configFormat.type;
@@ -43,10 +47,16 @@ with lib;
     systemd.services.meshcentral = {
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/meshcentral --datapath /var/lib/meshcentral --configfile ${configFile}";
+        # Run ExecStartPre as root to ensure access to secret files given dynamic user is turned on
+        ExecStartPre = "+${pkgs.writeShellScript "meshcentral-pre-start" (utils.genJqSecretsReplacementSnippet cfg.settings "/run/meshcentral/config.json")}";
+        ExecStart = "${cfg.package}/bin/meshcentral --datapath /var/lib/meshcentral --configfile /run/meshcentral/config.json";
         DynamicUser = true;
         StateDirectory = "meshcentral";
+        StateDirectoryMode = "0700";
         CacheDirectory = "meshcentral";
+        CacheDirectoryMode = "0700";
+        RuntimeDirectory = "meshcentral";
+        RuntimeDirectoryMode = "0700";
       };
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR makes MeshCentral NixOS configuration module support setting secret values using `._secret`. 

This would be useful for setting OIDC client secret as documented in https://ylianst.github.io/MeshCentral/meshcentral/#generic-openid-connect-setup

This implementation runs `ExecPreStart` as root while generating config files to ensure access to secret files. This can keep dynamic user on for this unit, so existing users won't have to migrate data.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
