### PR TITLE
ripasso-cursive: switch to `finalAttrs` pattern

### DIFF
--- a/pkgs/by-name/ri/ripasso-cursive/package.nix
+++ b/pkgs/by-name/ri/ripasso-cursive/package.nix
@@ -19,14 +19,14 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.0";
   pname = "ripasso-cursive";
 
   src = fetchFromGitHub {
     owner = "cortex";
     repo = "ripasso";
-    tag = "release-${version}";
+    tag = "release-${finalAttrs.version}";
     hash = "sha256-j98X/+UTea4lCtFfMpClnfcKlvxm4DpOujLc0xc3VUY=";
   };
 
@@ -81,4 +81,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ sgo ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ri/ripasso-cursive/package.nix
+++ b/pkgs/by-name/ri/ripasso-cursive/package.nix
@@ -9,6 +9,7 @@
   installShellFiles,
   pkg-config,
   python3,
+  writableTmpDirAsHomeHook,
 
   # buildInputs
   libgpg-error,
@@ -44,6 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pkg-config
     python3
     rustPlatform.bindgenHook
+    writableTmpDirAsHomeHook
   ];
 
   buildInputs = [
@@ -53,10 +55,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
     xorg.libxcb
   ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     # Fails in the darwin sandbox with:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
