### PR TITLE
passExtensions.pass-tail: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -199,6 +199,13 @@
     github = "2hexed";
     githubId = 54501296;
   };
+  _3442 = {
+    name = "Alejandro Soto";
+    email = "alejandro@34project.org";
+    github = "3442";
+    githubId = 31359863;
+    keys = [ { fingerprint = "E142 1858 9D0D 90B5 2B1A  5368 F264 360B 2C09 05A6"; } ];
+  };
   _360ied = {
     name = "Brian Zhu";
     email = "therealbarryplayer@gmail.com";

--- a/pkgs/tools/security/pass/extensions/default.nix
+++ b/pkgs/tools/security/pass/extensions/default.nix
@@ -13,4 +13,5 @@ in
   pass-update = callPackage ./update.nix { };
   pass-genphrase = callPackage ./genphrase.nix { };
   pass-file = callPackage ./file.nix { };
+  pass-tail = callPackage ./tail.nix { };
 }

--- a/pkgs/tools/security/pass/extensions/tail.nix
+++ b/pkgs/tools/security/pass/extensions/tail.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+let
+  version = "1.2.0";
+in
+stdenv.mkDerivation {
+  pname = "pass-tail";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "palortoff";
+    repo = "pass-extension-tail";
+    tag = "v${version}";
+    hash = "sha256-RyPXW4Lgx6GdF9j+zEJqKRGxinDwPCmF9WXJ5yW4Pcc=";
+  };
+
+  installFlags = [
+    "PREFIX=$(out)"
+    "BASHCOMPDIR=$(out)/share/bash-completion/completions"
+  ];
+
+  meta = {
+    description = "A pass extension to avoid printing the password to the console";
+    homepage = "https://github.com/palortoff/pass-extension-tail";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ _3442 ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
 A pass extension to avoid printing the password to the console 

https://github.com/palortoff/pass-extension-tail

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
