### PR TITLE
journald-notify-nu: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26951,6 +26951,12 @@
     githubId = 93639059;
     name = "wattmto";
   };
+  wvhulle = {
+    email = "wvanhulle@gmail.com";
+    github = "wvhulle";
+    githubId = 7688680;
+    name = "William Van Hulle";
+  };
   waynr = {
     name = "Wayne Warren";
     email = "wayne.warren.s@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27418,10 +27418,10 @@
     githubId = 104238274;
   };
   wvhulle = {
-    email = "wvanhulle@gmail.com";
+    email = "willemvanhulle@protonmail.com";
     github = "wvhulle";
     githubId = 7688680;
-    name = "William Van Hulle";
+    name = "Willem Vanhulle";
   };
   wykurz = {
     email = "wykurz@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26951,12 +26951,6 @@
     githubId = 93639059;
     name = "wattmto";
   };
-  wvhulle = {
-    email = "wvanhulle@gmail.com";
-    github = "wvhulle";
-    githubId = 7688680;
-    name = "William Van Hulle";
-  };
   waynr = {
     name = "Wayne Warren";
     email = "wayne.warren.s@gmail.com";
@@ -27422,6 +27416,12 @@
     email = "wuyoli@tilde.team";
     github = "wuyoli";
     githubId = 104238274;
+  };
+  wvhulle = {
+    email = "wvanhulle@gmail.com";
+    github = "wvhulle";
+    githubId = 7688680;
+    name = "William Van Hulle";
   };
   wykurz = {
     email = "wykurz@gmail.com";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -711,6 +711,7 @@
   ./services/logging/graylog.nix
   ./services/logging/heartbeat.nix
   ./services/logging/journalbeat.nix
+  ./services/logging/journald-notify-nu.nix
   ./services/logging/journaldriver.nix
   ./services/logging/journalwatch.nix
   ./services/logging/klogd.nix

--- a/nixos/modules/services/logging/journald-notify-nu.nix
+++ b/nixos/modules/services/logging/journald-notify-nu.nix
@@ -1,10 +1,16 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 
 let
   cfg = config.services.journald-notify-nu;
-in {
+in
+{
   options.services.journald-notify-nu = {
     enable = mkEnableOption "journald-notify-nu service for converting systemd journal entries to desktop notifications";
 
@@ -29,7 +35,10 @@ in {
       example = {
         filters = {
           priority = "warning";
-          units = [ "sshd.service" "systemd-logind.service" ];
+          units = [
+            "sshd.service"
+            "systemd-logind.service"
+          ];
         };
       };
     };
@@ -57,7 +66,7 @@ in {
         ExecStart = "${cfg.package}/bin/journald-notify-nu";
         Restart = "always";
         RestartSec = 5;
-        
+
         # Security settings
         NoNewPrivileges = true;
         PrivateTmp = true;
@@ -69,14 +78,15 @@ in {
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
         RemoveIPC = true;
-        
+
         # Journal access
         SupplementaryGroups = [ "systemd-journal" ];
       };
 
       environment = {
         # Pass configuration as environment variables if needed
-      } // (optionalAttrs (cfg.settings != { }) {
+      }
+      // (optionalAttrs (cfg.settings != { }) {
         JOURNALD_NOTIFY_CONFIG = builtins.toJSON cfg.settings;
       });
     };

--- a/pkgs/by-name/jo/journald-notify-nu/nixos-module.nix
+++ b/pkgs/by-name/jo/journald-notify-nu/nixos-module.nix
@@ -1,0 +1,84 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.journald-notify-nu;
+in {
+  options.services.journald-notify-nu = {
+    enable = mkEnableOption "journald-notify-nu service for converting systemd journal entries to desktop notifications";
+
+    package = mkPackageOption pkgs "journald-notify-nu" { };
+
+    user = mkOption {
+      type = types.str;
+      default = "journald-notify";
+      description = "User account under which journald-notify-nu runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "journald-notify";
+      description = "Group under which journald-notify-nu runs.";
+    };
+
+    settings = mkOption {
+      type = types.attrs;
+      default = { };
+      description = "Configuration for journald-notify-nu.";
+      example = {
+        filters = {
+          priority = "warning";
+          units = [ "sshd.service" "systemd-logind.service" ];
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      group = cfg.group;
+      isSystemUser = true;
+      description = "journald-notify-nu service user";
+    };
+
+    users.groups.${cfg.group} = { };
+
+    systemd.services.journald-notify-nu = {
+      description = "Journal to desktop notification service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "systemd-journald.service" ];
+      requires = [ "systemd-journald.service" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${cfg.package}/bin/journald-notify-nu";
+        Restart = "always";
+        RestartSec = 5;
+        
+        # Security settings
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        
+        # Journal access
+        SupplementaryGroups = [ "systemd-journal" ];
+      };
+
+      environment = {
+        # Pass configuration as environment variables if needed
+      } // (optionalAttrs (cfg.settings != { }) {
+        JOURNALD_NOTIFY_CONFIG = builtins.toJSON cfg.settings;
+      });
+    };
+  };
+}

--- a/pkgs/by-name/jo/journald-notify-nu/package.nix
+++ b/pkgs/by-name/jo/journald-notify-nu/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nushell,
+  makeWrapper,
+  libnotify,
+  systemd,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "journald-notify-nu";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "wvhulle";
+    repo = "journald-notify-nu";
+    rev = "6d8356a040c4406caf253925fc0cc24e82af0963";
+    hash = "sha256-aUn5nnPZq06Q11MxUsGw6076vGDmIW2PPMf9u1x+F8s=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = [ nushell ];
+
+  buildInputs = [
+    libnotify
+    systemd
+  ];
+
+  installPhase = ''
+        runHook preInstall
+
+        # Install the nushell module
+        mkdir -p $out/share/journald-notify-nu
+        cp mod.nu $out/share/journald-notify-nu/
+
+        # Install NixOS module
+        mkdir -p $out/share/nixos/modules
+        cp ${./nixos-module.nix} $out/share/nixos/modules/journald-notify-nu.nix
+
+        # Create wrapper scripts for command-line usage
+        mkdir -p $out/bin
+
+        # Main monitoring script
+        cat > $out/bin/journald-notify-nu << EOF
+    #!/usr/bin/env bash
+    exec ${nushell}/bin/nu -c "use $out/share/journald-notify-nu/mod.nu; mod main"
+    EOF
+        chmod +x $out/bin/journald-notify-nu
+
+        # Custom monitoring script
+        cat > $out/bin/journald-notify-monitor << EOF
+    #!/usr/bin/env bash
+    exec ${nushell}/bin/nu -c "use $out/share/journald-notify-nu/mod.nu; mod start-monitoring \$1"
+    EOF
+        chmod +x $out/bin/journald-notify-monitor
+
+        # Test notification script
+        cat > $out/bin/journald-notify-test << EOF
+    #!/usr/bin/env bash
+    exec ${nushell}/bin/nu -c "use $out/share/journald-notify-nu/mod.nu; mod test-notification"
+    EOF
+        chmod +x $out/bin/journald-notify-test
+
+        runHook postInstall
+  '';
+
+  passthru = {
+    nixosModules.journald-notify-nu = import "${placeholder "out"}/share/nixos/modules/journald-notify-nu.nix";
+  };
+
+  meta = {
+    description = "A nushell package for converting systemd journal entries to desktop notifications";
+    homepage = "https://github.com/wvhulle/journald-notify-nu";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.wvhulle ];
+    platforms = lib.platforms.linux;
+    mainProgram = "journald-notify-nu";
+  };
+}


### PR DESCRIPTION
Add `journald-notify-nu`: A Nushell package for converting systemd journal entries to desktop notifications.

This package monitors the systemd journal and sends desktop notifications for important log entries. It includes a NixOS module for running as a systemd service with proper security hardening.

## Features
- Monitor systemd journal entries and convert them to desktop notifications
- Multiple wrapper scripts for different use cases
- Includes NixOS module for running as a systemd service
- Configurable filtering and notification settings

## NixOS Integration
The package includes a NixOS module that can be enabled with:
```nix
services.journald-notify-nu.enable = true;
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc