### PR TITLE
autograder: init at 0-unstable-2025-09-11

### DIFF
--- a/pkgs/by-name/au/autograder/package.nix
+++ b/pkgs/by-name/au/autograder/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  digital,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "autograder";
+  version = "0-unstable-2025-09-09";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "phpeterson-usf";
+    repo = "autograder";
+    rev = "91a80d59b750a9e0454d4a0329d9cfd0739f3f27";
+    hash = "sha256-F1q50QS8LdIdceRa/a7FCseXvyPYbI+nl7cyPuSUpfM=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3Packages; [
+    certifi
+    charset-normalizer
+    idna
+    requests
+    tomlkit
+    urllib3
+    autopep8
+    pep8
+    pylint
+    simple-term-menu
+    pytest
+  ];
+
+  # patch digital JAR path
+  postPatch = ''
+    substituteInPlace src/autograder/actions/test.py \
+      --replace-fail '~/Digital/Digital.jar' '${lib.getBin digital}/share/java/Digital.jar'
+  '';
+
+  pythonImportsCheck = [ "autograder" ];
+
+  meta = {
+    description = "Clone and build repos from Github Classroom";
+    longDescription = ''
+      `grade` is a tool for Computer Science students and instructors
+      to test student projects for correctness.
+    '';
+    homepage = "https://github.com/phpeterson-usf/autograder";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "grade";
+  };
+}


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- ~~Nixpkgs Release Notes~~
  - [ ] ~~Package update: when the change is major or breaking.~~
- ~~NixOS Release Notes~~
  - [ ] ~~Module addition: when adding a new NixOS module.~~
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
