### PR TITLE
redo-apenwarr: Fix failure with bash-5.3

### DIFF
--- a/pkgs/by-name/re/redo-apenwarr/package.nix
+++ b/pkgs/by-name/re/redo-apenwarr/package.nix
@@ -45,6 +45,9 @@ stdenv.mkDerivation rec {
     substituteInPlace t/200-shell/nonshelltest.do \
       --replace-fail "/usr/bin/env perl" "${perl}/bin/perl"
 
+    # See https://github.com/apenwarr/redo/pull/47
+    substituteInPlace minimal/do \
+      --replace-fail 'cd "$dodir"' 'cd "''${dodir:-.}"'
   '';
 
   inherit doCheck;

--- a/pkgs/by-name/re/redo-apenwarr/package.nix
+++ b/pkgs/by-name/re/redo-apenwarr/package.nix
@@ -31,19 +31,19 @@ stdenv.mkDerivation rec {
     unset CC CXX
 
     substituteInPlace minimal/do.test \
-      --replace "/bin/pwd" "${coreutils}/bin/pwd"
+      --replace-fail "/bin/pwd" "${coreutils}/bin/pwd"
 
     substituteInPlace t/105-sympath/all.do \
-      --replace "/bin/pwd" "${coreutils}/bin/pwd"
+      --replace-fail "/bin/pwd" "${coreutils}/bin/pwd"
 
     substituteInPlace t/all.do \
-      --replace "/bin/ls" "ls"
+      --replace-fail "/bin/ls" "ls"
 
     substituteInPlace t/110-compile/hello.o.do \
-      --replace "/usr/include" "${lib.getDev stdenv.cc.libc}/include"
+      --replace-fail "/usr/include" "${lib.getDev stdenv.cc.libc}/include"
 
     substituteInPlace t/200-shell/nonshelltest.do \
-      --replace "/usr/bin/env perl" "${perl}/bin/perl"
+      --replace-fail "/usr/bin/env perl" "${perl}/bin/perl"
 
   '';
 


### PR DESCRIPTION
The failure manifests as:

    minimal/do: line 358: cd: null directory

(see https://hydra.nixos.org/build/303454733/nixlog/1)

In bash 5.3, command `cd ''` fails, while in the previous bash version it succeeds and no directory is changed. In the fix, we replace empty `$dodir` with `.`.

Context:
- https://github.com/apenwarr/redo/pull/47
- https://cgit.git.savannah.gnu.org/cgit/bash.git/tree/CHANGES?h=bash-5.3#n119.
- https://lists.gnu.org/archive/html/bug-bash/2025-07/msg00152.html

When at it, this also updates deprecated `substituteInPlace` arguments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
