### PR TITLE
linux: fix cross

### DIFF
--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   rust-bindgen-unwrapped,
   zlib,
   bash,
@@ -14,7 +13,6 @@ let
         #for substituteAll
         inherit bash;
         unwrapped = rust-bindgen-unwrapped;
-        libclang = (lib.getLib clang.cc);
         meta = rust-bindgen-unwrapped.meta // {
           longDescription = rust-bindgen-unwrapped.meta.longDescription + ''
             This version of bindgen is wrapped with the required compiler flags

--- a/pkgs/development/tools/rust/bindgen/unwrapped.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped.nix
@@ -21,11 +21,15 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-K/iM79RfNU+3f2ae6wy/FMFAD68vfqzSUebqALPJpJY=";
 
-  buildInputs = [ (lib.getLib clang.cc) ];
-
   preConfigure = ''
     export LIBCLANG_PATH="${lib.getLib clang.cc}/lib"
   '';
+
+  # Disable the "runtime" feature, so libclang is linked.
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "logging" ];
+  checkNoDefaultFeatures = buildNoDefaultFeatures;
+  checkFeatures = buildFeatures;
 
   doCheck = true;
   nativeCheckInputs = [ clang ];

--- a/pkgs/development/tools/rust/bindgen/wrapper.sh
+++ b/pkgs/development/tools/rust/bindgen/wrapper.sh
@@ -27,10 +27,8 @@ fi;
 if [[ -n "$NIX_DEBUG" ]]; then
   set -x;
 fi;
-export LIBCLANG_PATH="@libclang@/lib"
 # shellcheck disable=SC2086
 # cxxflags and NIX_CFLAGS_COMPILE should be word-split
 exec -a "$0" @unwrapped@/bin/bindgen "$@" $sep $cxxflags @cincludes@ $NIX_CFLAGS_COMPILE
 # note that we add the flags after $@ which is incorrect. This is only for the sake
 # of simplicity.
-

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -11,9 +11,9 @@
   pahole,
   lib,
   stdenv,
-  rustc,
+  rustc-unwrapped,
   rustPlatform,
-  rust-bindgen,
+  rust-bindgen-unwrapped,
   # testing
   emptyFile,
   nixos,
@@ -126,7 +126,7 @@ let
 
       commonStructuredConfig = import ./common-config.nix {
         inherit lib stdenv version;
-        rustAvailable = lib.meta.availableOn stdenv.hostPlatform rustc;
+        rustAvailable = lib.meta.availableOn stdenv.hostPlatform rustc-unwrapped;
 
         features = kernelFeatures; # Ensure we know of all extra patches, etc.
       };
@@ -190,8 +190,8 @@ let
         ]
         ++ lib.optional (lib.versionAtLeast version "5.2") pahole
         ++ lib.optionals withRust [
-          rust-bindgen.unwrapped
-          rustc.unwrapped
+          rust-bindgen-unwrapped
+          rustc-unwrapped
         ];
 
         RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -190,7 +190,7 @@ let
         ]
         ++ lib.optional (lib.versionAtLeast version "5.2") pahole
         ++ lib.optionals withRust [
-          rust-bindgen
+          rust-bindgen.unwrapped
           rustc.unwrapped
         ];
 

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -22,8 +22,8 @@
   kmod,
   ubootTools,
   fetchpatch,
-  rustc,
-  rust-bindgen,
+  rustc-unwrapped,
+  rust-bindgen-unwrapped,
   rustPlatform,
 }:
 
@@ -169,8 +169,8 @@ lib.makeOverridable (
         ]
         ++ optional (lib.versionAtLeast version "5.13") zstd
         ++ optionals withRust [
-          rustc.unwrapped
-          rust-bindgen.unwrapped
+          rustc-unwrapped
+          rust-bindgen-unwrapped
         ];
 
       in
@@ -229,8 +229,8 @@ lib.makeOverridable (
           zlib
         ]
         ++ optionals withRust [
-          rustc.unwrapped
-          rust-bindgen.unwrapped
+          rustc-unwrapped
+          rust-bindgen-unwrapped
         ];
 
         RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -169,7 +169,7 @@ lib.makeOverridable (
         ]
         ++ optional (lib.versionAtLeast version "5.13") zstd
         ++ optionals withRust [
-          rustc
+          rustc.unwrapped
           rust-bindgen.unwrapped
         ];
 
@@ -229,7 +229,7 @@ lib.makeOverridable (
           zlib
         ]
         ++ optionals withRust [
-          rustc
+          rustc.unwrapped
           rust-bindgen.unwrapped
         ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5961,6 +5961,7 @@ with pkgs;
     cargo-auditable-cargo-wrapper
     clippy
     rustc
+    rustc-unwrapped
     rustPlatform
     ;
 


### PR DESCRIPTION
The .unwrapped attributes are not correctly spliced.  Use the top level attributes instead, which are spliced correctly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
