### PR TITLE
owl-lisp: Use dash for tests

### DIFF
--- a/pkgs/by-name/ow/owl-lisp/package.nix
+++ b/pkgs/by-name/ow/owl-lisp/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitLab,
   which,
+  dash,
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +17,17 @@ stdenv.mkDerivation rec {
     hash = "sha256-GfvOkYLo8fgAvGuUa59hDy+sWJSwyntwqMO8TAK/lUo=";
   };
 
-  nativeBuildInputs = [ which ];
+  nativeBuildInputs = [
+    which
+    dash
+  ];
+
+  # Tests fail with bash, replacing with dash seems to work around it
+  # FIXME: Why?
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail 'sh tests/run' 'dash tests/run'
+  '';
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"


### PR DESCRIPTION
On aarch64-linux the test fail to terminate, with bash printing a message like this over and over again:

tests/run: line 63: wait: pid 105 is not a child of this shell

Running in GDB reveals that the is stuck in an infinite loop in wait_for_background_pids waiting for a child that is no longer there, suggesting that it's a bug in Bash.

Work around it for now by running tests in DASH instead.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
