### PR TITLE
nixos/x2goserver: add package option

### DIFF
--- a/nixos/modules/services/networking/x2goserver.nix
+++ b/nixos/modules/services/networking/x2goserver.nix
@@ -37,6 +37,15 @@ in
       '';
     };
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.x2goserver;
+      defaultText = literalExpression "pkgs.x2goserver";
+      description = ''
+        The x2goserver package to use.
+      '';
+    };
+
     superenicer = {
       enable = mkEnableOption "superenicer" // {
         description = ''
@@ -87,7 +96,7 @@ in
       icons.enable = true;
     };
 
-    environment.systemPackages = [ pkgs.x2goserver ];
+    environment.systemPackages = [ cfg.package ];
 
     users.groups.x2go = { };
     users.users.x2go = {
@@ -97,14 +106,14 @@ in
     };
 
     security.wrappers.x2gosqliteWrapper = {
-      source = "${pkgs.x2goserver}/lib/x2go/libx2go-server-db-sqlite3-wrapper.pl";
+      source = "${cfg.package}/lib/x2go/libx2go-server-db-sqlite3-wrapper.pl";
       owner = "x2go";
       group = "x2go";
       setuid = false;
       setgid = true;
     };
     security.wrappers.x2goprintWrapper = {
-      source = "${pkgs.x2goserver}/bin/x2goprint";
+      source = "${cfg.package}/bin/x2goprint";
       owner = "x2go";
       group = "x2go";
       setuid = false;
@@ -123,7 +132,7 @@ in
         # x2goclient sends SSH commands with preset PATH set to
         # "/usr/local/bin;/usr/bin;/bin". Since we cannot filter arbitrary ssh
         # commands, we have to make the following executables available.
-        map (f: "L+ /usr/local/bin/${f} - - - - ${x2goserver}/bin/${f}") [
+        map (f: "L+ /usr/local/bin/${f} - - - - ${cfg.package}/bin/${f}") [
           "x2goagent"
           "x2gobasepath"
           "x2gocleansessions"
@@ -173,7 +182,7 @@ in
       unitConfig.Documentation = "man:x2goserver.conf(5)";
       serviceConfig = {
         Type = "forking";
-        ExecStart = "${pkgs.x2goserver}/bin/x2gocleansessions";
+        ExecStart = "${cfg.package}/bin/x2gocleansessions";
         PIDFile = "/run/x2go/x2goserver.pid";
         User = "x2go";
         Group = "x2go";
@@ -184,10 +193,10 @@ in
         if [ ! -e /var/lib/x2go/setup_ran ]
         then
           mkdir -p /var/lib/x2go/conf
-          cp -r ${pkgs.x2goserver}/etc/x2go/* /var/lib/x2go/conf/
+          cp -r ${cfg.package}/etc/x2go/* /var/lib/x2go/conf/
           ln -sf ${x2goServerConf} /var/lib/x2go/conf/x2goserver.conf
           ln -sf ${x2goAgentOptions} /var/lib/x2go/conf/x2goagent.options
-          ${pkgs.x2goserver}/bin/x2godbadmin --createdb
+          ${cfg.package}/bin/x2godbadmin --createdb
           touch /var/lib/x2go/setup_ran
         fi
       '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a setting to override x2goserver package. 

The x2goserver package was broken, and builds can currently only be completed on unstable. This allows selecting an alternative package while using the module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
