### PR TITLE
xow_dongle-firmware: fix broken link

### DIFF
--- a/pkgs/by-name/xo/xow_dongle-firmware/package.nix
+++ b/pkgs/by-name/xo/xow_dongle-firmware/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   srcs = [
     (fetchurl {
       name = "xow_dongle.cab";
-      url = "http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab";
+      url = "https://catalog.s.download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab";
       hash = "sha256-ZXNqhP9ANmRbj47GAr7ZGrY1MBnJyzIz3sq5/uwPbwQ=";
     })
     (fetchurl {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes this build error:

```
error: builder for '/nix/store/3f9hllhnpbrngghww4gngxwl5k7n4qpn-xow_dongle.cab.drv' failed with exit code 1;
       last 16 log lines:
       >
       > trying http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:--  0:05:00 --:--:--     0
       > curl: (28) Connection timed out after 300054 milliseconds
       > Warning: Problem : timeout. Will retry in 1 second. 3 retries left.
       >   0     0    0     0    0     0      0      0 --:--:--  0:05:00 --:--:--     0
       > curl: (28) Connection timed out after 300413 milliseconds
       > Warning: Problem : timeout. Will retry in 2 seconds. 2 retries left.
       >   0     0    0     0    0     0      0      0 --:--:--  0:04:29 --:--:--     0
       > curl: (28) Failed to connect to download.windowsupdate.com port 80 after 269992 ms: Could not connect to server
       > Warning: Problem : timeout. Will retry in 4 seconds. 1 retry left.
       >   0     0    0     0    0     0      0      0 --:--:--  0:04:30 --:--:--     0
       > curl: (28) Failed to connect to download.windowsupdate.com port 80 after 270430 ms: Could not connect to server
       > error: cannot download xow_dongle.cab from any mirror
       For full logs, run:
         nix log /nix/store/3f9hllhnpbrngghww4gngxwl5k7n4qpn-xow_dongle.cab.drv
error: 1 dependencies of derivation '/nix/store/hrki4ppm31762ycf5pmlzc55vvq27yrd-xow_dongle-firmware-0-unstable-2025-04-22.drv' failed to build
error: 1 dependencies of derivation '/nix/store/ab3z5mggyy84fylzprd79ggmb4lhvd2m-xow_dongle-firmware-0-unstable-2025-04-22-zstd.drv' failed to build
error: 1 dependencies of derivation '/nix/store/p9p3d7sad4zcqvcixfycz1cvnqdc1zwh-firmware.drv' failed to build
error: 1 dependencies of derivation '/nix/store/ydrl4ajlan1ffksr71p6p4hf306w4qys-nixos-system-mjolnir-25.11.20250726.17f6bd1.drv' failed to build
Command 'nix --extra-experimental-features 'nix-command flakes' build --print-out-paths '.#nixosConfigurations."mjolnir".config.system.build.toplevel' --cores 16' returned non-zero exit status 1.
┏━ Dependency Graph:
┃                ┌─ ⏵ source ⏱ 18m55s
┃             ┌─ ⏸ ttf-envy-code-r-PR7
┃          ┌─ ⏸ X11-fonts
┃       ┌─ ⏸ system-path
┃    ┌─ ⏸ dbus-1
┃    │           ┌─ ⚠ xow_dongle.cab failed with exit code 1 after ⏱ 19m8s
┃    │        ┌─ ⏸ xow_dongle-firmware-0-unstable-2025-04-22
┃    │     ┌─ ⏸ xow_dongle-firmware-0-unstable-2025-04-22-zstd
┃    │  ┌─ ⏸ firmware
┃    ├─ ⏸ etc-modprobe.d-firmware.conf
┃ ┌─ ⏸ etc
```

The package downloads 2 cab files.
The first link (http) is non responsive, but the second link (https) works.

I applied the protocol and server / domain of the second link to the first one. Now it builds fine with `export NIXPKGS_ALLOW_UNFREE=1; nix build .#xow_dongle-firmware --impure`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
