### PR TITLE
nixos/vuls: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -142,6 +142,8 @@
 
 - [nvme-rs](https://github.com/liberodark/nvme-rs), NVMe monitoring [services.nvme-rs](#opt-services.nvme-rs.enable).
 
+- [vuls](https://github.com/future-architect/vuls), an agent-less vulnerability scanner for Linux, FreeBSD, Container, WordPress, Programming language libraries and Network devices. Available as [services.vuls](#opt-services.vuls.enable)
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -401,6 +401,7 @@
   ./security/sudo.nix
   ./security/systemd-confinement.nix
   ./security/tpm2.nix
+  ./security/vuls.nix
   ./security/wrappers/default.nix
   ./services/accessibility/orca.nix
   ./services/accessibility/speechd.nix

--- a/nixos/modules/security/vuls.nix
+++ b/nixos/modules/security/vuls.nix
@@ -1,0 +1,66 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.vuls;
+in
+{
+  meta.maintainers = [ lib.maintainers.kashw2 ];
+
+  options.services.vuls = {
+    enable = lib.mkEnableOption "Vuls, an Agent-less vulnerability scanner for Linux, FreeBSD, Container, WordPress, Programming language libraries, Network devices.";
+
+    package = lib.mkPackageOption pkgs "vuls" { };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open port in the firewall for the Vuls web interface.";
+    };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = "The listen address the server should serve from.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 5515;
+      description = "The port the Vuls UI should run on.";
+    };
+
+    configFile = lib.mkOption {
+      type = lib.types.path;
+      description = "The path to the configuration file.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.vuls = {
+      description = "Vuls, an Agent-less vulnerability scanner";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.vuls}/bin/vuls server \
+          ${
+            lib.optionalString cfg.configFile != null ''
+              -config=${cfg.configFile} \
+            ''
+          }
+            -listen=${cfg.listenAddress}:${toString cfg.port}
+        '';
+        DynamicUser = true;
+        Restart = "on-failure";
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/future-architect/vuls

Server for Vuls, the agent-less vulnerability scanner for Linux, FreeBSD, Container, WordPress, Programming language libraries, Network devices.

This module is not meant to allow Vuls to act as an agent. Instead the way Vuls is architected, Vuls when run as `vuls server` acts as a central hub for where vulnerability data from other vuls clients can be reported back to.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
