### PR TITLE
rego-query: init at 0.0.14

### DIFF
--- a/pkgs/by-name/re/rego-query/package.nix
+++ b/pkgs/by-name/re/rego-query/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromSourcehut,
+  which,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "rego-query";
+  version = "0.0.14";
+
+  src = fetchFromSourcehut {
+    owner = "~charles";
+    repo = "rq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SZnbjPiXW6mw3abyL2475sNq3s5Jw12D9ZqbLfvaHN8=";
+  };
+
+  vendorHash = "sha256-fOq62QRx7BoE7RJielTnu1dtvkLy2FkzG59uuMQVLc4=";
+
+  subPackages = [ "cmd/rq" ];
+
+  nativeCheckInputs = [ which ];
+
+  postCheck = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    substituteInPlace smoketest/smoketest.sh \
+      --replace-fail 'RQ="$(pwd)/../build/rq"' "RQ=$GOPATH/bin/rq"
+    patchShebangs --build smoketest
+    smoketest/smoketest.sh
+  '';
+
+  meta = {
+    description = "CLI tool for evaluating Rego Queries";
+    mainProgram = "rq";
+    homepage = "https://sr.ht/~charles/rq";
+    changelog = "https://git.sr.ht/~charles/rq/tree/${finalAttrs.src.rev}/item/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ refi64 ];
+  };
+})


### PR DESCRIPTION
This adds a package for [rq / Rego Query](https://sr.ht/~charles/rq), a "CLI tool for evaluating Rego Queries". I used `rego-query` as the package name since `rq` was already taken.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
