### PR TITLE
dts-lsp: init at 0.1.5

### DIFF
--- a/pkgs/by-name/dt/dts-lsp/package.nix
+++ b/pkgs/by-name/dt/dts-lsp/package.nix
@@ -1,0 +1,34 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dts-lsp";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "igor-prusov";
+    repo = "dts-lsp";
+    tag = finalAttrs.version;
+    hash = "sha256-8wMY0o8ceVl5UTsSpXf44gbX1ipSuR50cQTRng+MuNk=";
+  };
+
+  cargoHash = "sha256-hZZcu3LaG4kkXJSF0uxHrdPB3YWB3hMv+jrMLMDp2aI=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Language Server for Device Tree Source files";
+    homepage = "https://github.com/igor-prusov/dts-lsp";
+    changelog = "https://github.com/igor-prusov/dts-lsp/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = [ lib.maintainers.jmbaur ];
+    mainProgram = "dts-lsp";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

dts-lsp is an LSP for Devicetree source files

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
