### PR TITLE
forgejo-runner: 8.0.0 -> 8.0.1

### DIFF
--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -17,17 +17,17 @@ let
 in
 buildGoModule rec {
   pname = "forgejo-runner";
-  version = "8.0.0";
+  version = "8.0.1";
 
   src = fetchFromGitea {
     domain = "code.forgejo.org";
     owner = "forgejo";
     repo = "runner";
     rev = "v${version}";
-    hash = "sha256-ORFmCvKFbNQ1MGHifNhPmrPDep+WE603+xkIqMF/w6g=";
+    hash = "sha256-6FTJYs1dqIAHPxMzRNOHHZQv4be9LaR1wxMJsW3t5kg=";
   };
 
-  vendorHash = "sha256-4TX1ol2WwvZ4WYIzLFfVlYkcT5eLduESc+jg4Ysas2o=";
+  vendorHash = "sha256-NykeBR2dnWQaqJuY73i9KLIqehLHniaMqf9oTqUDstQ=";
 
   # See upstream Makefile
   # https://code.forgejo.org/forgejo/runner/src/branch/main/Makefile
@@ -39,7 +39,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X runner.forgejo.org/internal/pkg/ver.version=${src.rev}"
+    "-X code.forgejo.org/forgejo/runner/internal/pkg/ver.version=${src.rev}"
   ];
 
   checkFlags = [
@@ -49,7 +49,7 @@ buildGoModule rec {
   postInstall = ''
     # fix up go-specific executable naming derived from package name, upstream
     # also calls it `forgejo-runner`
-    mv $out/bin/runner.forgejo.org $out/bin/forgejo-runner
+    mv $out/bin/runner $out/bin/forgejo-runner
     # provide old binary name for compatibility
     ln -s $out/bin/forgejo-runner $out/bin/act_runner
   '';


### PR DESCRIPTION
changelog: https://code.forgejo.org/forgejo/runner/releases/tag/v8.0.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
