### PR TITLE
nixos/nebula: enable reloadable configuration

### DIFF
--- a/nixos/modules/services/networking/nebula.nix
+++ b/nixos/modules/services/networking/nebula.nix
@@ -60,6 +60,16 @@ in
                 example = "/etc/nebula/host.key";
               };
 
+              enableReload = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = ''
+                  Enable automatic config reload on config change.
+                  This setting is not enabled by default as nix cannot determine if the config change is reloadable.
+                  Please refer to the [config reference](https://nebula.defined.net/docs/config/) for documentation on reloadable changes.
+                '';
+              };
+
               staticHostMap = lib.mkOption {
                 type = lib.types.attrsOf (lib.types.listOf (lib.types.str));
                 default = { };
@@ -278,6 +288,8 @@ in
             ];
             before = [ "sshd.service" ];
             wantedBy = [ "multi-user.target" ];
+            restartTriggers = lib.optional (!netCfg.enableReload) configFile;
+            reloadTriggers = lib.optional netCfg.enableReload configFile;
             serviceConfig = {
               Type = "notify";
               Restart = "always";


### PR DESCRIPTION
Optional support for reloading instead of restarting. This also moves the config into /etc/nebula-config-${netName}.yml regardless of enableReload.

This succeeds #396898

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
