### PR TITLE
codex: 0.4.0 -> 0.10.0

### DIFF
--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -9,8 +9,8 @@
   stdenv,
   installShellFiles,
   installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-  git,
-  makeWrapper,
+  gitMinimal,
+  makeBinWrapper,
   python3,
   xdg-utils,
 }:
@@ -33,14 +33,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     installShellFiles
     pkg-config
-    makeWrapper
+    makeBinWrapper
   ];
   buildInputs = [
     openssl
   ];
 
   nativeCheckInputs = [
-    git
+    gitMinimal
   ];
   checkFlags = [
     "--skip=keeps_previous_response_id_between_tasks" # Requires network access

--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -6,36 +6,72 @@
   pkg-config,
   openssl,
   versionCheckHook,
+  stdenv,
+  installShellFiles,
+  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  git,
+  makeWrapper,
+  python3,
+  xdg-utils,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codex";
-  version = "0.4.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "codex";
     tag = "rust-v${finalAttrs.version}";
-    hash = "sha256-rRe0JFEO5ixxrZYDL8kxXDOH0n7lqabkXNNaSlNnQDg=";
+    hash = "sha256-ukQG6Ugc4lvJEdPmorNEdVh8XrgjuOO8x/8F+9jcw3U=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/codex-rs";
 
-  cargoHash = "sha256-QIZ3V4NUo1VxJN3cwdQf3S0zwePnwdKKfch0jlIJacU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-YZHmMRwJgZTPHyoB4GXlt6H2Igw1wh/4vMYt7+3Nz1Y=";
 
   nativeBuildInputs = [
+    installShellFiles
     pkg-config
+    makeWrapper
   ];
   buildInputs = [
     openssl
   ];
 
+  nativeCheckInputs = [
+    git
+  ];
   checkFlags = [
     "--skip=keeps_previous_response_id_between_tasks" # Requires network access
     "--skip=retries_on_early_close" # Requires network access
+
+    # Failing tests (broken upstream in v0.10.0 as tests hardcode version 0.0.0, remove these skips when fixed)
+    "--skip=test_patch_approval_triggers_elicitation"
+    "--skip=test_codex_tool_passes_base_instructions"
+    "--skip=test_shell_command_approval_triggers_elicitation"
+    "--skip=test_shell_command_interruption"
   ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  postInstall = lib.optionalString installShellCompletions ''
+    installShellCompletion --cmd codex \
+      --bash <($out/bin/codex completion bash) \
+      --fish <($out/bin/codex completion fish) \
+      --zsh <($out/bin/codex completion zsh)
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/codex \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          python3
+          xdg-utils
+        ]
+      }
+  '';
 
   passthru = {
     updateScript = nix-update-script {


### PR DESCRIPTION
Update codex to latest release on GitHub.

See also #425917

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
