### PR TITLE
 haskellPackages.cabal2nix-unstable: don't wrap with runtime deps 

### DIFF
--- a/maintainers/scripts/haskell/regenerate-hackage-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-hackage-packages.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p coreutils haskellPackages.cabal2nix-unstable git -I nixpkgs=.
+#! nix-shell -i bash -p coreutils haskellPackages.cabal2nix-unstable.bin git -I nixpkgs=.
 
 set -euo pipefail
 

--- a/maintainers/scripts/haskell/update-cabal2nix-unstable.sh
+++ b/maintainers/scripts/haskell/update-cabal2nix-unstable.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p coreutils curl jq gnused haskellPackages.cabal2nix-unstable.bin -I nixpkgs=.
+#! nix-shell -i bash -p coreutils curl jq gnused haskellPackages.cabal2nix-unstable.bin nix-prefetch-scripts -I nixpkgs=.
 
 # Updates cabal2nix-unstable to the latest master of the nixos/cabal2nix repository.
 # See regenerate-hackage-packages.sh for details on the purpose of this script.

--- a/maintainers/scripts/haskell/update-cabal2nix-unstable.sh
+++ b/maintainers/scripts/haskell/update-cabal2nix-unstable.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p coreutils curl jq gnused haskellPackages.cabal2nix-unstable -I nixpkgs=.
+#! nix-shell -i bash -p coreutils curl jq gnused haskellPackages.cabal2nix-unstable.bin -I nixpkgs=.
 
 # Updates cabal2nix-unstable to the latest master of the nixos/cabal2nix repository.
 # See regenerate-hackage-packages.sh for details on the purpose of this script.

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1301,7 +1301,7 @@ builtins.intersectAttrs super {
               >> "$out"
           '';
     };
-  }) (justStaticExecutables super.cabal2nix-unstable);
+  }) (enableSeparateBinOutput super.cabal2nix-unstable);
 
   # test suite needs local redis daemon
   nri-redis = dontCheck super.nri-redis;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1275,7 +1275,7 @@ builtins.intersectAttrs super {
         }"
     '';
 
-    passthru = {
+    passthru = drv.passthru or { } // {
       updateScript = ../../../maintainers/scripts/haskell/update-cabal2nix-unstable.sh;
 
       # This is used by regenerate-hackage-packages.nix to supply the configuration

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1260,21 +1260,6 @@ builtins.intersectAttrs super {
   # not used to link against by anyone, we can make it’s closure smaller and
   # add its runtime dependencies in `haskellPackages` (as opposed to cabal2nix).
   cabal2nix-unstable = overrideCabal (drv: {
-    buildTools = (drv.buildTools or [ ]) ++ [
-      pkgs.buildPackages.makeWrapper
-    ];
-    postInstall = ''
-      ${drv.postInstall or ""}
-
-      wrapProgram $out/bin/cabal2nix \
-        --prefix PATH ":" "${
-          pkgs.lib.makeBinPath [
-            pkgs.nix
-            pkgs.nix-prefetch-scripts
-          ]
-        }"
-    '';
-
     passthru = drv.passthru or { } // {
       updateScript = ../../../maintainers/scripts/haskell/update-cabal2nix-unstable.sh;
 

--- a/pkgs/development/tools/purescript/spago/update.sh
+++ b/pkgs/development/tools/purescript/spago/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p cabal2nix curl jq haskellPackages.cabal2nix-unstable.bin -I nixpkgs=.
+#!nix-shell -i bash -p cabal2nix curl jq haskellPackages.cabal2nix-unstable.bin nix-prefetch-scripts -I nixpkgs=.
 #
 # This script will update the spago derivation to the latest version using
 # cabal2nix.

--- a/pkgs/development/tools/purescript/spago/update.sh
+++ b/pkgs/development/tools/purescript/spago/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p cabal2nix curl jq haskellPackages.cabal2nix-unstable.bin nix-prefetch-scripts -I nixpkgs=.
+#!nix-shell -i bash -p curl jq haskellPackages.cabal2nix-unstable.bin nix-prefetch-scripts -I nixpkgs=.
 #
 # This script will update the spago derivation to the latest version using
 # cabal2nix.

--- a/pkgs/development/tools/purescript/spago/update.sh
+++ b/pkgs/development/tools/purescript/spago/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p cabal2nix curl jq haskellPackages.cabal2nix-unstable -I nixpkgs=.
+#!nix-shell -i bash -p cabal2nix curl jq haskellPackages.cabal2nix-unstable.bin -I nixpkgs=.
 #
 # This script will update the spago derivation to the latest version using
 # cabal2nix.


### PR DESCRIPTION
cabal2nix-unstable is mostly used for regenerating the Haskell package
set. Thus we should aim to make it quick to rebuild in case its hash
changes because of Haskell related changes.

- cabal2nix is not fussy about the Nix version it uses for nix-env(1)
  and we can just assume it is already in PATH like we do for
  maintainers/scripts/haskell/*.

- nix-prefetch-scripts causes the most trouble since its python
  dependencies depend on pandoc, so many Haskell changes require
  an additional Python rebuild when building cabal2nix-unstable.

  nix-prefetch-scripts is most likely installed and not necessary in
  many cases, e.g. hackage2nix doesn't need them which is the main use
  we have for cabal2nix-unstable. For the update scripts that do need
  them, we add them to the used nix-shell explicitly.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
