### PR TITLE
nixos/networkmanager: add `with pkgs; ` to example plugins

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -238,7 +238,7 @@ in
           types.listOf networkManagerPluginPackage;
         default = [ ];
         example = literalExpression ''
-          [
+          with pkgs; [
             networkmanager-fortisslvpn
             networkmanager-iodine
             networkmanager-l2tp


### PR DESCRIPTION
Just added a tiny `with pkgs; ` to the networking.networkmanager.plugins example to make a bit easier to understand. Similar to how the `with pkgs; ` is part of basically all other examples like https://github.com/NixOS/nixpkgs/blob/76efb9f313b326ed24dfae33ff0496a6df370e5a/nixos/modules/services/printing/cupsd.nix#L337 