### PR TITLE
[Backport release-25.05] dprint-plugins.dprint-plugin-typescript: 0.95.7 -> 0.95.9

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-typescript.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-typescript.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
   description = "TypeScript/JavaScript code formatter.";
-  hash = "sha256-mAePVUsjHVo9okkozXZmwvz456YeO36ghyU4gxKJdyw=";
+  hash = "sha256-u6DpQWhPyERphKmlXOTE6NW/08YzBDWgzWTJ4JLLAjE=";
   initConfig = {
     configExcludes = [ "**/node_modules" ];
     configKey = "typescript";
@@ -16,6 +16,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-typescript";
   updateUrl = "https://plugins.dprint.dev/dprint/typescript/latest.json";
-  url = "https://plugins.dprint.dev/typescript-0.95.7.wasm";
-  version = "0.95.7";
+  url = "https://plugins.dprint.dev/typescript-0.95.8.wasm";
+  version = "0.95.8";
 }

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-typescript.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-typescript.nix
@@ -1,7 +1,7 @@
 { mkDprintPlugin }:
 mkDprintPlugin {
-  description = "TypeScript/JavaScript code formatter.";
-  hash = "sha256-u6DpQWhPyERphKmlXOTE6NW/08YzBDWgzWTJ4JLLAjE=";
+  description = "TypeScript/JavaScript code formatter";
+  hash = "sha256-hn2t1y09OGcCY2fUziogOqTmVWJmLvPUBAXOaU7hTj4=";
   initConfig = {
     configExcludes = [ "**/node_modules" ];
     configKey = "typescript";
@@ -16,6 +16,6 @@ mkDprintPlugin {
   };
   pname = "dprint-plugin-typescript";
   updateUrl = "https://plugins.dprint.dev/dprint/typescript/latest.json";
-  url = "https://plugins.dprint.dev/typescript-0.95.8.wasm";
-  version = "0.95.8";
+  url = "https://plugins.dprint.dev/typescript-0.95.9.wasm";
+  version = "0.95.9";
 }


### PR DESCRIPTION
Manual backport to `release-25.05` for #429495.

* [ ]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2025-06-28T09%3A10%3A05Z#changes-acceptable-for-releases).
  * Even as a non-committer, if you find that it is not acceptable, leave a comment.
