### PR TITLE
mdns-scanner: 0.21.0 -> 0.22.1

### DIFF
--- a/pkgs/by-name/md/mdns-scanner/package.nix
+++ b/pkgs/by-name/md/mdns-scanner/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdns-scanner";
-  version = "0.21.0";
+  version = "0.22.1";
 
   src = fetchFromGitHub {
     owner = "CramBL";
     repo = "mdns-scanner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NtV/MnFjilxaB5+Kiug9JzqikTYMaw9BP/NpR2MxTl4=";
+    hash = "sha256-iZc+KY/b7xQKm9bBJ+bRmcu6zFJAXcCRy72gDrBKRzQ=";
   };
 
-  cargoHash = "sha256-Bsd+f8B7EBW/ugT0/k+T8gL/O4Ro6S2x8gMOcWia1Qs=";
+  cargoHash = "sha256-L2g49bTh+Il+fWfb7kgNqbxd0Y+qnO7Q4laB2pFlXbw=";
 
   meta = {
     homepage = "https://github.com/CramBL/mdns-scanner";


### PR DESCRIPTION
Update mdns-scanner from v0.21.0 to v0.22.1

## Changelogs

- [https://github.com/CramBL/mdns-scanner/releases/tag/v0.22.0](https://github.com/CramBL/mdns-scanner/releases/tag/v0.22.0)
- [https://github.com/CramBL/mdns-scanner/releases/tag/v0.22.1](https://github.com/CramBL/mdns-scanner/releases/tag/v0.22.1)

[https://github.com/CramBL/mdns-scanner/compare/v0.21.0...v0.22.1](https://github.com/CramBL/mdns-scanner/compare/v0.21.0...v0.22.1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
