### PR TITLE
material-kwin-decoration: migrate to by-name

### DIFF
--- a/pkgs/by-name/ma/material-kwin-decoration/package.nix
+++ b/pkgs/by-name/ma/material-kwin-decoration/package.nix
@@ -1,22 +1,13 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
-  extra-cmake-modules,
-  qtx11extras,
-  kcoreaddons,
-  kguiaddons,
-  kconfig,
-  kdecoration,
-  kconfigwidgets,
-  kwindowsystem,
-  kiconthemes,
-  kwayland,
+  libsForQt5,
   unstableGitUpdater,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "material-kwin-decoration";
   version = "7-unstable-2023-01-15";
 
@@ -24,7 +15,7 @@ mkDerivation {
     owner = "Zren";
     repo = "material-decoration";
     rev = "0e989e5b815b64ee5bca989f983da68fa5556644";
-    sha256 = "sha256-Ncn5jxkuN4ZBWihfycdQwpJ0j4sRpBGMCl6RNiH4mXg=";
+    hash = "sha256-Ncn5jxkuN4ZBWihfycdQwpJ0j4sRpBGMCl6RNiH4mXg=";
   };
 
   # Remove -Werror since it uses deprecated methods
@@ -35,10 +26,13 @@ mkDerivation {
 
   nativeBuildInputs = [
     cmake
+  ]
+  ++ (with libsForQt5; [
     extra-cmake-modules
-  ];
+    wrapQtAppsHook
+  ]);
 
-  buildInputs = [
+  buildInputs = with libsForQt5; [
     qtx11extras
     kcoreaddons
     kguiaddons
@@ -56,10 +50,10 @@ mkDerivation {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Material-ish window decoration theme for KWin";
     homepage = "https://github.com/Zren/material-decoration";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ nickcao ];
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ nickcao ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11520,8 +11520,6 @@ with pkgs;
     inherit (kdePackages) breeze-icons;
   };
 
-  material-kwin-decoration = libsForQt5.callPackage ../data/themes/material-kwin-decoration { };
-
   mplus-outline-fonts = recurseIntoAttrs (callPackage ../data/fonts/mplus-outline-fonts { });
 
   noto-fonts-cjk-serif-static = callPackage ../by-name/no/noto-fonts-cjk-serif/package.nix {


### PR DESCRIPTION
Move libsForQt5 out of toplevel
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
