### PR TITLE
odin: Fix arm64-apple-darwin builds

### DIFF
--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -29,7 +29,15 @@ stdenv.mkDerivation (finalAttrs: {
     # which can be provided by a pure Nix expression, for example in a shell.
     ./system-raylib.patch
   ];
+
   postPatch = ''
+    # Odin is still using 'arm64-apple-macos' as the target name on
+    # aarch64-darwin architectures. This results in a warning whenever the
+    # Odin compiler runs a build. Replacing the target in the Odin compiler
+    # removes the nix warning when the Odin compiler is ran on aarch64-darwin.
+    substituteInPlace src/build_settings.cpp \
+      --replace-fail "arm64-apple-macosx" "arm64-apple-darwin"
+
     rm -r vendor/raylib/{linux,macos,macos-arm64,wasm,windows}
 
     patchShebangs --build build_odin.sh


### PR DESCRIPTION
When installed on Apple Silicon, the Odin compiler will emit a warning everytime it runs a build.

The warning is is that `supplying the --target arm64-apple-macosx != arm64-apple-darwin argument to a nix-wrapped`.

This is because the Odin compiler uses the target name "arm64-apple-macosx" while the nix-wrapped C compiler uses "arm64-apple-darwin".

The warning is emitted here:

https://github.com/NixOS/nixpkgs/blob/6770f4556182b1c83bb583eadaeef41902b30d53/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh#L30

This patch fixes the warning by changing the target name used by the Odin compiler to match the nix-wrapped C compiler.

This looks like it's a nix convention, so I figured that fixing it here is more appropriate than the Odin compiler.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
