### PR TITLE
nixos/pam: switch to lastlog2

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1311,7 +1311,7 @@ let
                 name = "lastlog";
                 enable = cfg.updateWtmp;
                 control = "required";
-                modulePath = "${package}/lib/security/pam_lastlog.so";
+                modulePath = "${pkgs.util-linux.lastlog}/lib/security/pam_lastlog2.so";
                 settings = {
                   silent = true;
                 };
@@ -2310,6 +2310,12 @@ in
     };
 
     environment.etc = lib.mapAttrs' makePAMService enabledServices;
+
+    systemd = lib.optionalAttrs config.security.pam.services.login.updateWtmp {
+      tmpfiles.packages = [ pkgs.util-linux.lastlog ]; # /lib/tmpfiles.d/lastlog2-tmpfiles.conf
+      services.lastlog2-import.enable = true;
+      packages = [ pkgs.util-linux.lastlog ]; # lib/systemd/system/lastlog2-import.service
+    };
 
     security.pam.services = {
       other.text = ''

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1115,6 +1115,7 @@ in
   packagekit = runTest ./packagekit.nix;
   paisa = runTest ./paisa.nix;
   pam-file-contents = runTest ./pam/pam-file-contents.nix;
+  pam-lastlog = runTest ./pam/pam-lastlog.nix;
   pam-oath-login = runTest ./pam/pam-oath-login.nix;
   pam-u2f = runTest ./pam/pam-u2f.nix;
   pam-ussh = runTest ./pam/pam-ussh.nix;

--- a/nixos/tests/pam/pam-lastlog.nix
+++ b/nixos/tests/pam/pam-lastlog.nix
@@ -1,0 +1,21 @@
+{ ... }:
+
+{
+  name = "pam-lastlog";
+
+  nodes.machine =
+    { ... }:
+    {
+      # we abuse run0 for a quick login as root as to not require setting up accounts and passwords
+      security.pam.services.systemd-run0 = {
+        updateWtmp = true; # enable lastlog
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("run0 --pty true") # perform full login
+    print(machine.succeed("lastlog2 --active --user root"))
+    machine.succeed("stat /var/lib/lastlog/lastlog2.db")
+  '';
+}

--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -84,6 +84,7 @@ stdenv.mkDerivation rec {
     inherit (nixosTests)
       pam-oath-login
       pam-u2f
+      pam-lastlog
       shadow
       sssd-ldap
       ;

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -31,6 +31,7 @@
   # Doesn't build on Darwin, also doesn't really make sense on Darwin
   withLastlog ? !stdenv.hostPlatform.isDarwin,
   gitUpdater,
+  nixosTests,
 }:
 
 let
@@ -227,6 +228,10 @@ stdenv.mkDerivation (finalPackage: rec {
     # encode upstream assumption to be used in man-db
     # https://github.com/util-linux/util-linux/commit/8886d84e25a457702b45194d69a47313f76dc6bc
     hasCol = stdenv.hostPlatform.libc == "glibc";
+
+    tests = {
+      inherit (nixosTests) pam-lastlog;
+    };
   };
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11387,6 +11387,7 @@ with pkgs;
     shadowSupport = false;
     systemdSupport = false;
     translateManpages = false;
+    withLastlog = false;
   };
 
   v4l-utils = qt6.callPackage ../os-specific/linux/v4l-utils { };


### PR DESCRIPTION
Adaptation of #282337 to use `util-linux` as `lastlog2` provider

closes https://github.com/issues/created?issue=NixOS%7Cnixpkgs%7C429075

~~This does pass the nixos tests. However, the following log message might be concerning (flagged as error from tmpfiles):
`/etc/tmpfiles.d/uuidd-tmpfiles.conf:6: Failed to resolve user 'uuidd': No such process`~~

~~One option to fix this is to move all the relevant lastlog outputs of `util-linux` to a clean `$lastlog` output, which would contain the lastlog libs, service and tmpfiles definitions while not overly polluting the scope. There might be better ways, i am not sure. Until it is decided how (and whether) to treat this log output, this is a draft.~~

Fixed by separating `lastlog` to its own output in `util-linux`.

cc @arianvp 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
