### PR TITLE
svt-av1: 3.0.2 -> 3.1.2

### DIFF
--- a/pkgs/by-name/sv/svt-av1/package.nix
+++ b/pkgs/by-name/sv/svt-av1/package.nix
@@ -2,11 +2,9 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  fetchpatch2,
   gitUpdater,
   cmake,
   nasm,
-  cpuinfo,
 
   # for passthru.tests
   ffmpeg,
@@ -14,31 +12,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "svt-av1";
-  version = "3.0.2";
+  version = "3.1.2";
 
   src = fetchFromGitLab {
     owner = "AOMediaCodec";
     repo = "SVT-AV1";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-WS9awjnJV0ok6ePlLcpHPAr2gsZjbZcdFSDEmyx7vwk=";
+    hash = "sha256-/CpcxdyC4qf9wdzzySMYw17FbjYpasT+QVykXSlx28U=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://gitlab.com/AOMediaCodec/SVT-AV1/-/commit/ec699561b51f3204e2df6d4c2578eea1f7bd52be.patch?full_index=1";
-      hash = "sha256-QVdvqWWT5tlNKBX9pQJwWgaOq+wNkYiBJTSeytRxrwo=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
   ]
   ++ lib.optionals stdenv.hostPlatform.isx86_64 [
     nasm
-  ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isx86_64 [
-    cpuinfo
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
Changes:
- https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases/v3.1.0
- https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases/v3.1.1
- https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases/v3.1.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
