### PR TITLE
Ceph 19.2.3

### DIFF
--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -50,6 +50,7 @@
   kmod,
   libcap,
   libcap_ng,
+  libnbd,
   libnl,
   libxml2,
   lmdb,
@@ -360,10 +361,10 @@ let
   );
   inherit (ceph-python-env.python) sitePackages;
 
-  version = "19.2.2";
+  version = "19.2.3";
   src = fetchurl {
     url = "https://download.ceph.com/tarballs/ceph-${version}.tar.gz";
-    hash = "sha256-7FD9LJs25VzUCRIBm01Cm3ss1YLTN9YLwPZnHSMd8rs=";
+    hash = "sha256-zlgp28C81SZbaFJ4yvQk4ZgYz4K/aZqtcISTO8LscSU=";
   };
 in
 rec {
@@ -372,14 +373,6 @@ rec {
     inherit src version;
 
     patches = [
-      (fetchpatch2 {
-        name = "ceph-s3select-arrow-18-compat.patch";
-        url = "https://github.com/ceph/s3select/commit/f333ec82e6e8a3f7eb9ba1041d1442b2c7cd0f05.patch";
-        hash = "sha256-21fi5tMIs/JmuhwPYMWtampv/aqAe+EoPAXZLJlOvgo=";
-        stripLen = 1;
-        extraPrefix = "src/s3select/";
-      })
-
       ./boost-1.85.patch
 
       (fetchpatch2 {
@@ -393,14 +386,6 @@ rec {
       # * <https://aur.archlinux.org/cgit/aur.git/commit/?h=ceph&id=8c5cc7d8deec002f7596b6d0860859a0a718f12b>
       # * <https://github.com/ceph/ceph/pull/60999>
       ./boost-1.86-PyModule.patch
-
-      # TODO: Remove with Ceph >= 19.2.3
-      (fetchpatch2 {
-        name = "ceph-squid-client-disallow-unprivileged-users-to-escalate-root-privileges.patch";
-        url = "https://github.com/ceph/ceph/commit/380da5049e8ea7c35f34022fba24d3e2d4db6dd8.patch?full_index=1";
-        hash = "sha256-hVJ1v/n2YCJLusw+DEyK12MG73sJ/ccwbSc+2pLRxvw=";
-      })
-
     ];
 
     nativeBuildInputs = [
@@ -441,6 +426,7 @@ rec {
         gtest
         icu
         libcap
+        libnbd
         libnl
         libxml2
         lmdb


### PR DESCRIPTION
Upstream release notes: https://ceph.io/en/news/blog/2025/v19-2-3-squid-released/

Targeting `staging` because we just merged a fix to the tests there with (#427905), so on `master` we cannot run tests.

I tested it on the patches from #427905 rebased onto `nixos-unstable`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
