### PR TITLE
s7: support MinGW build

### DIFF
--- a/pkgs/by-name/s7/s7/package.nix
+++ b/pkgs/by-name/s7/s7/package.nix
@@ -8,6 +8,7 @@
   libmpc,
   mpfr,
   notcurses,
+  windows,
 
   gsl,
   man,
@@ -15,6 +16,11 @@
 
   unstableGitUpdater,
   writeScript,
+
+  static ? false,
+  withGMP ? !static,
+  withArb ? !static,
+  withNrepl ? if stdenv.hostPlatform.isMinGW then false else true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,13 +35,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-n6Uattns9TxXRi1lz/adexa13nlYXSp0usTT9uZ47JY=";
   };
 
-  buildInputs = [
-    notcurses
-    gmp
-    mpfr
-    libmpc
-    flint3
-  ];
+  buildInputs =
+    lib.optional withArb flint3
+    ++ lib.optionals withGMP [
+      gmp
+      mpfr
+      libmpc
+    ]
+    ++ lib.optional withNrepl notcurses
+    ++ lib.optional stdenv.hostPlatform.isMinGW windows.mingw_w64_pthreads;
 
   # The following scripts are modified from [Guix's](https://packages.guix.gnu.org/packages/s7/).
 
@@ -43,45 +51,83 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace s7.c \
         --replace-fail libc_s7.so $out/lib/libc_s7.so
   '';
+  env.NIX_CFLAGS_COMPILE = toString (
+    [
+      "-I."
+      "-O2"
+    ]
+    ++ lib.optionals withGMP [
+      "-DWITH_GMP"
+    ]
+    ++ lib.optional static "-static"
+  );
+  env.NIX_LDFLAGS = toString (
+    [
+      "-lm"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux) [
+      "-ldl"
+      "--export-dynamic"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isMinGW) [
+      "-lpthread"
+      "--export-all-symbols"
+    ]
+    ++ lib.optional (!static && stdenv.hostPlatform.isMinGW) [ "--out-implib,libs7dll.a" ]
+    ++ lib.optional withArb "-lflint"
+    ++ lib.optionals withGMP [
+      "-lgmp"
+      "-lmpfr"
+      "-lmpc"
+    ]
+  );
 
   buildPhase = ''
     runHook preBuild
 
     # The older REPL
-    cc s7.c -o s7-repl \
-        -O2 -I. \
-        -Wl,-export-dynamic \
-        -lm -ldl \
+    $CC s7.c -o s7-repl \
         -DWITH_MAIN \
         -DS7_LOAD_PATH=\"$out/share/s7/scm\"
+
+    $CC s7.c -c -o s7.o
+
+    # Static library (Unix: .a, Windows: .a)
+    ${lib.optionalString static ''
+      $AR rcs libs7.a s7.o
+    ''}
+
+    # Dynamic library (Unix: .so, Windows: .dll)
+    ${lib.optionalString (!static && stdenv.hostPlatform.isLinux) ''
+      $CC s7.o -o libs7.so \
+        -shared -fPIC
+    ''}
+    ${lib.optionalString (!static && stdenv.hostPlatform.isMinGW) ''
+      $CC s7.o -o libs7.dll \
+        -shared
+    ''}
+
+    ${lib.optionalString withArb ''
+      $CC libarb_s7.c s7.o -o libarb_s7.so \
+          -shared -fPIC
+    ''}
 
     # The newer REPL powered by Notcurses
-    cc s7.c -o s7-nrepl \
-        -O2 -I. \
-        -Wl,-export-dynamic \
-        -lm -ldl \
-        -DWITH_MAIN \
-        -DWITH_NOTCURSES -lnotcurses-core \
-        -DS7_LOAD_PATH=\"$out/share/s7/scm\"
+    ${lib.optionalString withNrepl ''
+      $CC s7.c -o s7-nrepl \
+          -DWITH_MAIN \
+          -DWITH_NOTCURSES -lnotcurses-core \
+          -DS7_LOAD_PATH=\"$out/share/s7/scm\"
 
-    cc libarb_s7.c -o libarb_s7.so \
-        -O2 -I. \
-        -shared \
-        -lflint -lmpc \
-        -fPIC
+      $CC notcurses_s7.c -o libnotcurses_s7.so \
+          -Wno-error=implicit-function-declaration \
+          -lnotcurses-core \
+          -shared -fPIC
+    ''}
 
