### PR TITLE
chataigne: init at 1.9.24

### DIFF
--- a/pkgs/by-name/ch/chataigne/package.nix
+++ b/pkgs/by-name/ch/chataigne/package.nix
@@ -1,0 +1,170 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  appimageTools,
+  makeWrapper,
+  xar,
+  cpio,
+  #curlWithGnuTls,
+  #autoPatchelfHook,
+}:
+
+let
+  version = "1.9.24";
+  pname = "chataigne";
+
+  platformInfo =
+    {
+      x86_64-linux = {
+        arch = "linux-x64";
+        ext = "AppImage";
+        hash = "sha256-cxvdrFVBvFIVCUZyCpTb1IyrM0oRlE6mlwzi+k3Aiy4=";
+      };
+      aarch64-linux = {
+        # compiled with QEMU -cpu max:cortex-a53
+        # using cpuinfo https://github.com/pguyot/arm-runner-action/blob/main/cpuinfo/raspberrypi_zero2_w_arm64
+        arch = "linux-aarch64";
+        ext = "AppImage";
+        hash = "sha256-x/70U6JmN/x502PuO0uTlI8HXw5kBKcw8IvnFCygS18=";
+      };
+      armv6l-linux = { # lib.systems.examples.raspberryPi
+        # named armv8 on Chataigne's website
+        # compiled with QEMU -cpu arm1176:cortex-a53
+        # using cpuinfo https://github.com/pguyot/arm-runner-action/blob/main/cpuinfo/raspberrypi_zero_w
+        arch = "linux-armhf";
+        ext = "AppImage";
+        hash = "sha256-VSSZnlKdHHg7h/QdF64Ggy06pIsWFpHq/Dz7g4QYHgQ=";
+      };
+      x86_64-darwin = {
+        arch = "osx-intel";
+        ext = "pkg";
+        hash = "sha256-E7z7O/oI8KWXUEo4wV9awqolAW6tCuYzOfyGkGdul10=";
+      };
+      aarch64-darwin = {
+        arch = "osx-silicon";
+        ext = "pkg";
+        hash = "sha256-KBEeNs3daAeomtGcvRyx0iX1uorsRUAj7abax/xF/H8=";
+      };
+      x86_64-windows = {
+        arch = "win-x64";
+        ext = "exe";
+        hash = "sha256-FCFoZDlHZ6BgNycTOPx9cIEOVr9BQQwysDL+M6Dq78Y=";
+      };
+      # Windows 7 version also exists
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported platform ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url = "https://benjamin.kuperberg.fr/chataigne/user/data/Chataigne-${platformInfo.arch}-${version}.${platformInfo.ext}";
+    hash = platformInfo.hash;
+  };
+
+  meta = {
+    description = "Artist-friendly Modular Machine for Art and Technology";
+    homepage = "https://github.com/benkuper/Chataigne";
+    downloadPage = "https://benjamin.kuperberg.fr/chataigne/en";
+    license = lib.licenses.gpl3Only;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = [ lib.maintainers.axka ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+      "x86_64-windows"
+      "x86_64-windows7"
+    ];
+  };
+
+  # .desktop and icons
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+if platformInfo.ext == "AppImage" then
+  appimageTools.wrapType2 {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+
+    # unshareIpc=false etc.?
+
+    #nativeBuildInputs = [
+    #  autoPatchelfHook
+    #];
+
+    passthru.updateScript = ./update.sh;
+
+    #buildInputs = [
+    #];
+    extraPkgs = pkgs: with pkgs; [
+      curlWithGnuTls
+      bluez
+      avahi
+      libGL
+    ];
+    # TODO: read pkgs.code-cursor derivation
+
+    /*
+      extraInstallCommands = ''
+        substituteInPlace $out/share/applications/${pname}.desktop \
+          --replace-fail 'Exec=AppRun' 'Exec=${meta.mainProgram}'
+      '';
+    */
+  }
+else if platformInfo.ext == "pkg" then
+  # macOS
+  stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+
+    nativeBuildInputs = [
+      makeWrapper
+      xar
+      cpio
+    ];
+
+    unpackPhase = ''
+      xar -xf $src
+      echo after xar
+      ls -al # TODO: remove!!
+      zcat < Chataigne.pkg/Payload | cpio -i
+      echo after cpio
+      ls -al # TODO: remove!!
+    '';
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      mkdir -p $out/Applications
+      # TODO: not sure if this is right
+      cp -R Chataigne.app $out/Applications/
+    '';
+  }
+else if platformInfo.ext == "exe" then
+  # Windows
+  stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+
+    dontUnpack = true;
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      install -D $src $out/bin/Chataigne.exe
+    '';
+  }
+else
+  throw "infallible"

--- a/pkgs/by-name/ch/chataigne/update.sh
+++ b/pkgs/by-name/ch/chataigne/update.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl ripgrep
+
+set -eu -o pipefail
+
+scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+nixpkgs=$(realpath "$scriptDir"/../../../..)
+
+# update-source-version and nix-instantiate expect to be at the root of nixpkgs
+cd "$nixpkgs"
+
+echo >&2 '=== Obtaining version data...'
+version=$(curl -L https://benjamin.kuperberg.fr/chataigne/en | rg -o "selectFileToDownload\('win-x64-([0-9]+.[0-9]+.[0-9]+).exe'" -r '$1')
+currentVersion=$(nix-instantiate --raw --eval --strict -A chataigne.version)
+
+if [[ "$currentVersion" = "$version" ]]; then
+    echo >&2 '=== No version change. Skipping!'
+    exit 0
+fi
+
+echo >&2 '=== Updating package.nix ...'
+
+# TODO: recommend this to zoom-us maintainer instead of prefetch and --system
+doCross() {
+    systemExample=${1?'Missing system example argument'}
+    shift
+    versionArg=${1?'Missing version argument'}
+    shift
+
+    echo >&2 "==== Updating system example $systemExample ..."
+    update-source-version pkgsCross."$systemExample".chataigne "$versionArg" --ignore-same-version --print-changes
+}
+
+# First update version, then just hashes
+doCross gnu64 "$version"
+doCross aarch64-multiplatform ''
+doCross raspberryPi ''
+doCross x86_64-darwin ''
+doCross aarch64-darwin ''
+doCross mingwW64 ''
+
+echo >&2 '=== Done!'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See https://github.com/NixOS/nixpkgs/pull/131872

Linux: I can't get it to run at all, it just errors with the following message. Can someone link me to `appimageTools` maintainers?
```
Chataigne: error while loading shared libraries: libcurl-gnutls.so.4: cannot open shared object file: No such file or directory
```

TODO: test macOS for build and missing libraries and Windows for runtime functionality

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
