### PR TITLE
vscode-extensions.esbenp.prettier-vscode: don't block local module

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/esbenp.prettier-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/esbenp.prettier-vscode/default.nix
@@ -1,8 +1,5 @@
 {
-  jq,
   lib,
-  moreutils,
-  prettier,
   vscode-utils,
 }:
 
@@ -13,18 +10,6 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "11.0.0";
     hash = "sha256-pNjkJhof19cuK0PsXJ/Q/Zb2H7eoIkfXJMLZJ4lDn7k=";
   };
-
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-
-  buildInputs = [ prettier ];
-
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."prettier.prettierPath".default = "${prettier}"' package.json | sponge package.json
-  '';
 
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/esbenp.prettier-vscode/changelog";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

#407386 added a `postInstall` script that forcibly sets a `default` value for the `prettier.prettierPath` config setting, which (because [explicit config is the highest precedence in the extension's implementation](https://github.com/prettier/prettier-vscode/blob/v11.0.0/src/ModuleResolver.ts#L153-L283)) causes the extension not to pick up the Prettier version locally installed in a project's `node_modules` as it should, unless one [specifically resets it to the empty string](https://github.com/samestep/env/commit/e730da6abfecfdf3bd5d2d542af714205d73351b).

This PR undoes that change, allowing the extension to correctly pick up local Prettier versions again without specific configuration. The extension already bundles its own version of Prettier in its own `node_modules` folder, so this PR does not degrade the user experience if no version of Prettier is globally installed, for instance.

cc @drupol @datafoo

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
