### PR TITLE
ttypr: init at 0.3.6

### DIFF
--- a/pkgs/by-name/tt/ttypr/package.nix
+++ b/pkgs/by-name/tt/ttypr/package.nix
@@ -1,0 +1,35 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ttypr";
+  version = "0.3.6";
+
+  src = fetchFromGitHub {
+    owner = "tanciaku";
+    repo = "ttypr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y6FXkNfd+4Nkus+Z6Ah2AJX9iWeXQnIDeKmuLFUZDdQ=";
+  };
+
+  cargoHash = "sha256-bmwvirAbjzD5NJDHJgbPhnNqTdfo8CWJ2JWgFEBz+2Y=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/tanciaku/ttypr/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Terminal typing practice";
+    longDescription = ''
+      ttypr is a simple, lightweight typing practice application that
+      runs in your terminal, built with Rust and Ratatui.
+    '';
+    homepage = "https://github.com/hotellogical05/ttypr";
+    license = lib.licenses.mit;
+    mainProgram = "ttypr";
+    maintainers = with lib.maintainers; [ yiyu ];
+  };
+})


### PR DESCRIPTION
ttypr is a simple, lightweight typing practice application that runs in your terminal, built with [Rust](https://www.rust-lang.org/) and [Ratatui](https://ratatui.rs/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- ~~Nixpkgs Release Notes~~
  - [ ] ~~Package update: when the change is major or breaking.~~
- ~~NixOS Release Notes~~
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
