### PR TITLE
python3Packages.arro3-core: init at 0.5.1

### DIFF
--- a/pkgs/development/python-modules/arro3-core/default.nix
+++ b/pkgs/development/python-modules/arro3-core/default.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  geoarrow-types,
+  pyarrow,
+  numpy,
+  pandas,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "arro3-core";
+  version = "0.5.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "kylebarron";
+    repo = "arro3";
+    tag = "py-v${version}";
+    hash = "sha256-RTr+mf5slfxxvXp9cwPuy08AZUswPtIIRz+vngdg/k0=";
+  };
+
+  sourceRoot = "${src.name}/arro3-core";
+
+  cargoRoot = "..";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit version src;
+    pname = "${pname}-vendor";
+    hash = "sha256-YQA8Z86Ul8yAHncMgYrGmNe10KSpubHjaokCjaqTAxo=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  env = {
+    CARGO_TARGET_DIR = "./target";
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    geoarrow-types
+    pandas
+    pyarrow
+    numpy
+  ];
+
+  enabledTestPaths = [
+    "../tests/core"
+  ];
+
+  disabledTestPaths = [
+    # arro3-compute dependency has not been packaged
+    "../tests/core/test_buffer_protocol.py"
+  ];
+
+  pythonImportsCheck = [ "arro3.core" ];
+
+  meta = {
+    description = "Minimal Python library for Apache Arrow, connecting to the Rust arrow crate";
+    homepage = "https://github.com/kylebarron/arro3";
+    changelog = "https://github.com/kylebarron/arro3/releases/tag/py-v${version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.mslingsby ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -899,6 +899,8 @@ self: super: with self; {
 
   arris-tg2492lg = callPackage ../development/python-modules/arris-tg2492lg { };
 
+  arro3-core = callPackage ../development/python-modules/arro3-core { };
+
   arrow = callPackage ../development/python-modules/arrow { };
 
   arsenic = callPackage ../development/python-modules/arsenic { };


### PR DESCRIPTION
A minimal Python library for Apache Arrow, connecting to the Rust arrow crate. The source repo contains 3 subpackages, which are built indivicually. This PR packages only arro3-core.

Required as dependency of the [deltalake pkg](https://github.com/NixOS/nixpkgs/blob/nixos-25.05/pkgs/development/python-modules/deltalake/default.nix) in v1.x.x.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
