### PR TITLE
home-assistant: 2025.7.3 -> 2025.7.4

### DIFF
--- a/pkgs/development/python-modules/aioamazondevices/default.nix
+++ b/pkgs/development/python-modules/aioamazondevices/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "aioamazondevices";
-  version = "3.5.0";
+  version = "3.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "chemelli74";
     repo = "aioamazondevices";
     tag = "v${version}";
-    hash = "sha256-gFO0E5tphInHOTAgaifp+jNQQvs+HfLDhvErmLwwrPU=";
+    hash = "sha256-CVwpu0TW6ah7Stx2GhQgw9EkmHJ6rRB7DN416EatUMo=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/habiticalib/default.nix
+++ b/pkgs/development/python-modules/habiticalib/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "habiticalib";
-  version = "0.4.0";
+  version = "0.4.1";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "tr4nt0r";
     repo = "habiticalib";
     tag = "v${version}";
-    hash = "sha256-RYtTJavfw5gQTo0m/Dgkv/6ghv+T5SSaaweiI370OOA=";
+    hash = "sha256-RHR7kXZkzv7wZ0napAT7Ukb4tJ2TiwmeZHiw20YpNkM=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/pyschlage/default.nix
+++ b/pkgs/development/python-modules/pyschlage/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pyschlage";
-  version = "2025.7.0";
+  version = "2025.7.3";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "dknowles2";
     repo = "pyschlage";
     tag = version;
-    hash = "sha256-XfYoui3xo8l3wi8nqvyzfYhsHsY8T1t/iYS4ZHNjGUE=";
+    hash = "sha256-6IY+rCz/tMaj+c2ME8g9KzdYcakW2rcgM9DFHJSF3Jc=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/pysuezv2/default.nix
+++ b/pkgs/development/python-modules/pysuezv2/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "pysuezv2";
-  version = "2.0.5";
+  version = "2.0.7";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "jb101010-2";
     repo = "pySuez";
     tag = version;
-    hash = "sha256-U5INSk3tcEgDJyRx17YaSDjPWgNwGeHIs2VB87E0l44=";
+    hash = "sha256-nPRHpT5j/AAxhCJen4mFzoyUWi/+0hIWK2dnpfhP/Gk=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.7.3";
+  version = "2025.7.4";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -354,7 +354,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.7.3";
+  hassVersion = "2025.7.4";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -375,13 +375,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-FT77obtb081QOgw+nqbQvvW+3x/L2WUr3DLT8X1Wpwg=";
+    hash = "sha256-2seMh1trP3PYnuQmWadTAiAPaI+v45+uzn9xkgUuGNE=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-jO+rNIzEvtQ1vhSD1Xbq/SKV5XvBOb4MmkkczoeD1Kc=";
+    hash = "sha256-KwiwgQ8gAMlHLzpuYYdcLXabVrukhnfFlaODyFpuF88=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.262";
+  version = "0.13.263";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     rev = "refs/tags/${version}";
-    hash = "sha256-dlGZD9JNEMGaDpH4RiX1LJtx2owdRJvJX+V2b5QzD7U=";
+    hash = "sha256-JqWe/tNYnNkFNx3D6E3X2TMyNwmfgoK2fkejX3f9NL8=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.7.3";
+  version = "2025.7.4";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-iHNBFtdIQMAKiQGJ35xCBqDbYYphoAJPXjhmgIEEE5E=";
+    hash = "sha256-boOhdro11wbLHWVuJHHSuov8qxSiOCuaS8yfJgIRyJk=";
   };
 
   build-system = [


### PR DESCRIPTION

    https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/blob/refs/tags/0.13.263/CHANGELOG.md
    https://github.com/KapJI/homeassistant-stubs/releases/tag/2025.7.4
    https://github.com/home-assistant/core/releases/tag/2025.7.4
    https://github.com/jb101010-2/pySuez/releases/tag/2.0.7
    https://github.com/dknowles2/pyschlage/releases/tag/2025.7.3
    https://github.com/tr4nt0r/habiticalib/releases/tag/v0.4.1
    https://github.com/chemelli74/aioamazondevices/blob/v3.6.0/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
