### PR TITLE
Improve `security.audit{,d}`

### DIFF
--- a/nixos/modules/security/audit.nix
+++ b/nixos/modules/security/audit.nix
@@ -6,7 +6,6 @@
 }:
 let
   cfg = config.security.audit;
-  enabled = cfg.enable == "lock" || cfg.enable;
 
   failureModes = {
     silent = 0;
@@ -14,43 +13,14 @@ let
     panic = 2;
   };
 
-  disableScript = pkgs.writeScript "audit-disable" ''
-    #!${pkgs.runtimeShell} -eu
-    # Explicitly disable everything, as otherwise journald might start it.
-    auditctl -D
-    auditctl -e 0 -a task,never
-  '';
-
-  # TODO: it seems like people like their rules to be somewhat secret, yet they will not be if
-  # put in the store like this. At the same time, it doesn't feel like a huge deal and working
-  # around that is a pain so I'm leaving it like this for now.
-  startScript = pkgs.writeScript "audit-start" ''
-    #!${pkgs.runtimeShell} -eu
-    # Clear out any rules we may start with
-    auditctl -D
-
-    # Put the rules in a temporary file owned and only readable by root
-    rulesfile="$(mktemp)"
-    ${lib.concatMapStrings (x: "echo '${x}' >> $rulesfile\n") cfg.rules}
-
-    # Apply the requested rules
-    auditctl -R "$rulesfile"
-
-    # Enable and configure auditing
-    auditctl \
-      -e ${if cfg.enable == "lock" then "2" else "1"} \
-      -b ${toString cfg.backlogLimit} \
-      -f ${toString failureModes.${cfg.failureMode}} \
-      -r ${toString cfg.rateLimit}
-  '';
-
-  stopScript = pkgs.writeScript "audit-stop" ''
-    #!${pkgs.runtimeShell} -eu
-    # Clear the rules
-    auditctl -D
-
-    # Disable auditing
-    auditctl -e 0
+  # The order of the fixed rules is determined by augenrules(8)
+  rules = pkgs.writeTextDir "audit.rules" ''
+    -D
+    -b ${toString cfg.backlogLimit}
+    -f ${toString failureModes.${cfg.failureMode}}
+    -r ${toString cfg.rateLimit}
+    ${lib.concatLines cfg.rules}
+    -e ${if cfg.enable == "lock" then "2" else "1"}
   '';
 in
 {
@@ -110,23 +80,35 @@ in
     };
   };
 
