### PR TITLE
nsncd: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/by-name/ns/nsncd/package.nix
+++ b/pkgs/by-name/ns/nsncd/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  version = "1.5.1";
+  version = "1.5.2";
 in
 
 rustPlatform.buildRustPackage {
@@ -18,11 +18,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "twosigma";
     repo = "nsncd";
-    rev = "v${version}";
-    hash = "sha256-0cFCX5pKvYv6yr4+X5kXGz8clNi/LYndFtHaxSmHN+I=";
+    tag = "v${version}";
+    hash = "sha256-HNg2pf6dUQW95B8x/xWa53+GZVWzpTMRVeqWT3dp/M8=";
   };
 
-  cargoHash = "sha256-9M8Y0WwXFlrpRleSQPYDpnjNnxKGvrtO6Istl9qM30M=";
+  cargoHash = "sha256-kjxRhrgKPLCKWc3/gOvdcmQX7IdxFLuwcV7DRZIte78=";
 
   checkFlags = [
     # Relies on the test environment to be able to resolve "localhost"
@@ -36,13 +36,6 @@ rustPlatform.buildRustPackage {
     "--skip=handlers::test::test_handle_getservbyport_port"
     "--skip=handlers::test::test_handle_getservbyport_port_proto"
     "--skip=handlers::test::test_handle_getservbyport_port_proto_aliases"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isBigEndian [
-    # Expected serialisation output in tests doesn't account for endianness differences
-    # https://github.com/twosigma/nsncd/issues/160
-    "--skip=handlers::test::test_hostent_serialization"
-    "--skip=handlers::test::test_innetgroup_serialization_in_group"
-    "--skip=handlers::test::test_netgroup_serialization"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
We can remove the big endian test barrier, it's been fixed upstream by https://github.com/twosigma/nsncd/pull/161.




## Things done

T

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
