### PR TITLE
cracklib: 2.10.0 -> 2.10.3: modernize & massively slim down

### DIFF
--- a/pkgs/by-name/cr/cracklib/package.nix
+++ b/pkgs/by-name/cr/cracklib/package.nix
@@ -1,70 +1,82 @@
-let
-  version = "2.10.0";
-in
 {
   stdenv,
   lib,
-  buildPackages,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
   zlib,
-  gettext,
-  fetchpatch2,
-  lists ? [
-    (fetchurl {
-      url = "https://github.com/cracklib/cracklib/releases/download/v${version}/cracklib-words-${version}.gz";
-      hash = "sha256-JDLo/bSLIijC2DUl+8Q704i2zgw5cxL6t68wvuivPpY=";
-    })
-  ],
+  bash,
+  buildPackages,
+  nix-update-script,
+  pkgsCross,
+  pkgsStatic,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cracklib";
-  inherit version;
+  version = "2.10.3";
 
-  src = fetchurl {
-    url = "https://github.com/${pname}/${pname}/releases/download/v${version}/${pname}-${version}.tar.bz2";
-    hash = "sha256-cAw5YMplCx6vAhfWmskZuBHyB1o4dGd7hMceOG3V51Y=";
+  src = fetchFromGitHub {
+    owner = "cracklib";
+    repo = "cracklib";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ORpJje4TGw1STtvRiNEwUwSDbLXdS+WgXGlc1Wtf/gw=";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isDarwin [
-    # Fixes build failure on Darwin due to missing byte order functions.
-    # https://github.com/cracklib/cracklib/pull/96
-    (fetchpatch2 {
-      url = "https://github.com/cracklib/cracklib/commit/dff319e543272c1fb958261cf9ee8bb82960bc40.patch";
-      hash = "sha256-QaWpEVV6l1kl4OIkJAqkXPVThbo040Rv9X2dY/+syqs=";
-      stripLen = 1;
-    })
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  outputs = [
+    "bin"
+    "out"
+    "dev"
+    "man"
   ];
 
-  nativeBuildInputs = lib.optional (
-    stdenv.hostPlatform != stdenv.buildPlatform
-  ) buildPackages.cracklib;
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ]
+  ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ buildPackages.cracklib ];
+
   buildInputs = [
     zlib
-    gettext
+    bash
   ];
 
-  postPatch =
-    lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
-      chmod +x util/cracklib-format
-      patchShebangs util
+  configureFlags = [
+    "--without-python"
+  ];
 
+  postInstall =
+    # For cross compilation use the tools from nativeBuildInputs. Otherwise use
+    # the ones in the util directory of the source tree.
+    lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+      PATH=$PATH:util
     ''
     + ''
-      ln -vs ${toString lists} dicts/
+      cracklib-format $out/share/cracklib/cracklib-small \
+      | cracklib-packer $out/share/cracklib/pw_dict
     '';
 
-  postInstall = ''
-    make dict-local
-  '';
-  doInstallCheck = true;
-  installCheckTarget = "test";
-
-  meta = with lib; {
-    homepage = "https://github.com/cracklib/cracklib";
-    description = "Library for checking the strength of passwords";
-    license = licenses.lgpl21; # Different license for the wordlist: http://www.openwall.com/wordlists
-    maintainers = with maintainers; [ lovek323 ];
-    platforms = platforms.unix;
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      cross =
+        let
+          systemString = if stdenv.buildPlatform.isAarch64 then "gnu64" else "aarch64-multiplatform";
+        in
+        pkgsCross.${systemString}.cracklib;
+      static = pkgsStatic.cracklib;
+    };
   };
-}
+
+  meta = {
+    homepage = "https://github.com/cracklib/cracklib";
+    description = "Password checking library";
+    changelog = "https://github.com/cracklib/cracklib/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ lovek323 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Use fetchFromGitHub to make the updateScript easier and avoid xz style supply chain issues.

Separate into multiple outputs. The "out" output now doesn't have a bash dependency anymore because all the scripts are in "bin".

Do not build the massive wordlist anymore. Instead rely on the built-in one. This is also what e.g. archlinux does and it leads to a massively smaller package: 10MiB -> 1MiB. This is especially dramatic/relevant because cracklib is in the mandatory NixOS system closure because it's a dependency of systemd. This change saves 9MiB transferred to literally every NixOS machine.

This is also relevant for https://github.com/NixOS/nixpkgs/issues/428908

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
