### PR TITLE
open-vm-tools: fix dlopen path to libguestStoreClient.so.0, fix vm-support script

### DIFF
--- a/pkgs/by-name/op/open-vm-tools/package.nix
+++ b/pkgs/by-name/op/open-vm-tools/package.nix
@@ -137,6 +137,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace lib/guestStoreClientHelper/guestStoreClient.c \
       --replace-fail "libguestStoreClient.so.0" "$out/lib/libguestStoreClient.so.0"
+
+    substituteInPlace udev/99-vmware-scsi-udev.rules \
+      --replace-fail "/bin/sh" "${bash}/bin/sh"
   '';
 
   configureFlags = [
@@ -164,7 +167,7 @@ stdenv.mkDerivation (finalAttrs: {
           which
         ]
       }"
-    substituteInPlace "$out/lib/udev/rules.d/99-vmware-scsi-udev.rules" --replace-fail "/bin/sh" "${bash}/bin/sh"
+
   '';
 
   meta = {

--- a/pkgs/by-name/op/open-vm-tools/package.nix
+++ b/pkgs/by-name/op/open-vm-tools/package.nix
@@ -134,6 +134,9 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace services/plugins/vix/foundryToolsDaemon.c \
      --replace-fail "/usr/bin/vmhgfs-fuse" "${placeholder "out"}/bin/vmhgfs-fuse" \
      --replace-fail "/bin/mount" "${util-linux}/bin/mount"
+
+    substituteInPlace lib/guestStoreClientHelper/guestStoreClient.c \
+      --replace-fail "libguestStoreClient.so.0" "$out/lib/libguestStoreClient.so.0"
   '';
 
   configureFlags = [


### PR DESCRIPTION
see commits

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
