### PR TITLE
models-dev: 0-unstable-2025-07-29 -> 0-unstable-2025-07-30

### DIFF
--- a/pkgs/by-name/mo/models-dev/package.nix
+++ b/pkgs/by-name/mo/models-dev/package.nix
@@ -41,6 +41,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     dontConfigure = true;
 
+    patches = [
+      # In bun 1.2.13 (release-25.05) HTML entrypoints get content hashes
+      # appended → index.html becomes index-pq8vj7za.html in ./dist. So, we
+      # rename the index file back to index.html
+      ./post-build-rename-index-file.patch
+    ];
+
     buildPhase = ''
       runHook preBuild
 

--- a/pkgs/by-name/mo/models-dev/package.nix
+++ b/pkgs/by-name/mo/models-dev/package.nix
@@ -17,12 +17,12 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "models-dev";
-  version = "0-unstable-2025-07-29";
+  version = "0-unstable-2025-07-30";
   src = fetchFromGitHub {
     owner = "sst";
     repo = "models.dev";
-    rev = "69e91b1cee1dbd737dc60f5f99ce123a81763cda";
-    hash = "sha256-fr4cgQsW03ukgCxNBtlokAXmqjGh1fFJucWx1dJ7xV0=";
+    rev = "2bc25f1c57a61c0bcb29e4a7ed331be332991c15";
+    hash = "sha256-xCYu8AsTtH9ZVhFZ/sxukj92RSwZGmeQRE3COmiRqI4=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {

--- a/pkgs/by-name/mo/models-dev/post-build-rename-index-file.patch
+++ b/pkgs/by-name/mo/models-dev/post-build-rename-index-file.patch
@@ -1,0 +1,18 @@
+diff --git i/packages/web/script/build.ts w/packages/web/script/build.ts
+index 9bdcdb3..e9ce1c9 100755
+--- i/packages/web/script/build.ts
++++ w/packages/web/script/build.ts
+@@ -14,6 +14,13 @@ for await (const file of new Bun.Glob("./public/*").scan()) {
+   await Bun.write(file.replace("./public/", "./dist/"), Bun.file(file));
+ }
+ 
++const distFiles = await fs.readdir("./dist");
++const htmlFile = distFiles.find(file => file.startsWith("index-") && file.endsWith(".html"));
++
++if (htmlFile) {
++  await fs.rename(`./dist/${htmlFile}`, "./dist/index.html");
++}
++
+ let html = await Bun.file("./dist/index.html").text();
+ html = html.replace("<!--static-->", Rendered);
+ await Bun.write("./dist/index.html", html);


### PR DESCRIPTION
This change also addresses an issue in Bun 1.2.13 (used in release 25.05) required for backporting `models-dev` where HTML entry points are generated with a hash appended to the filename. As a result, the build fails unless the hashed index file is renamed back to `index.html`.

The added patch scans the `./dist` directory for the hashed index file and renames it back to `index.html`
to ensure compatibility with subsequent build steps.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
