### PR TITLE
python3Packages.awkward: 2.8.5 -> 2.8.9

### DIFF
--- a/pkgs/development/python-modules/awkward-cpp/default.nix
+++ b/pkgs/development/python-modules/awkward-cpp/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "awkward-cpp";
-  version = "47";
+  version = "50";
   pyproject = true;
 
   src = fetchPypi {
     pname = "awkward_cpp";
     inherit version;
-    hash = "sha256-Z2z0l2gQ7asyGH7fWopxavlQR7kDjJbSfTvkTxMxlQ8=";
+    hash = "sha256-JktvtOgqzBBXtbL/DTP6vDYQMlKOIzgVzSIkxtvJbY4=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/awkward/default.nix
+++ b/pkgs/development/python-modules/awkward/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "awkward";
-  version = "2.8.5";
+  version = "2.8.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scikit-hep";
     repo = "awkward";
     tag = "v${version}";
-    hash = "sha256-vcVJ9dLiZ3wfZU989slefSJoD2hKlRCwxRALvRGLZPA=";
+    hash = "sha256-zECnqZapgvB9ngkoAwEDFMyebFbE0iJ7Yo/5iLcmRXs=";
   };
 
   build-system = [
@@ -62,7 +62,7 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # Need to be run on a GPU platform.
-    "tests-cuda"
+    "tests-cuda/*"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/coffea/default.nix
+++ b/pkgs/development/python-modules/coffea/default.nix
@@ -16,6 +16,7 @@
   dask,
   dask-awkward,
   dask-histogram,
+  fsspec,
   hist,
   lz4,
   matplotlib,
@@ -41,14 +42,14 @@
 
 buildPythonPackage rec {
   pname = "coffea";
-  version = "2025.7.3";
+  version = "2025.10.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CoffeaTeam";
     repo = "coffea";
     tag = "v${version}";
-    hash = "sha256-lCrmWcVzu8Ls0a+r2D1DMZ/Ysq3H9bPj13XOmAS1M5I=";
+    hash = "sha256-vTTjdffQHzKnU41rW5XYTD7C4pH2fxhSy8mfKGMZbLc=";
   };
 
   build-system = [
@@ -69,6 +70,7 @@ buildPythonPackage rec {
     dask
     dask-awkward
     dask-histogram
+    fsspec
     hist
     lz4
     matplotlib

--- a/pkgs/development/python-modules/dask-awkward/default.nix
+++ b/pkgs/development/python-modules/dask-awkward/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "dask-awkward";
-  version = "2025.5.0";
+  version = "2025.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dask-contrib";
     repo = "dask-awkward";
     tag = version;
-    hash = "sha256-TLMT7YxedBUfz05F8wTsS5LQ9LyBbcUhQENM8C7Xric=";
+    hash = "sha256-7z9SkkE4WqULW0m7lk+oohq1uwSO7XLcrnh6U7wqTgo=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -38,14 +38,14 @@
 
 buildPythonPackage rec {
   pname = "dask";
-  version = "2025.7.0";
+  version = "2025.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = "dask";
     tag = version;
-    hash = "sha256-bwM4Q95YTEp9pDz6LmBLOeYjmi8nH8Cc/srZlXfEIlg=";
+    hash = "sha256-xPgMhydsFmwg0kyl3Lst1N+CsbbnsWdPOtkZ8BMPDR8=";
   };
 
   postPatch = ''
@@ -119,11 +119,6 @@ buildPythonPackage rec {
   disabledTestMarks = [
     # Don't run tests that require network access
     "network"
-  ];
-
-  disabledTests = [
-    # UserWarning: Insufficient elements for `head`. 10 elements requested, only 5 elements available. Try passing larger `npartitions` to `head`.
-    "test_set_index_head_nlargest_string"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "distributed";
-  version = "2025.7.0";
+  version = "2025.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = "distributed";
     tag = version;
-    hash = "sha256-np4hCamNTbnmLdfjFeHsxEEm9XI1O0kOczDe1YjSziw=";
+    hash = "sha256-qO03jwZeOjDP/BQxK8OFma5BxGF9nBoXVFWFGa+EQ00=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/uproot/default.nix
+++ b/pkgs/development/python-modules/uproot/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "uproot";
-  version = "5.6.6";
+  version = "5.6.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scikit-hep";
     repo = "uproot5";
     tag = "v${version}";
-    hash = "sha256-1zZr+SrGRNBz/Wd1cT2aYOH/MzSZTCuqxYIlA+NXqLk=";
+    hash = "sha256-4ClZ5XK5W9fseskYlfBmxO65OdfhJsV6Iaime7tGnOk=";
   };
 
   build-system = [


### PR DESCRIPTION
## Things done

- **python3Packages.dask: 2025.7.0 -> 2025.10.0**
- **python3Packages.awkward-cpp: 47 -> 50**
- **python3Packages.awkward: 2.8.5 -> 2.8.9**
- **python3Packages.distributed: 2025.7.0 -> 2025.10.0**
- **python3Packages.dask-awkward: 2025.5.0 -> 2025.9.0**
- **python3Packages.coffea: 2025.7.3 -> 2025.10.0**
- **python3Packages.uproot: 5.6.6 -> 5.6.7**

cc @veprbl


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc