### PR TITLE
fail2ban-dashboard: init at 0.6.5, add service module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1450,6 +1450,7 @@
   ./services/security/endlessh-go.nix
   ./services/security/endlessh.nix
   ./services/security/esdm.nix
+  ./services/security/fail2ban-dashboard.nix
   ./services/security/fail2ban.nix
   ./services/security/fprintd.nix
   ./services/security/haveged.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1559,6 +1559,7 @@
   ./services/security/endlessh-go.nix
   ./services/security/endlessh.nix
   ./services/security/esdm.nix
+  ./services/security/fail2ban-dashboard.nix
   ./services/security/fail2ban.nix
   ./services/security/fprintd.nix
   ./services/security/haveged.nix

--- a/nixos/modules/services/security/fail2ban-dashboard.nix
+++ b/nixos/modules/services/security/fail2ban-dashboard.nix
@@ -1,0 +1,98 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.fail2ban-dashboard;
+in
+
+{
+  options = {
+    services.fail2ban-dashboard = {
+      enable = lib.mkEnableOption "fail2ban-dashboard";
+
+      package = lib.mkPackageOption pkgs "fail2ban-dashboard" { };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        description = "The port to listen on";
+        default = 3000;
+        example = 3001;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.services.fail2ban.enable;
+        message = ''
+          fail2ban-dashboard cannot function without fail2ban.
+        '';
+      }
+    ];
+
+    systemd.services.fail2ban-dashboard = {
+      description = "Web dashboard for fail2ban";
+      requires = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "fail2ban.service" ];
+
+      partOf = lib.optional config.networking.firewall.enable "firewall.service";
+
+      serviceConfig = {
+        Restart = "always";
+        ExecStart =
+          let
+            args = lib.cli.toGNUCommandLineShell { } {
+              port = cfg.port;
+              cache-dir = "/var/cache/fail2ban-dashboard";
+              socket = config.services.fail2ban.daemonSettings.Definition.socket;
+            };
+          in
+          "${lib.getExe cfg.package} ${args}";
+
+        DynamicUser = true;
+        User = "fail2ban-dashboard";
+
+        UMask = "0077";
+        CacheDirectory = "fail2ban-dashboard";
+        CacheDirectoryMode = "0700";
+
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "noaccess";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    matthiasbeyer
+  ];
+}

