### PR TITLE
wasilibc: 22-unstable-2024-10-26 -> 27

### DIFF
--- a/pkgs/by-name/wa/wasilibc/package.nix
+++ b/pkgs/by-name/wa/wasilibc/package.nix
@@ -4,6 +4,7 @@
   lib,
   firefox-unwrapped,
   firefox-esr-unwrapped,
+  enablePosixThreads ? false,
 }:
 
 stdenvNoLibc.mkDerivation (finalAttrs: {
@@ -40,6 +41,7 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
       "SYSROOT_LIB:=$SYSROOT_LIB"
       "SYSROOT_INC:=$SYSROOT_INC"
       "SYSROOT_SHARE:=$SYSROOT_SHARE"
+      ${lib.strings.optionalString enablePosixThreads "THREAD_MODEL:=posix"}
     )
   '';
 

--- a/pkgs/by-name/wa/wasilibc/package.nix
+++ b/pkgs/by-name/wa/wasilibc/package.nix
@@ -1,22 +1,19 @@
 {
   stdenvNoLibc,
-  buildPackages,
+  fetchFromGitHub,
   lib,
   firefox-unwrapped,
   firefox-esr-unwrapped,
 }:
 
-let
+stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "wasilibc";
-  version = "27-unstable-2025-07-27";
-in
-stdenvNoLibc.mkDerivation {
-  inherit pname version;
+  version = "27";
 
-  src = buildPackages.fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "wasi-libc";
-    rev = "3f7eb4c7d6ede4dde3c4bffa6ed14e8d656fe93f";
+    tag = "wasi-sdk-${finalAttrs.version}";
     hash = "sha256-RIjph1XdYc1aGywKks5JApcLajbNFEuWm+Wy/GMHddg=";
     fetchSubmodules = true;
   };
@@ -43,10 +40,7 @@ stdenvNoLibc.mkDerivation {
       "SYSROOT_LIB:=$SYSROOT_LIB"
       "SYSROOT_INC:=$SYSROOT_INC"
       "SYSROOT_SHARE:=$SYSROOT_SHARE"
-      # https://bugzilla.mozilla.org/show_bug.cgi?id=1773200
-      "BULK_MEMORY_SOURCES:="
     )
-
   '';
 
   enableParallelBuilding = true;
@@ -63,13 +57,14 @@ stdenvNoLibc.mkDerivation {
   };
 
   meta = with lib; {
-    changelog = "https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-${version}";
+    changelog = "https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-${finalAttrs.version}";
     description = "WASI libc implementation for WebAssembly";
     homepage = "https://wasi.dev";
     platforms = platforms.wasi;
     maintainers = with maintainers; [
       matthewbauer
       rvolosatovs
+      wucke13
     ];
     license = with licenses; [
       asl20
@@ -77,4 +72,4 @@ stdenvNoLibc.mkDerivation {
       mit
     ];
   };
-}
+})

--- a/pkgs/by-name/wa/wasilibc/package.nix
+++ b/pkgs/by-name/wa/wasilibc/package.nix
@@ -8,7 +8,7 @@
 
 let
   pname = "wasilibc";
-  version = "22-unstable-2024-10-16";
+  version = "27-unstable-2025-07-27";
 in
 stdenvNoLibc.mkDerivation {
   inherit pname version;
@@ -16,8 +16,8 @@ stdenvNoLibc.mkDerivation {
   src = buildPackages.fetchFromGitHub {
     owner = "WebAssembly";
     repo = "wasi-libc";
-    rev = "98897e29fcfc81e2b12e487e4154ac99188330c4";
-    hash = "sha256-NFKhMJj/quvN3mR7lmxzA9w46KhX92iG0rQA9qDeS8I=";
+    rev = "3f7eb4c7d6ede4dde3c4bffa6ed14e8d656fe93f";
+    hash = "sha256-RIjph1XdYc1aGywKks5JApcLajbNFEuWm+Wy/GMHddg=";
     fetchSubmodules = true;
   };
 
@@ -31,6 +31,7 @@ stdenvNoLibc.mkDerivation {
   postPatch = ''
     substituteInPlace Makefile \
       --replace "-Werror" ""
+    patchShebangs scripts/
   '';
 
   preBuild = ''


### PR DESCRIPTION
I'm interested in using the newest wasi releases. The package is quite outdated, hence I updated it. I also tidied up the derivation. For the clean-up, feedback would be welcome!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
