### PR TITLE
Update botocore, boto3, aiobotocore, aioboto3, moto, and awscli packages

### DIFF
--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -10,7 +10,6 @@
   cryptography,
   docker,
   fetchFromGitHub,
-  fetchpatch,
   flask-cors,
   flask,
   freezegun,
@@ -38,7 +37,7 @@
 
 buildPythonPackage rec {
   pname = "moto";
-  version = "5.1.4";
+  version = "5.1.9";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -47,17 +46,8 @@ buildPythonPackage rec {
     owner = "getmoto";
     repo = "moto";
     tag = version;
-    hash = "sha256-bDRd1FTBpv6t2j8cBzcYiK4B0F4sLcoW9K0Wnd0oo+4=";
+    hash = "sha256-UbCSGpvS8Jvpe8iV1rVplSoGykHSup9pVTd3odbPq6Y=";
   };
-
-  # Fix tests with botocore 1.38.32
-  # FIXME: remove in next update
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/getmoto/moto/commit/8dcaaca0eefdf9ac957650c1562317b6d07fadf9.diff";
-      hash = "sha256-5zaerJR1rsMZQLn8cXjS8RYiKlSQ6azp7dk7JzLp+7I=";
-    })
-  ];
 
   build-system = [
     setuptools
@@ -364,9 +354,6 @@ buildPythonPackage rec {
     # Parameter validation fails
     "test_conditional_write"
 
-    # Requires newer botocore version
-    "test_dynamodb_with_account_id_routing"
-
     # Assumes too much about threading.Timer() behavior (that it honors the
     # timeout precisely and that the thread handler will complete in just 0.1s
     # from the requested timeout)
@@ -395,6 +382,9 @@ buildPythonPackage rec {
 
     # botocore.exceptions.ParamValidationError: Parameter validation failed: Unknown parameter in input: "EnableWorkDocs", must be one of: [...]
     "tests/test_workspaces/test_workspaces.py"
+
+    # Requires sagemaker client
+    "other_langs/tests_sagemaker_client/test_model_training.py"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
