### PR TITLE
lsfg-vk{-ui}: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ls/lsfg-vk-ui/package.nix
+++ b/pkgs/by-name/ls/lsfg-vk-ui/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  glib,
+  pango,
+  gdk-pixbuf,
+  gtk4,
+  libadwaita,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lsfg-vk-ui";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "PancakeTAS";
+    repo = "lsfg-vk";
+    tag = "v${version}";
+    hash = "sha256-nIyVOil/gHC+5a+sH3vMlcqVhixjJaGWqXbyoh2Nqyw=";
+  };
+
+  cargoHash = "sha256-hIQRS/egIDU5Vu/1KWHtpt4S26h+9GadVr+lBAG2LDg=";
+
+  sourceRoot = "source/ui";
+
+  nativeBuildInputs = [
+    pkg-config
+    glib
+  ];
+
+  buildInputs = [
+    pango
+    gdk-pixbuf
+    gtk4
+    libadwaita
+  ];
+
+  postInstall = ''
+    install -Dm444 $src/ui/rsc/gay.pancake.lsfg-vk-ui.desktop $out/share/applications/gay.pancake.lsfg-vk-ui.desktop
+    install -Dm444 $src/ui/rsc/icon.png $out/share/icons/hicolor/256x256/apps/gay.pancake.lsfg-vk-ui.png
+  '';
+
+  meta = {
+    description = "Graphical configuration interface for lsfg-vk";
+    homepage = "https://github.com/PancakeTAS/lsfg-vk/";
+    changelog = "https://github.com/PancakeTAS/lsfg-vk/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ pabloaul ];
+    mainProgram = "lsfg-vk-ui";
+  };
+}

--- a/pkgs/by-name/ls/lsfg-vk/package.nix
+++ b/pkgs/by-name/ls/lsfg-vk/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  cmake,
+  vulkan-headers,
+  llvmPackages,
+}:
+
+llvmPackages.stdenv.mkDerivation rec {
+  pname = "lsfg-vk";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "PancakeTAS";
+    repo = "lsfg-vk";
+    tag = "v${version}";
+    hash = "sha256-hWpuPH7mKbeMaLaRUwtlkNLy4lOnJEe+yd54L7y2kV0=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace VkLayer_LS_frame_generation.json \
+      --replace-fail "liblsfg-vk.so" "$out/lib/liblsfg-vk.so"
+  '';
+
+  nativeBuildInputs = [
+    llvmPackages.clang-tools
+    llvmPackages.libllvm
+    cmake
+  ];
+
+  buildInputs = [
+    vulkan-headers
+  ];
+
+  meta = {
+    description = "Vulkan layer for frame generation (Requires owning Lossless Scaling)";
+    homepage = "https://github.com/PancakeTAS/lsfg-vk/";
+    changelog = "https://github.com/PancakeTAS/lsfg-vk/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ pabloaul ];
+  };
+}


### PR DESCRIPTION
Closes: #425013 
https://github.com/PancakeTAS/lsfg-vk/ got a 1.0.0 release now.

Only a substitute patch is needed to have the vulkan layer point to the library correctly.
The library statically links the few dependencies that it has, effort could be put in to unvendor those if necessary.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
