### PR TITLE
[Backport release-25.05] nest-cli: 10.4.9 -> 11.0.8

### DIFF
--- a/pkgs/by-name/ne/nest-cli/package.nix
+++ b/pkgs/by-name/ne/nest-cli/package.nix
@@ -7,16 +7,17 @@
 
 buildNpmPackage rec {
   pname = "nest-cli";
-  version = "10.4.9";
+  version = "11.0.8";
 
   src = fetchFromGitHub {
     owner = "nestjs";
     repo = "nest-cli";
-    rev = version;
-    hash = "sha256-dko+hOC3oZToNS+EOqmm+z7DLHfqqKDeQsH2sYxburU=";
+    tag = version;
+    hash = "sha256-vqu5eUtr8oO2HgQhXIHel92qHhHJSqyAJmI2+Oc5VoY=";
   };
 
-  npmDepsHash = "sha256-K4M6Jehy1854SuxDiaHQLlvhOecwInZZbOcgMqchiIM=";
+  npmDepsHash = "sha256-QLJBqVHEvOhRRGU9x/5hCvRSi0xKYMDXeqMi6yWNHbU=";
+  npmFlags = [ "--legacy-peer-deps" ];
 
   env = {
     npm_config_build_from_source = true;


### PR DESCRIPTION
Manual backport of #429092 to `release-25.05`.
* [ ]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-07-28T14%3A38%3A38Z#changes-acceptable-for-releases).
  * Even as a non-committer, if you find that it is not acceptable, leave a comment.
