### PR TITLE
osm-gps-map: patch libsoup 2.4 → 3.0

### DIFF
--- a/pkgs/by-name/os/osm-gps-map/dont-require-libsoup.patch
+++ b/pkgs/by-name/os/osm-gps-map/dont-require-libsoup.patch
@@ -6,8 +6,8 @@ index 86efb3c..da6d1a9 100644
  Name: @PACKAGE_NAME@
  Description: Moving map widget using openstreet map data
  Version: @PACKAGE_VERSION@
--Requires: gtk+-3.0 libsoup-2.4
+-Requires: gtk+-3.0 libsoup-3.0
 +Requires: gtk+-3.0
-+Requires.private: libsoup-2.4
++Requires.private: libsoup-3.0
  Libs: -L${libdir} -losmgpsmap-1.0
  Cflags: -I${includedir}/osmgpsmap-1.0

--- a/pkgs/by-name/os/osm-gps-map/package.nix
+++ b/pkgs/by-name/os/osm-gps-map/package.nix
@@ -1,8 +1,9 @@
 {
   cairo,
+  fetchpatch2,
   fetchzip,
   glib,
-  libsoup_2_4,
+  libsoup_3,
   gnome-common,
   gtk3,
   gobject-introspection,
@@ -21,6 +22,21 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # libsoup 2 is EOL
+    # 1. 0001-Drop-support-for-libsoup-older-than-2.42.patch
+    (fetchpatch2 {
+      url = "https://salsa.debian.org/debian-gis-team/osm-gps-map/-/raw/debian/1.2.0-4/debian/patches/0001-Drop-support-for-libsoup-older-than-2.42.patch";
+      hash = "sha256-9KSqXV1ZO21nERlhp0/nZkMuGuMpsr1RfszKkTjyvSo=";
+    })
+    # 2. port-to-libsoup3.patch
+    (fetchpatch2 {
+      url = "https://salsa.debian.org/debian-gis-team/osm-gps-map/-/raw/debian/1.2.0-4/debian/patches/0001-Port-to-libsoup3.patch";
+      hash = "sha256-/Ss/rGm08UXmSpDMNGlS79eQ35sOyU8vAMC9eEBOgKg=";
+      excludes = [ ".github/*" ];
+    })
+    # 3. fix autoconf checks
+    ./port-configure-to-libsoup3.patch
+
     # libsoup is only used internally
     # it should only be listed as private requirement
     # https://github.com/nzjrs/osm-gps-map/pull/108
@@ -42,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     cairo
     glib
-    libsoup_2_4
+    libsoup_3
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/os/osm-gps-map/port-configure-to-libsoup3.patch
+++ b/pkgs/by-name/os/osm-gps-map/port-configure-to-libsoup3.patch
@@ -1,0 +1,150 @@
+From 6a06cf897cd749dae0f68498893c7b6a45faf381 Mon Sep 17 00:00:00 2001
+From: Paul Joubert <paul@trespaul.com>
+Date: Tue, 29 Jul 2025 23:13:52 +0200
+Subject: [PATCH] patch configure
+
+---
+ configure | 60 +++++++++++++++++++++++++++----------------------------
+ 1 file changed, 30 insertions(+), 30 deletions(-)
+
+diff --git a/configure b/configure
+index ed557fe..d89e384 100755
+--- a/configure
++++ b/configure
+@@ -672,8 +672,8 @@ OS_WIN32_FALSE
+ OS_WIN32_TRUE
+ GTHREAD_LIBS
+ GTHREAD_CFLAGS
+-SOUP24_LIBS
+-SOUP24_CFLAGS
++SOUP30_LIBS
++SOUP30_CFLAGS
+ CAIRO_LIBS
+ CAIRO_CFLAGS
+ GTK_LIBS
+@@ -836,8 +836,8 @@ GTK_CFLAGS
+ GTK_LIBS
+ CAIRO_CFLAGS
+ CAIRO_LIBS
+-SOUP24_CFLAGS
+-SOUP24_LIBS
++SOUP30_CFLAGS
++SOUP30_LIBS
+ GTHREAD_CFLAGS
+ GTHREAD_LIBS
+ GTKDOC_DEPS_CFLAGS
+@@ -1524,9 +1524,9 @@ Some influential environment variables:
+   CAIRO_CFLAGS
+               C compiler flags for CAIRO, overriding pkg-config
+   CAIRO_LIBS  linker flags for CAIRO, overriding pkg-config
+-  SOUP24_CFLAGS
+-              C compiler flags for SOUP24, overriding pkg-config
+-  SOUP24_LIBS linker flags for SOUP24, overriding pkg-config
++  SOUP30_CFLAGS
++              C compiler flags for SOUP30, overriding pkg-config
++  SOUP30_LIBS linker flags for SOUP30, overriding pkg-config
+   GTHREAD_CFLAGS
+               C compiler flags for GTHREAD, overriding pkg-config
+   GTHREAD_LIBS
+@@ -12719,19 +12719,19 @@ $as_echo "yes" >&6; }
+ fi
+ 
+ pkg_failed=no
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libsoup-2.4" >&5
+-$as_echo_n "checking for libsoup-2.4... " >&6; }
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libsoup-3.0" >&5
++$as_echo_n "checking for libsoup-3.0... " >&6; }
+ 
+-if test -n "$SOUP24_CFLAGS"; then
+-    pkg_cv_SOUP24_CFLAGS="$SOUP24_CFLAGS"
++if test -n "$SOUP30_CFLAGS"; then
++    pkg_cv_SOUP30_CFLAGS="$SOUP30_CFLAGS"
+  elif test -n "$PKG_CONFIG"; then
+     if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsoup-2.4\""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "libsoup-2.4") 2>&5
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsoup-3.0\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "libsoup-3.0") 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+-  pkg_cv_SOUP24_CFLAGS=`$PKG_CONFIG --cflags "libsoup-2.4" 2>/dev/null`
++  pkg_cv_SOUP30_CFLAGS=`$PKG_CONFIG --cflags "libsoup-3.0" 2>/dev/null`
+ 		      test "x$?" != "x0" && pkg_failed=yes
+ else
+   pkg_failed=yes
+@@ -12739,16 +12739,16 @@ fi
+  else
+     pkg_failed=untried
+ fi
+-if test -n "$SOUP24_LIBS"; then
+-    pkg_cv_SOUP24_LIBS="$SOUP24_LIBS"
++if test -n "$SOUP30_LIBS"; then
++    pkg_cv_SOUP30_LIBS="$SOUP30_LIBS"
+  elif test -n "$PKG_CONFIG"; then
+     if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsoup-2.4\""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "libsoup-2.4") 2>&5
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsoup-3.0\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "libsoup-3.0") 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+-  pkg_cv_SOUP24_LIBS=`$PKG_CONFIG --libs "libsoup-2.4" 2>/dev/null`
++  pkg_cv_SOUP30_LIBS=`$PKG_CONFIG --libs "libsoup-3.0" 2>/dev/null`
+ 		      test "x$?" != "x0" && pkg_failed=yes
+ else
+   pkg_failed=yes
+@@ -12769,22 +12769,22 @@ else
+         _pkg_short_errors_supported=no
+ fi
+         if test $_pkg_short_errors_supported = yes; then
+-	        SOUP24_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libsoup-2.4" 2>&1`
++	        SOUP30_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libsoup-3.0" 2>&1`
+         else
+-	        SOUP24_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libsoup-2.4" 2>&1`
++	        SOUP30_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libsoup-3.0" 2>&1`
+         fi
+ 	# Put the nasty error message in config.log where it belongs
+-	echo "$SOUP24_PKG_ERRORS" >&5
++	echo "$SOUP30_PKG_ERRORS" >&5
+ 
+-	as_fn_error $? "Package requirements (libsoup-2.4) were not met:
++	as_fn_error $? "Package requirements (libsoup-3.0) were not met:
+ 
+-$SOUP24_PKG_ERRORS
++$SOUP30_PKG_ERRORS
+ 
+ Consider adjusting the PKG_CONFIG_PATH environment variable if you
+ installed software in a non-standard prefix.
+ 
+-Alternatively, you may set the environment variables SOUP24_CFLAGS
+-and SOUP24_LIBS to avoid the need to call pkg-config.
++Alternatively, you may set the environment variables SOUP30_CFLAGS
++and SOUP30_LIBS to avoid the need to call pkg-config.
+ See the pkg-config man page for more details." "$LINENO" 5
+ elif test $pkg_failed = untried; then
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+@@ -12795,15 +12795,15 @@ as_fn_error $? "The pkg-config script could not be found or is too old.  Make su
+ is in your PATH or set the PKG_CONFIG environment variable to the full
+ path to pkg-config.
+ 
+-Alternatively, you may set the environment variables SOUP24_CFLAGS
+-and SOUP24_LIBS to avoid the need to call pkg-config.
++Alternatively, you may set the environment variables SOUP30_CFLAGS
++and SOUP30_LIBS to avoid the need to call pkg-config.
+ See the pkg-config man page for more details.
+ 
+ To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+ See \`config.log' for more details" "$LINENO" 5; }
+ else
+-	SOUP24_CFLAGS=$pkg_cv_SOUP24_CFLAGS
+-	SOUP24_LIBS=$pkg_cv_SOUP24_LIBS
++	SOUP30_CFLAGS=$pkg_cv_SOUP30_CFLAGS
++	SOUP30_LIBS=$pkg_cv_SOUP30_LIBS
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+ 
+-- 
+2.50.1
+


### PR DESCRIPTION
`libsoup-2.4` is EOL and vulnerable (#427813), yet some packages still depend on it (#360897). `osm-gps-map` is one, but although `libsoup-3.0` is used in its dev branch, the project's development has slowed (the last update being in 2021), so we can't expect a release soon.

Until then, this change follows the lead of Debian, [which has patched-in support for libsoup-3.0 from upstream](https://salsa.debian.org/debian-gis-team/osm-gps-map/-/commit/d2224755698c9f57c18273601fe6239a0d290684). (Thanks to @yapxuan for pointing this out.)

I used the two patches from the Debian repo, but removed the part of the one patch which patches the CI config in the .github folder, which is not included in the tarball release from which nix builds.

I also added a patch to change the `configure` file. I just manually replaced the occurrences of `libsoup-2.4` and `SOUP24` with `libsoup-3.0` and `SOUP30` respectively. I'm not well versed in autoconf or building C projects in general, so this is maybe a kludge, but it seems to work. I'd appreciate if someone more experienced / knowledgable could let me know if there's a more appropriate way to do this.

I built darktable against this version, and the map widget works.

Closes #429268.
Contributes to progress of #360897.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
