### PR TITLE
mcp-nixos: init at 1.0.0

### DIFF
--- a/pkgs/by-name/mc/mcp-nixos/package.nix
+++ b/pkgs/by-name/mc/mcp-nixos/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "mcp-nixos";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "utensils";
+    repo = "mcp-nixos";
+    tag = "v${version}";
+    hash = "sha256-NwP+zM1VGLOzIm+mLZVK9/9ImFwuiWhRJ9QK3hGpQsY=";
+  };
+
+  patches = [
+    # This patch mocks nix channel listing network calls in tests
+    ./tests-mock-nix-channels.patch
+  ];
+
+  build-system = [ python3Packages.hatchling ];
+
+  dependencies = with python3Packages; [
+    beautifulsoup4
+    mcp
+    requests
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    anthropic
+    pytestCheckHook
+    pytest-asyncio
+    python-dotenv
+  ];
+
+  disabledTestMarks = [
+    # Require network access
+    "integration"
+  ];
+
+  disabledTestPaths = [
+    # Require network access
+    "tests/test_nixhub_evals.py"
+    "tests/test_mcp_behavior_evals.py"
+    "tests/test_option_info_improvements.py"
+    # Requires configured channels
+    "tests/test_dynamic_channels.py"
+  ];
+
+  pythonImportsCheck = [ "mcp_nixos" ];
+
+  meta = {
+    description = "MCP server for NixOS";
+    homepage = "https://github.com/utensils/mcp-nixos";
+    changelog = "https://github.com/utensils/mcp-nixos/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+    mainProgram = "mcp-nixos";
+  };
+}

--- a/pkgs/by-name/mc/mcp-nixos/tests-mock-nix-channels.patch
+++ b/pkgs/by-name/mc/mcp-nixos/tests-mock-nix-channels.patch
@@ -1,0 +1,35 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 0a11295..1172182 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -3,6 +3,30 @@
+ import pytest  # pylint: disable=unused-import
+ 
+ 
++@pytest.fixture(autouse=True)
++def mock_get_channels(monkeypatch):
++    """Mock get_channels function to return fixed channels for all tests."""
++    def mock_channels():
++        return {
++            "unstable": "latest-43-nixos-unstable",
++            "25.05": "latest-43-nixos-25.05",
++            "25.11": "latest-43-nixos-25.11",
++            "24.11": "latest-43-nixos-24.11",
++            "stable": "latest-43-nixos-25.05",
++            "beta": "latest-43-nixos-25.05"
++        }
++
++    # Patch the function in the server module
++    monkeypatch.setattr('mcp_nixos.server.get_channels', mock_channels)
++
++    # Also patch any imported references in test modules
++    monkeypatch.setattr('tests.test_channel_handling.get_channels', mock_channels)
++    monkeypatch.setattr('tests.test_dynamic_channels.get_channels', mock_channels, raising=False)
++    monkeypatch.setattr('tests.test_mcp_behavior_comprehensive.get_channels', mock_channels, raising=False)
++    monkeypatch.setattr('tests.test_real_world_scenarios.get_channels', mock_channels, raising=False)
++    monkeypatch.setattr('tests.test_server_comprehensive.get_channels', mock_channels, raising=False)
++
++
+ def pytest_addoption(parser):
+     """Add test filtering options."""
+     parser.addoption("--unit", action="store_true", help="Run unit tests only")


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
