### PR TITLE
anarch-re: init at z2

### DIFF
--- a/pkgs/by-name/an/anarch-re/package.nix
+++ b/pkgs/by-name/an/anarch-re/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromSourcehut,
+  sdl3,
+  pkg-config,
+  buildPackages,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "anarch-re";
+  version = "2";
+
+  src = fetchFromSourcehut {
+    owner = "~marcin-serwin";
+    repo = "anarch-re";
+    rev = "z${finalAttrs.version}";
+    hash = "sha256-k8zCLhcynVStaql4eGl0HFrLwF0WWfz4Prxn3x5Exxk=";
+  };
+
+  strictDeps = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    sdl3
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  dontConfigure = true;
+
+  makeFlags = [
+    "EXE=${stdenv.hostPlatform.extensions.executable}"
+    "PREFIX=${placeholder "out"}"
+    "HOSTCC=$(CC_FOR_BUILD)"
+    "VERSION_NUMBER=${finalAttrs.version}" # TODO: Remove when updating to z3
+    "VERSION_SUFFIX=-nixpkgs"
+    "CFLAGS=-O3"
+  ];
+
+  doCheck = true;
+  doInstallCheck = true;
+
+  meta = {
+    homepage = "https://git.sr.ht/~marcin-serwin/anarch-re";
+    description = "Public domain from-scratch suckless Doom clone";
+    maintainers = with lib.maintainers; [
+      dvn0
+      marcin-serwin
+    ];
+    license = lib.licenses.cc0;
+    platforms = lib.platforms.all;
+    mainProgram = "anarch-re";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds [anarch-re](https://git.sr.ht/~marcin-serwin/anarch-re), a fork of the "suckless FPS" [anarch](https://git.coom.tech/drummyfish/Anarch), adding an SDL3 frontend. The original is [already in](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/an/anarch/package.nix) nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
