### PR TITLE
force-riscv: init at 0.9.0-unstable-2023-10-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -199,6 +199,13 @@
     github = "2hexed";
     githubId = 54501296;
   };
+  _3442 = {
+    name = "Alejandro Soto";
+    email = "alejandro@34project.org";
+    github = "3442";
+    githubId = 31359863;
+    keys = [ { fingerprint = "E142 1858 9D0D 90B5 2B1A  5368 F264 360B 2C09 05A6"; } ];
+  };
   _360ied = {
     name = "Brian Zhu";
     email = "therealbarryplayer@gmail.com";

--- a/pkgs/by-name/fo/force-riscv/fix-includes.patch
+++ b/pkgs/by-name/fo/force-riscv/fix-includes.patch
@@ -1,0 +1,63 @@
+diff --git a/base/inc/ImageIO.h b/base/inc/ImageIO.h
+index f93866c..046dacb 100644
+--- a/base/inc/ImageIO.h
++++ b/base/inc/ImageIO.h
+@@ -17,6 +17,7 @@
+ #define Force_ImageIO_H
+
+ #include <map>
++#include <string>
+
+ #include "Defines.h"
+
+diff --git a/base/inc/TestIO.h b/base/inc/TestIO.h
+index 7d28c32..08a9167 100644
+--- a/base/inc/TestIO.h
++++ b/base/inc/TestIO.h
+@@ -17,6 +17,7 @@
+ #define Force_TestIO_H
+
+ #include <map>
++#include <string>
+
+ #include "Defines.h"
+
+diff --git a/base/inc/VectorElementUpdates.h b/base/inc/VectorElementUpdates.h
+index ad397b2..dd5e39d 100644
+--- a/base/inc/VectorElementUpdates.h
++++ b/base/inc/VectorElementUpdates.h
+@@ -19,6 +19,7 @@
+ #include <set>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ #include "Defines.h"
+ 
+diff --git a/fpix/src/load_program_options.cc b/fpix/src/load_program_options.cc
+index 580fcf5..72571d8 100644
+--- a/fpix/src/load_program_options.cc
++++ b/fpix/src/load_program_options.cc
+@@ -14,6 +14,7 @@
+ // limitations under the License.
+ //
+ #include <algorithm>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <iostream>
+
+diff --git a/fpix/riscv/Makefile b/fpix/riscv/Makefile
+index b1968e4..de66339 100644
+--- a/fpix/riscv/Makefile
++++ b/fpix/riscv/Makefile
+@@ -21,7 +21,7 @@ ALL_SRCS := $(ALL_SRCS) $(SIM_SRCS)
+ OPTIMIZATION = -O2
+ include ../../utils/make/Makefile.common
+ 
+-INC_PATHS = -I./inc -I../inc -I../../base/inc -I../../3rd_party/inc -I../../utils/handcar -I$(PYTHON_INC)
++INC_PATHS = -iquote ./inc -iquote ../inc -iquote ../../base/inc -I../../3rd_party/inc -I../../utils/handcar -I$(PYTHON_INC)
+ 
+ CFLAGS := $(CFLAGS) -DUNIT_TEST
+ NODEPS:=clean
+

--- a/pkgs/by-name/fo/force-riscv/package.nix
+++ b/pkgs/by-name/fo/force-riscv/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  python3,
+}:
+let
+  pythonWithPybind = python3.withPackages (py: [ py.pybind11 ]);
+in
+stdenv.mkDerivation {
+  pname = "force-riscv";
+  version = "0.9.0-unstable-2023-10-17";
+
+  src = fetchFromGitHub {
+    repo = "force-riscv";
+    owner = "openhwgroup";
+    rev = "5b66fd574c3aef3592cfcb6c6a112a040b127f36";
+    hash = "sha256-IDw+W+Ax+/QZp29Oy/o8aD2yhCnYNVaokrr1KBVgnvM=";
+  };
+
+  buildInputs = [ pythonWithPybind ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  patches = [
+    ./fix-includes.patch
+    ./remove-pyeval-initthreads.patch
+    ./wno-error-range-loop-construct.patch
+    ./urbg-static-constexpr-min-max.patch
+  ];
+
+  postPatch = ''
+    patchShebangs utils/ fpix/utils/
+
+    # Force building with nixpkgs pybind11
+    rm -r 3rd_party/inc/pybind11
+  '';
+
+  makeFlags = [
+    "FORCE_CC=${stdenv.cc.targetPrefix}c++"
+    "FORCE_PYTHON_LIB=${pythonWithPybind}/lib"
+    "FORCE_PYTHON_INC=${pythonWithPybind}/include/${pythonWithPybind.libPrefix}"
+    "PICKY=" # Fix build failure in pybind11 due to -Weffc++
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase =
+    let
+      paths = [
+        "3rd_party/py"
+        "utils"
+        "utils/builder"
+        "utils/builder/test_builder"
+        "utils/builder/shared"
+        "utils/regression"
+      ];
+
+      pythonPath = lib.concatStringsSep ":" (map (p: "$out/${p}") paths);
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out/{fpix,riscv,3rd_party}
+
+      # SimApiHANDCAR.so is in bin/ for some reason
+      cp -r bin/ py/ $out/
+      cp -r fpix/bin/ $out/fpix/
+
+      for binary in $out/{bin/friscv,fpix/bin/fpix_riscv}; do
+        wrapProgram $binary \
+          --prefix PYTHONPATH : ${pythonPath}
+      done
+
+      rm -r utils/handcar/make_area
+
+      cp -r 3rd_party/py/ $out/3rd_party/
+      cp -r config/ utils/ $out/
+      cp -r riscv/arch_data/ $out/riscv/
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Instruction sequence generator (ISG) for the RISC-V instruction set architecture";
+
+    homepage = "https://github.com/openhwgroup/force-riscv";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ _3442 ];
+  };
+}

