### PR TITLE
python3Packages.xcaplib: init at 2.0.1-unstable-2025-03-20

### DIFF
--- a/pkgs/development/python-modules/xcaplib/default.nix
+++ b/pkgs/development/python-modules/xcaplib/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  lxml,
+  twisted,
+  python3-application,
+  unstableGitUpdater,
+}:
+
+buildPythonPackage rec {
+  pname = "xcaplib";
+  # latest commit is needed for python 3.13 compat.
+  version = "2.0.1-unstable-2025-03-20";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "AGProjects";
+    repo = "python3-xcaplib";
+    rev = "925846f2520d823f0b83279ceca6202808a4ca4f";
+    hash = "sha256-8EtXwHMQcPzPfP8JpB6gTV7PADHz+bJIJMhvR3DkPkk=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    lxml
+    twisted
+    python3-application
+  ];
+
+  # the one and only upstream test relies on networking
+  doCheck = false;
+
+  pythonImportsCheck = [ "xcaplib" ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "XCAP (RFC4825) client library";
+    homepage = "https://github.com/AGProjects/python3-xcaplib";
+    license = lib.licenses.lgpl21Plus;
+    teams = [ lib.teams.ngi ];
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+    mainProgram = "xcapclient3";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19768,6 +19768,8 @@ self: super: with self; {
 
   xboxapi = callPackage ../development/python-modules/xboxapi { };
 
+  xcaplib = callPackage ../development/python-modules/xcaplib { };
+
   xcffib = callPackage ../development/python-modules/xcffib { };
 
   xdg = callPackage ../development/python-modules/xdg { };


### PR DESCRIPTION
NGI project.

Closes: https://github.com/ngi-nix/projects/issues/1744
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
