### PR TITLE
bar-rs: init at unstable-2025-11-19

### DIFF
--- a/pkgs/by-name/ba/bar-rs/package.nix
+++ b/pkgs/by-name/ba/bar-rs/package.nix
@@ -1,0 +1,59 @@
+{
+  coreutils,
+  dbus,
+  fetchFromGitHub,
+  lib,
+  libudev-zero,
+  libxkbcommon,
+  makeWrapper,
+  openssl,
+  pkg-config,
+  pulseaudio,
+  rustPlatform,
+  wayland,
+  wireplumber,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "bar-rs";
+  version = "0-unstable-2025-11-19";
+
+  src = fetchFromGitHub {
+    owner = "faervan";
+    repo = "bar-rs";
+    rev = "497e797860b6047f5ef04fac52fd89f34f5d0b6a";
+    hash = "sha256-7E/sRl7qeuuHc6F0UJ1P7C6s52v7sQTHi5C30T0o8Jc=";
+  };
+
+  cargoHash = "sha256-ll1EfZnW2+KeK8TCyn+LrLCUQCP5A0hEhhRN7b+nc8E=";
+
+  nativeBuildInputs = [
+    coreutils
+    makeWrapper
+    pkg-config
+    pulseaudio
+    wireplumber
+  ];
+
+  buildInputs = [
+    dbus
+    libudev-zero
+    libxkbcommon
+    openssl
+    pkg-config
+    wayland
+  ];
+
+  postFixup = ''
+    wrapProgram "$out/bin/bar-rs" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}"
+  '';
+
+  meta = {
+    description = "Status bar for hyprland, niri and wayfire, written in rust using iced-rs";
+    homepage = "https://github.com/faervan/bar-rs";
+    license = lib.licenses.gpl3;
+    mainProgram = "bar-rs";
+    maintainers = with lib.maintainers; [ yanganto ];
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [X] Manually test and daily in use with niri
  
<img width="600" height="20" style="padding-left: 200;" alt="bar-rs" src="https://github.com/user-attachments/assets/b6a73a1c-b766-494c-abeb-6c73f42ffb15" />

- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
