### PR TITLE
gdcm: remove unused patch

### DIFF
--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -34,13 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix vtk deprecated api, See https://docs.vtk.org/en/latest/release_details/9.3.html#id13.
     # Upstream mailing list: https://sourceforge.net/p/gdcm/mailman/message/59197515.
     ./fix-vtk-deprecated-api.patch
-  ]
-  ++ lib.optionals (lib.versionOlder vtk.version "9.3") [
-    (fetchpatch2 {
-      url = "https://github.com/malaterre/GDCM/commit/3be6c2fa0945c91889bcf06e8c20e88f69692dd5.patch?full_index=1";
-      hash = "sha256-Yt5f4mxhP5n+L0A/CRq3CxKCqUT7LZ8uKdbCf9P71Zc=";
-      revert = true;
-    })
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
since vtk has been upgraded to 9.5, we no longer need the revert patch in gdcm.
should triggger no rebuild.
post pr of  https://github.com/NixOS/nixpkgs/pull/417613

cc @wegank

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
