### PR TITLE
postgresql18Packages: fix build or mark as broken

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/citus.nix
+++ b/pkgs/servers/sql/postgresql/ext/citus.nix
@@ -66,7 +66,14 @@ postgresqlBuildExtension (finalAttrs: {
     # "Our soft policy for Postgres version compatibility is to support Citus'
     # latest release with Postgres' 3 latest releases."
     # https://www.citusdata.com/updates/v12-0/#deprecated_features
-    broken = lib.versionOlder postgresql.version "15";
+    broken =
+      lib.versionOlder postgresql.version "15"
+      ||
+        # PostgreSQL 18 support issue upstream: https://github.com/citusdata/citus/issues/7978
+        # Check after next package update.
+        lib.warnIf (finalAttrs.version != "13.0.3") "Is postgresql18Packages.citus still broken?" (
+          lib.versionAtLeast postgresql.version "18"
+        );
     description = "Distributed PostgreSQL as an extension";
     homepage = "https://www.citusdata.com/";
     changelog = "https://github.com/citusdata/citus/blob/${finalAttrs.src.rev}/CHANGELOG.md";

--- a/pkgs/servers/sql/postgresql/ext/lantern.nix
+++ b/pkgs/servers/sql/postgresql/ext/lantern.nix
@@ -51,6 +51,11 @@ postgresqlBuildExtension (finalAttrs: {
   };
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/lanterndata/lantern/issues/375
+    # Check after next package update.
+    broken = lib.warnIf (
+      finalAttrs.version != "0.5.0"
+    ) "Is postgresql18Packages.lantern still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "PostgreSQL vector database extension for building AI applications";
     homepage = "https://lantern.dev/";
     changelog = "https://github.com/lanterndata/lantern/blob/${finalAttrs.src.rev}/CHANGELOG.md";

--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -19,6 +19,11 @@ postgresqlBuildExtension (finalAttrs: {
   buildInputs = postgresql.buildInputs;
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/hapostgres/pg_auto_failover/issues/1083
+    # Check after next package update.
+    broken =
+      lib.warnIf (finalAttrs.version != "2.2") "Is postgresql18Packages.pg_auto_failover still broken?"
+        (lib.versionAtLeast postgresql.version "18");
     description = "PostgreSQL extension and service for automated failover and high-availability";
     mainProgram = "pg_autoctl";
     homepage = "https://github.com/citusdata/pg_auto_failover";

--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -19,6 +19,11 @@ postgresqlBuildExtension (finalAttrs: {
   makeFlags = [ "USE_PGXS=1" ];
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/pgbigm/pg_bigm/issues/28
+    # Check after next package update.
+    broken = lib.warnIf (
+      finalAttrs.version != "1.2-20240606"
+    ) "Is postgresql18Packages.pg_bigm still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "Text similarity measurement and index searching based on bigrams";
     homepage = "https://pgbigm.osdn.jp/";
     maintainers = [ ];

--- a/pkgs/servers/sql/postgresql/ext/pg_cron.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_cron.nix
@@ -17,6 +17,12 @@ postgresqlBuildExtension (finalAttrs: {
   };
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/citusdata/pg_cron/issues/396
+    # Note: already fixed on `main` branch.
+    # Check after next package update.
+    broken = lib.warnIf (
+      finalAttrs.version != "1.6.5"
+    ) "Is postgresql18Packages.pg_cron still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "Run Cron jobs through PostgreSQL";
     homepage = "https://github.com/citusdata/pg_cron";
     changelog = "https://github.com/citusdata/pg_cron/releases/tag/v${finalAttrs.version}";

--- a/pkgs/servers/sql/postgresql/ext/pg_hll.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hll.nix
@@ -16,6 +16,9 @@ postgresqlBuildExtension (finalAttrs: {
     hash = "sha256-Latdxph1Ura8yKEokEjalJ+/GY+pAKOT3GXjuLprj6c=";
   };
 
+  # https://github.com/citusdata/postgresql-hll/issues/166#issuecomment-3165489050
+  NIX_CFLAGS_COMPILE = "-Wno-error=missing-variable-declarations";
+
   meta = {
     description = "HyperLogLog for PostgreSQL";
     homepage = "https://github.com/citusdata/postgresql-hll";

--- a/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
@@ -23,6 +23,14 @@ postgresqlBuildExtension (finalAttrs: {
     maintainers = with lib.maintainers; [ ivan ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
-    broken = lib.versionOlder postgresql.version "13";
+    broken =
+      lib.versionOlder postgresql.version "13"
+      ||
+        # PostgreSQL 18 support issue upstream: https://github.com/sraoss/pg_ivm/issues/133
+        # Note: already fixed on `main` branch.
+        # Check after next package update.
+        lib.warnIf (finalAttrs.version != "1.11") "Is postgresql18Packages.pg_ivm still broken?" (
+          lib.versionAtLeast postgresql.version "18"
+        );
   };
 })

--- a/pkgs/servers/sql/postgresql/ext/pg_tle.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_tle.nix
@@ -19,6 +19,11 @@ postgresqlBuildExtension rec {
   buildInputs = postgresql.buildInputs;
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/aws/pg_tle/issues/302
+    # Check after next package update.
+    broken = lib.warnIf (version != "1.5.1") "Is postgresql18Packages.pg_tle still broken?" (
+      lib.versionAtLeast postgresql.version "18"
+    );
     description = "Framework for building trusted language extensions for PostgreSQL";
     homepage = "https://github.com/aws/pg_tle";
     changelog = "https://github.com/aws/pg_tle/releases/tag/v${version}";

--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -34,6 +34,11 @@ postgresqlBuildExtension (finalAttrs: {
   ];
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/pgroonga/pgroonga/issues/708
+    # Check after next package update.
+    broken = lib.warnIf (
+      finalAttrs.version != "4.0.1"
+    ) "Is postgresql18Packages.pgroonga still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "PostgreSQL extension to use Groonga as the index";
     longDescription = ''
       PGroonga is a PostgreSQL extension to use Groonga as the index.

--- a/pkgs/servers/sql/postgresql/ext/pgvector.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvector.nix
@@ -17,6 +17,12 @@ postgresqlBuildExtension (finalAttrs: {
   };
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/pgvector/pgvector/issues/869
+    # Note: already fixed on `master` branch.
+    # Check after next package update.
+    broken = lib.warnIf (
+      finalAttrs.version != "0.8.0"
+    ) "Is postgresql18Packages.pgvector still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "Open-source vector similarity search for PostgreSQL";
     homepage = "https://github.com/pgvector/pgvector";
     changelog = "https://github.com/pgvector/pgvector/raw/v${finalAttrs.version}/CHANGELOG.md";

--- a/pkgs/servers/sql/postgresql/ext/pgvectorscale/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvectorscale/package.nix
@@ -65,6 +65,11 @@ buildPgrxExtension (finalAttrs: {
   };
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/timescale/pgvectorscale/issues/249
+    # Check after next package update.
+    broken =
+      lib.warnIf (finalAttrs.version != "0.7.0") "Is postgresql18Packages.pgvectorscale still broken?"
+        (lib.versionAtLeast postgresql.version "18");
     homepage = "https://github.com/timescale/pgvectorscale";
     teams = [ lib.teams.flyingcircus ];
     description = "Complement to pgvector for high performance, cost efficient vector search on large workloads";

--- a/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
@@ -40,7 +40,15 @@ buildPgrxExtension (finalAttrs: {
 
   meta = {
     # Support for PostgreSQL 13 was removed in 0.2.0: https://github.com/pksunkara/pgx_ulid/blob/084778c3e2af08d16ec5ec3ef4e8f345ba0daa33/CHANGELOG.md?plain=1#L6
-    broken = lib.versionOlder postgresql.version "14";
+    broken =
+      lib.versionOlder postgresql.version "14"
+      ||
+        # PostgreSQL 18 support issue upstream: https://github.com/pksunkara/pgx_ulid/issues/65
+        # Note: already fixed on `master` branch.
+        # Check after next package update.
+        lib.warnIf (finalAttrs.version != "0.2.0") "Is postgresql18Packages.pgx_ulid still broken?" (
+          lib.versionAtLeast postgresql.version "18"
+        );
     description = "ULID Postgres extension written in Rust";
     homepage = "https://github.com/pksunkara/pgx_ulid";
     changelog = "https://github.com/pksunkara/pgx_ulid/blob/v${finalAttrs.version}/CHANGELOG.md";

--- a/pkgs/servers/sql/postgresql/ext/rum.nix
+++ b/pkgs/servers/sql/postgresql/ext/rum.nix
@@ -29,6 +29,11 @@ postgresqlBuildExtension (finalAttrs: {
   };
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/postgrespro/rum/issues/156
+    # Check after next package update.
+    broken = lib.warnIf (finalAttrs.version != "1.3.14") "Is postgresql18Packages.rum still broken?" (
+      lib.versionAtLeast postgresql.version "18"
+    );
     description = "Full text search index method for PostgreSQL";
     homepage = "https://github.com/postgrespro/rum";
     license = lib.licenses.postgresql;

--- a/pkgs/servers/sql/postgresql/ext/sqlite_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/sqlite_fdw.nix
@@ -22,6 +22,12 @@ postgresqlBuildExtension (finalAttrs: {
   makeFlags = [ "USE_PGXS=1" ];
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/pgspider/sqlite_fdw/issues/117
+    # Note: already fixed on `master` branch.
+    # Check after next package update.
+    broken = lib.warnIf (
+      finalAttrs.version != "2.5.0"
+    ) "Is postgresql18Packages.sqlite_fdw still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "SQLite Foreign Data Wrapper for PostgreSQL";
     homepage = "https://github.com/pgspider/sqlite_fdw";
     changelog = "https://github.com/pgspider/sqlite_fdw/releases/tag/v${finalAttrs.version}";

--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -20,6 +20,11 @@ postgresqlBuildExtension (finalAttrs: {
   };
 
   meta = {
+    # PostgreSQL 18 support issue upstream: https://github.com/tds-fdw/tds_fdw/issues/384
+    # Check after next package update.
+    broken = lib.warnIf (
+      finalAttrs.version != "2.0.4"
+    ) "Is postgresql18Packages.tds_fdw still broken?" (lib.versionAtLeast postgresql.version "18");
     description = "PostgreSQL foreign data wrapper to connect to TDS databases (Sybase and Microsoft SQL Server)";
     homepage = "https://github.com/tds-fdw/tds_fdw";
     changelog = "https://github.com/tds-fdw/tds_fdw/releases/tag/v${finalAttrs.version}";

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -101,6 +101,13 @@ postgresqlBuildExtension (finalAttrs: {
     maintainers = with lib.maintainers; [ kirillrdy ];
     platforms = postgresql.meta.platforms;
     license = with lib.licenses; if enableUnfree then tsl else asl20;
-    broken = lib.versionOlder postgresql.version "15";
+    broken =
+      lib.versionOlder postgresql.version "15"
+      ||
+        # PostgreSQL 18 support issue upstream: https://github.com/timescale/timescaledb/issues/8233
+        # Check after next package update.
+        lib.warnIf (finalAttrs.version != "2.21.1") "Is postgresql18Packages.timescaledb still broken?" (
+          lib.versionAtLeast postgresql.version "18"
+        );
   };
 })

--- a/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
@@ -123,6 +123,12 @@ buildPgrxExtension (finalAttrs: {
   };
 
   meta = {
+    # PostgreSQL 18 is not yet supported
+    # Will be supported in the next release (likely 0.5.0), as it's already supported in the main branch
+    # Check after next package update.
+    broken = lib.warnIf (
+      finalAttrs.version != "0.4.2"
+    ) "Is postgresql18Packages.vectorchord still broken?" (lib.versionAtLeast postgresql.version "18");
     changelog = "https://github.com/tensorchord/VectorChord/releases/tag/${finalAttrs.version}";
     description = "Scalable, fast, and disk-friendly vector search in Postgres, the successor of pgvecto.rs";
     homepage = "https://github.com/tensorchord/VectorChord";


### PR DESCRIPTION
~~The extension doesn't build on postgres 18 yet: https://hydra.nixos.org/build/303621630~~

~~From what I can see in upstream's main branch, the [next release will support it](https://github.com/tensorchord/VectorChord/blob/9ffc7be38c3f8c35f593e52cd743a97963025e1d/Cargo.toml#L22).~~

Upgraded/fixed:
- ~~pg_squeeze: 1.7.0 -> 1.9.0~~ done in https://github.com/NixOS/nixpkgs/pull/422133 instead
- pg_hll: fix build on pg18

Marked remaining build failures as broken.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
