### PR TITLE
pymol: fix build

### DIFF
--- a/pkgs/by-name/py/pymol/package.nix
+++ b/pkgs/by-name/py/pymol/package.nix
@@ -58,21 +58,21 @@ python3Packages.buildPythonApplication rec {
 
   # A script is already created by the `[project.scripts]` directive
   # in `pyproject.toml`.
-  patches = [ 
+  patches = [
     ./script-already-exists.patch
 
     # Fix python3.13 and numpy 2 compatibility
     (fetchpatch {
-      url="https://github.com/schrodinger/pymol-open-source/commit/fef4a026425d195185e84d46ab88b2bbd6d96cf8.patch";
+      url = "https://github.com/schrodinger/pymol-open-source/commit/fef4a026425d195185e84d46ab88b2bbd6d96cf8.patch";
       hash = "sha256-F/5UcYwgHgcMQ+zeigedc1rr3WkN9rhxAxH+gQfWKIY=";
     })
     (fetchpatch {
-      url="https://github.com/schrodinger/pymol-open-source/commit/97cc1797695ee0850621762491e93dc611b04165.patch";
+      url = "https://github.com/schrodinger/pymol-open-source/commit/97cc1797695ee0850621762491e93dc611b04165.patch";
       hash = "sha256-H2PsRFn7brYTtLff/iMvJbZ+RZr7GYElMSINa4RDYdA=";
     })
     # Fixes failing test testLoadPWG
     (fetchpatch {
-      url="https://github.com/schrodinger/pymol-open-source/commit/17c6cbd96d52e9692fd298daec6c9bda273a8aad.patch";
+      url = "https://github.com/schrodinger/pymol-open-source/commit/17c6cbd96d52e9692fd298daec6c9bda273a8aad.patch";
       hash = "sha256-dcYRzUhiaGlR3CjQ0BktA5L+8lFyVdw0+hIz3Li7gDQ=";
     })
   ];
@@ -95,8 +95,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   buildInputs = [
-    python3Packages.numpy
-    python3Packages.pyqt5
     qt5.qtbase
     glew
     glm
@@ -108,6 +106,11 @@ python3Packages.buildPythonApplication rec {
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     mmtf-cpp
     msgpack
+  ];
+
+  dependencies = with python3Packages; [
+    numpy
+    pyqt5
   ];
 
   env.NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2";
@@ -173,12 +176,12 @@ python3Packages.buildPythonApplication rec {
     wrapQtApp "$out/bin/pymol"
   '';
 
-  meta = with lib; {
+  meta = {
     inherit description;
     mainProgram = "pymol";
     homepage = "https://www.pymol.org/";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       natsukium
       samlich
     ];


### PR DESCRIPTION
Added upstream patches to make pymol compatible with numpy 2.

Closes #429364

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
