### PR TITLE
[Backport release-25.05] go-httpbin: init at 2.18.3, nixos/go-httpbin: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -14,6 +14,8 @@
 - [Chrysalis](https://github.com/keyboardio/Chrysalis), a graphical configurator for Kaleidoscope-powered keyboards. Available as [programs.chrysalis](#opt-programs.chrysalis.enable).
 - [Chhoto URL](https://github.com/SinTan1729/chhoto-url), a simple, blazingly fast, selfhosted URL shortener with no unnecessary features, written in Rust. Available as [services.chhoto-url](#opt-services.chhoto-url.enable).
 
+- [go-httpbin](https://github.com/mccutchen/go-httpbin), a reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib. Available as [services.go-httpbin](#opt-services.go-httpbin.enable).
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1554,6 +1554,7 @@
   ./services/web-apps/gerrit.nix
   ./services/web-apps/glance.nix
   ./services/web-apps/glitchtip.nix
+  ./services/web-apps/go-httpbin.nix
   ./services/web-apps/goatcounter.nix
   ./services/web-apps/gotify-server.nix
   ./services/web-apps/gotosocial.nix

--- a/nixos/modules/services/web-apps/go-httpbin.nix
+++ b/nixos/modules/services/web-apps/go-httpbin.nix
@@ -1,0 +1,111 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.go-httpbin;
+
+  environment = lib.mapAttrs (
+    _: value: if lib.isBool value then lib.boolToString value else toString value
+  ) cfg.settings;
+in
+
+{
+  meta.maintainers = with lib.maintainers; [ defelo ];
+
+  options.services.go-httpbin = {
+    enable = lib.mkEnableOption "go-httpbin";
+
+    package = lib.mkPackageOption pkgs "go-httpbin" { };
+
+    settings = lib.mkOption {
+      description = ''
+        Configuration of go-httpbin.
+        See <https://github.com/mccutchen/go-httpbin#configuration> for a list of options.
+      '';
+      example = {
+        HOST = "0.0.0.0";
+        PORT = 8080;
+      };
+
+      type = lib.types.submodule {
+        freeformType =
+          with lib.types;
+          attrsOf (oneOf [
+            str
+            int
+            bool
+          ]);
+
+        options = {
+          HOST = lib.mkOption {
+            type = lib.types.str;
+            description = "The host to listen on.";
+            default = "127.0.0.1";
+            example = "0.0.0.0";
+          };
+
+          PORT = lib.mkOption {
+            type = lib.types.port;
+            description = "The port to listen on.";
+            example = 8080;
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.go-httpbin = {
+      wantedBy = [ "multi-user.target" ];
+
+      inherit environment;
+
+      serviceConfig = {
+        User = "go-httpbin";
+        Group = "go-httpbin";
+        DynamicUser = true;
+
+        ExecStart = lib.getExe cfg.package;
+
+        # hardening
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = [ "" ];
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [ "AF_INET AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SocketBindAllow = "tcp:${toString cfg.settings.PORT}";
+        SocketBindDeny = "any";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -568,6 +568,7 @@ in
   gnupg = handleTest ./gnupg.nix { };
   goatcounter = handleTest ./goatcounter.nix { };
   go-camo = handleTest ./go-camo.nix { };
+  go-httpbin = runTest ./go-httpbin.nix;
   go-neb = runTest ./go-neb.nix;
   gobgpd = handleTest ./gobgpd.nix { };
   gocd-agent = handleTest ./gocd-agent.nix { };

--- a/nixos/tests/go-httpbin.nix
+++ b/nixos/tests/go-httpbin.nix
@@ -1,0 +1,38 @@
+{ lib, ... }:
+
+{
+  name = "go-httpbin";
+  meta.maintainers = with lib.maintainers; [ defelo ];
+
+  nodes.machine = {
+    services.go-httpbin = {
+      enable = true;
+      settings.PORT = 8000;
+    };
+  };
+
+  interactive.nodes.machine = {
+    services.go-httpbin.settings.HOST = "0.0.0.0";
+    networking.firewall.allowedTCPPorts = [ 8000 ];
+    virtualisation.forwardPorts = [
+      {
+        from = "host";
+        host.port = 8000;
+        guest.port = 8000;
+      }
+    ];
+  };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("go-httpbin.service")
+    machine.wait_for_open_port(8000)
+
+    resp = json.loads(machine.succeed("curl localhost:8000/get?foo=bar"))
+    assert resp["args"]["foo"] == ["bar"]
+    assert resp["method"] == "GET"
+    assert resp["origin"] == "127.0.0.1"
+    assert resp["url"] == "http://localhost:8000/get?foo=bar"
+  '';
+}

--- a/pkgs/by-name/go/go-httpbin/package.nix
+++ b/pkgs/by-name/go/go-httpbin/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-httpbin";
+  version = "2.18.3";
+
+  src = fetchFromGitHub {
+    owner = "mccutchen";
+    repo = "go-httpbin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ixEbmppQ+4Udc5ytV4YPOpOT/iEbhjQIYGoOGL0dIw8=";
+  };
+
+  vendorHash = null;
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # tests are flaky
+  doCheck = false;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/go-httpbin --help &> /dev/null
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib";
+    homepage = "https://github.com/mccutchen/go-httpbin";
+    changelog = "https://github.com/mccutchen/go-httpbin/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ defelo ];
+    mainProgram = "go-httpbin";
+  };
+})

--- a/pkgs/by-name/go/go-httpbin/package.nix
+++ b/pkgs/by-name/go/go-httpbin/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
   nix-update-script,
 }:
 
@@ -35,7 +36,10 @@ buildGoModule (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = { inherit (nixosTests) go-httpbin; };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib";


### PR DESCRIPTION
Manual backport of #427717 to `release-25.05`.
* [ ]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-07-28T14%3A38%3A38Z#changes-acceptable-for-releases).
  * Even as a non-committer, if you find that it is not acceptable, leave a comment.