### PR TITLE
nixos/vaultwarden: Start after network-online.target

### DIFF
--- a/nixos/modules/services/security/vaultwarden/default.nix
+++ b/nixos/modules/services/security/vaultwarden/default.nix
@@ -224,7 +224,8 @@ in
     users.groups.vaultwarden = { };
 
     systemd.services.vaultwarden = {
-      after = [ "network.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
       path = with pkgs; [ openssl ];
       serviceConfig = {
         User = user;


### PR DESCRIPTION
On my system, Vaultwarden fails on boot with an AddrNotAvailable error, presumably because `services.vaultwarden.config.ROCKET_ADDRESS` is not available yet.

Here's an example of the startup error in journalctl:

```
Jul 26 21:56:48 banana vaultwarden[2514]: Error: Rocket.
Jul 26 21:56:48 banana vaultwarden[2514]: [CAUSE] Bind(
Jul 26 21:56:48 banana vaultwarden[2514]:     Os {
Jul 26 21:56:48 banana vaultwarden[2514]:         code: 99,
Jul 26 21:56:48 banana vaultwarden[2514]:         kind: AddrNotAvailable,
Jul 26 21:56:48 banana vaultwarden[2514]:         message: "Cannot assign requested address",
Jul 26 21:56:48 banana vaultwarden[2514]:     },
Jul 26 21:56:48 banana vaultwarden[2514]: )
```

According to systemd docs [1], `network.target` has little meaning during startup, but `network-online.target` actually waits until an IP address is available. The docs recommend putting `network-online.target` in both `After=` and `Wants=`.

[1]: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

----

I've tested this PR by cherry-picking onto nixos-unstable, rebuilding my system with `sudo nixos-rebuild switch -I nixpkgs=./` in the repo's root directory, and rebooting. Vaultwarden started without errors!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
