### PR TITLE
rv8: init at 0-unstable-2018-09-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -199,6 +199,13 @@
     github = "2hexed";
     githubId = 54501296;
   };
+  _3442 = {
+    name = "Alejandro Soto";
+    email = "alejandro@34project.org";
+    github = "3442";
+    githubId = 31359863;
+    keys = [ { fingerprint = "E142 1858 9D0D 90B5 2B1A  5368 F264 360B 2C09 05A6"; } ];
+  };
   _360ied = {
     name = "Brian Zhu";
     email = "therealbarryplayer@gmail.com";

--- a/pkgs/by-name/rv/rv8/package.nix
+++ b/pkgs/by-name/rv/rv8/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "rv8";
+  version = "0-unstable-2018-09-22";
+
+  src = fetchFromGitHub {
+    owner = "michaeljclark";
+    repo = "rv8";
+    rev = "834259098a5c182874aac97d82a164d144244e1a";
+    hash = "sha256-I1lMKxfu+04Ap9WNjr8S1FLcUpQ3pVlTu61L/LFFGJ0=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # src/gen/gen-{cc,fpu-test}.cc fail to build because they mention
+    # std::numeric_limits without first including the <limits> header
+    ./rv8-include-limits.patch
+  ];
+
+  makeFlags = [
+    "AR=${stdenv.cc.targetPrefix}ar"
+    "DEST_DIR=$(out)"
+  ];
+
+  enableParallelBuilding = true;
+
+  preInstall = ''
+    mkdir -p $out/{bin,lib}
+  '';
+
+  meta = {
+    description = "RISC-V simulator for x86-64";
+    longDescription = ''
+      rv8 is a RISC-V simulation suite comprising a high performance x86-64 binary
+      translator, a user mode simulator, a full system emulator, an ELF binary
+      analysis tool and ISA metadata.
+    '';
+
+    homepage = "https://michaeljclark.github.io/";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.x86_64;
+    maintainers = with lib.maintainers; [ _3442 ];
+  };
+}

--- a/pkgs/by-name/rv/rv8/rv8-include-limits.patch
+++ b/pkgs/by-name/rv/rv8/rv8-include-limits.patch
@@ -1,0 +1,24 @@
+diff --git a/src/gen/gen-cc.cc b/src/gen/gen-cc.cc
+index fd9f948..44c8bf7 100644
+--- a/src/gen/gen-cc.cc
++++ b/src/gen/gen-cc.cc
+@@ -12,6 +12,7 @@
+ #include <deque>
+ #include <map>
+ #include <set>
++#include <limits>
+
+ #include "util.h"
+ #include "cmdline.h"
+diff --git a/src/gen/gen-fpu-test.cc b/src/gen/gen-fpu-test.cc
+index f1b8f84..d0a2f32 100644
+--- a/src/gen/gen-fpu-test.cc
++++ b/src/gen/gen-fpu-test.cc
+@@ -12,6 +12,7 @@
+ #include <deque>
+ #include <map>
+ #include <set>
++#include <limits>
+
+ #include "util.h"
+ #include "cmdline.h"


### PR DESCRIPTION
rv8 is a RISC-V simulation suite comprising a high performance x86-64 binary translator, a user mode simulator, a full system emulator, an ELF binary analysis tool and ISA metadata. The rv8 simulator suite contains libraries and command line tools for creating instruction opcode maps, C headers and source containing instruction set metadata, instruction decoders, a JIT assembler, LaTeX documentation, a metadata based RISC-V disassembler, a histogram tool for generating statistics on RISC-V ELF executables, a RISC-V proxy syscall simulator, a RISC-V full system emulator that implements the RISC-V 1.9.1 privileged specification and an x86-64 binary translator.

https://github.com/michaeljclark/rv8

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
