### PR TITLE
franz: Add `pipewire` and `libpulseaudio` as dependencies for Franz

### DIFF
--- a/pkgs/applications/networking/instant-messengers/franz/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/generic.nix
@@ -26,6 +26,8 @@
   libgbm,
   libglvnd,
   libappindicator-gtk3,
+  pipewire,
+  libpulseaudio,
 }:
 
 # Helper function for building a derivation for Franz and forks.
@@ -99,6 +101,8 @@ stdenv.mkDerivation (
         cups
         expat
         stdenv.cc.cc
+        pipewire
+        libpulseaudio
       ];
     runtimeDependencies = [
       libglvnd
@@ -106,6 +110,8 @@ stdenv.mkDerivation (
       (lib.getLib udev)
       libnotify
       libappindicator-gtk3
+      pipewire
+      libpulseaudio
     ];
 
     installPhase = ''


### PR DESCRIPTION
This update introduces PipeWire and PulseAudio dependencies to Franz and its derivatives. Previously, the application was defaulting to ALSA as the audio backend. This limitation affected audio settings and caused screensharing issues under Wayland for me.  

I primarily use Ferdium and have tested these changes in that context, but as the dependencies are managed within the mkFranzDerivation function, this will appy to all its derivatives aswell.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