-    cc notcurses_s7.c -o libnotcurses_s7.so \
-        -O2 -I. \
-        -Wno-error=implicit-function-declaration \
-        -shared \
-        -lnotcurses-core \
-        -fPIC
-
-    cc s7.c -c -o s7.o \
-        -O2 -I. \
-        -ldl -lm
-
-    ./s7-repl libc.scm
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      ./s7-repl libc.scm
+    ''}
 
     runHook postBuild
   '';
@@ -97,9 +143,33 @@ stdenv.mkDerivation (finalAttrs: {
     dst_doc=$out/share/doc/s7
     mkdir -p $dst_bin $dst_lib $dst_inc $dst_share $dst_scm $dst_doc
 
-    mv -t $dst_bin s7-repl s7-nrepl
-    ln -s s7-nrepl $dst_bin/s7
-    mv -t $dst_lib libarb_s7.so libnotcurses_s7.so libc_s7.so
+    ${lib.optionalString static ''
+      mv -t $dst_lib libs7.a
+    ''}
+    ${lib.optionalString (!static && stdenv.hostPlatform.isLinux) ''
+      mv -t $dst_lib libs7.so
+    ''}
+    ${lib.optionalString (!static && stdenv.hostPlatform.isMinGW) ''
+      mv -t $dst_lib libs7.dll libs7dll.a
+    ''}
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      mv -t $dst_bin s7-repl
+      mv -t $dst_lib libc_s7.so
+    ''}
+    ${lib.optionalString stdenv.hostPlatform.isMinGW ''
+      mv -t $dst_bin s7-repl.exe
+    ''}
+
+    ${lib.optionalString withArb ''
+      mv -t $dst_lib libarb_s7.so
+    ''}
+    ${lib.optionalString withNrepl ''
+      mv -t $dst_bin s7-nrepl
+      ln -s s7-nrepl $dst_bin/s7
+      mv -t $dst_lib libnotcurses_s7.so
+    ''}
+
     cp -pr -t $dst_share s7.c
     cp -pr -t $dst_inc s7.h
     cp -pr -t $dst_scm *.scm
@@ -128,13 +198,18 @@ stdenv.mkDerivation (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    cc ffitest.c s7.o -o ffitest \
-        -I. \
-        -Wl,-export-dynamic \
-        -ldl -lm
+    $CC s7.c -c -o s7.o
+    $CC ffitest.c s7.o -o ffitest
     mv ffitest $dst_bin
     mkdir -p nix-build/home
     ln -sr . nix-build/home/cl
+
+    ${lib.optionalString withArb ''
+      substituteInPlace s7test.scm \
+          --replace-fail '(system "gcc -fPIC -c libarb_s7.c")' "" \
+          --replace-fail '(system "gcc libarb_s7.o -shared -o libarb_s7.so -lflint -larb")' ""
+      cp $out/lib/libarb_s7.so .
+    ''}
 
     USER=nix-s7-builder PATH="$dst_bin:$PATH" HOME=$PWD/nix-build/home \
         s7-repl s7test.scm
@@ -176,8 +251,11 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://ccrma.stanford.edu/software/s7/";
     license = lib.licenses.bsd0;
-    maintainers = with lib.maintainers; [ rc-zb ];
+    maintainers = with lib.maintainers; [
+      rc-zb
+      jinser
+    ];
     mainProgram = "s7";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.windows;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Support MinGW build for s7 scheme.

Added `static`, `withGMP`, `withArb` and `withNrepl` overridable arguments.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
