### PR TITLE
nixos/display-managers: tty1 everywhere

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -54,6 +54,8 @@
 
 - `go-mockery` has been updated to v3. For migration instructions see the [upstream documentation](https://vektra.github.io/mockery/latest/v3/). If v2 is still required `go-mockery_v2` has been added but will be removed on or before 2029-12-31 in-line with it's [upstream support lifecycle](https://vektra.github.io/mockery/
 
+- NixOS display manager modules now strictly use tty1, where many of them previously used tty7. Options to configure display managers' VT have been dropped. A configuration with a display manager enabled will not start `getty@tty1.service`, even if the system is forced to boot into `multi-user.target` instead of `graphical.target`.
+
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -526,9 +526,6 @@ rec {
           ln -s ${cfg.ctrlAltDelUnit} $out/ctrl-alt-del.target
           ln -s rescue.target $out/kbrequest.target
 
-          mkdir -p $out/getty.target.wants/
-          ln -s ../autovt@tty1.service $out/getty.target.wants/
-
           ln -s ../remote-fs.target $out/multi-user.target.wants/
         ''}
       ''; # */

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -267,12 +267,22 @@ in
       in
       lib.mkIf noDmUsed (lib.mkDefault false);
 
+    # We can't just rely on 'Conflicts=autovt@tty1.service' because
+    # 'switch-to-configuration switch' will start 'autovt@tty1.service'
+    # and kill us.
+    systemd.services."autovt@tty1".enable =
+      lib.mkIf config.systemd.services.display-manager.enable false;
+
     systemd.services.display-manager = {
       description = "Display Manager";
       after = [
         "acpid.service"
         "systemd-logind.service"
         "systemd-user-sessions.service"
+        "autovt@tty1.service"
+      ];
+      conflicts = [
+        "autovt@tty1.service"
       ];
       restartIfChanged = false;
 

--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -259,12 +259,10 @@ in
       "rc-local.service"
       "systemd-machined.service"
       "systemd-user-sessions.service"
-      "getty@tty${gdm.initialVT}.service"
       "plymouth-quit.service"
       "plymouth-start.service"
     ];
     systemd.services.display-manager.conflicts = [
-      "getty@tty${gdm.initialVT}.service"
       "plymouth-quit.service"
     ];
     systemd.services.display-manager.onFailure = [

--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -190,7 +190,6 @@ in
     users.groups.gdm.gid = config.ids.gids.gdm;
 
     # GDM needs different xserverArgs, presumable because using wayland by default.
-    services.xserver.tty = null;
     services.xserver.display = null;
     services.xserver.verbose = null;
 

--- a/nixos/modules/services/display-managers/greetd.nix
+++ b/nixos/modules/services/display-managers/greetd.nix
@@ -6,10 +6,18 @@
 }:
 let
   cfg = config.services.greetd;
-  tty = "tty${toString cfg.vt}";
+  tty = "tty1";
   settingsFormat = pkgs.formats.toml { };
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "services"
+      "greetd"
+      "vt"
+    ] "The VT is now fixed to VT1.")
+  ];
+
   options.services.greetd = {
     enable = lib.mkEnableOption "greetd, a minimal and flexible login manager daemon";
 
@@ -41,14 +49,6 @@ in
       '';
     };
 
