### PR TITLE
patch-shebangs: fix regression in patching of hard links

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -124,30 +124,19 @@ patchShebangs() {
                 # escape the escape chars so that sed doesn't interpret them
                 escapedInterpreterLine=${newInterpreterLine//\\/\\\\}
 
-                # Preserve times, see: https://github.com/NixOS/nixpkgs/pull/33281
-                timestamp=$(stat --printf "%y" "$f")
-
                 # Manually create temporary file instead of using sed -i
                 # (sed -i on $out/x creates tmpfile /nix/store/x which fails on macos + sandbox)
-                tmpFile=$(mktemp -t patchShebangs.XXXXXXXXXX)
+                tmpFile="$(mktemp -t patchShebangs.XXXXXXXXXX)"
                 sed -e "1 s|.*|#\!$escapedInterpreterLine|" "$f" > "$tmpFile"
 
-                # Make original file writable if it is read-only
-                local restoreReadOnly
-                if [[ ! -w "$f" ]]; then
-                    chmod +w "$f"
-                    restoreReadOnly=true
-                fi
+                # Preserve permissions
+                chmod --reference="$f" "$tmpFile"
 
-                # Replace the original file's content with the patched content
-                # (preserving permissions)
-                cat "$tmpFile" > "$f"
-                rm "$tmpFile"
-                if [[ -n "${restoreReadOnly:-}" ]]; then
-                    chmod -w "$f"
-                fi
+                # Preserve times, see: https://github.com/NixOS/nixpkgs/pull/33281
+                timestamp="$(stat --printf "%y" "$f")"
+                touch --date "$timestamp" "$tmpFile"
 
-                touch --date "$timestamp" "$f"
+                mv "$tmpFile" "$f"
             fi
         fi
     done < <(find "$@" -type f -perm -0100 -print0)


### PR DESCRIPTION
This was discovered with issues related to pnpm that hard links on some systems, see #426636.

This is a regression introduced by #414448 and #423137.

When `sed -i` is used on a file with hard links, then the file is seperated and only the file named in the command is changed.

https://real-world-systems.com/docs/sed-in-place.html

We have solved the pnpm issue by avoiding hard-links (#429554), but the question is what the desired behavior is of the `patch-shebangs`.

It was a very confusing behavior when hard-links was used. Either way we should probably have a test for the desired hard-linking behavior.

Also I feel even going down the other route the code could be simplified along these lines.

This needs to be tested on macOS to ensure the fix for macOS was not reverted with this change.

I have built renovate with this as an alternative fix to the pnpm one.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
