### PR TITLE
kbuild-standalone: init at 6.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -199,6 +199,13 @@
     github = "2hexed";
     githubId = 54501296;
   };
+  _3442 = {
+    name = "Alejandro Soto";
+    email = "alejandro@34project.org";
+    github = "3442";
+    githubId = 31359863;
+    keys = [ { fingerprint = "E142 1858 9D0D 90B5 2B1A  5368 F264 360B 2C09 05A6"; } ];
+  };
   _360ied = {
     name = "Brian Zhu";
     email = "therealbarryplayer@gmail.com";

--- a/pkgs/by-name/kb/kbuild-standalone/package.nix
+++ b/pkgs/by-name/kb/kbuild-standalone/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  autoreconfHook,
+  bison,
+  fetchFromGitHub,
+  flex,
+  ncurses,
+  pkg-config,
+}:
+let
+  version = "6.9";
+in
+stdenv.mkDerivation {
+  pname = "kbuild-standalone";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "WangNan0";
+    repo = "kbuild-standalone";
+    tag = "v${version}";
+    hash = "sha256-CsHRn91RmDWa4xBnQqH0F63Qsos1q/iKbLtMQ7ehHnc=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [
+    ncurses
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
+    pkg-config
+  ];
+
+  preBuild = ''
+    mkdir -p $out/{lib/pkgconfig,share}
+
+    patchShebangs kbuild/_fixdep
+    cp kbuild-standalone.pc $out/lib/pkgconfig/
+    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$out/lib/pkgconfig"
+
+    cp -r kbuild/ $out/share/kbuild-standalone/
+  '';
+
+  meta = {
+    description = "Standalone kconfig and kbuild";
+    homepage = "https://github.com/WangNan0/kbuild-standalone";
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ _3442 ];
+  };
+}


### PR DESCRIPTION
KConfig and KBuild are powerful tools for building large projects written in mostly .c. They are parts of Linux kernel source code. Linux uses them to build itself. Some open source projects such as busybox and UBoot also use it as their building framework. However, sinces they are part of Linux kernel, they have to be forked and merged into the project who wish to use it. After forking, the connection between the project and Linux kernel is broken. Projects choose to use them has to maintain these tools by itself to get new features and fix bugs.

The goal of this project is to provide standalone kconfig and kbuild. Other projects can depend on this project as basic tools for building like gcc and make, instead of merging them into their own source code.

Currently, this project contains:

- kconfig: Standalone conf and mconf executable which reads Kconfig source code and output .config.
- kbuild: Basic kbuild makefile scripts are brought from Linux kernel. A wrapper is provided to make it work standalone.
- fixdep, unifdef: Small tools in Linux kernel for building.

https://github.com/WangNan0/kbuild-standalone

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