-    vt = lib.mkOption {
-      type = lib.types.int;
-      default = 1;
-      description = ''
-        The virtual console (tty) that greetd should use. This option also disables getty on that tty.
-      '';
-    };
-
     restart = lib.mkOption {
       type = lib.types.bool;
       default = !(cfg.settings ? initial_session);
@@ -62,7 +62,7 @@ in
   };
   config = lib.mkIf cfg.enable {
 
-    services.greetd.settings.terminal.vt = lib.mkDefault cfg.vt;
+    services.greetd.settings.terminal.vt = 1;
     services.greetd.settings.default_session.user = lib.mkDefault "greeter";
 
     security.pam.services.greetd = {

--- a/nixos/modules/services/display-managers/lemurs.nix
+++ b/nixos/modules/services/display-managers/lemurs.nix
@@ -113,6 +113,8 @@ in
         TTYPath = "/dev/tty${toString cfg.vt}";
         TTYReset = "yes";
         TTYVHangup = "yes";
+        # Clear the console before starting
+        TTYVTDisallocate = true;
       };
       # Don't kill a user session when using nixos-rebuild
       restartIfChanged = false;

--- a/nixos/modules/services/display-managers/lemurs.nix
+++ b/nixos/modules/services/display-managers/lemurs.nix
@@ -9,6 +9,15 @@ let
   settingsFormat = pkgs.formats.toml { };
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "services"
+      "displayManager"
+      "lemurs"
+      "vt"
+    ] "The VT is now fixed to VT1.")
+  ];
+
   options.services.displayManager.lemurs = {
     enable = lib.mkEnableOption "" // {
       description = ''
@@ -34,14 +43,6 @@ in
         Configuration for lemurs, provided as a Nix attribute set and automatically
         serialized to TOML.
         See [lemurs configuration documentation](https://github.com/coastalwhite/lemurs/blob/main/extra/config.toml) for available options.
-      '';
-    };
-
-    vt = lib.mkOption {
-      type = lib.types.ints.positive;
-      default = 2;
-      description = ''
-        The virtual console (tty) that lemurs should use.
       '';
     };
   };
