### PR TITLE
ch9344: support Linux 6.16

### DIFF
--- a/pkgs/os-specific/linux/ch9344/default.nix
+++ b/pkgs/os-specific/linux/ch9344/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./fix-linux-6-12-build.patch
     ./fix-linux-6-15-build.patch
+    ./fix-linux-6-16-build.patch
   ];
 
   sourceRoot = "${src.name}/driver";

--- a/pkgs/os-specific/linux/ch9344/fix-linux-6-16-build.patch
+++ b/pkgs/os-specific/linux/ch9344/fix-linux-6-16-build.patch
@@ -1,0 +1,16 @@
+diff --git a/ch9344.c b/ch9344.c
+index 36402c0..9f0df54 100644
+--- a/ch9344.c
++++ b/ch9344.c
+@@ -929,7 +929,11 @@ static void timer_function(unsigned long arg)
+ static void timer_function(struct timer_list *t)
+ {
+ 	unsigned char *buffer;
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
++	struct ch9344_ttyport *ttyport = timer_container_of(ttyport, t, timer);
++#else
+ 	struct ch9344_ttyport *ttyport = from_timer(ttyport, t, timer);
++#endif
+ 	int fifolen = kfifo_len(&ttyport->rfifo);
+ 	int len;
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix build issue with Linux 6.16.

Tested with `insmod` and devices showed up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
