### PR TITLE
wahay: init at 0.2

### DIFF
--- a/pkgs/by-name/wa/wahay/package.nix
+++ b/pkgs/by-name/wa/wahay/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  gnumake,
+  pkg-config,
+  gtk3,
+  rubyPackages,
+  tor,
+  mumble,
+  installShellFiles,
+  wrapGAppsHook3,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "wahay";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "digitalautonomy";
+    repo = "wahay";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-59gVGDElIs+OQ/ELwOFjz6YqG18iHqoa2yYF2Ddi0/o=";
+  };
+
+  vendorHash = "sha256-w8lUnvy5dPMHWbzyyTq9Q/kE/4vSuOHffaY9CeasvQ0=";
+
+  buildInputs = [
+    gtk3
+  ];
+
+  nativeBuildInputs = [
+    gnumake
+    pkg-config
+    rubyPackages.sass
+    installShellFiles
+    wrapGAppsHook3
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  postPatch = ''
+    # Avoid Git invocation: Remove assignments starting with ‘$(shell git’
+    sed -E -i \
+      -e '/^\w+\s*[+:]?=\s*\$\(shell\s+git\>/d' \
+      Makefile
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make TAG_VERSION=v${finalAttrs.version} \
+         BUILD_TIMESTAMP="$(date -u -d "@$SOURCE_DATE_EPOCH" '+%Y-%m-%d %H:%M:%S')" \
+         build
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    make test
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    installBin bin/wahay
+    installManPage packaging/ubuntu/ubuntu/usr/share/man/man1/wahay.1.gz
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${
+        lib.escapeShellArg (
+          lib.makeBinPath [
+            tor
+            mumble
+          ]
+        )
+      }
+    )
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    broken = stdenv.hostPlatform.isDarwin;
+    description = "Decentralized encrypted conference call application";
+    homepage = "https://wahay.org/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ dvn0 ];
+    mainProgram = "wahay";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds [Wahay](https://wahay.org/en/), an application which allows one to host and participate in voice calls in a decentralized and end-to-end encrypted manner.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
