### PR TITLE
nixos: allow more things to be disabled

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -8,41 +8,47 @@
 }:
 let
 
-  requiredPackages =
-    map (pkg: lib.setPrio ((pkg.meta.priority or lib.meta.defaultPriority) + 3) pkg)
-      [
-        pkgs.acl
-        pkgs.attr
-        pkgs.bashInteractive # bash with ncurses support
-        pkgs.bzip2
-        pkgs.coreutils-full
-        pkgs.cpio
-        pkgs.curl
-        pkgs.diffutils
-        pkgs.findutils
-        pkgs.gawk
-        pkgs.stdenv.cc.libc
-        pkgs.getent
-        pkgs.getconf
-        pkgs.gnugrep
-        pkgs.gnupatch
-        pkgs.gnused
-        pkgs.gnutar
-        pkgs.gzip
-        pkgs.xz
-        pkgs.less
-        pkgs.libcap
-        pkgs.ncurses
-        pkgs.netcat
-        config.programs.ssh.package
-        pkgs.mkpasswd
-        pkgs.procps
-        pkgs.su
-        pkgs.time
-        pkgs.util-linux
-        pkgs.which
-        pkgs.zstd
-      ];
+  corePackageNames = [
+    "acl"
+    "attr"
+    "bashInteractive" # bash with ncurses support
+    "bzip2"
+    "coreutils-full"
+    "cpio"
+    "curl"
+    "diffutils"
+    "findutils"
+    "gawk"
+    "getent"
+    "getconf"
+    "gnugrep"
+    "gnupatch"
+    "gnused"
+    "gnutar"
+    "gzip"
+    "xz"
+    "less"
+    "libcap"
+    "ncurses"
+    "netcat"
+    "mkpasswd"
+    "procps"
+    "su"
+    "time"
+    "util-linux"
+    "which"
+    "zstd"
+  ];
+  corePackages =
+    (map (
+      n:
+      let
+        pkg = pkgs.${n};
+      in
+      lib.setPrio ((pkg.meta.priority or lib.meta.defaultPriority) + 3) pkg
+    ) corePackageNames)
+    ++ [ pkgs.stdenv.cc.libc ];
+  corePackagesText = "[ ${lib.concatMapStringsSep " " (n: "pkgs.${n}") corePackageNames} ]";
 
   defaultPackageNames = [
     "perl"
@@ -77,6 +83,29 @@ in
           configuration.  (The latter is the main difference with
           installing them in the default profile,
           {file}`/nix/var/nix/profiles/default`.
+        '';
+      };
+
+      corePackages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = corePackages;
+        defaultText = lib.literalMD ''
+          these packages, with their `meta.priority` numerically increased
+          (thus lowering their installation priority):
+
+              ${corePackagesText}
+        '';
+        example = [ ];
+        description = ''
+          Set of core packages for a normal interactive system.
+
+          Only change this if you know what you're doing!
+
+          Like with systemPackages, packages are installed to
+          {file}`/run/current-system/sw`. They are
+          automatically available to all users, and are
+          automatically updated every time you rebuild the system
+          configuration.
         '';
       };
 
@@ -151,7 +180,7 @@ in
 
   config = {
 
-    environment.systemPackages = requiredPackages ++ config.environment.defaultPackages;
+    environment.systemPackages = config.environment.corePackages ++ config.environment.defaultPackages;
 
     environment.pathsToLink = [
       "/bin"

--- a/nixos/modules/programs/fuse.nix
+++ b/nixos/modules/programs/fuse.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.programs.fuse;
@@ -7,6 +12,10 @@ in
   meta.maintainers = with lib.maintainers; [ ];
 
   options.programs.fuse = {
+    enable = lib.mkEnableOption "fuse" // {
+      default = true;
+    };
+
     mountMax = lib.mkOption {
       # In the C code it's an "int" (i.e. signed and at least 16 bit), but
       # negative numbers obviously make no sense:
@@ -27,10 +36,30 @@ in
     };
   };
 
-  config = {
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      pkgs.fuse
+      pkgs.fuse3
+    ];
+
+    security.wrappers =
+      let
+        mkSetuidRoot = source: {
+          setuid = true;
+          owner = "root";
+          group = "root";
+          inherit source;
+        };
+      in
+      {
+        fusermount = mkSetuidRoot "${lib.getBin pkgs.fuse}/bin/fusermount";
+        fusermount3 = mkSetuidRoot "${lib.getBin pkgs.fuse3}/bin/fusermount3";
+      };
+
     environment.etc."fuse.conf".text = ''
       ${lib.optionalString (!cfg.userAllowOther) "#"}user_allow_other
       mount_max = ${builtins.toString cfg.mountMax}
     '';
+
   };
 }

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -335,6 +335,8 @@ in
       }
     );
 
