### PR TITLE
nixos/uv: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -25,6 +25,8 @@
 
 - [umami](https://github.com/umami-software/umami), a simple, fast, privacy-focused alternative to Google Analytics. Available with [services.umami](#opt-services.umami.enable).
 
+- [uv](https://github.com/astral-sh/uv), Extremely fast Python package installer and resolver, written in Rust. Available as [programs.uv](#opt-programs.uv.enable).
+
 - [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files. Available as [services.filebrowser](#opt-services.filebrowser.enable).
 
 - Options under [networking.getaddrinfo](#opt-networking.getaddrinfo.enable) are now allowed to declaratively configure address selection and sorting behavior of `getaddrinfo` in dual-stack networks.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -330,6 +330,7 @@
   ./programs/turbovnc.nix
   ./programs/udevil.nix
   ./programs/usbtop.nix
+  ./programs/uv.nix
   ./programs/vim.nix
   ./programs/virt-manager.nix
   ./programs/vivid.nix

--- a/nixos/modules/programs/uv.nix
+++ b/nixos/modules/programs/uv.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.uv;
+in
+{
+  options.programs.uv = {
+    enable = lib.mkEnableOption "uv";
+    package = lib.mkPackageOption pkgs "uv" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    programs.nix-ld.enable = true;
+  };
+
+  meta.maintainers = with lib.maintainers; [ yiyu ];
+}


### PR DESCRIPTION
[`uv`](https://github.com/astral-sh/uv) currently doesn't work on NixOS.

```
$ uv run foobar
error: Querying Python at `/home/username/.local/share/uv/python/cpython-3.13.5-linux-x86_64-gnu/bin/python3.13` failed with exit status exit status: 127

[stderr]
Could not start dynamically linked executable: /home/username/.local/share/uv/python/cpython-3.13.5-linux-x86_64-gnu/bin/python3.13
NixOS cannot run dynamically linked executables intended for generic
linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld
```

This module ensures `nix-ld` is enabled on the system so `uv` can run properly.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] ~~Tested basic functionality of all binary files, usually in `./result/bin/`.~~
- ~~Nixpkgs Release Notes~~
  - [ ] ~~Package update: when the change is major or breaking.~~
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] ~~Module update: when the change is significant.~~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
