### PR TITLE
libpcap: enable dbus, rdma, bluetooth features

### DIFF
--- a/pkgs/by-name/li/libpcap/package.nix
+++ b/pkgs/by-name/li/libpcap/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  flex,
   bison,
   bluez,
+  fetchurl,
+  flex,
   libnl,
   libxcrypt,
   pkg-config,
@@ -16,13 +16,13 @@
 
   # for passthru.tests
   ettercap,
+  haskellPackages,
   nmap,
   ostinato,
+  python3,
   tcpreplay,
   vde2,
   wireshark,
-  python3,
-  haskellPackages,
 }:
 
 stdenv.mkDerivation rec {
@@ -40,8 +40,8 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withRemote [ libxcrypt ];
 
   nativeBuildInputs = [
-    flex
     bison
+    flex
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 
@@ -49,15 +49,11 @@ stdenv.mkDerivation rec {
   # work in pure build environments.
   configureFlags = [
     "--with-pcap=${if stdenv.hostPlatform.isLinux then "linux" else "bpf"}"
+    (lib.enableFeature withBluez "bluetooth")
+    (lib.enableFeature withRemote "remote")
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "--disable-universal"
-  ]
-  ++ lib.optionals withBluez [
-    "--enable-bluetooth"
-  ]
-  ++ lib.optionals withRemote [
-    "--enable-remote"
   ]
   ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "ac_cv_linux_vers=2" ];
 
@@ -68,6 +64,7 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+  strictDeps = true;
 
   passthru.tests = {
     inherit

--- a/pkgs/by-name/li/libpcap/package.nix
+++ b/pkgs/by-name/li/libpcap/package.nix
@@ -8,7 +8,10 @@
   libnl,
   libxcrypt,
   pkg-config,
-  withBluez ? false,
+  withBluez ? lib.meta.availableOn stdenv.hostPlatform bluez,
+  # `withRemote` disabled by default because:
+  # > configure: WARNING: Remote packet capture may expose libpcap-based
+  # > applications to attacks by malicious remote capture servers!
   withRemote ? false,
 
   # for passthru.tests
@@ -32,14 +35,15 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    lib.optionals stdenv.hostPlatform.isLinux [ libnl ] ++ lib.optionals withRemote [ libxcrypt ];
+    lib.optionals stdenv.hostPlatform.isLinux [ libnl ]
+    ++ lib.optionals withBluez [ bluez.dev ]
+    ++ lib.optionals withRemote [ libxcrypt ];
 
   nativeBuildInputs = [
     flex
     bison
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ]
-  ++ lib.optionals withBluez [ bluez.dev ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 
   # We need to force the autodetection because detection doesn't
   # work in pure build environments.
@@ -48,6 +52,9 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "--disable-universal"
+  ]
+  ++ lib.optionals withBluez [
+    "--enable-bluetooth"
   ]
   ++ lib.optionals withRemote [
     "--enable-remote"

--- a/pkgs/by-name/rd/rdma-core/package.nix
+++ b/pkgs/by-name/rd/rdma-core/package.nix
@@ -6,8 +6,6 @@
   pkg-config,
   docutils,
   pandoc,
-  ethtool,
-  iproute2,
   libnl,
   udev,
   udevCheckHook,
@@ -44,8 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    ethtool
-    iproute2
     libnl
     perl
     udev

--- a/pkgs/top-level/unixtools.nix
+++ b/pkgs/top-level/unixtools.nix
@@ -207,7 +207,10 @@ let
       darwin = pkgs.darwin.shell_cmds;
     };
     sysctl = {
-      linux = pkgs.procps;
+      linux = pkgs.procps.override {
+        # bypass sysctl -> systemd -> sysctl dependency loop
+        withSystemd = false;
+      };
       darwin = pkgs.darwin.system_cmds;
       freebsd = pkgs.freebsd.sysctl;
       openbsd = pkgs.openbsd.sysctl;


### PR DESCRIPTION
also includes some changes to `rdma-core` and `unixtools.sysctl` necessary to avoid dependency cycles.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].  `nixosTests.{ulogd,curl-impersonate,libreswan,keepalived,libreswan-nat,ndppd}` (these tests all use `tcpdump`, a CLI interface to libpcap)
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