-  config = {
-    systemd.services.audit = {
-      description = "Kernel Auditing";
-      wantedBy = [ "basic.target" ];
+  config = lib.mkIf (cfg.enable == "lock" || cfg.enable) {
+    systemd.services.audit-rules = {
+      description = "Load Audit Rules";
+      wantedBy = [ "sysinit.target" ];
+      before = [
+        "sysinit.target"
+        "shutdown.target"
+      ];
+      conflicts = [ "shutdown.target" ];
 
       unitConfig = {
+        DefaultDependencies = false;
         ConditionVirtualization = "!container";
-        ConditionSecurity = [ "audit" ];
+        ConditionKernelCommandLine = [
+          "!audit=0"
+          "!audit=off"
+        ];
       };
-
-      path = [ pkgs.audit ];
 
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStart = "@${if enabled then startScript else disableScript} audit-start";
-        ExecStop = "@${stopScript} audit-stop";
+        ExecStart = "${lib.getExe' pkgs.audit "auditctl"} -R ${rules}/audit.rules";
+        ExecStopPost = [
+          # Disable auditing
+          "${lib.getExe' pkgs.audit "auditctl"} -e 0"
+          # Delete all rules
+          "${lib.getExe' pkgs.audit "auditctl"} -D"
+        ];
       };
     };
   };

--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -9,12 +9,13 @@
   options.security.auditd.enable = lib.mkEnableOption "the Linux Audit daemon";
 
   config = lib.mkIf config.security.auditd.enable {
-    boot.kernelParams = [ "audit=1" ];
+    # Starting auditd should also enable loading the audit rules..
+    security.audit.enable = lib.mkDefault true;
 
     environment.systemPackages = [ pkgs.audit ];
 
     systemd.services.auditd = {
-      description = "Linux Audit daemon";
+      description = "Security Audit Logging Service";
       documentation = [ "man:auditd(8)" ];
       wantedBy = [ "sysinit.target" ];
       after = [
@@ -28,16 +29,26 @@
       conflicts = [ "shutdown.target" ];
 
       unitConfig = {
-        ConditionVirtualization = "!container";
-        ConditionSecurity = [ "audit" ];
         DefaultDependencies = false;
+        RefuseManualStop = true;
+        ConditionVirtualization = "!container";
+        ConditionKernelCommandLine = [
+          "!audit=0"
+          "!audit=off"
+        ];
       };
 
-      path = [ pkgs.audit ];
-
       serviceConfig = {
-        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /var/log/audit";
+        LogsDirectory = "audit";
         ExecStart = "${pkgs.audit}/bin/auditd -l -n -s nochange";
+        Restart = "on-failure";
+        # Do not restart for intentional exits. See EXIT CODES section in auditd(8).
+        RestartPreventExitStatus = "2 4 6";
+
+        # Upstream hardening settings
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
       };
     };
   };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -226,6 +226,7 @@ in
   atticd = runTest ./atticd.nix;
   atuin = runTest ./atuin.nix;
   ax25 = runTest ./ax25.nix;
+  audit = runTest ./audit.nix;
   audiobookshelf = runTest ./audiobookshelf.nix;
   auth-mysql = runTest ./auth-mysql.nix;
   authelia = runTest ./authelia.nix;

--- a/nixos/tests/audit.nix
+++ b/nixos/tests/audit.nix
@@ -1,0 +1,37 @@
+{
+
+  name = "audit";
+
+  nodes = {
+    machine =
+      { lib, pkgs, ... }:
+      {
+        security.audit = {
+          enable = true;
+          rules = [
+            "-a always,exit -F exe=${lib.getExe pkgs.hello} -k nixos-test"
+          ];
+        };
+        security.auditd.enable = true;
+
+        environment.systemPackages = [ pkgs.hello ];
+      };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("audit-rules.service")
+    machine.wait_for_unit("auditd.service")
+
+    with subtest("Audit subsystem gets enabled"):
+      assert "enabled 1" in machine.succeed("auditctl -s")
+
+    with subtest("Custom rule produces audit traces"):
+      machine.succeed("hello")
+      print(machine.succeed("ausearch -k nixos-test -sc exit_group"))
+
+    with subtest("Stopping audit-rules.service disables the audit subsystem"):
+      machine.succeed("systemctl stop audit-rules.service")
+      assert "enabled 0" in machine.succeed("auditctl -s")
+  '';
+
+}

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -17,6 +17,7 @@
   enablePython ? stdenv.hostPlatform == stdenv.buildPlatform,
   nix-update-script,
   testers,
+  nixosTests,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "audit";
@@ -90,6 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     tests = {
       musl = pkgsCross.musl64.audit;
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+      audit = nixosTests.audit;
     };
   };
 


### PR DESCRIPTION
The audit module behaved very weirdly. Instead of being guarded behind an `mkIf` it would start a "disable" script if the service wasn't enabled. This would thus always pull in the service making `pkgs.audit` (the bin output) a mandatory part of every NixOS system closure (the lib output has always been because of systemd).
@arianvp also reported that this sometimes led to race conditions with journald which also tries to communicate with the audit subsystem. This PR fixes this behaviour and along the way gets rid of unnecessary (mandatory) bash script.

The `audit` and `auditd` module are aligned with upstream and some weird options are removed. For example `ConditionSecurity = [ "audit" ];` which doesn't make sense to set because `audit-rules` is supposed to enable the subsystem in the first place. The only reason this has ever worked in the past is because of some unfortunate misbehaviour of journald (which would enable the audit subsystem itself).

To summarize: `security.audit` is now responsible for loading the audit rules and enabling the audit subsystem. `security.auditd` is only responsible for starting auditd. 

Closes #11864

This isssue can now be closed from my perspective. Shipping default rules might be possible but can be tracked separately.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