+    environment.corePackages = [ cfg.package ];
+
     # SSH configuration. Slight duplication of the sshd_config
     # generation in the sshd service.
     environment.etc."ssh/ssh_config".text = ''

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -266,8 +266,6 @@ in
       in
       {
         # These are mount related wrappers that require the +s permission.
-        fusermount = mkSetuidRoot "${lib.getBin pkgs.fuse}/bin/fusermount";
-        fusermount3 = mkSetuidRoot "${lib.getBin pkgs.fuse3}/bin/fusermount3";
         mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
         umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
       };

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -317,7 +317,7 @@ in
       source ${config.system.build.earlyMountScript}
     '';
 
-    systemd.user = {
+    systemd.user = lib.mkIf config.system.activatable {
       services.nixos-activation = {
         description = "Run user-specific NixOS activation";
         script = config.system.userActivationScripts.script;

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -414,7 +414,9 @@ in
 
           ln -s ${initrdPath} $out/initrd
 
-          ln -s ${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets $out
+          ${optionalString (config.boot.initrd.secrets != { }) ''
+            ln -s ${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets $out
+          ''}
 
           ln -s ${config.hardware.firmware}/lib/firmware $out/firmware
         '';

--- a/nixos/modules/system/boot/kexec.nix
+++ b/nixos/modules/system/boot/kexec.nix
@@ -1,7 +1,22 @@
-{ pkgs, lib, ... }:
-
 {
-  config = lib.mkIf (lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.kexec-tools) {
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.boot.kexec;
+in
+{
+  options.boot.kexec = {
+    enable = lib.mkEnableOption "kexec" // {
+      default = lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.kexec-tools;
+      defaultText = lib.literalExpression ''lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.kexec-tools'';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ pkgs.kexec-tools ];
 
     systemd.services.prepare-kexec = {

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -461,13 +461,7 @@ in
     # Add the mount helpers to the system path so that `mount' can find them.
     system.fsPackages = [ pkgs.dosfstools ];
 
-    environment.systemPackages =
-      with pkgs;
-      [
-        fuse3
-        fuse
-      ]
-      ++ config.system.fsPackages;
+    environment.systemPackages = config.system.fsPackages;
 
     environment.etc.fstab.text =
       let

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1767,17 +1767,19 @@ in
       text = cfg.hostName + "\n";
     };
 
-    environment.systemPackages = [
-      pkgs.host
-      pkgs.hostname-debian
-      pkgs.iproute2
-      pkgs.iputils
-    ]
-    ++ optionals config.networking.wireless.enable [
-      pkgs.wirelesstools # FIXME: obsolete?
-      pkgs.iw
-    ]
-    ++ bridgeStp;
+    environment.corePackages = lib.mkOptionDefault (
+      [
+        pkgs.host
+        pkgs.hostname-debian
+        pkgs.iproute2
+        pkgs.iputils
+      ]
+      ++ optionals config.networking.wireless.enable [
+        pkgs.wirelesstools # FIXME: obsolete?
+        pkgs.iw
+      ]
+      ++ bridgeStp
+    );
 
     # Wake-on-LAN configuration is shared by the scripted and networkd backends.
     systemd.network.links = pipe interfaces [


### PR DESCRIPTION
Doesn't change any NixOS default but reduces the mandatory system closure by enabling users to exclude more things.

Is part of the larger work of https://github.com/NixOS/nixpkgs/issues/428908.
These changes are necessary to eventually make activation bashless. However, they are absolutely valuable even if you don't care at all about bashless because they give the user more control over their closure.

See the commits for more details on what is changed.

Commit-by-commit review is recommended.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
