### PR TITLE
buildMix: add support for removing target config

### DIFF
--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -28,8 +28,11 @@
   # A config directory that is considered for all the dependencies of an app, typically in $src/config/
   # This was initially added, as some of Mobilizon's dependencies need to access the config at build time.
   appConfigPath ? null,
+  removeConfig ? false,
   ...
 }@attrs:
+
+assert removeConfig -> appConfigPath == null;
 
 let
   shell =
@@ -86,6 +89,15 @@ let
               ''
                 rm -rf config
                 cp -r ${appConfigPath} config
+              ''
+            }
+            ${lib.optionalString removeConfig
+              # As above, but if we don't have any particular app config to
+              # use. This will be the case when compiling the majority of
+              # (independent) dependencies.
+              ''
+                rm -rf config
+                mkdir config
               ''
             }
 


### PR DESCRIPTION
This is equivalent to giving `appConfigPath` an empty directory, but expresses intent better (and doesn't require throwing an empty directory into the store).

The Elixir ecosystem assumes [1] that dependencies are compiled without their config; the `config/` directory is therefore used in library-only projects to supply config values only intended for use when _developing_ them.  This leads to errors only seen in Nix when compile-time config lacks runtime equivalents in end-user applications (per the whole conversation at [1]).

Right now, the only way to get `buildMix` to build without config is to manually remove the target's config directory in a hook/override, or (as above) give `appConfigPath` an empty directory.  This PR adds a clearer mechanism, which would be nice to use from [`mix2nix`](https://github.com/ydlr/mix2nix) et al.

[1] https://github.com/dashbitco/lazy_html/pull/11#issuecomment-3138715485

Attribute tested as working as expected.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
