### PR TITLE
sudo: 1.9.17p1 -> 1.9.17p2

### DIFF
--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -192,7 +192,7 @@ in
                             "NOINTERCEPT"
                           ]);
                         description = ''
-                          Options for running the command. Refer to the [sudo manual](https://www.sudo.ws/docs/man/1.9.15/sudoers.man/#Tag_Spec).
+                          Options for running the command. Refer to the [sudo manual](https://www.sudo.ws/docs/man/1.9.17/sudoers.man/#Tag_Spec).
                         '';
                         default = [ ];
                       };

--- a/pkgs/by-name/su/sudo/package.nix
+++ b/pkgs/by-name/su/sudo/package.nix
@@ -17,13 +17,13 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "sudo";
   # be sure to check if nixos/modules/security/sudo.nix needs updating when bumping
   # e.g. links to man pages, value constraints etc.
-  version = "1.9.17p1";
+  version = "1.9.17p2";
 
   __structuredAttrs = true;
 
   src = fetchurl {
     url = "https://www.sudo.ws/dist/sudo-${finalAttrs.version}.tar.gz";
-    hash = "sha256-/2B+pxcHIZdzinj3eGks1t+afj5ARWX1HeBjyidFXTI=";
+    hash = "sha256-SjihqzrbEZklftwqfEor1xRmXrYFsENohDsG2tos/Ps=";
   };
 
   prePatch = ''


### PR DESCRIPTION
Changes:
https://www.sudo.ws/releases/stable/#1.9.17p2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 429466`
Commit: `a3a0962f23f7e6a1eb9860519b7fcea2ede4168f`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 17 packages built:</summary>
  <ul>
    <li>charliecloud</li>
    <li>kitty</li>
    <li>kitty.kitten</li>
    <li>kitty.shell_integration</li>
    <li>kitty.terminfo</li>
    <li>lxqt.lxqt-sudo</li>
    <li>mysql-workbench</li>
    <li>nagiosPlugins.check_zfs</li>
    <li>pmbootstrap</li>
    <li>pmbootstrap.dist</li>
    <li>qsudo</li>
    <li>sudo</li>
    <li>tests.devShellTools.nixos</li>
    <li>tests.testers.lycheeLinkCheck.network</li>
    <li>tests.testers.nixosTest-example</li>
    <li>tests.testers.runNixOSTest-example (tests.testers.runNixOSTest-extendNixOS)</li>
    <li>tests.trivial-builders.references</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
