### PR TITLE
libhsts: fix build with gettext 0.25.0, adopt; wget2: fix build with gettext 0.25.0

### DIFF
--- a/pkgs/by-name/li/libhsts/gettext-0.25.patch
+++ b/pkgs/by-name/li/libhsts/gettext-0.25.patch
@@ -1,0 +1,20 @@
+diff --git a/configure.ac b/configure.ac
+index 4d443c1..42c3568 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -31,13 +31,8 @@ AC_CONFIG_FILES([include/libhsts.h])
+ #
+ # Gettext
+ #
+-m4_ifdef([AM_GNU_GETTEXT], [
+-  AM_GNU_GETTEXT([external],[need-ngettext])
+-])
+-m4_ifdef([AM_GNU_GETTEXT_VERSION], [
+-#do not indent here
+-AM_GNU_GETTEXT_VERSION([0.18.2])
+-])
++AM_GNU_GETTEXT([external],[need-ngettext])
++AM_GNU_GETTEXT_VERSION([0.19.8])
+ 
+ #
+ # check for doxygen and pandoc

--- a/pkgs/by-name/li/libhsts/package.nix
+++ b/pkgs/by-name/li/libhsts/package.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation rec {
     sha256 = "0gbchzf0f4xzb6zjc56dk74hqrmdgyirmgxvvsqp9vqn9wb5kkx4";
   };
 
+  patches = [
+    ./gettext-0.25.patch
+  ];
+
   postPatch = ''
     pushd tests
     cp ${hsts_list} transport_security_state_static.json

--- a/pkgs/by-name/li/libhsts/package.nix
+++ b/pkgs/by-name/li/libhsts/package.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation rec {
     python3
   ];
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Library to easily check a domain against the Chromium HSTS Preload list";
     mainProgram = "hsts";

--- a/pkgs/by-name/li/libhsts/package.nix
+++ b/pkgs/by-name/li/libhsts/package.nix
@@ -9,11 +9,11 @@
   python3,
 }:
 let
-  chromium_version = "90.0.4417.1";
+  chromium_version = "140.0.7324.1";
 
   hsts_list = fetchurl {
     url = "https://raw.github.com/chromium/chromium/${chromium_version}/net/http/transport_security_state_static.json";
-    sha256 = "09f24n30x5dmqk8zk7k2glcilgr27832a3304wj1yp97158sqsfx";
+    hash = "sha256-XV3yZA3Ai4It7S/y4V0h+UtKm8SXm6x1hlITD7jGY9I=";
   };
 
 in

--- a/pkgs/by-name/li/libhsts/package.nix
+++ b/pkgs/by-name/li/libhsts/package.nix
@@ -21,11 +21,16 @@ stdenv.mkDerivation rec {
   pname = "libhsts";
   version = "0.1.0";
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   src = fetchFromGitLab {
     owner = "rockdaboot";
     repo = "libhsts";
-    rev = "libhsts-${version}";
-    sha256 = "0gbchzf0f4xzb6zjc56dk74hqrmdgyirmgxvvsqp9vqn9wb5kkx4";
+    tag = "libhsts-${version}";
+    hash = "sha256-pM9ZFk8W73Sx3ru/mqN/rWYMyZnNFCa/Wb8TB9yHbD0=";
   };
 
   patches = [
@@ -35,6 +40,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     pushd tests
     cp ${hsts_list} transport_security_state_static.json
+    # strip comments from json
     sed 's/^ *\/\/.*$//g' transport_security_state_static.json >hsts.json
     popd
     patchShebangs src/hsts-make-dafsa
@@ -47,19 +53,14 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  outputs = [
-    "out"
-    "dev"
-  ];
-
-  meta = with lib; {
+  meta = {
     description = "Library to easily check a domain against the Chromium HSTS Preload list";
     mainProgram = "hsts";
     homepage = "https://gitlab.com/rockdaboot/libhsts";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit
       bsd3
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
   };
 }

--- a/pkgs/by-name/li/libhsts/update.sh
+++ b/pkgs/by-name/li/libhsts/update.sh
@@ -5,9 +5,10 @@ set -euo pipefail -x
 
 cd "$(dirname "$0")"
 
-chromium_version=$(curl -s "https://api.github.com/repos/chromium/chromium/tags" | jq -r 'map(select(.prerelease | not)) | .[1].name')
+chromium_version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/chromium/chromium/tags" | jq -r 'map(select(.prerelease | not)) | .[1].name')
 sha256=$(nix-prefetch-url "https://raw.github.com/chromium/chromium/$chromium_version/net/http/transport_security_state_static.json")
+hash=$(nix hash convert --to sri "$sha256")
 
 sed -e "0,/chromium_version/s/chromium_version = \".*\"/chromium_version = \"$chromium_version\"/" \
-    -e "0,/sha256/s/sha256 = \".*\"/sha256 = \"$sha256\"/" \
+    -e "0,/hash/s/hash = \".*\"/sha256 = \"$hash\"/" \
   --in-place ./default.nix

--- a/pkgs/by-name/wg/wget2/gettext-0.25.patch
+++ b/pkgs/by-name/wg/wget2/gettext-0.25.patch
@@ -1,0 +1,25 @@
+diff --git a/configure.ac b/configure.ac
+index 7429f614..67b0bf0c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -410,17 +410,11 @@ test "${ENABLE_XATTR}" = "yes" && AC_DEFINE([ENABLE_XATTR], 1,
+ #
+ # Gettext
+ #
+-m4_ifdef([AM_GNU_GETTEXT], [
+-  AM_GNU_GETTEXT([external],[need-ngettext])
+-  AC_CONFIG_FILES([po/Makefile.in])
+-  have_po=yes
+-], [
+-  have_po=no
+-])
+-m4_ifdef([AM_GNU_GETTEXT_VERSION], [
++AM_GNU_GETTEXT([external],[need-ngettext])
++AC_CONFIG_FILES([po/Makefile.in])
++have_po=yes
+ #do not indent here
+ AM_GNU_GETTEXT_VERSION([0.21])
+-])
+ AM_CONDITIONAL([HAVE_PO], [ test "$have_po" = "yes" ])
+ 
+ #

--- a/pkgs/by-name/wg/wget2/package.nix
+++ b/pkgs/by-name/wg/wget2/package.nix
@@ -43,6 +43,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-0tOoStZHr5opehFmuQdFRPYvOv8IMrDTBNFtoweY3VM=";
   };
 
+  patches = [
+    ./gettext-0.25.patch
+  ];
+
   # wget2_noinstall contains forbidden reference to /build/
   postPatch = ''
     substituteInPlace src/Makefile.am \

--- a/pkgs/by-name/wg/wget2/package.nix
+++ b/pkgs/by-name/wg/wget2/package.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
   versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
   versionCheckProgramArg = "--version";
 
-  meta = with lib; {
+  meta = {
     description = "Successor of GNU Wget, a file and recursive website downloader";
     longDescription = ''
       Designed and written from scratch it wraps around libwget, that provides the basic
@@ -115,11 +115,11 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://gitlab.com/gnuwget/wget2";
     # wget2 GPLv3+; libwget LGPLv3+
-    license = with licenses; [
+    license = with lib.licenses; [
       gpl3Plus
       lgpl3Plus
     ];
-    maintainers = with maintainers; [ SuperSandro2000 ];
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
     mainProgram = "wget2";
   };
 }


### PR DESCRIPTION
Fixes #429366

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
