### PR TITLE
tk-safe: init at 25.8.1

### DIFF
--- a/pkgs/by-name/tk/tk-safe/package.nix
+++ b/pkgs/by-name/tk/tk-safe/package.nix
@@ -1,0 +1,103 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  squashfsTools,
+  autoPatchelfHook,
+  copyDesktopItems,
+  alsa-lib,
+  nss,
+  libdrm,
+  libgbm,
+  libGL,
+  libxkbcommon,
+  pcsclite,
+  makeDesktopItem,
+  makeWrapper,
+  wrapGAppsHook3,
+  udev,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tk-safe";
+  version = "25.8.1";
+
+  # To update, check https://search.apps.ubuntu.com/api/v1/package/tk-safe and copy the anon_download_url and version.
+  src = fetchurl {
+    url = "https://api.snapcraft.io/api/v1/snaps/download/rLNeIGEaag0TKFQLO0TxF3ARXg3rcTNx_18.snap";
+    hash = "sha256-OrDbxLcmbL/yTANCMHcJsdGE+LK8rondGQvj+YBqS0E=";
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "tk-safe";
+      icon = "tk-safe";
+      exec = "tk-safe";
+      desktopName = "TK-Safe";
+      comment = meta.description;
+      genericName = "Eletronic medical record (ePA)";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+    squashfsTools
+    wrapGAppsHook3
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    unsquashfs $src
+
+    runHook postUnpack
+  '';
+
+  sourceRoot = "squashfs-root";
+
+  postPatch = ''
+    rm -rf lib usr
+  '';
+
+  buildInputs = [
+    alsa-lib
+    nss
+    libdrm
+    libgbm
+    libxkbcommon
+    udev
+    pcsclite
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,opt/tk-safe}
+    mv * $out/opt/tk-safe
+    ln -s $out/opt/tk-safe/app/tk-safe $out/bin/tk-safe
+
+    mkdir -p $out/share/icons/hicolor/1024x1024/apps
+    ln -s $out/opt/tk-safe/meta/gui/icon.png $out/share/icons/hicolor/1024x1024/apps/tk-safe.png
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    wrapProgram $out/opt/tk-safe/app/tk-safe \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}"
+  '';
+
+  meta = {
+    description = "Electronic medical record (ePA) by Techniker Krankenkasse (TK)";
+    homepage = "https://snapcraft.io/tk-safe";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    # Vendored copy of Electron.
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ felschr ];
+    mainProgram = "tk-safe";
+  };
+}


### PR DESCRIPTION
Adds TK-Safe, a German eletronic medical record (ePA) from Techniker Krankenkasse (TK).

It's a redistribution of the official release on the Snapcraft Snap Store: https://snapcraft.io/tk-safe

General information about TK-Safe:
https://www.tk.de/techniker/leistungen-und-mitgliedschaft/online-services-versicherte/elektronische-patientenakte-tk-safe-2028798
https://www.tk.de/en/support-faq/faq-easy-access-to-health-care/tk-safe-2169522
https://www.tk.de/techniker/unternehmensseiten/nutzungs-und-teilnahmebedingungen/tk-safe-nutzungsbedingungen-2096786

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
