### PR TITLE
go-ios: patch paths

### DIFF
--- a/pkgs/by-name/go/go-ios/package.nix
+++ b/pkgs/by-name/go/go-ios/package.nix
@@ -5,6 +5,8 @@
   nix-update-script,
   pkg-config,
   libusb1,
+  iproute2,
+  net-tools,
 }:
 
 buildGoModule rec {
@@ -24,6 +26,14 @@ buildGoModule rec {
   excludedPackages = [
     "restapi"
   ];
+
+  postPatch = ''
+    substituteInPlace ncm/linux_commands.go \
+      --replace-fail "ip " "${lib.getExe' iproute2 "ip"} "
+
+    substituteInPlace ios/tunnel/tunnel.go \
+      --replace-fail "ifconfig" "${lib.getExe' net-tools "ifconfig"}"
+  '';
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Things done
Patches the places where it executes commands. There are a few places where it doesn't e.g. tests or things we don't build, but this should take the majority of it.

I've run these patches for some time, and have had no issues.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
