### PR TITLE
komga: bugfix allow komga access to /proc/mounts

### DIFF
--- a/nixos/modules/services/web-apps/komga.nix
+++ b/nixos/modules/services/web-apps/komga.nix
@@ -144,7 +144,7 @@ in
           PrivateTmp = true;
           ProtectProc = "invisible";
           ProtectClock = true;
-          ProcSubset = "pid";
+          ProcSubset = "all";
           PrivateUsers = true;
           PrivateDevices = true;
           ProtectHostname = true;

--- a/nixos/modules/services/web-apps/komga.nix
+++ b/nixos/modules/services/web-apps/komga.nix
@@ -166,5 +166,8 @@ in
       };
     };
 
-  meta.maintainers = with maintainers; [ govanify ];
+  meta.maintainers = with maintainers; [
+    govanify
+    tebriel
+  ];
 }


### PR DESCRIPTION
New Java call to the [Files.getFileStore](https://github.com/gotson/komga/blob/9046a61fc6bb308b786d0bbfd36e2749183a9ebd/komga/src/main/kotlin/org/gotson/komga/infrastructure/configuration/ConfigurationChecker.kt#L50) introduced in https://github.com/gotson/komga/commit/93b21307d15c185a54981a5fe69290e87d479130 uses [/proc/mounts](https://github.com/openjdk/jdk/blob/jdk-23%2B0/src/java.base/linux/classes/sun/nio/fs/LinuxFileStore.java#L73-L74) so we can no longer have ProcSubset as only "pid".

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
