### PR TITLE
nixpkgs-committer: init at 0-unstable-2024-07-09

### DIFF
--- a/pkgs/by-name/ni/nixpkgs-committer/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-committer/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  bashNonInteractive,
+  gh,
+  makeWrapper,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "nixpkgs-committer";
+  version = "0-unstable-2024-07-09";
+
+  src = fetchurl {
+    # latest commit to gist
+    url = "https://gist.githubusercontent.com/lorenzleutgeb/239214f1d60b1cf8c79e7b0dc0483deb/raw/2d9f486711177fc3de26e109cefac15b85e42456/committer-progress.sh";
+    hash = "sha256-Fwf6Qb5+uznKgy5PHHZmzYfbqxGBX8KBNg3R2/N8uas=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ bashNonInteractive ];
+
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0755 ${src} ${placeholder "out"}/bin/nixpkgs-committer
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram ${placeholder "out"}/bin/nixpkgs-committer \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          gh
+        ]
+      }
+  '';
+
+  meta = {
+    homepage = "https://gist.github.com/lorenzleutgeb/239214f1d60b1cf8c79e7b0dc0483deb";
+    description = "Simple shell script to detect nixpkgs commit progress";
+    mainProgram = "nixpkgs-committer";
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
