### PR TITLE
libuv: fix tests on sandboxed Darwin with recent Nix/Lix

### DIFF
--- a/pkgs/by-name/li/libuv/fix-tests-in-darwin-sandbox.patch
+++ b/pkgs/by-name/li/libuv/fix-tests-in-darwin-sandbox.patch
@@ -1,0 +1,65 @@
+From c4d7c6711f5ce3d09e6f629ba49e15dfc3390948 Mon Sep 17 00:00:00 2001
+From: Emily <hello@emily.moe>
+Date: Tue, 29 Jul 2025 18:04:17 +0100
+Subject: [PATCH] test: use relative paths for pipes and Unix sockets
+
+This fixes the test suite in environments where `/tmp` is not writable
+or does not allow the use of Unix sockets, and matches the use of
+relative paths elsewhere in the tests.
+---
+ docs/code/pipe-echo-server/main.c |  2 +-
+ test/task.h                       | 10 +++-------
+ test/test-poll.c                  |  2 +-
+ 3 files changed, 5 insertions(+), 9 deletions(-)
+
+diff --git a/docs/code/pipe-echo-server/main.c b/docs/code/pipe-echo-server/main.c
+index 4f28fd03..6a233888 100644
+--- a/docs/code/pipe-echo-server/main.c
++++ b/docs/code/pipe-echo-server/main.c
+@@ -6,7 +6,7 @@
+ #ifdef _WIN32
+ #define PIPENAME "\\\\?\\pipe\\echo.sock"
+ #else
+-#define PIPENAME "/tmp/echo.sock"
++#define PIPENAME "echo.sock"
+ #endif
+ 
+ uv_loop_t *loop;
+diff --git a/test/task.h b/test/task.h
+index 2600da5e..e16af147 100644
+--- a/test/task.h
++++ b/test/task.h
+@@ -53,14 +53,10 @@
+ # define TEST_PIPENAME "\\\\.\\pipe\\uv-test"
+ # define TEST_PIPENAME_2 "\\\\.\\pipe\\uv-test2"
+ # define TEST_PIPENAME_3 "\\\\.\\pipe\\uv-test3"
+-#elif __ANDROID__
+-# define TEST_PIPENAME "/data/local/tmp/uv-test-sock"
+-# define TEST_PIPENAME_2 "/data/local/tmp/uv-test-sock2"
+-# define TEST_PIPENAME_3 "/data/local/tmp/uv-test-sock3"
+ #else
+-# define TEST_PIPENAME "/tmp/uv-test-sock"
+-# define TEST_PIPENAME_2 "/tmp/uv-test-sock2"
+-# define TEST_PIPENAME_3 "/tmp/uv-test-sock3"
++# define TEST_PIPENAME "uv-test-sock"
++# define TEST_PIPENAME_2 "uv-test-sock2"
++# define TEST_PIPENAME_3 "uv-test-sock3"
+ #endif
+ 
+ #ifdef _WIN32
+diff --git a/test/test-poll.c b/test/test-poll.c
+index 11974424..e291e737 100644
+--- a/test/test-poll.c
++++ b/test/test-poll.c
+@@ -633,7 +633,7 @@ TEST_IMPL(poll_unidirectional) {
+  * In addition to regular files, we also disallow FIFOs on Darwin.
+  */
+ #ifdef __APPLE__
+-#define TEST_POLL_FIFO_PATH "/tmp/uv-test-poll-fifo"
++#define TEST_POLL_FIFO_PATH "uv-test-poll-fifo"
+ #endif
+ TEST_IMPL(poll_bad_fdtype) {
+ #if !defined(__sun) && \
+-- 
+2.50.1
+

--- a/pkgs/by-name/li/libuv/package.nix
+++ b/pkgs/by-name/li/libuv/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   autoconf,
   automake,
   darwin,
@@ -33,6 +34,17 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-ayTk3qkeeAjrGj5ab7wF7vpWI8XWS1EeKKUqzaD/LY0=";
   };
+
+  patches = [
+    # Fix the tests on Darwin when the build directory is outside of
+    # `/tmp`, as on Nix ≥ 2.30.0 and Lix ≥ 2.91.2, ≥ 2.92.2, ≥ 2.93.1.
+    #
+    # Remove on next release.
+    (fetchpatch {
+      url = "https://github.com/libuv/libuv/commit/8aad181416c289bdf5afb221ff24f55c5f39039b.patch";
+      hash = "sha256-9+cYyQrS3wBHpW598AtSw5WMBwfl/Mycw7P4HpX9DRQ=";
+    })
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
I think this is actually our regression, but we should be closing off `/tmp` for security reasons anyway, so I just sent a fix upstream.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
