### PR TITLE
cargo-valgrind: add rustc-1.88 suppressions

### DIFF
--- a/pkgs/by-name/ca/cargo-valgrind/package.nix
+++ b/pkgs/by-name/ca/cargo-valgrind/package.nix
@@ -32,11 +32,13 @@ rustPlatform.buildRustPackage rec {
     wrapProgram $out/bin/cargo-valgrind --prefix PATH : ${lib.makeBinPath [ valgrind ]}
   '';
 
-  checkFlags = [
-    "--skip tests_are_runnable"
-    "--skip default_cargo_project_reports_no_violations"
-    "--skip empty_tests_not_leak_in_release_mode"
-  ];
+  # Valgrind detects a memory leak in the std library of rustc 1.88 in nixos,
+  # but not in the version available via rustup
+  # (https://github.com/NixOS/nixpkgs/issues/428375#issuecomment-3125921626).
+  # This suppresses reporting this leak.
+  postPatch = ''
+    cp ${./suppressions-rust-1.88} suppressions/rust-1.88
+  '';
 
   meta = with lib; {
     description = ''Cargo subcommand "valgrind": runs valgrind and collects its output in a helpful manner'';

--- a/pkgs/by-name/ca/cargo-valgrind/suppressions-rust-1.88
+++ b/pkgs/by-name/ca/cargo-valgrind/suppressions-rust-1.88
@@ -1,0 +1,11 @@
+{
+   Rust 1.88 standard library (NixOS)
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_ZN3std6thread7current12init_current*.llvm.*
+   fun:_ZN3std4sync4mpmc7context7Context3new*
+   fun:_ZN3std3sys12thread_local6native4lazy20Storage$LT$T$C$D$GT$10initialize*
+   fun:_ZN3std4sync4mpmc4list16Channel$LT$T$GT$4recv*
+   fun:_ZN3std4sync4mpmc17Receiver$LT$T$GT$12recv_timeout*
+}


### PR DESCRIPTION
Closes #428375
Replaces #428634

As detailed in https://github.com/NixOS/nixpkgs/issues/428375#issuecomment-3125921626, the issue reported in #428375 only appears with the NixOS/nixpkgs `rustc` version, and not with the version available via `rustup`.
Furthermore the issue isn't properly fixed by #428634, by simply ignoring the test while building, as the issue persists in actual usage.
This PR does two things:
- Removes skipped tests to properly test the functionality of `cargo-valgrind`
- Adds suppressions only necessary with the NixOS version of `rustc 1.88`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
