### PR TITLE
vimPlugins.ethersync: init at 0.7.0

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -133,6 +133,8 @@
   # search-and-replace.nvim dependencies
   fd,
   sad,
+  # ethersync vim plugin
+  ethersync,
 }:
 self: super:
 let
@@ -1125,6 +1127,17 @@ in
     fixupPhase = ''
       patchShebangs $(find $out/bin/ -type f -not -name credo-language-server)
     '';
+  };
+
+  ethersync = buildVimPlugin rec {
+    inherit (ethersync)
+      pname
+      version
+      src
+      meta
+      ;
+
+    sourceRoot = "${src.name}/nvim-plugin";
   };
 
   executor-nvim = super.executor-nvim.overrideAttrs {

--- a/pkgs/by-name/et/ethersync/package.nix
+++ b/pkgs/by-name/et/ethersync/package.nix
@@ -8,18 +8,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ethersync";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "ethersync";
     repo = "ethersync";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dHV4+WxNdEvRZK8WNK0qp9f43Y9oSUtlXrq/mI0yWls=";
+    hash = "sha256-Swh8C8FMjPdIFpHOsNb3W9W7JAZGzPXHXTwwnr1gFok=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/daemon";
 
-  cargoHash = "sha256-uKtJp4RD0YbOmtzbxebpYQxlBmP+5k88d+76hT4cTI8=";
+  cargoHash = "sha256-ZgbxaEtsaBQLl9PJbo1O2wA3OxEfPKRl3KkFvR4c97Q=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";

--- a/pkgs/by-name/et/ethersync/package.nix
+++ b/pkgs/by-name/et/ethersync/package.nix
@@ -33,6 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     downloadPage = "https://github.com/ethersync/ethersync";
     changelog = "https://github.com/ethersync/ethersync/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Plus;
+    teams = [ lib.teams.ngi ];
     maintainers = with lib.maintainers; [
       prince213
       ethancedwards8


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I bumped ethersync so that the plugin is exposed under `nvim-plugin`

Closes: https://github.com/ngi-nix/projects/issues/1742

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
