### PR TITLE
git-statuses: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/by-name/gi/git-statuses/package.nix
+++ b/pkgs/by-name/gi/git-statuses/package.nix
@@ -2,10 +2,12 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  installShellFiles,
   pkg-config,
   openssl,
   git,
   versionCheckHook,
+  stdenv,
   nix-update-script,
 }:
 
@@ -26,6 +28,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env.OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [
+    installShellFiles
     pkg-config
   ];
   buildInputs = [
@@ -36,6 +39,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     versionCheckHook
   ];
   doInstallCheck = true;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd git-statuses \
+      --bash <($out/bin/git-statuses --completions bash) \
+      --fish <($out/bin/git-statuses --completions fish) \
+      --zsh <($out/bin/git-statuses --completions zsh)
+  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/gi/git-statuses/package.nix
+++ b/pkgs/by-name/gi/git-statuses/package.nix
@@ -4,22 +4,23 @@
   rustPlatform,
   pkg-config,
   openssl,
+  git,
   versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "git-statuses";
-  version = "0.4.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "bircni";
     repo = "git-statuses";
     tag = finalAttrs.version;
-    hash = "sha256-e4g4tiewhN5acrkGN9Y5+WO+ihogiJXmT4PlhLtyWcs=";
+    hash = "sha256-nuWtW1NEECBqQ5uZKRqnvbjMUeYBg04j51zrHi/SDm0=";
   };
 
-  cargoHash = "sha256-IqlVwh80yTzVHWi5L+EQzt5SksK7SlBowZy46HnA+FI=";
+  cargoHash = "sha256-WAr5AkT4C14HupJHHZi209jtE8a9IUwOCw76cYu8Yjc=";
 
   # Needed to get openssl-sys to use pkg-config.
   env.OPENSSL_NO_VENDOR = 1;
@@ -31,6 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
   ];
   nativeInstallCheckInputs = [
+    git
     versionCheckHook
   ];
   doInstallCheck = true;


### PR DESCRIPTION
Changelog: https://github.com/bircni/git-statuses/blob/0.5.1/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
