### PR TITLE
steck: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/servers/pinnwand/steck.nix
+++ b/pkgs/servers/pinnwand/steck.nix
@@ -2,32 +2,27 @@
   lib,
   pkgs,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
   nixosTests,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "steck";
-  version = "0.7.0";
-  format = "setuptools";
+  version = "0.8.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1a3l427ibwck9zzzy1sp10hmjgminya08i4r9j4559qzy7lxghs1";
+  src = fetchFromGitHub {
+    owner = "supakeen";
+    repo = "steck";
+    tag = "v${version}";
+    hash = "sha256-5Spops8ERQ7TgFYH7n+c4hKdIQfjjujKaGhmhfAszgQ=";
   };
 
-  postPatch = ''
-    cat setup.py
-    substituteInPlace setup.py \
-      --replace 'click>=7.0,<8.0' 'click' \
-      --replace 'termcolor>=1.1.0,<2.0.0' 'termcolor'
-  '';
-
-  nativeBuildInputs = with python3Packages; [
-    setuptools
+  build-system = with python3Packages; [
+    poetry-core
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     pkgs.git
     appdirs
     click
@@ -37,16 +32,19 @@ python3Packages.buildPythonApplication rec {
     toml
   ];
 
-  # tests are not in pypi package
-  doCheck = false;
+  pythonRelaxDeps = [ "termcolor" ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
 
   passthru.tests = nixosTests.pinnwand;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/supakeen/steck";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     description = "Client for pinnwand pastebin";
     mainProgram = "steck";
-    maintainers = with maintainers; [ hexa ];
+    maintainers = with lib.maintainers; [ hexa ];
   };
 }


### PR DESCRIPTION
https://github.com/supakeen/steck/compare/v0.7.0...v0.8.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
