### PR TITLE
Updated the Internet-Draft link and package description.

### DIFF
--- a/pkgs/by-name/br/brotli/package.nix
+++ b/pkgs/by-name/br/brotli/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     homepage = "https://github.com/google/brotli";
-    description = "Generic-purpose lossless compression algorithm and tool";
+    description = "General-purpose lossless compression library with CLI";
     longDescription = ''
       Brotli is a generic-purpose lossless compression algorithm that
       compresses data using a combination of a modern variant of the LZ77
@@ -68,8 +68,8 @@ stdenv.mkDerivation (finalAttrs: {
       deflate but offers more dense compression.
 
       The specification of the Brotli Compressed Data Format is defined
-      in the following internet draft:
-      http://www.ietf.org/id/draft-alakuijala-brotli
+      in the following Internet-Draft:
+      https://datatracker.ietf.org/doc/html/rfc7932
     '';
     license = licenses.mit;
     maintainers = with maintainers; [ freezeboy ];


### PR DESCRIPTION
Current link leads to a 404:
http://www.ietf.org/id/draft-alakuijala-brotli
—
New replacement link [source]: 
https://github.com/google/brotli?tab=readme-ov-file#introduction

Correction of the official name [source]:
https://www.ietf.org/participate/ids/
—
Reasoning of slight description change:
The original is accurate, but felt a bit dry.
Even the official, Brotli's GitHub repository 
“About” section: “Brotli compression format” 
felt lacking in its short description.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
