### PR TITLE
openjpeg: Fix CMake variables about CMake module install location and improve overridability with `finalAttrs`

### DIFF
--- a/pkgs/by-name/op/openjpeg/package.nix
+++ b/pkgs/by-name/op/openjpeg/package.nix
@@ -44,6 +44,14 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
+  postPatch = lib.optionalString (lib.elem "dev" finalAttrs.outputs) ''
+    # Fix OPENJPEG_INSTALL_PACKAGE_DIR, the directory to install OpenJPEG cmake modules.
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        ${lib.escapeShellArg ''set(OPENJPEG_INSTALL_PACKAGE_DIR "''${CMAKE_INSTALL_LIBDIR}/cmake/''${OPENJPEG_INSTALL_SUBDIR}")''} \
+        ${lib.escapeShellArg ''set(OPENJPEG_INSTALL_PACKAGE_DIR "${placeholder "dev"}/lib/cmake/''${OPENJPEG_INSTALL_SUBDIR}")''}
+  '';
+
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     "-DBUILD_CODEC=ON"

--- a/pkgs/by-name/op/openjpeg/package.nix
+++ b/pkgs/by-name/op/openjpeg/package.nix
@@ -38,14 +38,14 @@ let
     hash = "sha256-ckZHCZV5UJicVUoi/mZDwvCJneXC3X+NA8Byp6GLE0w=";
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openjpeg";
   version = "2.5.4";
 
   src = fetchFromGitHub {
     owner = "uclouvain";
     repo = "openjpeg";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-HSXGdpHUbwlYy5a+zKpcLo2d+b507Qf5nsaMghVBlZ8=";
   };
 
@@ -62,9 +62,9 @@ stdenv.mkDerivation rec {
     (lib.cmakeBool "BUILD_JPIP_SERVER" jpipServerSupport)
     "-DBUILD_VIEWER=OFF"
     "-DBUILD_JAVA=OFF"
-    (lib.cmakeBool "BUILD_TESTING" doCheck)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
   ]
-  ++ lib.optional doCheck "-DOPJ_DATA_ROOT=${test-data}";
+  ++ lib.optional finalAttrs.doCheck "-DOPJ_DATA_ROOT=${test-data}";
 
   nativeBuildInputs = [
     cmake
@@ -94,7 +94,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    incDir = "openjpeg-${lib.versions.majorMinor version}";
+    incDir = "openjpeg-${lib.versions.majorMinor finalAttrs.version}";
     tests = {
       ffmpeg = ffmpeg.override { withOpenjpeg = true; };
       imagemagick = imagemagick.override { openjpegSupport = true; };
@@ -118,6 +118,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ codyopel ];
     platforms = lib.platforms.all;
-    changelog = "https://github.com/uclouvain/openjpeg/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/uclouvain/openjpeg/blob/v${finalAttrs.version}/CHANGELOG.md";
   };
-}
+})

--- a/pkgs/by-name/op/openjpeg/package.nix
+++ b/pkgs/by-name/op/openjpeg/package.nix
@@ -28,16 +28,6 @@
   vips,
 }:
 
-let
-  # may need to get updated with package
-  # https://github.com/uclouvain/openjpeg-data
-  test-data = fetchFromGitHub {
-    owner = "uclouvain";
-    repo = "openjpeg-data";
-    rev = "39524bd3a601d90ed8e0177559400d23945f96a9";
-    hash = "sha256-ckZHCZV5UJicVUoi/mZDwvCJneXC3X+NA8Byp6GLE0w=";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openjpeg";
   version = "2.5.4";
@@ -64,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DBUILD_JAVA=OFF"
     (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
   ]
-  ++ lib.optional finalAttrs.doCheck "-DOPJ_DATA_ROOT=${test-data}";
+  ++ lib.optional finalAttrs.doCheck "-DOPJ_DATA_ROOT=${finalAttrs.passthru.test-data}";
 
   nativeBuildInputs = [
     cmake
@@ -95,6 +85,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     incDir = "openjpeg-${lib.versions.majorMinor finalAttrs.version}";
+
+    # may need to get updated with package
+    # https://github.com/uclouvain/openjpeg-data
+    test-data = fetchFromGitHub {
+      owner = "uclouvain";
+      repo = "openjpeg-data";
+      rev = "39524bd3a601d90ed8e0177559400d23945f96a9";
+      hash = "sha256-ckZHCZV5UJicVUoi/mZDwvCJneXC3X+NA8Byp6GLE0w=";
+    };
+
     tests = {
       ffmpeg = ffmpeg.override { withOpenjpeg = true; };
       imagemagick = imagemagick.override { openjpegSupport = true; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Description

The `openjpeg` package has two outputs, `out` and `dev`. The CMake files should be placed at the `dev` output, but happens to go to the `out` output due to the way upstream CMake file find the library directory.

This PR guides the `openjpeg` CMake file installation to the correct output by patching the CMake file responsible for the installation.

This PR also makes `openjpeg` more overridable by adopting `stdenv.mkDerivation`'s fixed-point arguments support. If merged, users can override `doCheck`, `outputs`, and `version` directly, and `test-data` via `passthru.test-data`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
