### PR TITLE
superfile: 1.3.2 -> 1.3.3; fix build

### DIFF
--- a/pkgs/by-name/su/superfile/package.nix
+++ b/pkgs/by-name/su/superfile/package.nix
@@ -1,9 +1,11 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
   writableTmpDirAsHomeHook,
+  exiftool,
 }:
 let
   version = "1.3.2";
@@ -27,10 +29,19 @@ buildGoModule {
     "-w"
   ];
 
+  nativeBuildInputs = [ exiftool ];
+
   nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
-  # Upstream notes that this could be flakey, and it consistently fails for me.
-  checkFlags = [ "-skip=^TestReturnDirElement/Sort_by_Date$" ];
+  # Upstream notes that this could be flaky, and it consistently fails for me.
+  checkFlags = [
+    "-skip=^TestReturnDirElement/Sort_by_Date$"
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    # Only failing on nix darwin. I suspect this is due to the way
+    # darwin handles file permissions.
+    "-skip=^TestCompressSelectedFiles"
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/su/superfile/package.nix
+++ b/pkgs/by-name/su/superfile/package.nix
@@ -8,7 +8,7 @@
   exiftool,
 }:
 let
-  version = "1.3.2";
+  version = "1.3.3";
   tag = "v${version}";
 in
 buildGoModule {
@@ -19,7 +19,7 @@ buildGoModule {
     owner = "yorukot";
     repo = "superfile";
     inherit tag;
-    hash = "sha256-IzdaOJcwi7+8d8QpTLPJwEhffEz4h0Rdv7APOMcnTHw=";
+    hash = "sha256-A1SWsBcPtGNbSReslp5L3Gg4hy3lDSccqGxFpLfVPrk=";
   };
 
   vendorHash = "sha256-sqt0BzJW1nu6gYAhscrXlTAbwIoUY7JAOuzsenHpKEI=";


### PR DESCRIPTION
closes #429331

Fixed the build by skipping a test is only failing in nix darwin (couldn't really pinpoint what is the issue) and added a missing dependency.

Also noticed there was a new version available, so I bumped it.
Changelog: https://github.com/yorukot/superfile/releases/tag/v1.3.3


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
