### PR TITLE
vectorcode: use makeWrapperArgs to prefix PYTHONPATH

### DIFF
--- a/pkgs/by-name/ve/vectorcode/package.nix
+++ b/pkgs/by-name/ve/vectorcode/package.nix
@@ -160,15 +160,12 @@ python.pkgs.buildPythonApplication rec {
     installShellCompletion vectorcode.{bash,zsh}
   '';
 
-  postFixup = ''
-    wrapProgram $out/bin/vectorcode \
-      --prefix PYTHONPATH : "$PYTHONPATH" \
-      --set PATH ${
-        lib.makeBinPath [
-          python
-        ]
-      };
-  '';
+  makeWrapperArgs = [
+    "--prefix"
+    "PYTHONPATH"
+    ":"
+    "$PYTHONPATH"
+  ];
 
   pythonImportsCheck = [ "vectorcode" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow up to #419344

Confirmed that it still solves issue #415770:

```console
$ nix run .#vectorcode -- ls
WARNING: vectorcode.common : Starting bundled ChromaDB server at http://127.0.0.1:58983.
ERROR: chromadb.telemetry.product.posthog : Failed to send telemetry event ClientStartEvent: capture() takes 1 positional argument but 3 were given
Project Root    Collection Size    Number of Files    Embedding Function
--------------  -----------------  -----------------  --------------------
```

I got driven into updating this when I tried to override `makeWrapperArgs` with more flags and it had no effect.

<details>
<summary>diff of the wrapper</summary>

```diff
diff --git a/nix/store/4ag8k7yy9ka5051pg5ai0fpp7gwbpjbv-vectorcode-0.7.7/bin/vectorcode b/nix/store/58nf1fxh8h3pd2rklbwwfm4k1yypfcpi-vectorcode-0.7.7/bin/vectorcode
index 998681aa2509..22a196aec269 100755
--- a/nix/store/4ag8k7yy9ka5051pg5ai0fpp7gwbpjbv-vectorcode-0.7.7/bin/vectorcode
+++ b/nix/store/58nf1fxh8h3pd2rklbwwfm4k1yypfcpi-vectorcode-0.7.7/bin/vectorcode
@@ -1,4 +1,233 @@
 #! /nix/store/a6akyvyh3j60yz9gajqbm155k2c7m5fc-bash-5.3p0/bin/bash -e
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/2bqydycgapahl00f8dphwxgqaasa9bwj-python3.13-tabulate-0.9.0/bin'':'/':'}
+PATH='/nix/store/2bqydycgapahl00f8dphwxgqaasa9bwj-python3.13-tabulate-0.9.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/388wxrhx91gxvqq3zcg2ssfyzim1g3jh-python3.13-shtab-1.7.1/bin'':'/':'}
+PATH='/nix/store/388wxrhx91gxvqq3zcg2ssfyzim1g3jh-python3.13-shtab-1.7.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/zjg33yhzlsmxw2cm7n4fkkhqgwww7bkn-python3.13-transformers-4.54.0/bin'':'/':'}
+PATH='/nix/store/zjg33yhzlsmxw2cm7n4fkkhqgwww7bkn-python3.13-transformers-4.54.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/jbf417r2hxf4wfgg6k7lm5z7k8yj1vzp-python3.13-torch-2.7.1/bin'':'/':'}
+PATH='/nix/store/jbf417r2hxf4wfgg6k7lm5z7k8yj1vzp-python3.13-torch-2.7.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/2pih382s92h7gh5ma6dyp7gqz5jq8igf-python3.13-pybind11-2.13.6/bin'':'/':'}
+PATH='/nix/store/2pih382s92h7gh5ma6dyp7gqz5jq8igf-python3.13-pybind11-2.13.6/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/9iij8ica8val62wc978cw6qzbhqr6l2q-python3.13-markdown-3.8/bin'':'/':'}
+PATH='/nix/store/9iij8ica8val62wc978cw6qzbhqr6l2q-python3.13-markdown-3.8/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/qc1rjabx2zs2p1w6yqbfk4ddmqb1zg8n-python3.13-tensorboard-2.19.0/bin'':'/':'}
+PATH='/nix/store/qc1rjabx2zs2p1w6yqbfk4ddmqb1zg8n-python3.13-tensorboard-2.19.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/wqnxx0c40lh224sg8nc41r5s0gx1gnnz-python3.13-sympy-1.14.0/bin'':'/':'}
+PATH='/nix/store/wqnxx0c40lh224sg8nc41r5s0gx1gnnz-python3.13-sympy-1.14.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/gpzwjnhaz04y2lnb92ardimcmfc7xpjq-python3.13-ninja-1.12.1/bin'':'/':'}
+PATH='/nix/store/gpzwjnhaz04y2lnb92ardimcmfc7xpjq-python3.13-ninja-1.12.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/2f8fqrnlzllrf3h308kiibkk926r7gxp-python3.13-hypothesis-6.131.17/bin'':'/':'}
+PATH='/nix/store/2f8fqrnlzllrf3h308kiibkk926r7gxp-python3.13-hypothesis-6.131.17/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/sql8p2hbrxz3qsrs6k38dmwbs4gvlfr5-python3.13-wheel-0.46.1/bin'':'/':'}
+PATH='/nix/store/sql8p2hbrxz3qsrs6k38dmwbs4gvlfr5-python3.13-wheel-0.46.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/x2qs9jh0liqg11jzwxiifxs3mv56a47d-python3.13-python-dotenv-1.1.0/bin'':'/':'}
+PATH='/nix/store/x2qs9jh0liqg11jzwxiifxs3mv56a47d-python3.13-python-dotenv-1.1.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/rw8gknpz05wq88p7g1zkzr5ad0v6vkql-python3.13-json5-0.12.0/bin'':'/':'}
+PATH='/nix/store/rw8gknpz05wq88p7g1zkzr5ad0v6vkql-python3.13-json5-0.12.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/mwvjz0sqp8b47cpp654jrma8dv7jy6wa-python3.13-uvicorn-0.34.2/bin'':'/':'}
+PATH='/nix/store/mwvjz0sqp8b47cpp654jrma8dv7jy6wa-python3.13-uvicorn-0.34.2/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/xmdnwwwl6frnp927nhi5d5npnwbf3plx-python3.13-pygments-2.19.1/bin'':'/':'}
+PATH='/nix/store/xmdnwwwl6frnp927nhi5d5npnwbf3plx-python3.13-pygments-2.19.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/1ndb6yc91b0gvhnzfy6fycszlja0nbs5-python3.13-markdown-it-py-3.0.0/bin'':'/':'}
+PATH='/nix/store/1ndb6yc91b0gvhnzfy6fycszlja0nbs5-python3.13-markdown-it-py-3.0.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/s65szpjzc3nqpmd5z111ix78hcbl7cyz-python3.13-typer-0.15.4/bin'':'/':'}
+PATH='/nix/store/s65szpjzc3nqpmd5z111ix78hcbl7cyz-python3.13-typer-0.15.4/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/zlz4rm3wrw3cjqyzinf1d3iqasjfd7k6-python3.13-tqdm-4.67.1/bin'':'/':'}
+PATH='/nix/store/zlz4rm3wrw3cjqyzinf1d3iqasjfd7k6-python3.13-tqdm-4.67.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/6sc6c1n5nkxdylchg2yzbm4jgpcfavzs-python3.13-huggingface-hub-0.34.1/bin'':'/':'}
+PATH='/nix/store/6sc6c1n5nkxdylchg2yzbm4jgpcfavzs-python3.13-huggingface-hub-0.34.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/cncfr5b2ghnm7r824cc08cjbamsdjm4m-python3.13-distro-1.9.0/bin'':'/':'}
+PATH='/nix/store/cncfr5b2ghnm7r824cc08cjbamsdjm4m-python3.13-distro-1.9.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/bhwkny414iq1znkzpw0572hn2k5qah0l-python3.13-opentelemetry-instrumentation-0.52b1/bin'':'/':'}
+PATH='/nix/store/bhwkny414iq1znkzpw0572hn2k5qah0l-python3.13-opentelemetry-instrumentation-0.52b1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/87bqqllnld1sp3yx1h5z3lzkk4a8fp95-icu4c-76.1-dev/bin'':'/':'}
+PATH='/nix/store/87bqqllnld1sp3yx1h5z3lzkk4a8fp95-icu4c-76.1-dev/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/a7p9wyv6s2j8g94j2r2lv97k3qcpnx81-c-ares-1.34.5/bin'':'/':'}
+PATH='/nix/store/a7p9wyv6s2j8g94j2r2lv97k3qcpnx81-c-ares-1.34.5/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/239fbsrjskgvrq4l02whw39prkmi8jf7-grpc-1.73.1/bin'':'/':'}
+PATH='/nix/store/239fbsrjskgvrq4l02whw39prkmi8jf7-grpc-1.73.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/8czc9w35sxvi579ij715f68njmzkwc5r-python3.13-humanfriendly-10.0/bin'':'/':'}
+PATH='/nix/store/8czc9w35sxvi579ij715f68njmzkwc5r-python3.13-humanfriendly-10.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/zlw2ayrh501p0xkdd36kw7w5n8pj0ncq-python3.13-coloredlogs-15.0.1/bin'':'/':'}
+PATH='/nix/store/zlw2ayrh501p0xkdd36kw7w5n8pj0ncq-python3.13-coloredlogs-15.0.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/vvcd9a0s457skb8cnj2783k7xcll6mnm-python3.13-onnxruntime-1.22.0/bin'':'/':'}
+PATH='/nix/store/vvcd9a0s457skb8cnj2783k7xcll6mnm-python3.13-onnxruntime-1.22.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/wwvbrs67rb53c0mwclgsr03zrxr6mmis-python3.13-numpy-2.3.1/bin'':'/':'}
+PATH='/nix/store/wwvbrs67rb53c0mwclgsr03zrxr6mmis-python3.13-numpy-2.3.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/wni7fkd66w8d0nx0c2dpq6r7wlblg5q6-python3.13-websocket-client-1.8.0/bin'':'/':'}
+PATH='/nix/store/wni7fkd66w8d0nx0c2dpq6r7wlblg5q6-python3.13-websocket-client-1.8.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/cyjl3k5yjh02r9x48042amhyg4hhq8n0-python3.13-charset-normalizer-3.4.2/bin'':'/':'}
+PATH='/nix/store/cyjl3k5yjh02r9x48042amhyg4hhq8n0-python3.13-charset-normalizer-3.4.2/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/86rwwp8p27jkmn8x30l7by4wgppyabvm-python3.13-rsa-4.9/bin'':'/':'}
+PATH='/nix/store/86rwwp8p27jkmn8x30l7by4wgppyabvm-python3.13-rsa-4.9/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/fpsiwp61hg9h50wzmxbcxv67cvwsxhs4-python3.13-jsonschema-4.23.0/bin'':'/':'}
+PATH='/nix/store/fpsiwp61hg9h50wzmxbcxv67cvwsxhs4-python3.13-jsonschema-4.23.0/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/p866225vfj8wi4mqll2v6ljri2phr9bx-python3.13-httpx-0.28.1/bin'':'/':'}
+PATH='/nix/store/p866225vfj8wi4mqll2v6ljri2phr9bx-python3.13-httpx-0.28.1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/fy2lq9rnjj2vrrwx6kq5qxnmp92hhvdv-python3.13-fastapi-0.115.12/bin'':'/':'}
+PATH='/nix/store/fy2lq9rnjj2vrrwx6kq5qxnmp92hhvdv-python3.13-fastapi-0.115.12/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/ka5zqgmj8wdsrxag5y8p44hn6v8sk0k6-python3.13-build-1.2.2.post1/bin'':'/':'}
+PATH='/nix/store/ka5zqgmj8wdsrxag5y8p44hn6v8sk0k6-python3.13-build-1.2.2.post1/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/f4rabhk5nwsvki4bxzx789fjdfa5r1vd-python3.13-chromadb-0.6.3/bin'':'/':'}
+PATH='/nix/store/f4rabhk5nwsvki4bxzx789fjdfa5r1vd-python3.13-chromadb-0.6.3/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/58nf1fxh8h3pd2rklbwwfm4k1yypfcpi-vectorcode-0.7.7/bin'':'/':'}
+PATH='/nix/store/58nf1fxh8h3pd2rklbwwfm4k1yypfcpi-vectorcode-0.7.7/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+PATH=${PATH:+':'$PATH':'}
+PATH=${PATH/':''/nix/store/v72ywdz0dd2d6sb3knymx9ww8r6pcqba-python3-3.13.5/bin'':'/':'}
+PATH='/nix/store/v72ywdz0dd2d6sb3knymx9ww8r6pcqba-python3-3.13.5/bin'$PATH
+PATH=${PATH#':'}
+PATH=${PATH%':'}
+export PATH
+export PYTHONNOUSERSITE='true'
 PYTHONPATH=${PYTHONPATH:+':'$PYTHONPATH':'}
 PYTHONPATH=${PYTHONPATH/':''/nix/store/igznysczwl4pqcglmaz62wfg8g6j1byz-python3.13-tree-sitter-yaml-0.7.1/lib/python3.13/site-packages'':'/':'}
 PYTHONPATH='/nix/store/igznysczwl4pqcglmaz62wfg8g6j1byz-python3.13-tree-sitter-yaml-0.7.1/lib/python3.13/site-packages'$PYTHONPATH
@@ -876,16 +1105,15 @@ PYTHONPATH=${PYTHONPATH#':'}
 PYTHONPATH=${PYTHONPATH%':'}
 export PYTHONPATH
 PYTHONPATH=${PYTHONPATH:+':'$PYTHONPATH':'}
-PYTHONPATH=${PYTHONPATH/':''/nix/store/4ag8k7yy9ka5051pg5ai0fpp7gwbpjbv-vectorcode-0.7.7/lib/python3.13/site-packages'':'/':'}
-PYTHONPATH='/nix/store/4ag8k7yy9ka5051pg5ai0fpp7gwbpjbv-vectorcode-0.7.7/lib/python3.13/site-packages'$PYTHONPATH
+PYTHONPATH=${PYTHONPATH/':''/nix/store/58nf1fxh8h3pd2rklbwwfm4k1yypfcpi-vectorcode-0.7.7/lib/python3.13/site-packages'':'/':'}
+PYTHONPATH='/nix/store/58nf1fxh8h3pd2rklbwwfm4k1yypfcpi-vectorcode-0.7.7/lib/python3.13/site-packages'$PYTHONPATH
 PYTHONPATH=${PYTHONPATH#':'}
 PYTHONPATH=${PYTHONPATH%':'}
 export PYTHONPATH
 PYTHONPATH=${PYTHONPATH:+':'$PYTHONPATH':'}
-PYTHONPATH=${PYTHONPATH/':''/nix/store/4ag8k7yy9ka5051pg5ai0fpp7gwbpjbv-vectorcode-0.7.7/lib/python3.13/site-packages'':'/':'}
-PYTHONPATH='/nix/store/4ag8k7yy9ka5051pg5ai0fpp7gwbpjbv-vectorcode-0.7.7/lib/python3.13/site-packages'$PYTHONPATH
+PYTHONPATH=${PYTHONPATH/':''/nix/store/58nf1fxh8h3pd2rklbwwfm4k1yypfcpi-vectorcode-0.7.7/lib/python3.13/site-packages'':'/':'}
+PYTHONPATH='/nix/store/58nf1fxh8h3pd2rklbwwfm4k1yypfcpi-vectorcode-0.7.7/lib/python3.13/site-packages'$PYTHONPATH
 PYTHONPATH=${PYTHONPATH#':'}
 PYTHONPATH=${PYTHONPATH%':'}
 export PYTHONPATH
-export PATH='/nix/store/v72ywdz0dd2d6sb3knymx9ww8r6pcqba-python3-3.13.5/bin'
-exec -a "$0" "/nix/store/4ag8k7yy9ka5051pg5ai0fpp7gwbpjbv-vectorcode-0.7.7/bin/.vectorcode-wrapped_"  "$@" 
+exec -a "$0" "/nix/store/58nf1fxh8h3pd2rklbwwfm4k1yypfcpi-vectorcode-0.7.7/bin/.vectorcode-wrapped"  "$@" 
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