--- a/pkgs/by-name/fo/force-riscv/remove-pyeval-initthreads.patch
+++ b/pkgs/by-name/fo/force-riscv/remove-pyeval-initthreads.patch
@@ -1,0 +1,12 @@
+diff --git a/3rd_party/inc/pybind11/detail/internals.h b/3rd_party/inc/pybind11/detail/internals.h
+index 86fbe92..31ff371 100644
+--- a/3rd_party/inc/pybind11/detail/internals.h
++++ b/3rd_party/inc/pybind11/detail/internals.h
+@@ -265,7 +265,6 @@ PYBIND11_NOINLINE inline internals &get_internals() {
+         auto *&internals_ptr = *internals_pp;
+         internals_ptr = new internals();
+ #if defined(WITH_THREAD)
+-        PyEval_InitThreads();
+         PyThreadState *tstate = PyThreadState_Get();
+         #if PY_VERSION_HEX >= 0x03070000
+             internals_ptr->tstate = PyThread_tss_alloc();

--- a/pkgs/by-name/fo/force-riscv/urbg-static-constexpr-min-max.patch
+++ b/pkgs/by-name/fo/force-riscv/urbg-static-constexpr-min-max.patch
@@ -1,0 +1,15 @@
+diff --git a/base/inc/Random.h b/base/inc/Random.h
+index 6354dee..21660a9 100644
+--- a/base/inc/Random.h
++++ b/base/inc/Random.h
+@@ -56,8 +56,8 @@ namespace Force {
+   class RandomURBG32 {
+   public:
+     typedef uint32 result_type; //!< Type define required by STL
+-    uint32 min() const { return 0; } //!< min function required by STL
+-    uint32 max() const { return MAX_UINT32; } //!< max function required by STL
++    static constexpr uint32 min() { return 0; } //!< min function required by STL
++    static constexpr uint32 max() { return MAX_UINT32; } //!< max function required by STL
+     uint32 operator () () const { return mpRandomInstance->Random32(min(), max()); }
+
+     explicit RandomURBG32(const Random* randomInstance) : mpRandomInstance(randomInstance) { } //!< Constructor with pointer to a Random object provieded.

--- a/pkgs/by-name/fo/force-riscv/wno-error-range-loop-construct.patch
+++ b/pkgs/by-name/fo/force-riscv/wno-error-range-loop-construct.patch
@@ -1,0 +1,13 @@
+diff --git a/utils/make/Makefile.common b/utils/make/Makefile.common
+index d0c96d3..422f6eb 100644
+--- a/utils/make/Makefile.common
++++ b/utils/make/Makefile.common
+@@ -60,7 +60,7 @@ else
+     PYTHON_LIB_TYPE=
+ endif
+
+-CFLAGS = -Wall -std=c++11 -gdwarf-3 -m64 -Werror $(OPTIMIZATION) $(PICKY_FLAGS) $(VISIBILITY) -D $(ARCH_ENUM_HEADER)
++CFLAGS = -Wall -std=c++11 -gdwarf-3 -m64 -Werror $(OPTIMIZATION) $(PICKY_FLAGS) $(VISIBILITY) -D $(ARCH_ENUM_HEADER) -Wno-error=range-loop-construct
+ LFLAGS = -lpthread -static-libstdc++ -static-libgcc -L$(PYTHON_LIB) -lpython$(PYTHON_VER)$(PYTHON_LIB_TYPE) -lutil -ldl -rdynamic
+
+ ALL_OBJS := $(ALL_SRCS:%.cc=$(OBJ_DIR)/%.o)


### PR DESCRIPTION
FORCE-RISCV is an instruction sequence generator (ISG) for the RISC-V instruction set architecture. It can be used to generate tests for design verification of RISC-V processors. FORCE-RISCV uses randomization to choose instructions, registers, addresses and data for the tests, and can generate valid test sequences with very little input from the user. However, FORCE-RISCV provides a set of APIs with extensive capabilities which gives the user a high level of control over how the instruction generation takes place.

https://github.com/openhwgroup/force-riscv

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
