### PR TITLE
vips: 8.16.1 -> 8.17.1

### DIFF
--- a/pkgs/by-name/vi/vips/package.nix
+++ b/pkgs/by-name/vi/vips/package.nix
@@ -5,8 +5,8 @@
 
   # Native build inputs
   docbook-xsl-nons,
+  gi-docgen,
   gobject-introspection,
-  gtk-doc,
   meson,
   ninja,
   pkg-config,
@@ -52,7 +52,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vips";
-  version = "8.16.1";
+  version = "8.17.1";
 
   outputs = [
     "bin"
@@ -66,13 +66,17 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libvips";
     repo = "libvips";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F2ymfvqwuCtNtFIOLgXvqRWATSMaeV7EQKYyQalCNfc=";
+    hash = "sha256-Sc2BWdQIgL/dI0zfbEQVCs3+1QBrLE7BsE3uFHe9C/c=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     postFetch = ''
       rm -r $out/test/test-suite/images/
     '';
   };
+
+  postPatch = ''
+    patchShebangs .
+  '';
 
   nativeBuildInputs = [
     docbook-xsl-nons
@@ -82,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) [
-    gtk-doc
+    gi-docgen
   ];
 
   buildInputs = [
@@ -128,9 +132,13 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "introspection" withIntrospection)
   ]
   ++ lib.optional (!stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isFreeBSD) (
-    lib.mesonBool "gtk_doc" true
+    lib.mesonBool "docs" true
   )
   ++ lib.optional (imagemagick == null) (lib.mesonEnable "magick" false);
+
+  postFixup = ''
+    moveToOutput "share/doc" "$devdoc"
+  '';
 
   passthru = {
     tests = {
@@ -145,17 +153,17 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"
-        "v([0-9.]+)"
+        "^v([0-9.]+)$"
       ];
     };
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/libvips/libvips/blob/${finalAttrs.src.rev}/ChangeLog";
     homepage = "https://www.libvips.org/";
     description = "Image processing system for large images";
-    license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.lgpl2Plus;
+    maintainers = with lib.maintainers; [
       kovirobi
       anthonyroussel
     ];
@@ -163,7 +171,7 @@ stdenv.mkDerivation (finalAttrs: {
       "vips"
       "vips-cpp"
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
     mainProgram = "vips";
   };
 })


### PR DESCRIPTION
Diff: https://github.com/libvips/libvips/compare/refs/tags/v8.16.1...refs/tags/v8.17.1

Changelog: https://github.com/libvips/libvips/blob/refs/tags/v8.17.1/ChangeLog


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
