### PR TITLE
puddletag: 2.3.0 -> 2.5.0

### DIFF
--- a/pkgs/by-name/pu/puddletag/package.nix
+++ b/pkgs/by-name/pu/puddletag/package.nix
@@ -1,32 +1,25 @@
 {
   lib,
   fetchFromGitHub,
-  fetchurl,
   python3,
-  qtbase,
-  qtwayland,
-  wrapQtAppsHook,
+  libsForQt5,
 }:
 
+let
+  qt = libsForQt5;
+
+in
 python3.pkgs.buildPythonApplication rec {
   pname = "puddletag";
-  version = "2.3.0";
+  version = "2.5.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "puddletag";
     repo = "puddletag";
     tag = version;
-    hash = "sha256-oScT8YcQoDf2qZ+J7xKm22Sbfym3tkVUrWT5D2LU5e8=";
+    hash = "sha256-Per+olIi2yd2cNRO22Fi6cC7/90AqRP1NpRK1XU1i0A=";
   };
-
-  patches = [
-    (fetchurl {
-      url = "https://github.com/puddletag/puddletag/commit/54074824adb05da42c03d7adfbba94d8e24982f0.patch";
-      hash = "sha256-DkgaFWgp2m2bRuhdXhHW+nxV/2GaCgeRNdwLMYAkcYQ=";
-      name = "fix_for_pyparsing_3_1_2.patch";
-    })
-  ];
 
   pythonRelaxDeps = true;
 
@@ -37,19 +30,19 @@ python3.pkgs.buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace share/pixmaps share/icons
+      --replace-fail share/pixmaps share/icons
   '';
 
-  buildInputs = [
+  buildInputs = with qt; [
     qtbase
     qtwayland
   ];
 
-  nativeBuildInputs = [
+  nativeBuildInputs = with qt; [
     wrapQtAppsHook
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     configobj
     levenshtein
     lxml
@@ -73,15 +66,15 @@ python3.pkgs.buildPythonApplication rec {
 
   dontStrip = true; # we are not generating any binaries
 
-  meta = with lib; {
+  meta = {
     description = "Audio tag editor similar to the Windows program, Mp3tag";
     mainProgram = "puddletag";
     homepage = "https://docs.puddletag.net";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
       peterhoeg
       dschrempf
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12185,8 +12185,6 @@ with pkgs;
     fftw = fftwSinglePrec;
   };
 
-  puddletag = libsForQt5.callPackage ../applications/audio/puddletag { };
-
   welle-io = qt6Packages.callPackage ../applications/radio/welle-io { };
 
   wireshark = qt6Packages.callPackage ../applications/networking/sniffers/wireshark {


### PR DESCRIPTION
Also move to `pkgs/by-name`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
