### PR TITLE
xandikos: optionally depend on python-systemd to support socket activ…

### DIFF
--- a/pkgs/by-name/xa/xandikos/package.nix
+++ b/pkgs/by-name/xa/xandikos/package.nix
@@ -3,6 +3,7 @@
   lib,
   nixosTests,
   python3Packages,
+  withSystemd ? false,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -23,17 +24,22 @@ python3Packages.buildPythonApplication rec {
     setuptools
   ];
 
-  dependencies = with python3Packages; [
-    aiohttp
-    aiohttp-openmetrics
-    dulwich
-    defusedxml
-    icalendar
-    jinja2
-    multidict
-    pytz
-    vobject
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      aiohttp
+      aiohttp-openmetrics
+      dulwich
+      defusedxml
+      icalendar
+      jinja2
+      multidict
+      pytz
+      vobject
+    ]
+    ++ lib.optionals withSystemd [
+      systemd
+    ];
 
   passthru.tests.xandikos = nixosTests.xandikos;
 


### PR DESCRIPTION
Xandikos requires python-systemd in order for the socket activation to work. This introduces a flag `withSystemd` (defaults to false) that enables this dependency.

Usage: https://xandikos.org/docs/getting-started.html#running-from-systemd

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
