### PR TITLE
python3Packages.smolagents: temporary fix for transformers compat

### DIFF
--- a/pkgs/development/python-modules/smolagents/default.nix
+++ b/pkgs/development/python-modules/smolagents/default.nix
@@ -62,6 +62,15 @@ buildPythonPackage rec {
     hash = "sha256-ING+C2MACKFto+1FON5OGFgzLf8SM99ViTdADzNzQLw=";
   };
 
+  # TODO: remove at the next release
+  # ImportError: cannot import name 'require_soundfile' from 'transformers.testing_utils'
+  # Caused by: https://github.com/huggingface/transformers/commit/1ecd52e50a31e7c344c32564e0484d7e9a0f2256
+  # Fixed in: https://github.com/huggingface/smolagents/pull/1625
+  postPatch = ''
+    substituteInPlace tests/test_types.py \
+      --replace-fail "require_soundfile" "require_torchcodec"
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/txtai/default.nix
+++ b/pkgs/development/python-modules/txtai/default.nix
@@ -224,6 +224,7 @@ let
       graph
       model
       pipeline-audio
+      pipeline-data
       pipeline-image
       pipeline-llm
       pipeline-text
@@ -289,26 +290,8 @@ buildPythonPackage {
   ++ optional-dependencies.api
   ++ optional-dependencies.similarity;
 
-  enabledTestPaths = [
-    "test/python/test*.py"
-  ];
-
-  # The deselected paths depend on the huggingface hub and should be run as a passthru test
-  # disabledTestPaths won't work as the problem is with the classes containing the tests
-  # (in other words, it fails on __init__)
-  disabledTestPaths = [
-    "test/python/testagent.py"
-    "test/python/testcloud.py"
-    "test/python/testconsole.py"
-    "test/python/testembeddings.py"
-    "test/python/testgraph.py"
-    "test/python/testapi/testapiembeddings.py"
-    "test/python/testapi/testapipipelines.py"
-    "test/python/testapi/testapiworkflow.py"
-    "test/python/testdatabase/testclient.py"
-    "test/python/testdatabase/testduckdb.py"
-    "test/python/testdatabase/testencoder.py"
-    "test/python/testworkflow.py"
+  pytestFlagsArray = [
+    "test/python/*"
   ];
 
   disabledTests = [
@@ -316,6 +299,12 @@ buildPythonPackage {
     "testInvalidTar"
     "testInvalidZip"
     # Downloads from Huggingface
+    "TestAgent"
+    "TestCloud"
+    "TestConsole"
+    "TestEmbeddings"
+    "TestGraph"
+    "TestWorkflow"
     "testPipeline"
     "testVectors"
     # Not finding sqlite-vec despite being supplied


### PR DESCRIPTION
## Things done

Broken since #428429.
This path will not be needed when the next release is out: https://github.com/huggingface/smolagents/pull/1625

cc @fabaff

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
