### PR TITLE
bitchat-tui: init at 0.1.0

### DIFF
--- a/pkgs/by-name/bi/bitchat-tui/package.nix
+++ b/pkgs/by-name/bi/bitchat-tui/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  dbus,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bitchat-tui";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "vaibhav-mattoo";
+    repo = "bitchat-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dk2VGXoOjs+cT8yKIsdhPSi8RG5WGN3Bi97ZW2dXQfA=";
+  };
+
+  cargoHash = "sha256-ynV/VGSDCCE06uOpNwBhb8wPgriS3KbVeTOnnn75u7U=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ dbus ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Secure, anonymous, P2P Bluetooth chat in your terminal.";
+    longDescription = ''
+      A modern Terminal User Interface (TUI) client for BitChat, a
+      secure, anonymous, and peer-to-peer chat protocol that runs over
+      Bluetooth Low Energy (BLE). Communicate completely off-grid with
+      end-to-end encryption, public channels, and direct messaging,
+      all from your terminal.
+    '';
+    homepage = "https://github.com/vaibhav-mattoo/bitchat-tui";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "bitchat-tui";
+  };
+})


### PR DESCRIPTION
A modern Terminal User Interface (TUI) client for BitChat, a secure, anonymous, and peer-to-peer chat protocol that runs over Bluetooth Low Energy (BLE). Communicate completely off-grid with end-to-end encryption, public channels, and direct messaging, all from your terminal.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- ~~Nixpkgs Release Notes~~
  - [ ] ~~Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