@@ -82,7 +83,7 @@ in
             desktops = config.services.displayManager.sessionData.desktops;
           in
           {
-            tty = lib.mkDefault cfg.vt;
+            tty = 1;
             system_shell = lib.mkDefault "${pkgs.bash}/bin/bash";
             initial_path = lib.mkDefault "/run/current-system/sw/bin";
             x11 = {
@@ -101,16 +102,14 @@ in
         Wants = [ "systemd-user-sessions.service" ];
         After = [
           "systemd-user-sessions.service"
-          "getty@tty${toString cfg.vt}.service"
           "plymouth-quit-wait.service"
         ];
-        Conflicts = [ "getty@tty${toString cfg.vt}.service" ];
       };
       serviceConfig = {
         Type = "idle";
         # Defaults from lemurs upstream configuration
         StandardInput = "tty";
-        TTYPath = "/dev/tty${toString cfg.vt}";
+        TTYPath = "/dev/tty1";
         TTYReset = "yes";
         TTYVHangup = "yes";
         # Clear the console before starting

--- a/nixos/modules/services/display-managers/lemurs.nix
+++ b/nixos/modules/services/display-managers/lemurs.nix
@@ -70,8 +70,7 @@ in
       # Required for wayland with setLoginUid = false;
       seatd.enable = true;
       xserver = {
-        # To enable user switching, allow lemurs to allocate TTYs/displays dynamically.
-        tty = null;
+        # To enable user switching, allow lemurs to allocate displays dynamically.
         display = null;
       };
       displayManager = {

--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -118,8 +118,7 @@ in
       };
 
       xserver = {
-        # To enable user switching, allow ly to allocate TTYs/displays dynamically.
-        tty = null;
+        # To enable user switching, allow ly to allocate displays dynamically.
         display = null;
       };
     };

--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -36,7 +36,6 @@ let
   defaultConfig = {
     shutdown_cmd = "/run/current-system/systemd/bin/systemctl poweroff";
     restart_cmd = "/run/current-system/systemd/bin/systemctl reboot";
-    tty = 2;
     service_name = "ly";
     path = "/run/current-system/sw/bin";
     term_reset_cmd = "${pkgs.ncurses}/bin/tput reset";
@@ -115,6 +114,10 @@ in
       displayManager = {
         enable = true;
         execCmd = "exec /run/current-system/sw/bin/ly";
+
+        # Set this here instead of 'defaultConfig' so users get eval
+        # errors when they change it.
+        ly.settings.tty = 1;
       };
 
       xserver = {
@@ -130,10 +133,7 @@ in
         after = [
           "systemd-user-sessions.service"
           "plymouth-quit-wait.service"
-          "getty@tty${toString finalConfig.tty}.service"
         ];
-
-        conflicts = [ "getty@tty7.service" ];
 
         serviceConfig = {
           Type = "idle";

--- a/nixos/modules/services/display-managers/sddm.nix
+++ b/nixos/modules/services/display-managers/sddm.nix
@@ -93,7 +93,6 @@ let
   }
   // optionalAttrs xcfg.enable {
     X11 = {
-      MinimumVT = if xcfg.tty != null then xcfg.tty else 7;
       ServerPath = toString xserverWrapper;
       XephyrPath = "${pkgs.xorg.xorgserver.out}/bin/Xephyr";
       SessionCommand = toString dmcfg.sessionData.wrapper;
@@ -419,8 +418,7 @@ in
     services = {
       dbus.packages = [ sddm ];
       xserver = {
-        # To enable user switching, allow sddm to allocate TTYs/displays dynamically.
-        tty = null;
+        # To enable user switching, allow sddm to allocate displays dynamically.
         display = null;
       };
     };

--- a/nixos/modules/services/display-managers/sddm.nix
+++ b/nixos/modules/services/display-managers/sddm.nix
@@ -430,12 +430,8 @@ in
       services.display-manager = {
         after = [
           "systemd-user-sessions.service"
-          "getty@tty7.service"
           "plymouth-quit.service"
           "systemd-logind.service"
-        ];
-        conflicts = [
-          "getty@tty7.service"
         ];
       };
     };

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -148,6 +148,8 @@ in
       "container-getty@.service"
     ];
 
+    systemd.targets.getty.wants = [ "autovt@tty1.service" ];
+
     systemd.services."getty@" = {
       serviceConfig.ExecStart = [
         # override upstream default with an empty ExecStart

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -336,7 +336,6 @@ in
     ];
 
     users.groups.lightdm.gid = config.ids.gids.lightdm;
-    services.xserver.tty = null; # We might start multiple X servers so let the tty increment themselves..
     services.xserver.display = null; # We specify our own display (and logfile) in xserver-wrapper up there
   };
 }

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -42,6 +42,7 @@ let
 
   lightdmConf = writeText "lightdm.conf" ''
     [LightDM]
+    minimum-vt = 1
     ${optionalString cfg.greeter.enable ''
       greeter-user = ${config.users.users.lightdm.name}
       greeters-directory = ${cfg.greeter.package}
@@ -234,19 +235,11 @@ in
       exec ${lightdm}/sbin/lightdm
     '';
 
-    # Replaces getty
-    systemd.services.display-manager.conflicts = [
-      "getty@tty7.service"
-      # TODO: Add "plymouth-quit.service" so LightDM can control when plymouth
-      # quits. Currently this breaks switching to configurations with plymouth.
-    ];
-
     # Pull in dependencies of services we replace.
     systemd.services.display-manager.after = [
       "rc-local.service"
       "systemd-machined.service"
       "systemd-user-sessions.service"
-      "getty@tty7.service"
       "user.slice"
     ];
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -277,6 +277,11 @@ in
         "dir"
       ];
     })
+    (lib.mkRemovedOptionModule [
+      "services"
+      "xserver"
+      "tty"
+    ] "'services.xserver.tty' was removed because it was ineffective.")
   ];
 
   ###### interface
@@ -675,12 +680,6 @@ in
         '';
       };
 
-      tty = mkOption {
-        type = types.nullOr types.int;
-        default = 7;
-        description = "Virtual console for the X server.";
-      };
-
       display = mkOption {
         type = types.nullOr types.int;
         default = 0;
@@ -886,7 +885,6 @@ in
       "${cfg.xkb.dir}"
     ]
     ++ optional (cfg.display != null) ":${toString cfg.display}"
