### PR TITLE
zlib: use default configure script on windows

### DIFF
--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
   # https://github.com/madler/zlib/pull/1171
   patches = [
     ./export-variable.patch
+    # https://github.com/madler/zlib/pull/1296
+    ./mingw-shared.patch
   ];
 
   postPatch = ''
@@ -69,15 +71,13 @@ stdenv.mkDerivation (finalAttrs: {
   setOutputFlags = false;
   outputDoc = "dev"; # single tiny man3 page
 
-  dontConfigure = (stdenv.hostPlatform.isMinGW || stdenv.hostPlatform.isCygwin);
-
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     export CHOST=${stdenv.hostPlatform.config}
   '';
 
   configureFlags = [
     "--includedir=${placeholder "dev"}/include"
-    "--sharedlibdir=${placeholder "out"}/lib"
+    "--sharedlibdir=${placeholder "out"}/${if stdenv.hostPlatform.isWindows then "bin" else "lib"}"
     "--libdir=${placeholder (if splitStaticOutput then "static" else "out")}/lib"
     # See comment near splitStaticOutput argument
     (lib.enableFeature shared "shared")
@@ -101,11 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
       for file in $out/lib/*.so* $out/lib/*.dylib* ; do
         ${stdenv.cc.bintools.targetPrefix}install_name_tool -id "$file" $file
       done
-    ''
-    # Non-typical naming confuses libtool which then refuses to use zlib's DLL
-    # in some cases, e.g. when compiling libpng.
-    + lib.optionalString (stdenv.hostPlatform.isMinGW && shared) ''
-      ln -s zlib1.dll $out/bin/libz.dll
     '';
 
   env = lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
@@ -134,18 +129,9 @@ stdenv.mkDerivation (finalAttrs: {
     "PREFIX=${stdenv.cc.targetPrefix}"
     "pkgconfigdir=${placeholder "dev"}/share/pkgconfig"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isMinGW || stdenv.hostPlatform.isCygwin) [
-    "-f"
-    "win32/Makefile.gcc"
-  ]
   ++ lib.optionals stdenv.hostPlatform.isCygwin [
     "SHAREDLIB=cygz.dll"
     "IMPLIB=libz.dll.a"
-  ]
-  ++ lib.optionals shared [
-    # Note that as of writing (zlib 1.2.11), this flag only has an effect
-    # for Windows as it is specific to `win32/Makefile.gcc`.
-    "SHARED_MODE=1"
   ];
 
   passthru.tests = {

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -108,20 +108,13 @@ stdenv.mkDerivation (finalAttrs: {
       ln -s zlib1.dll $out/bin/libz.dll
     '';
 
-  env =
-    lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
-      # As zlib takes part in the stdenv building, we don't want references
-      # to the bootstrap-tools libgcc (as uses to happen on arm/mips)
-      NIX_CFLAGS_COMPILE = toString (
-        [ "-static-libgcc" ] ++ lib.optional stdenv.hostPlatform.isCygwin "-DHAVE_UNISTD_H"
-      );
-    }
-    // lib.optionalAttrs (stdenv.hostPlatform.linker == "lld") {
-      # lld 16 enables --no-undefined-version by default
-      # This makes configure think it can't build dynamic libraries
-      # this may be removed when a version is packaged with https://github.com/madler/zlib/issues/960 fixed
-      NIX_LDFLAGS = "--undefined-version";
-    };
+  env = lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
+    # As zlib takes part in the stdenv building, we don't want references
+    # to the bootstrap-tools libgcc (as uses to happen on arm/mips)
+    NIX_CFLAGS_COMPILE = toString (
+      [ "-static-libgcc" ] ++ lib.optional stdenv.hostPlatform.isCygwin "-DHAVE_UNISTD_H"
+    );
+  };
 
   # We don't strip on static cross-compilation because of reports that native
   # stripping corrupted the target library; see commit 12e960f5 for the report.

--- a/pkgs/development/libraries/zlib/mingw-shared.patch
+++ b/pkgs/development/libraries/zlib/mingw-shared.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index c55098a..07f7c08 100755
+--- a/configure
++++ b/configure
+@@ -243,6 +243,8 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
+         echo "If this doesn't work for you, try win32/Makefile.gcc." | tee -a configure.log
+         LDSHARED=${LDSHARED-"$cc -shared"}
+         LDSHAREDLIBC=""
++        shared_ext='.dll'
++        SHAREDLIB='libz.dll'
+         EXE='.exe' ;;
+   QNX*) # This is for QNX6. I suppose that the QNX rule below is for QNX2,QNX4
+         # (alain.bonnefoy@icbt.com)


### PR DESCRIPTION
This avoids the pitfalls of win32/Makefile.gcc (which prevents building
on compilers other than gcc without patching and has non-standard
installation behavior) and fixes cross compilation for ucrtAarch64


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
