### PR TITLE
nixos/outline: add support for S3 Transfer Acceleration

### DIFF
--- a/nixos/modules/services/web-apps/outline.nix
+++ b/nixos/modules/services/web-apps/outline.nix
@@ -166,6 +166,13 @@ in
             type = lib.types.str;
             description = "S3 access key.";
           };
+          accelerateUrl = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = ''
+              URL for AWS S3 [transfer acceleration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html).
+            '';
+          };
           secretKeyFile = lib.mkOption {
             type = lib.types.path;
             description = "File path that contains the S3 secret key.";
@@ -680,6 +687,10 @@ in
             AWS_S3_UPLOAD_BUCKET_NAME = cfg.storage.uploadBucketName;
             AWS_S3_FORCE_PATH_STYLE = builtins.toString cfg.storage.forcePathStyle;
             AWS_S3_ACL = cfg.storage.acl;
+          })
+
+          (lib.mkIf (cfg.storage.storageType == "s3" && cfg.storage.accelerateUrl != null) {
+            AWS_S3_ACCELERATE_URL = cfg.storage.accelerateUrl;
           })
 
           (lib.mkIf (cfg.slackAuthentication != null) {


### PR DESCRIPTION
An optional extension for anyone using the transfer acceleration, either on S3 or as a workaround for non-public S3 services.

The description is an except from the [official hosting](https://docs.getoutline.com/s/hosting/doc/file-storage-N4M0T6Ypu7#h-transfer-acceleration) documentation.

---

Still waiting on builds/ test, might take a second as an LLVM build is blocking it for me.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
