### PR TITLE
nh: Add options for specific flakes

### DIFF
--- a/nixos/modules/programs/nh.nix
+++ b/nixos/modules/programs/nh.nix
@@ -28,9 +28,9 @@ in
         `nh os switch`. This behaviour can be overriden per-command with environment
         variables that will take priority.
 
-        - `osFlake`: will take priority for `nh os` commands.
-        - `homeFlake`: will take priority for `nh home` commands.
-        - `darwinFlake`: will take priority for `nh darwin` commands.
+        - `NH_OS_FLAKE`: will take priority for `nh os` commands.
+        - `NH_HOME_FLAKE`: will take priority for `nh home` commands.
+        - `NH_DARWIN_FLAKE`: will take priority for `nh darwin` commands.
 
         The formerly valid `FLAKE` is now deprecated by nh, and will cause hard errors
         in future releases if `NH_FLAKE` is not set.
@@ -112,17 +112,18 @@ in
         assertion = cfg.clean.enable -> cfg.enable;
         message = "programs.nh.clean.enable requires programs.nh.enable";
       }
-      map
-      (name: {
-        assertion = cfg.${name} != null -> !(lib.hasSuffix ".nix" cfg.${name});
-        message = "nh.${name} must be a directory, not a nix file";
-      })
-      [
-        "darwinFlake"
-        "flake"
-        "homeFlake"
-        "osFlake"
-      ]
+      (map
+        (name: {
+          assertion = cfg.${name} != null -> !(lib.hasSuffix ".nix" cfg.${name});
+          message = "nh.${name} must be a directory, not a nix file";
+        })
+        [
+          "darwinFlake"
+          "flake"
+          "homeFlake"
+          "osFlake"
+        ]
+      )
     ];
 
     environment = lib.mkIf cfg.enable {

--- a/nixos/modules/programs/nh.nix
+++ b/nixos/modules/programs/nh.nix
@@ -28,12 +28,45 @@ in
         `nh os switch`. This behaviour can be overriden per-command with environment
         variables that will take priority.
 
-        - `NH_OS_FLAKE`: will take priority for `nh os` commands.
-        - `NH_HOME_FLAKE`: will take priority for `nh home` commands.
-        - `NH_DARWIN_FLAKE`: will take priority for `nh darwin` commands.
+        - `osFlake`: will take priority for `nh os` commands.
+        - `homeFlake`: will take priority for `nh home` commands.
+        - `darwinFlake`: will take priority for `nh darwin` commands.
 
         The formerly valid `FLAKE` is now deprecated by nh, and will cause hard errors
         in future releases if `NH_FLAKE` is not set.
+      '';
+    };
+
+    osFlake = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        The string that will be used for the `NH_OS_FLAKE` environment variable.
+
+        `NH_OS_FLAKE` is used by nh as the default flake for performing `nh os` actions,
+        such as `nh os switch`. Setting this will take priority over the `flake` option.
+      '';
+    };
+
+    homeFlake = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        The string that will be used for the `NH_HOME_FLAKE` environment variable.
+
+        `NH_HOME_FLAKE` is used by nh as the default flake for performing `nh home` actions,
+        such as `nh home switch`. Setting this will take priority over the `flake` option.
+      '';
+    };
+
+    darwinFlake = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        The string that will be used for the `NH_DARWIN_FLAKE` environment variable.
+
+        `NH_DARWIN_FLAKE` is used by nh as the default flake for performing `nh darwin` actions,
+        such as `nh darwin switch`. Setting this will take priority over the `flake` option.
       '';
     };
 
@@ -84,13 +117,44 @@ in
         assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
         message = "nh.flake must be a directory, not a nix file";
       }
