### PR TITLE
Revert "perf: inherit makeFlags from kernel"

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf/default.nix
+++ b/pkgs/os-specific/linux/kernel/perf/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchurl,
   kernel,
-  kernelModuleMakeFlags,
   elfutils,
   python3,
   perl,
@@ -103,8 +102,9 @@ stdenv.mkDerivation {
     "prefix=$(out)"
     "WERROR=0"
     "ASCIIDOC8=1"
+    "ARCH=${stdenv.hostPlatform.linuxArch}"
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ]
-  ++ kernelModuleMakeFlags
   ++ lib.optional (!withGtk) "NO_GTK2=1"
   ++ lib.optional (!withZstd) "NO_LIBZSTD=1"
   ++ lib.optional (!withLibcap) "NO_LIBCAP=1";


### PR DESCRIPTION
This reverts commit 94276da9e98691be7d083b06301c3e434ba2cfa4.

[Original justification][1] was:

> it reduces unnecessary code duplication and should help with cross compilation (although this cannot be tested yet because some dependencies fail).

However, as time as gone on its become increasingly clear that the kernels make flags are going to be specific to building a kernel, not a userspace program, hence them having been renamed to kernelModuleMakeFlags in the meantime.  This has become even more apparent now that we're using unwrapped compilers for the kernel, which doesn't go at all well with building a userspace program like perf, so we stop inheriting any make flags from the kernel, and instead just set the two flags necessary for cross compilation to work.

Fixes: e9b2edb49163 ("linux: un-simplify toolchain selection")

[1]: https://github.com/NixOS/nixpkgs/pull/34068


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
