### PR TITLE
subsurface: 6.0.5231 -> 6.0.5414

### DIFF
--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -30,14 +30,14 @@
 }:
 
 let
-  version = "6.0.5231";
+  version = "6.0.5414";
 
   subsurfaceSrc = (
     fetchFromGitHub {
       owner = "Subsurface";
       repo = "subsurface";
-      rev = "38a0050ac33566dfd34bf94cf1d7ac66034e4118";
-      hash = "sha256-6fNcBF/Ep2xs2z83ZQ09XNb/ZkhK1nUNLChV1x8qh0Y=";
+      rev = "528bc9785d53a485bf38270687abfe239060a8af";
+      hash = "sha256-TtqT+H/kvyP7LXrDv/pwPxmZcTCsmzuqS3/IJmBAdRY=";
       fetchSubmodules = true;
     }
   );

--- a/pkgs/applications/misc/subsurface/default.nix
+++ b/pkgs/applications/misc/subsurface/default.nix
@@ -167,6 +167,7 @@ stdenv.mkDerivation {
       pushd $tmpdir
       git clone -b current https://github.com/subsurface/subsurface.git
       cd subsurface
+      sed -i '1s/#!\/bin\/bash/#!\/usr\/bin\/env bash/' ./scripts/get-version.sh
       # this returns 6.0.????-local
       new_version=$(./scripts/get-version.sh | cut -d '-' -f 1)
       new_rev=$(git rev-list -1 HEAD)


### PR DESCRIPTION


## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
