### PR TITLE
boost188: fix cmake file

### DIFF
--- a/pkgs/development/libraries/boost/cmake-paths-188.patch
+++ b/pkgs/development/libraries/boost/cmake-paths-188.patch
@@ -1,0 +1,21 @@
+diff --color -ur boost_1_88_0-unpatched/tools/boost_install/boost-install.jam boost_1_88_0/tools/boost_install/boost-install.jam
+--- boost_1_88_0-unpatched/tools/boost_install/boost-install.jam	2025-07-29 21:46:33.010181683 +0800
++++ boost_1_88_0/tools/boost_install/boost-install.jam	2025-07-29 21:47:34.346642613 +0800
+@@ -794,7 +794,7 @@
+         ""
+         "# Compute the include and library directories relative to this file."
+         ""
+-        "get_filename_component(_BOOST_CMAKEDIR \"${CMAKE_CURRENT_LIST_DIR}/../\" REALPATH)"
++        "get_filename_component(_BOOST_REAL_CMAKEDIR \"${CMAKE_CURRENT_LIST_DIR}/../\" REALPATH)"
+         : true ;
+ 
+     if [ path.is-rooted $(cmakedir) ]
+@@ -813,6 +813,8 @@
+             "  unset(_BOOST_CMAKEDIR_ORIGINAL)"
+             "endif()"
+             ""
++	    "# Assume that the installer actually did know where the libs were to be installed"
++            "get_filename_component(_BOOST_CMAKEDIR \"$(cmakedir-native)\" REALPATH)"
+             : true ;
+     }
+ 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -170,6 +170,7 @@ stdenv.mkDerivation {
       lib.versionOlder version "1.88" && stdenv.hostPlatform.isDarwin
     ) ./darwin-no-system-python.patch
     ++ lib.optional (lib.versionOlder version "1.88") ./cmake-paths-173.patch
+    ++ lib.optional (lib.versionAtLeast version "1.88") ./cmake-paths-188.patch
     ++ lib.optional (version == "1.77.0") (fetchpatch {
       url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";
       relative = "include";


### PR DESCRIPTION
Boost 1.88 still needs to patch cmake file to make it works with nix.

To reproduce the issue, run the following example build: `nix build github:CHN-beta/boost-cmake-bug#without-fix`, you will get:
```
make[2]: *** No rule to make target '/nix/store/g158rrd24shbvsl7axd2w66fwzbz4aa2-boost-1.88.0-dev/lib/libboost_iostreams.so.1.88.0', needed by 'test'.  Stop.
```

After applying the patch to boost, the build success. You could try it yourself by running `nix build github:CHN-beta/boost-cmake-bug#with-fix`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
