### PR TITLE
alfaview: add xcb-util-cursor dependency

### DIFF
--- a/pkgs/by-name/al/alfaview/package.nix
+++ b/pkgs/by-name/al/alfaview/package.nix
@@ -21,6 +21,7 @@
   libgbm,
   openssl,
   systemd,
+  xcb-util-cursor,
   xorg,
 }:
 
@@ -59,6 +60,7 @@ stdenv.mkDerivation rec {
     openssl
     stdenv.cc.cc
     systemd
+    xcb-util-cursor
     xorg.libX11
     xorg.xcbutilwm
     xorg.xcbutilimage


### PR DESCRIPTION
> in order to provide libxcb-cursor.so.0

I'm unsure how long this is the case, but after I set up `nixpkgs-review` earlier this morning, I was greeted with this:

```console
$ nix build --file /nix/store/f1x7h74a7bhdh4mfc0qlrw1811x7h6x6-nixpkgs-review-3.2.0/lib/python3.12/site-packages/nixpkgs_review/nix/review-shell.nix --nix-path 'nixpkgs=/home/aiyion/.cache/nixpkgs-review/pr-429304-1/nixpkgs nixpkgs-overlays=/tmp/nix-shell-88106-0/tmpmj39fi5f' --extra-experimental-features 'nix-command no-url-literals' --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed --argstr local-system x86_64-linux --argstr nixpkgs-path /home/aiyion/.cache/nixpkgs-review/pr-429304-1/nixpkgs --argstr nixpkgs-config-path /tmp/nix-shell-88106-0/tmphc9u71kd.nix --argstr attrs-path /home/aiyion/.cache/nixpkgs-review/pr-429304-1/attrs.nix
error: builder for '/nix/store/bkxd9i4i286683pm2lqk64vaf3rksrn7-alfaview-9.22.10.drv' failed with exit code 1;
       last 25 log lines:
       >     libxcb-xkb.so.1 -> found: /nix/store/gk2g52fcbwlh0qvczci2clc5zxjnb28m-libxcb-1.17.0/lib
       >     libxcb.so.1 -> found: /nix/store/gk2g52fcbwlh0qvczci2clc5zxjnb28m-libxcb-1.17.0/lib
       >     libX11-xcb.so.1 -> found: /nix/store/cc238fjs80avjnhfqi4l8gwflqa8lb10-libX11-1.8.12/lib
       >     libdbus-1.so.3 -> found: /nix/store/rpl71za25x0kf5dw28vgcgwhpvwjg006-dbus-1.14.10-lib/lib
       >     libgthread-2.0.so.0 -> found: /nix/store/kww24b3s330m61gy3n7fdl6517vpayv6-glib-2.84.3/lib
       >     libbrotlidec.so.1 -> found: /nix/store/csa88p9sbvp9hidfq0dpl23sshalmx2c-brotli-1.1.0-lib/lib
       >     libstdc++.so.6 -> found: /nix/store/fkw48vh7ivlvlmhp4j30hy2gvg00jgin-gcc-14.3.0-lib/lib
       >     libgcc_s.so.1 -> found: /nix/store/cg41x0ldk43qlsndsbladyl0k4dxanvh-gcc-14.3.0-libgcc/lib
       > setting RPATH to: /nix/store/97jdzvwjgwy2g4xcijimadl0vpj6laqh-zlib-1.3.1/lib:/nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview:/nix/store/8hj889hr3a1d98fndqks0m07r0qrzmnc-libsecret-0.21.7/lib:/nix/store/kww24b3s330m61gy3n7fdl6517vpayv6-glib-2.84.3/lib:/nix/store/7plm1w55qdjpj349vbxbjqq1ja4zzf3m-libXfixes-6.0.1/lib:/nix/store/xxm9rhjdxpmp1kdjcq3j0gzc1b4s4y00-wayland-1.24.0/lib:/nix/store/cc238fjs80avjnhfqi4l8gwflqa8lb10-libX11-1.8.12/lib:/nix/store/qmhwq5h5wvgpi0qx97rdynpq1cf9xp5a-libpulseaudio-17.0/lib:/nix/store/5r4dl3vqnzmrkxzsap3ww4lrddnmvhqf-libXrandr-1.5.4/lib:/nix/store/fhidyiaqww37gzc6fh0ph5qk3vpv8vv6-libXext-1.3.6/lib:/nix/store/gk2g52fcbwlh0qvczci2clc5zxjnb28m-libxcb-1.17.0/lib:/nix/store/28hvz5qsipq2n92qbrr8d0xlacs312fh-libglvnd-1.7.0/lib:/nix/store/vy0mz3qcqdycf9dxp7s06a1dizg7xwqi-freetype-2.13.3/lib:/nix/store/lgcmyi7kylyx7d2kf8bszfr5vwpfnvfh-fontconfig-2.16.2-lib/lib:/nix/store/7nm8j8gf7g6sp6jp0kiiln3p1kklzslr-libxkbcommon-1.10.0/lib:/nix/store/369n4grgdkxfcjiyc8d0rrckhv7n4l9k-xcb-util-wm-0.4.2/lib:/nix/store/3p74csgrwzpcdzyrz5hmzncvxrp02j3p-xcb-util-image-0.4.1/lib:/nix/store/4lpvyabxdhk2db1njv5wszh6zpvis3pb-xcb-util-keysyms-0.4.1/lib:/nix/store/dmrvjalihqdbq4zwhvwakd1sb8zs2k9i-xcb-util-renderutil-0.3.10/lib:/nix/store/rpl71za25x0kf5dw28vgcgwhpvwjg006-dbus-1.14.10-lib/lib:/nix/store/csa88p9sbvp9hidfq0dpl23sshalmx2c-brotli-1.1.0-lib/lib:/nix/store/fkw48vh7ivlvlmhp4j30hy2gvg00jgin-gcc-14.3.0-lib/lib:/nix/store/cg41x0ldk43qlsndsbladyl0k4dxanvh-gcc-14.3.0-libgcc/lib
       > searching for dependencies of /nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview/libonnxruntime_av.so
       >     libstdc++.so.6 -> found: /nix/store/fkw48vh7ivlvlmhp4j30hy2gvg00jgin-gcc-14.3.0-lib/lib
       >     libgcc_s.so.1 -> found: /nix/store/cg41x0ldk43qlsndsbladyl0k4dxanvh-gcc-14.3.0-libgcc/lib
       > setting RPATH to: /nix/store/fkw48vh7ivlvlmhp4j30hy2gvg00jgin-gcc-14.3.0-lib/lib:/nix/store/cg41x0ldk43qlsndsbladyl0k4dxanvh-gcc-14.3.0-libgcc/lib
       > searching for dependencies of /nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview/libavformat.so
       >     libavcodec.so -> found: /nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview
       >     libavutil.so -> found: /nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview
       >     libz.so.1 -> found: /nix/store/97jdzvwjgwy2g4xcijimadl0vpj6laqh-zlib-1.3.1/lib
       > setting RPATH to: /nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview:/nix/store/97jdzvwjgwy2g4xcijimadl0vpj6laqh-zlib-1.3.1/lib
       > searching for dependencies of /nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview/libbassmix.so
       >     libbass.so -> found: /nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview
       > setting RPATH to: /nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview
       > auto-patchelf: 1 dependencies could not be satisfied
       > error: auto-patchelf could not satisfy dependency libxcb-cursor.so.0 wanted by /nix/store/h901spyhcwm30yq2qid4nm6qi78jlmvn-alfaview-9.22.10/opt/alfaview/alfaview
       > auto-patchelf failed to find all the required dependencies.
       > Add the missing dependencies to --libs or use `--ignore-missing="foo.so.1 bar.so etc.so"`.
       For full logs, run:
         nix-store -l /nix/store/bkxd9i4i286683pm2lqk64vaf3rksrn7-alfaview-9.22.10.drv
error: 1 dependencies of derivation '/nix/store/5h0mjrk25vmcsnpipz3dpv10mjd4jn95-review-shell.drv' failed to build

```

`nix-locate` provides:

```console
nix-locate libxcb-cursor.so.0
xcb-util-cursor-HEAD.out                              0 s /nix/store/2hhcqq0f1pkiqadp0rwhy2zppnifymyb-xcb-util-cursor-0.1.1-3-unstable-2017-04-05/lib/libxcb-cursor.so.0
xcb-util-cursor-HEAD.out                         27,184 x /nix/store/2hhcqq0f1pkiqadp0rwhy2zppnifymyb-xcb-util-cursor-0.1.1-3-unstable-2017-04-05/lib/libxcb-cursor.so.0.0.0
xcb-util-cursor.out                                   0 s /nix/store/xspw0fwrpr4ij70rzgz31gasvlq1axzj-xcb-util-cursor-0.1.5/lib/libxcb-cursor.so.0
xcb-util-cursor.out                              27,640 x /nix/store/xspw0fwrpr4ij70rzgz31gasvlq1axzj-xcb-util-cursor-0.1.5/lib/libxcb-cursor.so.0.0.0
(protonup-qt.out)                                     0 s /nix/store/sadc6ljjqim5nsk6wzq2b0rz1cfzd5ah-protonup-qt-2.12.0-extracted/usr/lib/x86_64-linux-gnu/libxcb-cursor.so.0
(protonup-qt.out)                                24,080 r /nix/store/sadc6ljjqim5nsk6wzq2b0rz1cfzd5ah-protonup-qt-2.12.0-extracted/usr/lib/x86_64-linux-gnu/libxcb-cursor.so.0.0.0
(cura-appimage.out)                              24,080 x /nix/store/792517xx9b1lxcwpaxwjc59l8awm3ssk-cura-appimage-tools-output-5.10.0-extracted/libxcb-cursor.so.0
(artisan.out)                                    24,080 r /nix/store/0vrq9ad6alpd1vkcdw4xyl4fd7q5wqj9-artisan-3.1.4-extracted/usr/share/artisan/_internal/libxcb-cursor.so.0
(anki-bin.out)                                        0 s /nix/store/wxraagr3q42zvq4mx4jwlpxmgc8cy52a-anki-bin-25.02.5-fhsenv-rootfs/usr/lib64/libxcb-cursor.so.0
(anki-bin.out)                                        0 s /nix/store/wxraagr3q42zvq4mx4jwlpxmgc8cy52a-anki-bin-25.02.5-fhsenv-rootfs/usr/lib64/libxcb-cursor.so.0.0.0
```

So I'd go with `xcb-util-cursor`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
