### PR TITLE
usbguard: unpin protobuf, cleanup

### DIFF
--- a/pkgs/by-name/us/usbguard/package.nix
+++ b/pkgs/by-name/us/usbguard/package.nix
@@ -21,14 +21,14 @@
   libsodium,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "1.1.4";
   pname = "usbguard";
 
   src = fetchFromGitHub {
     owner = "USBGuard";
     repo = "usbguard";
-    rev = "usbguard-${version}";
+    tag = "usbguard-${finalAttrs.version}";
     hash = "sha256-PDuYszdG6BK4fkAHWWBct1d7tnwwe+5XOw+xmSPoPCY=";
     fetchSubmodules = true;
   };
@@ -74,17 +74,17 @@ stdenv.mkDerivation rec {
 
   passthru.tests = nixosTests.usbguard;
 
-  meta = with lib; {
-    description = "USBGuard software framework helps to protect your computer against BadUSB";
+  meta = {
+    description = "Protect your computer against rogue USB devices (a.k.a. BadUSB)";
     longDescription = ''
       USBGuard is a software framework for implementing USB device authorization
       policies (what kind of USB devices are authorized) as well as method of
       use policies (how a USB device may interact with the system). Simply put,
-      it is a USB device whitelisting tool.
+      it is a USB device allowlisting tool.
     '';
     homepage = "https://usbguard.github.io/";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
-    maintainers = [ maintainers.tnias ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.tnias ];
   };
-}
+})

--- a/pkgs/by-name/us/usbguard/package.nix
+++ b/pkgs/by-name/us/usbguard/package.nix
@@ -16,14 +16,11 @@
   libqb,
   libseccomp,
   polkit,
-  protobuf_29,
+  protobuf,
   audit,
   libsodium,
 }:
 
-let
-  protobuf = protobuf_29;
-in
 stdenv.mkDerivation rec {
   version = "1.1.4";
   pname = "usbguard";


### PR DESCRIPTION
Because usbguard versions 1.1.3 and before were incompatible with API changes introduced by protobuf 30,
protobuf 29 was pinned with PR https://github.com/NixOS/nixpkgs/pull/404706 by @andersk.

Since release 1.1.4 usbguard is protobuf 30 compatible.
The version bump PR https://github.com/NixOS/nixpkgs/pull/425466 was merged.
So we can now unpin the protobuf version.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
