### PR TITLE
eigenwallet: use buildFHSEnv

### DIFF
--- a/pkgs/by-name/ei/eigenwallet/package.nix
+++ b/pkgs/by-name/ei/eigenwallet/package.nix
@@ -8,45 +8,65 @@
   gdk-pixbuf,
   webkitgtk_4_1,
   gtk3,
+  buildFHSEnv,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  name = "eigenwallet";
+let
   version = "2.0.3";
 
-  src = fetchurl {
-    url = "https://github.com/eigenwallet/core/releases/download/${finalAttrs.version}/UnstoppableSwap_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-2uOsZ6IvaQes+FYGQ0cNYlySzjyNwf/3fqk3DJzN+WI=";
-  };
-
-  nativeBuildInputs = [
-    dpkg
-    autoPatchelfHook
-  ];
-
-  buildInputs = [
+  deps = [
     cairo
     gdk-pixbuf
     webkitgtk_4_1
     gtk3
   ];
 
-  installPhase = ''
-    runHook preInstall
+  thisPackage = stdenv.mkDerivation (finalAttrs: {
+    pname = "eigenwallet";
+    inherit version;
 
-    mkdir -p $out
-    mv {usr/bin,usr/share} $out
+    src = fetchurl {
+      url = "https://github.com/eigenwallet/core/releases/download/${finalAttrs.version}/UnstoppableSwap_${finalAttrs.version}_amd64.deb";
+      hash = "sha256-2uOsZ6IvaQes+FYGQ0cNYlySzjyNwf/3fqk3DJzN+WI=";
+    };
 
-    runHook postInstall
-  '';
+    nativeBuildInputs = [
+      dpkg
+      autoPatchelfHook
+    ];
 
-  meta = {
-    description = "Protocol and desktop application for swapping Monero and Bitcoin";
-    homepage = "https://unstoppableswap.net";
-    maintainers = with lib.maintainers; [ JacoMalan1 ];
-    license = lib.licenses.gpl3Only;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    platforms = [ "x86_64-linux" ];
-    mainProgram = "unstoppableswap-gui-rs";
-  };
-})
+    buildInputs = [
+      cairo
+      gdk-pixbuf
+      webkitgtk_4_1
+      gtk3
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      mv {usr/bin,usr/share} $out
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Protocol and desktop application for swapping Monero and Bitcoin";
+      homepage = "https://unstoppableswap.net";
+      maintainers = with lib.maintainers; [ JacoMalan1 ];
+      license = lib.licenses.gpl3Only;
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      platforms = [ "x86_64-linux" ];
+      mainProgram = "unstoppableswap-gui-rs";
+    };
+  });
+in
+
+buildFHSEnv {
+  name = "unstoppableswap-gui-rs";
+  targetPkgs = _: deps ++ [ thisPackage ];
+  runScript = "unstoppableswap-gui-rs";
+
+  inherit (thisPackage) meta;
+}


### PR DESCRIPTION
Eigenwallet on version 2.0.3 downloads the `monero-wallet-rpc` binary which, obviously, doesn't run by default on NixOS. On my system I have nix-ld enabled, so I didn't notice the issue until a user pointed it out.

Resolves #428903 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
