### PR TITLE
Dedup bcachefs filesystems before unlocking

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -232,6 +232,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `services.slurm` now supports slurmrestd usage through the `services.slurm.rest` NixOS options.
 
+- Encrypted bcachefs filesystem now prompts for a password only once during boot, even if mounted at multiple points.
+
 - The `services.calibre-web` systemd service has been hardened with additional sandboxing restrictions.
 
 - `services.kanidm` options for server, client and unix were moved under dedicated namespaces.

--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -89,6 +89,25 @@ let
         tryUnlock ${name} ${firstDevice fs}
       '';
 
+  groupByDevice = builtins.groupBy (fileSystem: fileSystem.value.device);
+
+  nameGrouped = lib.mapAttrs (
+    name: value: builtins.concatStringsSep "," (builtins.map (fileSystem: fileSystem.name) value)
+  );
+
+  reverseAttrs =
+    attrs:
+    builtins.foldl' (acc: x: acc // x) { } (
+      lib.mapAttrsToList (name: value: {
+        "${value}" = {
+          device = name;
+        };
+      }) attrs
+    );
+
+  dedupDevices =
+    fileSystems: reverseAttrs (nameGrouped (groupByDevice (lib.attrsToList fileSystems)));
+
   mkUnits =
     prefix: name: fs:
     let
@@ -282,7 +301,7 @@ in
         '';
 
         boot.initrd.postDeviceCommands = lib.mkIf (!config.boot.initrd.systemd.enable) (
-          commonFunctions + lib.concatStrings (lib.mapAttrsToList openCommand bootFs)
+          commonFunctions + lib.concatStrings (lib.mapAttrsToList openCommand (dedupDevices bootFs))
         );
 
         boot.initrd.systemd.services = lib.mapAttrs' (mkUnits "/sysroot") bootFs;


### PR DESCRIPTION
I have /, /nix, and /home on the same device, each mounted from a separate subvolume. Previously, I had to enter my password three times during boot, once for each mountpoint. This patch deduplicates bcachefs unlocks by grouping devices, so the password only needs to be entered once per device.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