+      {
+        assertion = (cfg.osFlake != null) -> !(lib.hasSuffix ".nix" cfg.osFlake);
+        message = "nh.osFlake must be a directory, not a nix file";
+      }
+      {
+        assertion = (cfg.homeFlake != null) -> !(lib.hasSuffix ".nix" cfg.homeFlake);
+        message = "nh.homeFlake must be a directory, not a nix file";
+      }
+      {
+        assertion = (cfg.darwinFlake != null) -> !(lib.hasSuffix ".nix" cfg.darwinFlake);
+        message = "nh.darwinFlake must be a directory, not a nix file";
+      }
     ];
 
     environment = lib.mkIf cfg.enable {
       systemPackages = [ cfg.package ];
-      variables = lib.mkIf (cfg.flake != null) {
-        NH_FLAKE = cfg.flake;
-      };
+      variables = lib.mkMerge [
+        lib.mkIf
+        (cfg.flake != null)
+        {
+          NH_FLAKE = cfg.flake;
+        }
+        lib.mkIf
+        (cfg.osFlake != null)
+        {
+          NH_OS_FLAKE = cfg.osFlake;
+        }
+        lib.mkIf
+        (cfg.homeFlake != null)
+        {
+          NH_HOME_FLAKE = cfg.homeFlake;
+        }
+        lib.mkIf
+        (cfg.darwinFlake != null)
+        {
+          NH_DARWIN_FLAKE = cfg.darwinFlake;
+        }
+      ];
     };
 
     systemd = lib.mkIf cfg.clean.enable {

--- a/nixos/modules/programs/nh.nix
+++ b/nixos/modules/programs/nh.nix
@@ -112,48 +112,38 @@ in
         assertion = cfg.clean.enable -> cfg.enable;
         message = "programs.nh.clean.enable requires programs.nh.enable";
       }
-
-      {
-        assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
-        message = "nh.flake must be a directory, not a nix file";
-      }
-      {
-        assertion = (cfg.osFlake != null) -> !(lib.hasSuffix ".nix" cfg.osFlake);
-        message = "nh.osFlake must be a directory, not a nix file";
-      }
-      {
-        assertion = (cfg.homeFlake != null) -> !(lib.hasSuffix ".nix" cfg.homeFlake);
-        message = "nh.homeFlake must be a directory, not a nix file";
-      }
-      {
-        assertion = (cfg.darwinFlake != null) -> !(lib.hasSuffix ".nix" cfg.darwinFlake);
-        message = "nh.darwinFlake must be a directory, not a nix file";
-      }
+      map
+      (name: {
+        assertion = cfg.${name} != null -> !(lib.hasSuffix ".nix" cfg.${name});
+        message = "nh.${name} must be a directory, not a nix file";
+      })
+      [
+        "darwinFlake"
+        "flake"
+        "homeFlake"
+        "osFlake"
+      ]
     ];
 
     environment = lib.mkIf cfg.enable {
       systemPackages = [ cfg.package ];
       variables = lib.mkMerge [
-        lib.mkIf
-        (cfg.flake != null)
-        {
+        (lib.mkIf (cfg.flake != null) {
           NH_FLAKE = cfg.flake;
-        }
-        lib.mkIf
-        (cfg.osFlake != null)
-        {
-          NH_OS_FLAKE = cfg.osFlake;
-        }
-        lib.mkIf
-        (cfg.homeFlake != null)
-        {
-          NH_HOME_FLAKE = cfg.homeFlake;
-        }
-        lib.mkIf
-        (cfg.darwinFlake != null)
-        {
-          NH_DARWIN_FLAKE = cfg.darwinFlake;
-        }
+        })
+        (map
+          (
+            name:
+            lib.mkIf (cfg."${nane}Flake" != null) {
+              "NH_${lib.toUpper name}_FLAKE" = cfg."${name}Flake";
+            }
+          )
+          [
+            "darwin"
+            "home"
+            "os"
+          ]
+        )
       ];
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

nh provides an environment variable setting for defining the default flake, which was added in #401255 and is available as the `programs.nh.flake` setting. However, nh also provides three environment-specific settings for OS, home-manager, and Darwin. These are useful when, for one reason or another, different flakes are used for configuring the OS and the user's environment (e.g. on a shared machine). 

This PR makes the other three settings available in a similar manner.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [N/A] [NixOS tests] in [nixos/tests].
  - [N/A] [Package tests] at `passthru.tests`.
  - [N/A] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [N/A] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [N/A] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [N/A] Module addition: when adding a new NixOS module.
  - [N/A] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
