### PR TITLE
wpaperd: added support for avif

### DIFF
--- a/pkgs/by-name/wp/wpaperd/package.nix
+++ b/pkgs/by-name/wp/wpaperd/package.nix
@@ -6,6 +6,7 @@
   libxkbcommon,
   wayland,
   libGL,
+  dav1d,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -29,6 +30,11 @@ rustPlatform.buildRustPackage rec {
     wayland
     libGL
     libxkbcommon
+    dav1d
+  ];
+
+  buildFeatures = [
+    "avif"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
added dav1d build requirement and avif cargo feature flag to enable support of .AVIF image files.

references:
https://github.com/danyspin97/wpaperd?tab=readme-ov-file#image-formats-support https://github.com/image-rs/image/blob/main/README.md#supported-image-formats

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
