### PR TITLE
probe-rs-udev-rules: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27417,6 +27417,12 @@
     github = "wuyoli";
     githubId = 104238274;
   };
+  wvhulle = {
+    email = "willemvanhulle@protonmail.com";
+    github = "wvhulle";
+    githubId = 7688680;
+    name = "Willem Vanhulle";
+  };
   wykurz = {
     email = "wykurz@gmail.com";
     github = "wykurz";

--- a/pkgs/by-name/pr/probe-rs-tools/package.nix
+++ b/pkgs/by-name/pr/probe-rs-tools/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   libusb1,
   openssl,
+  probe-rs-udev-rules,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -33,6 +34,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     libusb1
     openssl
+    probe-rs-udev-rules
   ];
 
   checkFlags = [

--- a/pkgs/by-name/pr/probe-rs-udev-rules/package.nix
+++ b/pkgs/by-name/pr/probe-rs-udev-rules/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  udevCheckHook,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "probe-rs-udev-rules";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://probe.rs/files/69-probe-rs.rules";
+    hash = "sha256-yjxld5ebm2jpfyzkw+vngBfHu5Nfh2ioLUKQQDY4KYo=";
+  };
+
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontUnpack = true;
+  doInstallCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 644 $src $out/lib/udev/rules.d/69-probe-rs.rules
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Udev rules for probe-rs debugging probes";
+    longDescription = ''
+      This package provides official udev rules for debugging probes used with
+      probe-rs, including ST-LINK, SEGGER J-Link, FTDI-based devices,
+      Espressif USB JTAG, CMSIS-DAP compatible adapters, and WCH Link adapters.
+
+      The rules use TAG+="uaccess" to grant access to locally logged-in users
+      via systemd-logind, eliminating the need for manual group configuration.
+    '';
+    homepage = "https://probe.rs/docs/getting-started/probe-setup/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wvhulle ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds udev rules for debugging probes used with probe-rs, including ST-LINK, SEGGER J-Link, FTDI-based devices, Espressif USB JTAG, CMSIS-DAP compatible adapters, and WCH Link adapters.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - N/A (Linux-only package)
- [x] Tested, as applicable:
  - [x] Built and tested with `nix-build -A probe-rs-udev-rules`
  - [x] udev rules validation passes with `udevCheckHook`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
  - N/A (new package, no dependents)
- [x] Tested basic functionality of the resulting program
- [x] Added myself as package maintainer 
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)

## Technical details

- Fetches official udev rules directly from upstream (https://probe.rs/files/69-probe-rs.rules)
- Uses modern `TAG+="uaccess"` for systemd-logind based access control
- Includes `udevCheckHook` for build-time rule validation
- Properly licensed under GPL-2.0+ per upstream

This eliminates the need for users to manually configure group membership, as `TAG+="uaccess"` automatically grants access to locally logged-in users via systemd-logind.