### PR TITLE
bpfilter: 0.4.0 -> 0.5.2

### DIFF
--- a/pkgs/by-name/bp/bpfilter/package.nix
+++ b/pkgs/by-name/bp/bpfilter/package.nix
@@ -1,5 +1,6 @@
 {
   bison,
+  clangStdenv,
   cmake,
   cmocka,
   doxygen,
@@ -14,19 +15,19 @@
   nix-update-script,
   pkg-config,
   sphinx,
-  stdenv,
+  tinyxxd,
   zlib,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "bpfilter";
-  version = "0.4.0";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "bpfilter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Z0L4sY944cj/rqfOwwjNWOU0tZDAsZ1ocf4/djHad2Q=";
+    hash = "sha256-qL5wRm6QmfMa5L+oZc5E2kAVqvJfCt5fBxjmtWzb2kA=";
   };
 
   nativeBuildInputs = [
@@ -38,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     lcov
     pkg-config
     sphinx
+    tinyxxd
 
     # bpfilter's cmake files requires this, even if we specify the version
     # we're using without needing to detect the version during the build.
@@ -63,6 +65,9 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
     "dev"
   ];
+
+  # invalid with -target bpf
+  hardeningDisable = [ "zerocallusedregs" ];
 
   preFixup = ''
     substituteInPlace $out/lib/systemd/system/bpfilter.service --replace-fail /usr/sbin/bpfilter $out/bin/bpfilter


### PR DESCRIPTION
https://github.com/facebook/bpfilter/releases/tag/v0.5.0

Not mentioned in the release notes:
- clang required, so derivation changed to use clangStdenv
- some new utilities required at build time

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
