### PR TITLE
NixOS test framework: Add macOS VMs

### DIFF
--- a/nixos/lib/qemu-common.nix
+++ b/nixos/lib/qemu-common.nix
@@ -39,7 +39,7 @@ rec {
         powerpc64-linux = "${qemuPkg}/bin/qemu-system-ppc64 -machine powernv";
         riscv32-linux = "${qemuPkg}/bin/qemu-system-riscv32 -machine virt";
         riscv64-linux = "${qemuPkg}/bin/qemu-system-riscv64 -machine virt";
-        x86_64-darwin = "${qemuPkg}/bin/qemu-system-x86_64 -machine accel=kvm:tcg -cpu max";
+        x86_64-darwin = "${qemuPkg}/bin/qemu-system-x86_64";
       };
       otherHostGuestMatrix = {
         aarch64-darwin = {

--- a/nixos/lib/testing/machine/options.nix
+++ b/nixos/lib/testing/machine/options.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+in
+{
+  options = {
+    osType = mkOption {
+      type = types.optionType;
+      defaultText = lib.literalMD ''
+        NixOS as an option type
+        '';
+    };
+    moduleForName = mkOption {
+      type = types.functionTo types.deferredModule;
+      default = { };
+      description = ''
+        A function that receives the machine name and returns a module that may use the machine name.
+        This is added to all nodes.
+      '';
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -175,6 +175,7 @@ in
           [[ 143 = $(cat $failed/testBuildFailure.exit) ]]
           touch $out
         '';
+    multi-os = runTest ./nixos-test-driver/multi-os.nix;
   };
 
   # NixOS vm tests and non-vm unit tests

--- a/nixos/tests/nixos-test-driver/multi-os.nix
+++ b/nixos/tests/nixos-test-driver/multi-os.nix
@@ -1,0 +1,79 @@
+{ lib, hostPkgs, ... }:
+
+let
+
+  nixThePlanet = builtins.getFlake "github:MatthewCroughan/NixThePlanet/c9d159dc2e0049e7b250a767a3a01def52c3412b";
+
+   # no specific commit in particular
+  nix-darwin = builtins.getFlake "github:nix-darwin/nix-darwin/e04a388232d9a6ba56967ce5b53a8a6f713cdfcf";
+
+  guestDarwin =
+    let
+      inherit (hostPkgs.stdenv) hostPlatform;
+    in
+      if hostPlatform.isDarwin then
+        hostPlatform.system
+      else
+        let
+          hostToGuest = {
+            "x86_64-linux" = "x86_64-darwin";
+            "aarch64-linux" = "aarch64-darwin";
+          };
+
+          supportedHosts = lib.concatStringsSep ", " (lib.attrNames hostToGuest);
+
+          message = "NixOS Test: don't know which VM guest system to pair with VM host system: ${hostPlatform.system}. Perhaps you intended to run the tests on a Darwin host, or one of the following systems that may run NixOS tests: ${supportedHosts}";
+        in
+        hostToGuest.${hostPlatform.system} or (throw message);
+
+  defaultDarwinModule = { config, name, ... }:
+  {
+    _file = "${__curPos.file}:${toString (__curPos.line - 1)}";
+    imports = [ ./multi-os/qemu-vm.nix ];
+    virtualisation.host.pkgs = hostPkgs;
+  };
+
+  darwinBaseEval = nix-darwin.lib.darwinSystem {
+    system = guestDarwin;
+    modules = [ defaultDarwinModule ];
+  };
+
+in
+
+{
+  name = "nixos-test-driver-multi-os";
+  passthru = {
+    /** NixThePlanet flake, for use in repl */
+    inherit nixThePlanet;
+    /** nix-darwin flake, for use in repl */
+    inherit nix-darwin;
+  };
+  node.specialArgs = {
+    inherit nixThePlanet;
+  };
+  nodes = {
+    # A NixOS VM
+    rose = { };
+    # A macOS VM
+    daisy = {
+      system.stateVersion = 6;
+      virtualisation.diskImage = "${nixThePlanet.packages.${hostPkgs.stdenv.hostPlatform.system}.macos-ventura-image}";
+      virtualisation.qemu.options = [
+        "-drive" "if=pflash,format=raw,readonly=on,file=${nixThePlanet.legacyPackages.${hostPkgs.stdenv.hostPlatform.system}.osx-kvm}/OVMF_CODE.fd"
+        "-drive" "if=pflash,format=raw,readonly=on,file=${nixThePlanet.legacyPackages.${hostPkgs.stdenv.hostPlatform.system}.osx-kvm}/OVMF_VARS-1920x1080.fd"
+        "-drive" "id=OpenCoreBoot,if=virtio,snapshot=on,readonly=on,format=qcow2,file=${nixThePlanet.legacyPackages.${hostPkgs.stdenv.hostPlatform.system}.osx-kvm}/OpenCore/OpenCore.qcow2"
+
+      ];
+    };
+  };
+  machines = {
+    daisy = {
+      osType = darwinBaseEval.type;
+
+    };
+  };
+  testScript = ''
+    # start_all();
+    daisy.succeed("uname -s | tee /dev/stderr | grep '^Darwin$'");
+  '';
+}

--- a/nixos/tests/nixos-test-driver/multi-os/qemu-vm.nix
+++ b/nixos/tests/nixos-test-driver/multi-os/qemu-vm.nix
@@ -1,0 +1,352 @@
+{ config, lib, name, options, pkgs, nixThePlanet, ... }:
+let
+  inherit (lib)
+    literalExpression
+    mkOption
+    types
+    ;
+  inherit (lib)
+    concatStringsSep
+    generators
+    imap1
+    mapAttrsToList
+    mkIf
+    mkMerge
+    ;
+
+  cfg = config.virtualisation;
+
+  hostPkgs = cfg.host.pkgs;
+
+  inherit (hostPkgs) qemu;
+
+  qemu-common = import ../../../lib/qemu-common.nix { inherit lib pkgs; };
+
+  driveCmdline =
+    idx:
+    {
+      file,
+      driveExtraOpts,
+      deviceExtraOpts,
+      ...
+    }:
+    let
+      drvId = "drive${toString idx}";
+      mkKeyValue = generators.mkKeyValueDefault { } "=";
+      mkOpts = opts: concatStringsSep "," (mapAttrsToList mkKeyValue opts);
+      driveOpts = mkOpts (
+        driveExtraOpts
+        // {
+          index = idx;
+          id = drvId;
+          "if" = "none";
+          inherit file;
+        }
+      );
+      deviceOpts = mkOpts (
+        deviceExtraOpts
+        // {
+          drive = drvId;
+        }
+      );
+      device = "-device virtio-blk-pci,${deviceOpts}";
+    in
+    "-drive ${driveOpts} ${device}";
+
+  rootDriveSerialAttr = "root";
+  drivesCmdLine = drives: concatStringsSep "\\\n    " (imap1 driveCmdline drives);
+  driveOpts =
+    { ... }:
+    {
+
+      options = {
+
+        file = mkOption {
+          type = types.str;
+          description = "The file image used for this drive.";
+        };
+
+        driveExtraOpts = mkOption {
+          type = types.attrsOf types.str;
+          default = { };
+          description = "Extra options passed to drive flag.";
+        };
+
+        deviceExtraOpts = mkOption {
+          type = types.attrsOf types.str;
+          default = { };
+          description = "Extra options passed to device flag.";
+        };
+
+        name = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "A name for the drive. Must be unique in the drives list. Not passed to qemu.";
+        };
+
+      };
+
+    };
+
+  startVM = ''
+    #! ${hostPkgs.runtimeShell}
+
+    set -eux -o pipefail
+
+    # TODO: should this refer to systemImage instead?
+    NIX_DISK_IMAGE=$(readlink -f "''${NIX_DISK_IMAGE:-${toString config.virtualisation.diskImage}}") || test -z "$NIX_DISK_IMAGE"
+
+    if [[ -e root.qcow2 ]]; then
+      echo root.qcow2 already exists, not creating it again.
+      exit 1
+    fi
+    ${qemu}/bin/qemu-img create -b $NIX_DISK_IMAGE -F qcow2 -f qcow2 root.qcow2
+    NIX_DISK_IMAGE=root.qcow2
+
+    exec ${qemu-common.qemuBinary qemu} \
+        -name ${config.system.name} \
+        -m ${toString config.virtualisation.memorySize} \
+        -smp ${toString config.virtualisation.cores} \
+        -device virtio-rng-pci \
+        ${concatStringsSep " " config.virtualisation.qemu.networkingOptions} \
+        ${
+          concatStringsSep " \\\n    " (
+            mapAttrsToList (
+              tag: share:
+              "-virtfs local,path=${share.source},security_model=${share.securityModel},mount_tag=${tag}"
+            ) config.virtualisation.sharedDirectories
+          )
+        } \
+        ${drivesCmdLine config.virtualisation.qemu.drives} \
+        ${concatStringsSep " \\\n    " config.virtualisation.qemu.options} \
+        -drive id=MacHDD,if=virtio,file="root.qcow2",format=qcow2
+        ''${QEMU_OPTS:-} \
+        "$@"
+  '';
+
+in
+{
+  options = {
+    # FIXME (copied from qemu-vm.nix)
+    virtualisation.host.pkgs = mkOption {
+      type = options.nixpkgs.pkgs.type;
+      # default = pkgs;
+      defaultText = literalExpression "pkgs";
+      example = literalExpression ''
+        import pkgs.path { system = "x86_64-darwin"; }
+      '';
+      description = ''
+        Package set to use for the host-specific packages of the VM runner.
+        Changing this to e.g. a Darwin package set allows running NixOS VMs on Darwin.
+      '';
+    };
+    # FIXME (copied from qemu-vm.nix, increased 1G -> 4G)
+    virtualisation.memorySize = mkOption {
+      type = types.ints.positive;
+      default = 6144; # 6 GiB
+      description = ''
+        The memory size of the virtual machine in MiB (1024×1024 bytes).
+      '';
+    };
+    # FIXME (copied from qemu-vm.nix)
+    virtualisation.cores = mkOption {
+      type = types.ints.positive;
+      default = 1;
+      description = ''
+        Specify the number of cores the guest is permitted to use.
+        The number can be higher than the available cores on the
+        host system.
+      '';
+    };
+    # FIXME (copied from qemu-vm.nix)
+    virtualisation.diskImage = mkOption {
+      type = types.nullOr types.str;
+      default = "./${config.system.name}.qcow2";
+      defaultText = literalExpression ''"./''${config.system.name}.qcow2"'';
+      description = ''
+        Path to the disk image containing the root filesystem.
+        The image will be created on startup if it does not
+        exist.
+
+        If null, a tmpfs will be used as the root filesystem and
+        the VM's state will not be persistent.
+      '';
+    };
+    # FIXME (copied from qemu-vm.nix)
+    networking.primaryIPAddress = mkOption {
+      type = types.str;
+      default = "";
+      internal = true;
+      description = "Primary IP address used in /etc/hosts.";
+    };
+    # FIXME (copied from qemu-vm.nix)
+    networking.primaryIPv6Address = mkOption {
+      type = types.str;
+      default = "";
+      internal = true;
+      description = "Primary IPv6 address used in /etc/hosts.";
+    };
+    # FIXME (copied from qemu-vm.nix)
+    virtualisation.vlans = mkOption {
+      type = types.listOf types.ints.unsigned;
+      default = if config.virtualisation.interfaces == { } then [ 1 ] else [ ];
+    };
+    # FIXME (copied from qemu-vm.nix)
+    virtualisation.qemu = {
+      networkingOptions = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [
+          "-net nic,netdev=user.0,model=virtio"
+          "-netdev user,id=user.0,\${QEMU_NET_OPTS:+,$QEMU_NET_OPTS}"
+        ];
+        description = ''
+          Networking-related command-line options that should be passed to qemu.
+          The default is to use userspace networking (SLiRP).
+          See the [QEMU Wiki on Networking](https://wiki.qemu.org/Documentation/Networking) for details.
+
+          If you override this option, be advised to keep
+          `''${QEMU_NET_OPTS:+,$QEMU_NET_OPTS}` (as seen in the example)
+          to keep the default runtime behaviour.
+        '';
+      };
+      options = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "-vga std" ];
+        description = ''
+          Options passed to QEMU.
+          See [QEMU User Documentation](https://www.qemu.org/docs/master/system/qemu-manpage) for a complete list.
+        '';
+      };
+      drives = mkOption {
+        type = types.listOf (types.submodule driveOpts);
+        description = "Drives passed to qemu.";
+      };
+
+    };
+    # FIXME (copied from qemu-vm.nix)
+    virtualisation.sharedDirectories = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options.source = mkOption {
+            type = types.str;
+            description = "The path of the directory to share, can be a shell variable";
+          };
+          options.target = mkOption {
+            type = types.path;
+            description = "The mount point of the directory inside the virtual machine";
+          };
+          options.securityModel = mkOption {
+            type = types.enum [
+              "passthrough"
+              "mapped-xattr"
+              "mapped-file"
+              "none"
+            ];
+            default = "mapped-xattr";
+            description = ''
+              The security model to use for this share:
+
+              - `passthrough`: files are stored using the same credentials as they are created on the guest (this requires QEMU to run as root)
+              - `mapped-xattr`: some of the file attributes like uid, gid, mode bits and link target are stored as file attributes
+              - `mapped-file`: the attributes are stored in the hidden .virtfs_metadata directory. Directories exported by this security model cannot interact with other unix tools
+              - `none`: same as "passthrough" except the sever won't report failures if it fails to set file attributes like ownership
+            '';
+          };
+        }
+      );
+      default = { };
+      example = {
+        my-share = {
+          source = "/path/to/be/shared";
+          target = "/mnt/shared";
+        };
+      };
+      description = ''
+        An attributes set of directories that will be shared with the
+        virtual machine using VirtFS (9P filesystem over VirtIO).
+        The attribute name will be used as the 9P mount tag.
+      '';
+    };
+    # FIXME (copied from qemu-vm.nix)
+    virtualisation.interfaces = mkOption {
+      default = { };
+      example = {
+        enp1s0.vlan = 1;
+      };
+      description = ''
+        Network interfaces to add to the VM.
+      '';
+      type =
+        with types;
+        attrsOf (submodule {
+          options = {
+            vlan = mkOption {
+              type = types.ints.unsigned;
+              description = ''
+                VLAN to which the network interface is connected.
+              '';
+            };
+
+            assignIP = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Automatically assign an IP address to the network interface using the same scheme as
+                virtualisation.vlans.
+              '';
+            };
+          };
+        });
+    };
+    system.name = mkOption {
+      type = types.str;
+      # FIXME: not accurate?
+      default = name;
+    };
+  };
+  config = {
+    # FIXME
+    system.build.vm =
+      hostPkgs.runCommand "nixos-vm"
+        {
+          preferLocalBuild = true;
+          meta.mainProgram = "run-${config.system.name}-vm";
+        }
+        ''
+          mkdir -p $out/bin
+          ln -s ${config.system.build.toplevel} $out/system
+          ln -s ${hostPkgs.writeScript "run-nixos-vm" startVM} $out/bin/run-${config.system.name}-vm
+        '';
+    virtualisation.qemu.options = [
+      "-enable-kvm" # ??
+      "-machine"
+      "q35,accel=kvm"
+      "-usb" "-device" "usb-kbd" "-device" "usb-tablet" "-device" "usb-tablet"
+      "-cpu" "Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check"
+      "-device" "usb-ehci,id=ehci"
+      "-device" "nec-usb-xhci,id=xhci"
+      "-global" "nec-usb-xhci.msi=off"
+      "-device" ''isa-applesmc,osk="ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc"''
+      "-smbios" "type=2"
+      "-device" "ich9-intel-hda" "-device" "hda-duplex"
+      "-device" "virtio-vga"
+
+    ];
+    virtualisation.qemu.drives = mkMerge [
+      []
+      # (mkIf (cfg.diskImage != null) [
+      #   {
+      #     name = "MacHDD";
+      #     file = ''"$NIX_DISK_IMAGE"'';
+      #     driveExtraOpts.cache = "writeback";
+      #     driveExtraOpts.werror = "report";
+      #     deviceExtraOpts.bootindex = "1";
+      #     deviceExtraOpts.serial = rootDriveSerialAttr;
+      #   }
+      # ])
+    ];
+
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Goal: enable automated testing of Nix on macOS

Done
- [x] `nix run -f . nixosTests.nixos-test-driver.multi-os.driverInteractive` launches macOS

TODO:
- [ ] add the testing backdoor service somehow
- [ ] `requiredFeatures = ["apple-branded-computer"];` to support license compliance
- [ ] do not use `getFlake` somehow (not sure if those parts can be in-tree)
- [ ] factor generic parts out of `qemu-vm.nix`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
