### PR TITLE
linbox: 1.7.0 -> 1.7.1, givaro: 4.2.0 -> 4.2.1

### DIFF
--- a/pkgs/by-name/gi/givaro/package.nix
+++ b/pkgs/by-name/gi/givaro/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   automake,
   autoconf,
   libtool,
@@ -11,41 +10,16 @@
 }:
 stdenv.mkDerivation rec {
   pname = "givaro";
-  version = "4.2.0";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "linbox-team";
     repo = "givaro";
     tag = "v${version}";
-    sha256 = "sha256-KR0WJc0CSvaBnPRott4hQJhWNBb/Wi6MIhcTExtVobQ=";
+    sha256 = "sha256-vSkWmKqpbVk1qdsqCU7qF7o+YgV5YRc9p4mlgl6yrto=";
   };
 
   patches = [
-    # Pull upstream fix for gcc-13:
-    #   https://github.com/linbox-team/givaro/pull/218
-    (fetchpatch {
-      name = "gcc-13.patch";
-      url = "https://github.com/linbox-team/givaro/commit/c7744bb133496cd7ac04688f345646d505e1bf52.patch";
-      hash = "sha256-aAA5o8Va10v0Pqgcpx7qM0TAZiNQgXoR6N9xecj7tDA=";
-    })
-    (fetchpatch {
-      name = "clang-16.patch";
-      url = "https://github.com/linbox-team/givaro/commit/a81d44b3b57c275bcb04ab00db79be02561deaa2.patch";
-      hash = "sha256-sSk+VWffoEjZRTJcHRISLHPyW6yuvI1u8knBOfxNUIE=";
-    })
-    # https://github.com/linbox-team/givaro/issues/226
-    (fetchpatch {
-      name = "gcc-14.patch";
-      url = "https://github.com/linbox-team/givaro/commit/b0cf33e1d4437530c7e4b3db90b6c80057a7f2f3.patch";
-      includes = [ "src/kernel/integer/random-integer.h" ];
-      hash = "sha256-b2Q8apP9ueEqIUtibTeP47x6TlroRzLgAxuv5ZM1EUw=";
-    })
-    # https://github.com/linbox-team/givaro/issues/232
-    (fetchpatch {
-      name = "clang-19.patch";
-      url = "https://github.com/linbox-team/givaro/commit/a18baf5227d4f3e81a50850fe98e0d954eaa3ddb.patch";
-      hash = "sha256-IR0IHhCqbxgtsST30vxM9ak1nGtt0apxcLUQ1kS1DHw=";
-    })
     # skip gmp version check for cross-compiling, our version is new enough
     ./skip-gmp-check.patch
   ];

--- a/pkgs/by-name/li/linbox/package.nix
+++ b/pkgs/by-name/li/linbox/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   autoreconfHook,
   givaro,
   pkg-config,
@@ -16,40 +15,14 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "linbox";
-  version = "1.7.0";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "linbox-team";
     repo = "linbox";
     rev = "v${version}";
-    sha256 = "sha256-mW84a98KPLqcHMjX3LIYTmVe0ngUdz6RJLpoDaAqKU8=";
+    sha256 = "sha256-WUSQI9svxbrDTtWBjCF2XMhRFdKwCht8XBmJIJ3DR1E=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/linbox-team/linbox/commit/4be26e9ef0eaf36a9909e5008940e8bf7dc625b6.patch";
-      sha256 = "PX0Tik7blXOV2vHUq92xMxaADkNoNGiax4qrjQyGK6U=";
-    })
-    (fetchpatch {
-      name = "gcc-14.patch";
-      url = "https://github.com/linbox-team/linbox/commit/b8f2d4ccdc0af4418d14f72caf6c4d01969092a3.patch";
-      includes = [
-        "linbox/matrix/sparsematrix/sparse-ell-matrix.h"
-        "linbox/matrix/sparsematrix/sparse-ellr-matrix.h"
-      ];
-      hash = "sha256-sqwgHkECexR2uX/SwYP7r9ZGHnGG+i4RXtfnvWsVQlk=";
-    })
-    (fetchpatch {
-      name = "clang-19.patch";
-      url = "https://github.com/linbox-team/linbox/commit/4f7a9bc830696b2f2c0219feaa74e85202700412.patch";
-      hash = "sha256-DoKh8/+2WPbMhN9MhpKmQ5sKmizD9iE81zS/XI0aM9Q=";
-    })
-    (fetchpatch {
-      name = "clang-19.patch";
-      url = "https://github.com/linbox-team/linbox/commit/4a1e1395804d4630ec556c61ba3f2cb67e140248.patch";
-      hash = "sha256-sCe/8hb27RuMxU1XXWsVU5gaGk2V+T6Ee7yrC5G5Hsc=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
https://github.com/linbox-team/linbox/releases/tag/v1.7.1
https://github.com/linbox-team/givaro/releases/tag/v4.2.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
