### PR TITLE
python3Packages.orbax-checkpoint: 0.11.19 -> 0.11.20

### DIFF
--- a/pkgs/development/python-modules/orbax-checkpoint/default.nix
+++ b/pkgs/development/python-modules/orbax-checkpoint/default.nix
@@ -9,6 +9,7 @@
   flit-core,
 
   # dependencies
+  aiofiles,
   etils,
   humanize,
   importlib-resources,
@@ -23,7 +24,6 @@
   typing-extensions,
 
   # tests
-  aiofiles,
   chex,
   google-cloud-logging,
   mock,
@@ -31,18 +31,19 @@
   portpicker,
   pytest-xdist,
   pytestCheckHook,
+  safetensors,
 }:
 
 buildPythonPackage rec {
   pname = "orbax-checkpoint";
-  version = "0.11.19";
+  version = "0.11.20";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "orbax";
     tag = "v${version}";
-    hash = "sha256-j15E4jGvxIjEdWG6Lwr9mvPXr9WifrD1zFF6Vj+7wik=";
+    hash = "sha256-ZZTmWW0PZHk8Evhk6JnbAyl7RQOAxN4GwXUv5M6GfIQ=";
   };
 
   sourceRoot = "${src.name}/checkpoint";
@@ -55,6 +56,7 @@ buildPythonPackage rec {
 
   dependencies = [
     absl-py
+    aiofiles
     etils
     humanize
     importlib-resources
@@ -70,7 +72,6 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    aiofiles
     chex
     google-cloud-logging
     mock
@@ -78,6 +79,7 @@ buildPythonPackage rec {
     portpicker
     pytest-xdist
     pytestCheckHook
+    safetensors
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/google/orbax/compare/refs/tags/v0.11.19...refs/tags/v0.11.20
Changelog: https://github.com/google/orbax/blob/v0.11.20/checkpoint/CHANGELOG.md

cc @fabaff


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc