### PR TITLE
psitransfer: 2.2.0 -> 2.3.0, add updateScript, modernize

### DIFF
--- a/pkgs/by-name/ps/psitransfer/package.nix
+++ b/pkgs/by-name/ps/psitransfer/package.nix
@@ -48,6 +48,8 @@ buildNpmPackage (finalAttrs: {
 
   dontBuild = true;
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Simple open source self-hosted file sharing solution";
     homepage = "https://github.com/psi-4ward/psitransfer";

--- a/pkgs/by-name/ps/psitransfer/package.nix
+++ b/pkgs/by-name/ps/psitransfer/package.nix
@@ -13,7 +13,7 @@ buildNpmPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "psi-4ward";
     repo = "psitransfer";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-5o4QliAXgSZekIy0CNWfEuOxNl0uetL8C8RKUJ8HsNA=";
   };
 

--- a/pkgs/by-name/ps/psitransfer/package.nix
+++ b/pkgs/by-name/ps/psitransfer/package.nix
@@ -8,22 +8,22 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "psitransfer";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "psi-4ward";
     repo = "psitransfer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5o4QliAXgSZekIy0CNWfEuOxNl0uetL8C8RKUJ8HsNA=";
+    hash = "sha256-XUEvR8dWwFBbZdwVM8PQnYBc17SvGF5uO04vb/nAR2A=";
   };
 
-  npmDepsHash = "sha256-EW/Fej58LE/nbJomPtWvEjDveAUdo0jIWwC+ziN0gy0=";
+  npmDepsHash = "sha256-BZpd/fsuV77uj2bGZcqBpIuOq3YlUw2bxovOfu8b9iE=";
 
   app = buildNpmPackage {
     pname = "psitransfer-app";
     inherit (finalAttrs) version src;
 
-    npmDepsHash = "sha256-q7E+osWIf6VZ3JvxCXoZYeF28aMgmKP6EzQkksUUjeY=";
+    npmDepsHash = "sha256-zEGYv6TaHzgPCB3mHP2UMh8VkFqSBdrLuP5KjuEU0p8=";
 
     postPatch = ''
       # https://github.com/psi-4ward/psitransfer/pull/284

--- a/pkgs/by-name/ps/psitransfer/package.nix
+++ b/pkgs/by-name/ps/psitransfer/package.nix
@@ -49,8 +49,9 @@ buildNpmPackage (finalAttrs: {
   dontBuild = true;
 
   meta = {
-    homepage = "https://github.com/psi-4ward/psitransfer";
     description = "Simple open source self-hosted file sharing solution";
+    homepage = "https://github.com/psi-4ward/psitransfer";
+    changelog = "https://github.com/psi-4ward/psitransfer/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ hyshka ];
     mainProgram = "psitransfer";

--- a/pkgs/by-name/ps/psitransfer/package.nix
+++ b/pkgs/by-name/ps/psitransfer/package.nix
@@ -6,18 +6,22 @@
   vips,
 }:
 
-let
+buildNpmPackage (finalAttrs: {
   pname = "psitransfer";
   version = "2.2.0";
+
   src = fetchFromGitHub {
     owner = "psi-4ward";
     repo = "psitransfer";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-5o4QliAXgSZekIy0CNWfEuOxNl0uetL8C8RKUJ8HsNA=";
   };
+
+  npmDepsHash = "sha256-EW/Fej58LE/nbJomPtWvEjDveAUdo0jIWwC+ziN0gy0=";
+
   app = buildNpmPackage {
-    pname = "${pname}-app";
-    inherit version src;
+    pname = "psitransfer-app";
+    inherit (finalAttrs) version src;
 
     npmDepsHash = "sha256-q7E+osWIf6VZ3JvxCXoZYeF28aMgmKP6EzQkksUUjeY=";
 
@@ -31,11 +35,6 @@ let
       cp -r ../public/app $out
     '';
   };
-in
-buildNpmPackage {
-  inherit pname version src;
-
-  npmDepsHash = "sha256-EW/Fej58LE/nbJomPtWvEjDveAUdo0jIWwC+ziN0gy0=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
@@ -44,7 +43,7 @@ buildNpmPackage {
 
   postPatch = ''
     rm -r public/app
-    cp -r ${app} public/app
+    cp -r ${finalAttrs.app} public/app
   '';
 
   dontBuild = true;
@@ -56,4 +55,4 @@ buildNpmPackage {
     maintainers = with lib.maintainers; [ hyshka ];
     mainProgram = "psitransfer";
   };
-}
+})

--- a/pkgs/by-name/ps/psitransfer/update.sh
+++ b/pkgs/by-name/ps/psitransfer/update.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+
+set -euo pipefail
+
+nix-update psitransfer --src-only --version-regex='^v(\d+\.\d+\.\d+)$'
+nix-update psitransfer.app --version=skip
+nix-update psitransfer --version=skip


### PR DESCRIPTION
Changelog: https://github.com/psi-4ward/psitransfer/releases/tag/v2.3.0
Diff: https://github.com/psi-4ward/psitransfer/compare/v2.2.0...v2.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
