### PR TITLE
nixos/proxmox-image: add cloudImage build output

### DIFF
--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -289,7 +289,7 @@ with lib;
           echo "file vma $out/${config.image.fileName}" > $out/nix-support/hydra-build-products
         '';
       pveBaseConfigs = {
-        name = "proxmox-${cfg.filenameSuffix}";
+        name = config.image.baseName;
         baseName = config.image.baseName;
         inherit (cfg) partitionTableType;
         inherit (cfg.qemuConf) additionalSpace bootSize;

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -274,7 +274,7 @@ rec {
   );
 
   # KVM image for proxmox in VMA format
-  proxmoxImage = forMatchingSystems [ "x86_64-linux" ] (
+  proxmoxVMA = forMatchingSystems [ "x86_64-linux" ] (
     system:
     with import ./.. { inherit system; };
 
@@ -285,6 +285,25 @@ rec {
           ./modules/virtualisation/proxmox-image.nix
         ];
       }).config.system.build.VMA
+    )
+  );
+
+  # Keeping the old name for compatibility
+  proxmoxImage = proxmoxVMA;
+
+  # cloud-init image compatible with instructions given here:
+  # https://pve.proxmox.com/wiki/Cloud-Init_Support
+  proxmoxCloudImage = forMatchingSystems [ "x86_64-linux" ] (
+    system:
+    with import ./.. { inherit system; };
+
+    hydraJob (
+      (import lib/eval-config.nix {
+        inherit system;
+        modules = [
+          ./modules/virtualisation/proxmox-image.nix
+        ];
+      }).config.system.build.cloudImage
     )
   );
 


### PR DESCRIPTION
Refactor proxmox image module to support both VMA and cloud-init compatible images. Extract common configuration into pveBaseConfigs and add system.build.cloudImage for cloud-init use case.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
