### PR TITLE
wrangler: 4.22.0 -> 4.26.1 & use nix-update-script

### DIFF
--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -12,7 +12,7 @@
   xorg,
   jq,
   moreutils,
-  gitUpdater,
+  nix-update-script,
   versionCheckHook,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -41,7 +41,11 @@ stdenv.mkDerivation (finalAttrs: {
     jq 'del(.packageManager)' package.json | sponge package.json
   '';
 
-  passthru.updateScript = gitUpdater { rev-prefix = "wrangler@"; };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex=wrangler@(.*)"
+    ];
+  };
 
   buildInputs = [
     llvmPackages.libcxx

--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -17,13 +17,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wrangler";
-  version = "4.22.0";
+  version = "4.26.1";
 
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = "workers-sdk";
     rev = "wrangler@${finalAttrs.version}";
-    hash = "sha256-4uE1Jv70aDqAUk7GWmFr65SNXLnDDIZiFN87DQxluKg=";
+    hash = "sha256-7Z2MCG9YKwIkZ2eJucSgFr9R+rR+GFKiSXQX0xR5Xas=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
@@ -33,8 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       postPatch
       ;
-    fetcherVersion = 1;
-    hash = "sha256-r3QswmqP6CNufnsFM0KeKojm/HjHogrfYO/TdL3SrmA=";
+    fetcherVersion = 2;
+    hash = "sha256-Gsiq0+PIA3rJ0D9JryqaO0ThQcY+hC02AtzxdS+wSPg=";
   };
   # pnpm packageManager version in workers-sdk root package.json may not match nixpkgs
   postPatch = ''


### PR DESCRIPTION
Release notes:
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.23.0
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.24.0
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.24.1
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.24.2
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.24.3
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.24.4
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.25.0
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.25.1
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.26.0
- https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%404.26.1

gitUpdater won't update pnpmDeps so I've changed it to use nix-update-script.  It has been tested for the update from 4.26.0 to 4.26.1.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
