### PR TITLE
ramparts: init at 0.6.1

### DIFF
--- a/pkgs/by-name/ra/ramparts/package.nix
+++ b/pkgs/by-name/ra/ramparts/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ramparts";
+  version = "0.6.9";
+
+  src = fetchFromGitHub {
+    owner = "getjavelin";
+    repo = "ramparts";
+    tag = finalAttrs.version;
+    hash = "sha256-2mv/FWTbDxzLt1ArcbWje+pjErEZ8S5U+KDGxm4f6ao=";
+  };
+
+  cargoHash = "sha256-vJbBK7KqrGJQ0zFGXXMCBKw3Q+UmLFeDP7dmOkmc8cs=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "mcp (model context protocol) scanner";
+    longDescription = ''
+      Mcp scan that scans any mcp server for indirect attack vectors
+      and security or configuration vulnerabilities.
+    '';
+    homepage = "https://github.com/getjavelin/ramparts";
+    changelog = "https://github.com/getjavelin/ramparts/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "ramparts";
+  };
+})


### PR DESCRIPTION
Mcp scan that scans any mcp server for indirect attack vectors and security or configuration vulnerabilities

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- ~~Nixpkgs Release Notes~~
  - [ ] ~~Package update: when the change is major or breaking.~~
- ~~NixOS Release Notes~~
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
