### PR TITLE
python3Packages.pyglove: init at 0.4.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10044,6 +10044,12 @@
     githubId = 1631166;
     name = "Marcel Müller";
   };
+  hendrikheil = {
+    email = "hendrik@ciidyr.com";
+    github = "hendrikheil";
+    githubId = 19904485;
+    name = "Hendrik Heil";
+  };
   henkery = {
     email = "jim@reupload.nl";
     github = "henkery";

--- a/pkgs/development/python-modules/pyglove/default.nix
+++ b/pkgs/development/python-modules/pyglove/default.nix
@@ -1,0 +1,50 @@
+{
+  buildPythonPackage,
+  docstring-parser,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+  termcolor,
+}:
+
+buildPythonPackage rec {
+  pname = "pyglove";
+  version = "0.4.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "pyglove";
+    tag = "v${version}";
+    hash = "sha256-mvLu/zYxtNdG3mIw0rsy2q8vYbF9V9Z0yJgeaRm3qNs=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    docstring-parser
+    termcolor
+  ];
+
+  pythonImportsCheck = [ "pyglove" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # AssertionError: Lists differ, flaky test on smaller machines
+    "EvolutionTest::test_thread_safety"
+  ];
+
+  meta = {
+    changelog = "https://github.com/google/pyglove/releases/tag/${src.tag}";
+    description = "Library for manipulating Python objects";
+    homepage = "https://github.com/google/pyglove";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hendrikheil ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12871,6 +12871,8 @@ self: super: with self; {
 
   pyglm = callPackage ../development/python-modules/pyglm { };
 
+  pyglove = callPackage ../development/python-modules/pyglove { };
+
   pygls = callPackage ../development/python-modules/pygls { };
 
   pygltflib = callPackage ../development/python-modules/pygltflib { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR adds a new python3 module, pyglove. This package by google introduces symbolic object-oriented programming to python, allowing you to write meta-programs much easier.

This package is also a dependency for another python package, langfun, which itself is a requirement for the newly released 1.0.0 of langextract. Both of these libraries are also written by google.

The project is located at https://github.com/google/pyglove

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
