### PR TITLE
ocamlPackages.ppx_deriving: propagate `ppxlib` dependency

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -47,12 +47,12 @@ buildDunePackage rec {
   nativeBuildInputs = [ cppo ];
   buildInputs = [
     findlib
-    ppxlib
   ];
   propagatedBuildInputs =
     lib.optional (lib.versionOlder version "5.2") ocaml-migrate-parsetree
     ++ [
       ppx_derivers
+      ppxlib
     ]
     ++ lib.optional (lib.versionOlder version "6.0") result;
 


### PR DESCRIPTION
this fixes an error when using `ppx_deriving` in a downstream project.

```
ocaml5.3.0-basil_lsp> File "/nix/store/x-ocaml5.3.0-ppx_deriving-6.0.3/lib/ocaml/5.3.0/site-lib/ppx_deriving/META", line 1, characters 0-0:
ocaml5.3.0-basil_lsp> Error: Library "ppxlib.ast" not found.
ocaml5.3.0-basil_lsp> -> required by library "ppx_deriving.show" in
ocaml5.3.0-basil_lsp>    /nix/store/x-ocaml5.3.0-ppx_deriving-6.0.3/lib/ocaml/5.3.0/site-lib/ppx_deriving/show
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
