### PR TITLE
vhost-device-sound: init at 0.2.0

### DIFF
--- a/pkgs/by-name/vh/vhost-device-sound/package.nix
+++ b/pkgs/by-name/vh/vhost-device-sound/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  alsa-lib,
+  pipewire,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "vhost-device-sound";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "rust-vmm";
+    repo = "vhost-device";
+    tag = "vhost-device-sound-v${finalAttrs.version}";
+    hash = "sha256-MJRjnJewT1kyy37QzjJ0OToEwdZMZkKxtbyGees/vYU=";
+  };
+
+  cargoHash = "sha256-PXJZouhPeylpqX/FLY7pmX+eV+IanRqHSwaJriXFhw8=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+  buildInputs = [
+    alsa-lib
+    pipewire
+  ];
+
+  cargoBuildFlags = "-p vhost-device-sound";
+  cargoTestFlags = "-p vhost-device-sound";
+
+  # Runs dbus-daemon, which tries to load config from /etc.
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/rust-vmm/vhost-device/tree/main/vhost-device-sound";
+    description = "virtio-sound device using the vhost-user protocol";
+    license = [
+      lib.licenses.asl20
+      lib.licenses.bsd3
+    ];
+    maintainers = [ lib.maintainers.qyliss ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
All the vhost-device programs are in a single repository and Cargo workspace, but they do separate release tags for each one.  From this, I'm inferring that it makes the most sense to package them separately.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