--- a/nixos/modules/services/security/fail2ban-dashboard.nix
+++ b/nixos/modules/services/security/fail2ban-dashboard.nix
@@ -1,0 +1,100 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.fail2ban-dashboard;
+in
+
+{
+  options = {
+    services.fail2ban-dashboard = {
+      enable = lib.mkEnableOption "fail2ban-dashboard";
+
+      package = lib.mkPackageOption pkgs "fail2ban-dashboard" { };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        description = "The port to listen on";
+        default = 3000;
+        example = 3001;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.services.fail2ban.enable;
+        message = ''
+          fail2ban-dashboard cannot function without fail2ban.
+        '';
+      }
+    ];
+
+    systemd.services.fail2ban-dashboard = {
+      description = "Web dashboard for fail2ban";
+      requires = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "fail2ban.socket" ];
+      requires = [ "fail2ban.socket" ];
+
+      partOf = lib.optional config.networking.firewall.enable "firewall.service";
+
+      serviceConfig = {
+        Restart = "always";
+        ExecStart =
+          let
+            args = lib.cli.toGNUCommandLineShell { } {
+              port = cfg.port;
+              cache-dir = "/var/cache/fail2ban-dashboard";
+              socket = config.services.fail2ban.daemonSettings.Definition.socket;
+            };
+          in
+          "${lib.getExe cfg.package} ${args}";
+
+        DynamicUser = true;
+        User = "fail2ban-dashboard";
+        SupplementaryGroups = [ "fail2ban" ];
+
+        UMask = "0077";
+        CacheDirectory = "fail2ban-dashboard";
+        CacheDirectoryMode = "0700";
+
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "noaccess";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    matthiasbeyer
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -511,6 +511,7 @@ in
   dep-scan = runTest ./dep-scan.nix;
   evcc = runTest ./evcc.nix;
   fail2ban = runTest ./fail2ban.nix;
+  fail2ban-dashboard = runTest ./fail2ban-dashboard.nix;
   fakeroute = runTest ./fakeroute.nix;
   fancontrol = runTest ./fancontrol.nix;
   fanout = runTest ./fanout.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -580,6 +580,7 @@ in
   };
   facter = runTest ./facter;
   fail2ban = runTest ./fail2ban.nix;
+  fail2ban-dashboard = runTest ./fail2ban-dashboard.nix;
   fakeroute = runTest ./fakeroute.nix;
   fancontrol = runTest ./fancontrol.nix;
   fanout = runTest ./fanout.nix;

--- a/nixos/tests/fail2ban-dashboard.nix
+++ b/nixos/tests/fail2ban-dashboard.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+{
+  name = "fail2ban-dashboard";
+
+  nodes.machine = _: {
+    services.fail2ban = {
+      enable = true;
+      bantime-increment.enable = true;
+    };
+
+    services.fail2ban-dashboard = {
+      enable = true;
+      port = 5123;
+    };
+
+    environment.systemPackages = [ pkgs.curl ];
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("fail2ban.service")
+    machine.wait_for_unit("fail2ban-dashboard.service")
+
+    machine.succeed("curl --fail http://localhost:5123")
+  '';
+}

--- a/pkgs/by-name/fa/fail2ban-dashboard/package.nix
+++ b/pkgs/by-name/fa/fail2ban-dashboard/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGo125Module,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 buildGo125Module rec {
@@ -16,6 +17,8 @@ buildGo125Module rec {
   };
 
   vendorHash = "sha256-HYCr0tZebhBE7jTB/ec1JZr4dT1WUsCjpdXN97r1Jes=";
+
+  passthru.tests.nixos = nixosTests.fail2ban-dashboard;
 
   meta = {
     description = "Web based dashboard for fail2ban";

--- a/pkgs/by-name/fa/fail2ban-dashboard/package.nix
+++ b/pkgs/by-name/fa/fail2ban-dashboard/package.nix
@@ -1,21 +1,21 @@
 {
   lib,
-  buildGoModule,
+  buildGo125Module,
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGo125Module rec {
   pname = "fail2ban-dashboard";
-  version = "0.6.3";
+  version = "0.6.5";
 
   src = fetchFromGitHub {
     owner = "webishdev";
     repo = "fail2ban-dashboard";
     tag = "v${version}";
-    hash = "sha256-z1zsymP9HAd9q7wCdJJ0622kcGhI9FtuxovbWo7sKf8=";
+    hash = "sha256-MQ0gPdMcdPDtXMOULLZ1cU8HuDioGi47wmcZ2/iClug=";
   };
 
-  vendorHash = "sha256-puQ8BPuKzUXBDwr2qBvV2KclfxpSrtCTQSCfGaaxKqc=";
+  vendorHash = "sha256-HYCr0tZebhBE7jTB/ec1JZr4dT1WUsCjpdXN97r1Jes=";
 
   meta = {
     description = "Web based dashboard for fail2ban";

--- a/pkgs/by-name/fa/fail2ban-dashboard/package.nix
+++ b/pkgs/by-name/fa/fail2ban-dashboard/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "fail2ban-dashboard";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "webishdev";
+    repo = "fail2ban-dashboard";
+    tag = "v${version}";
+    hash = "sha256-z1zsymP9HAd9q7wCdJJ0622kcGhI9FtuxovbWo7sKf8=";
+  };
+
+  vendorHash = "sha256-puQ8BPuKzUXBDwr2qBvV2KclfxpSrtCTQSCfGaaxKqc=";
+
+  meta = {
+    description = "Web based dashboard for fail2ban";
+    homepage = "https://github.com/webishdev/fail2ban-dashboard";
+    changelog = "https://github.com/webishdev/fail2ban-dashboard/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
+    platforms = lib.platforms.linux;
+    mainProgram = "fail2ban-dashboard";
+  };
+}


### PR DESCRIPTION
<s>This is *not* ready yet, as I am waiting for https://github.com/webishdev/fail2ban-dashboard/issues/1 because we really want users to be able to bind to a specific port, right?</s>

Also, I am not sure whether this application (as is) can access `/var/run/fail2ban/fail2ban.sock` when the service is configured as I did it in the service module.

Maybe someone with more experience with the nixos service module abstractions and systemd and so on wants to have a look.

I would also love to have a nixos tests for this.

So overall, this is a draft.

If someone _really_ wants tot try this software, though, I can split off the package commit into a seperate PR and merge only that piece. :heart: :+1: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
