### PR TITLE
gnunet-messenger-cli: init at 0.3.1 

### DIFF
--- a/pkgs/by-name/gn/gnunet-messenger-cli/package.nix
+++ b/pkgs/by-name/gn/gnunet-messenger-cli/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  meson,
+  ninja,
+  pkg-config,
+  gnunet,
+  libsodium,
+  libgcrypt,
+  libgnunetchat,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gnunet-messenger-cli";
+  version = "0.3.1";
+
+  src = fetchgit {
+    url = "https://git.gnunet.org/messenger-cli.git";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8Iby3IZXEZJ1dqVV62xDzXx/qq7JKhVtn6ZLb697ZSw=";
+  };
+
+  env.INSTALL_DIR = (placeholder "out") + "/";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    gnunet
+    libgcrypt
+    libgnunetchat
+    libsodium
+    ncurses
+  ];
+
+  preInstall = "mkdir -p $out/bin";
+
+  preFixup = "mv $out/bin/messenger-cli $out/bin/gnunet-messenger-cli";
+
+  meta = {
+    description = "Decentralized, privacy-preserving networking framework for secure peer-to-peer communication";
+    homepage = "https://git.gnunet.org/messenger-cli.git";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+    mainProgram = "gnunet-messenger-cli";
+  };
+})

--- a/pkgs/by-name/li/libgnunetchat/package.nix
+++ b/pkgs/by-name/li/libgnunetchat/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  meson,
+  ninja,
+  pkg-config,
+  validatePkgConfig,
+  testers,
+  check,
+  gnunet,
+  libsodium,
+  libgcrypt,
+  libextractor,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "libgnunetchat";
+  version = "0.5.3";
+
+  src = fetchgit {
+    url = "https://git.gnunet.org/libgnunetchat.git";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DhXPYa8ya9cEbwa4btQTrpjfoTGhzBInWXXH4gmDAQw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    validatePkgConfig
+  ];
+
+  buildInputs = [
+    check
+    gnunet
+    libextractor
+    libgcrypt
+    libsodium
+  ];
+
+  env.INSTALL_DIR = (placeholder "out") + "/";
+
+  prePatch = "mkdir -p $out/lib";
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = {
+    pkgConfigModules = [ "gnunetchat" ];
+    description = "Library for secure, decentralized chat using GNUnet network services";
+    homepage = "https://git.gnunet.org/libgnunetchat.git";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+    maintainers = [ lib.maintainers.ethancedwards8 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Closes: https://github.com/ngi-nix/projects/issues/1912
Closes: https://github.com/ngi-nix/projects/issues/1903
Replaces: https://github.com/NixOS/nixpkgs/pull/403256

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
