### PR TITLE
iwd: get rid of readline segfault

### DIFF
--- a/pkgs/by-name/iw/iwd/package.nix
+++ b/pkgs/by-name/iw/iwd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchgit,
+  fetchpatch,
   autoreconfHook,
   pkg-config,
   ell,
@@ -12,6 +13,24 @@
   python3Packages,
   gitUpdater,
 }:
+
+let
+  # fix segfault in iwctl with readline-8.3
+  # https://lists.gnu.org/archive/html/bug-readline/2025-07/msg00007.htmlP
+  readline-patch = fetchpatch {
+    url = "https://lists.gnu.org/archive/html/bug-readline/2025-07/txtmA7rksnmmi.txt";
+    hash = "sha256-QSS1GUJ2i/bF2ksvUtw27oqFHuTHALi+7QwxMFt9ZaM=";
+    stripLen = 2;
+  };
+
+  myreadline = (
+    readline.overrideAttrs (
+      _final: prev: {
+        patches = (prev.patches or [ ]) ++ [ readline-patch ];
+      }
+    )
+  );
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "iwd";
@@ -47,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     ell
     python3Packages.python
-    readline
+    myreadline
   ];
 
   nativeCheckInputs = [ openssl ];


### PR DESCRIPTION
Did a red-green test: on master it segfaults, after this patch it doesn't anymore.

See https://github.com/NixOS/nixpkgs/pull/422619#issuecomment-3130056679

Let's hope no other affected packages 🤞🏼 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
