### PR TITLE
qolibri: 2.1.5-unstable-2024-03-17 -> 2.1.5-unstable-2025-01-18

### DIFF
--- a/pkgs/applications/misc/qolibri/default.nix
+++ b/pkgs/applications/misc/qolibri/default.nix
@@ -8,25 +8,15 @@
   qtwebengine,
   wrapQtAppsHook,
 }:
-
-let
-  eb = fetchFromGitHub {
-    owner = "mvf";
-    repo = "eb";
-    rev = "58e1c3bb9847ed5d05863f478f21e7a8ca3d74c8";
-    hash = "sha256-gZP+2P6fFADWht2c0hXmljVJQX8RpCq2mWP+KDi+GzE=";
-  };
-in
-
 stdenv.mkDerivation {
   pname = "qolibri";
-  version = "2.1.5-unstable-2024-03-17";
+  version = "2.1.5-unstable-2025-01-18";
 
   src = fetchFromGitHub {
     owner = "mvf";
     repo = "qolibri";
-    rev = "99f0771184fcb2c5f47aad11c16002ebb8469a3f";
-    hash = "sha256-ArupqwejOO2YK9a3Ky0j20dIHs1jIqJksNIb4K2jwgI=";
+    rev = "edc0683915c0a99872a4c04ff53afe0f5df101fb";
+    hash = "sha256-RPcA9pPbd86gJtoHxalDKze0t8DNg/uVQYp9eYTxxyc=";
   };
 
   nativeBuildInputs = [
@@ -41,7 +31,14 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DQOLIBRI_EB_SOURCE_DIR=${eb}"
+    (lib.cmakeOptionType "filepath" "QOLIBRI_EB_SOURCE_DIR"
+      "${fetchFromGitHub {
+        owner = "mvf";
+        repo = "eb";
+        rev = "58e1c3bb9847ed5d05863f478f21e7a8ca3d74c8";
+        hash = "sha256-gZP+2P6fFADWht2c0hXmljVJQX8RpCq2mWP+KDi+GzE=";
+      }}"
+    )
   ];
 
   postInstall = ''
@@ -54,12 +51,12 @@ stdenv.mkDerivation {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "EPWING reader for viewing Japanese dictionaries";
     homepage = "https://github.com/mvf/qolibri";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ azahi ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.azahi ];
+    platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64; # Looks like a libcxx version mismatch problem.
     mainProgram = "qolibri";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/mvf/qolibri/compare/99f0771184fcb2c5f47aad11c16002ebb8469a3f..edc0683915c0a99872a4c04ff53afe0f5df101fb

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
