### PR TITLE
persepolis: 5.1.1->5.2.0

### DIFF
--- a/pkgs/by-name/pe/persepolis/package.nix
+++ b/pkgs/by-name/pe/persepolis/package.nix
@@ -1,12 +1,9 @@
 {
   lib,
-  qt5,
+  qt6,
   python3,
   fetchFromGitHub,
   ffmpeg,
-  libnotify,
-  pulseaudio,
-  sound-theme-freedesktop,
   pkg-config,
   meson,
   ninja,
@@ -14,20 +11,15 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "persepolis";
-  version = "5.1.1";
+  version = "5.2.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "persepolisdm";
     repo = "persepolis";
     tag = version;
-    hash = "sha256-+gdrcEOUrMZw4nTO4bFLGanD4f7OumxTE99hpXlo69w=";
+    hash = "sha256-E295Y76EmG6H1nwu7d4+OVPRtoCthROqYY5sIsBvUPI=";
   };
-
-  postPatch = ''
-    # Ensure dependencies with hard-coded FHS dependencies are properly detected
-    substituteInPlace check_dependencies.py --replace-fail "isdir(notifications_path)" "isdir('${sound-theme-freedesktop}/share/sounds/freedesktop')"
-  '';
 
   # prevent double wrapping
   dontWrapQtApps = true;
@@ -35,7 +27,8 @@ python3.pkgs.buildPythonApplication rec {
     meson
     ninja
     pkg-config
-    qt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
+    qt6.qtbase
   ];
 
   # feed args to wrapPythonApp
@@ -43,24 +36,24 @@ python3.pkgs.buildPythonApplication rec {
     "--prefix PATH : ${
       lib.makeBinPath [
         ffmpeg
-        libnotify
       ]
     }"
     "\${qtWrapperArgs[@]}"
   ];
 
   propagatedBuildInputs = [
-    pulseaudio
-    sound-theme-freedesktop
-  ]
-  ++ (with python3.pkgs; [
-    psutil
-    pyqt5
-    requests
-    setproctitle
-    setuptools
-    yt-dlp
-  ]);
+    (with python3.pkgs; [
+      psutil
+      pyside6
+      pysocks
+      urllib3
+      dasbus
+      requests
+      setproctitle
+      setuptools
+      yt-dlp
+    ])
+  ];
 
   meta = with lib; {
     description = "Download manager GUI written in Python";

--- a/pkgs/by-name/pe/persepolis/package.nix
+++ b/pkgs/by-name/pe/persepolis/package.nix
@@ -8,7 +8,6 @@
   meson,
   ninja,
 }:
-
 python3.pkgs.buildPythonApplication rec {
   pname = "persepolis";
   version = "5.2.0";
@@ -60,6 +59,9 @@ python3.pkgs.buildPythonApplication rec {
     mainProgram = "persepolis";
     homepage = "https://persepolisdm.github.io/";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ iFreilicht ];
+    maintainers = with maintainers; [
+      iFreilicht
+      L0L1P0P
+    ];
   };
 }


### PR DESCRIPTION
Updated persepolis from 5.1.1 to 5.2.0

## Things done
updated the package from 5.1.1 to the recent 5.2.0 version
changed qt5 dependency to qt6
added myself (@L0L1P0P1) to persepolis maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
