### PR TITLE
iproute2: do not use dark blue in dark background palette

### DIFF
--- a/pkgs/by-name/ip/iproute2/package.nix
+++ b/pkgs/by-name/ip/iproute2/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   buildPackages,
   bison,
   flex,
@@ -26,6 +27,16 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    (fetchpatch {
+      name = "color-assume-background-is-dark-if-unknown.patch";
+      url = "https://git.kernel.org/pub/scm/network/iproute2/iproute2-next.git/patch/?id=cc0f1109d2864686180ba2ce6fba5fcb3bf437bf";
+      hash = "sha256-BGD70cXKnDvk7IEU5RQA+pn1dErWjgr74GeSkYtFXoI=";
+    })
+    (fetchpatch {
+      name = "color-do-not-use-dark-blue-in-dark-background-palette.patch";
+      url = "https://git.kernel.org/pub/scm/network/iproute2/iproute2-next.git/patch/?id=46a4659313c2610427a088d8f03b731819f2b87a";
+      hash = "sha256-TXrmGZNsYWdYLsLoBXZEr3cd8HT4EhRg+jACRrC0gKE=";
+    })
     (fetchurl {
       name = "musl-endian.patch";
       url = "https://lore.kernel.org/netdev/20240712191209.31324-1-contact@hacktivis.me/raw";


### PR DESCRIPTION
Change color to light blue in dark background.
Currently the iproute2 tools produce output that is hard to read when color is enabled and the background is dark.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