-    ++ optional (cfg.tty != null) "vt${toString cfg.tty}"
     ++ optional (cfg.dpi != null) "-dpi ${toString cfg.dpi}"
     ++ optional (cfg.logFile != null) "-logfile ${toString cfg.logFile}"
     ++ optional (cfg.verbose != null) "-verbose ${toString cfg.verbose}"

--- a/nixos/tests/lemurs/lemurs.nix
+++ b/nixos/tests/lemurs/lemurs.nix
@@ -11,6 +11,8 @@
     ];
   };
 
+  enableOCR = true;
+
   nodes.machine = _: {
     imports = [ ../common/user-account.nix ];
     services.displayManager.lemurs.enable = true;
@@ -20,7 +22,7 @@
     machine.start()
 
     machine.wait_for_unit("multi-user.target")
-    machine.wait_until_succeeds("pgrep -f 'lemurs.*tty1'")
+    machine.wait_for_text("Login")
     machine.screenshot("postboot")
 
     with subtest("Log in as alice on a virtual console"):

--- a/pkgs/applications/display-managers/sddm/unwrapped.nix
+++ b/pkgs/applications/display-managers/sddm/unwrapped.nix
@@ -72,9 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DUID_MIN=1000"
     "-DUID_MAX=29999"
 
-    # we still want to run the DM on VT 7 for the time being, as 1-6 are
-    # occupied by getties by default
-    "-DSDDM_INITIAL_VT=7"
+    "-DSDDM_INITIAL_VT=1"
 
     "-DQT_IMPORTS_DIR=${placeholder "out"}/${qtbase.qtQmlPrefix}"
     "-DCMAKE_INSTALL_SYSCONFDIR=${placeholder "out"}/etc"

--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Dgdm-xsession=true"
     # TODO: Setup a default-path? https://gitlab.gnome.org/GNOME/gdm/-/blob/6fc40ac6aa37c8ad87c32f0b1a5d813d34bf7770/meson_options.txt#L6
-    "-Dinitial-vt=${finalAttrs.passthru.initialVT}"
+    "-Dinitial-vt=1"
     "-Dudev-dir=${placeholder "out"}/lib/udev/rules.d"
     "-Dsystemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
@@ -185,9 +185,6 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = gnome.updateScript { packageName = "gdm"; };
 
-    # Used in GDM NixOS module
-    # Don't remove.
-    initialVT = "7";
     dconfDb = "${finalAttrs.finalPackage}/share/gdm/greeter-dconf-defaults";
     dconfProfile = "user-db:user\nfile-db:${finalAttrs.passthru.dconfDb}";
 


### PR DESCRIPTION
VT1 is the upstream default for various display managers, including GDM and SDDM, and indeed most distros these days put their display managers there. VT7 was historically used because there was a single X server there and VTs 1-6 were reserved for static getty instances. Nowadays getty is launched dynamically on unused VTs via `logind`, and there is a separate X / Wayland server on a different VT per graphical session.

Remaining on VT7 is unaligned [with upstream expectations](https://0pointer.de/blog/projects/serial-console.html). For instance, `logind` does *not* dynamically start getty on `tty1` because the expectation is that the distro will decide whether a getty or a display manager will go there. VT7 has also caused at least one major bug in #309190 (which blocks enabling systemd initrd by default). It *probably* also harms any efforts for flicker-free boot.

The main reason we haven't done this already is because `switch-to-configuration switch|test` will see an inactive `autovt@tty1.service` unit and try to start it, which kills the display manager thanks to the `Conflicts=autovt@tty1.service` directive that would be used to prevent `autovt@tty1.service` starting in the first place. This PR does not resolve this problem with `switch-to-configuration`, and instead disables `autovt@tty1.service` altogether when a display manager is enabled. This has the drawback that there won't be a getty on `tty1` when the system boots into `multi-user.target` rather than `graphical.target`, but I think that's an acceptable tradeoff.

As is, this PR is written to *strictly* enforce VT1 for all display managers, and remove any configurability. Options were considered that allowed the initial VT to be configurable for all display managers that allow it, but it seems better to just align with upstream expectations and simplify.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
