### PR TITLE
vulkan-tools: Fix build of vkcube

### DIFF
--- a/pkgs/by-name/vu/vulkan-tools/package.nix
+++ b/pkgs/by-name/vu/vulkan-tools/package.nix
@@ -20,6 +20,7 @@
   wayland-protocols,
   wayland-scanner,
   moltenvk,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -33,7 +34,15 @@ stdenv.mkDerivation rec {
     hash = "sha256-47RVuhK9NDtOazG4awTjwbZSnG+thGw6GpyKmcCgWpQ=";
   };
 
-  patches = [ ./wayland-scanner.patch ];
+  patches = [
+    ./wayland-scanner.patch
+    # Fixes build of vkcube
+    (fetchpatch {
+      name = "remove-pkg-config-lib-names.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/KhronosGroup/Vulkan-Tools/pull/1134.patch";
+      hash = "sha256-MX9jaxs3KK2stWwotGkZLS1WCUg0XUGJPyi440ltlCg=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -70,9 +79,6 @@ stdenv.mkDerivation rec {
   env.PKG_CONFIG_WAYLAND_SCANNER_WAYLAND_SCANNER = lib.getExe buildPackages.wayland-scanner;
 
   cmakeFlags = [
-    # Temporarily disabled, see https://github.com/KhronosGroup/Vulkan-Tools/issues/1130
-    # FIXME: remove when fixed upstream
-    "-DBUILD_CUBE=OFF"
     # Don't build the mock ICD as it may get used instead of other drivers, if installed
     "-DBUILD_ICD=OFF"
     # vulkaninfo loads libvulkan using dlopen, so we have to add it manually to RPATH


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
