### PR TITLE
fetchFromSourcehut: add tag as an alternative for rev

### DIFF
--- a/pkgs/build-support/fetchsourcehut/default.nix
+++ b/pkgs/build-support/fetchsourcehut/default.nix
@@ -18,13 +18,20 @@ makeOverridable (
   {
     owner,
     repo,
-    rev,
-    name ? repoRevToNameMaybe repo rev "sourcehut",
+    rev ? null,
+    tag ? null,
+    name ? repoRevToNameMaybe repo (lib.revOrTag rev tag) "sourcehut",
     domain ? "sr.ht",
     vc ? "git",
     fetchSubmodules ? false,
     ... # For hash agility
   }@args:
+
+  assert (
+    lib.assertMsg (lib.xor (tag == null) (
+      rev == null
+    )) "fetchFromSourcehut requires one of either `rev` or `tag` to be provided (not both)."
+  );
 
   assert (
     assertOneOf "vc" vc [
@@ -35,6 +42,7 @@ makeOverridable (
 
   let
     urlFor = resource: "https://${resource}.${domain}/${owner}/${repo}";
+    rev' = if tag != null then tag else rev;
     baseUrl = urlFor vc;
     baseArgs = {
       inherit name;
@@ -43,13 +51,14 @@ makeOverridable (
       "owner"
       "repo"
       "rev"
+      "tag"
       "domain"
       "vc"
       "name"
       "fetchSubmodules"
     ];
     vcArgs = baseArgs // {
-      inherit rev;
+      rev = rev';
       url = baseUrl;
     };
     fetcher = if fetchSubmodules then vc else "zip";
@@ -69,7 +78,7 @@ makeOverridable (
       zip = {
         fetch = fetchzip;
         arguments = baseArgs // {
-          url = "${baseUrl}/archive/${rev}.tar.gz";
+          url = "${baseUrl}/archive/${rev'}.tar.gz";
           postFetch = optionalString (vc == "hg") ''
             rm -f "$out/.hg_archival.txt"
           ''; # impure file; see #12002
@@ -82,7 +91,7 @@ makeOverridable (
   in
   cases.${fetcher}.fetch cases.${fetcher}.arguments
   // {
-    inherit rev;
+    rev = rev';
     meta.homepage = "${baseUrl}";
   }
 )

--- a/pkgs/by-name/mu/muon/package.nix
+++ b/pkgs/by-name/mu/muon/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     name = "muon-src";
     owner = "~lattis";
     repo = "muon";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-xTdyqK8t741raMhjjJBMbWnAorLMMdZ02TeMXK7O+Yw=";
   };
 


### PR DESCRIPTION
This is just for consistency with fetchFromGitHub and fetchFromGitLab since the URLs used are the same.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
