### PR TITLE
garak: init at 0.13.1

### DIFF
--- a/pkgs/by-name/ga/garak/package.nix
+++ b/pkgs/by-name/ga/garak/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication garak

--- a/pkgs/development/python-modules/ecoji/default.nix
+++ b/pkgs/development/python-modules/ecoji/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+
+  setuptools,
+
+  unittestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "ecoji";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mecforlove";
+    repo = "ecoji-py";
+    # no tags on github
+    rev = "bc021cf1c78263aa3d07e2db9016637caf26d2b7";
+    hash = "sha256-mfgw9LTE1T8XQ9G3CDthMLk+4m58lU3nff9H/Gh4VoQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  # remove when project is correctly tagged
+  # currently released on pypi as 0.1.1, diff shows the only difference is
+  # the version in setup.py
+  # https://github.com/mecforlove/ecoji-py/issues/7
+  postPatch = ''
+    substituteInPlace setup.py --replace-fail "0.1.0" "0.1.1"
+  '';
+
+  pythonImportsCheck = [ "ecoji" ];
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  meta = {
+    description = "Encode and decode data as emojis, in Python";
+    homepage = "https://github.com/mecforlove/ecoji-py";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+  };
+}

--- a/pkgs/development/python-modules/garak/default.nix
+++ b/pkgs/development/python-modules/garak/default.nix
@@ -1,0 +1,350 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  fetchpatch2,
+  buildPythonPackage,
+
+  # build-system
+  flit-core,
+
+  # dependencies
+  accelerate,
+  avidtools,
+  backoff,
+  base2048,
+  cmd2,
+  cohere,
+  colorama,
+  datasets,
+  deepl,
+  ecoji,
+  fschat,
+  ftfy,
+  google-api-python-client,
+  google-cloud-translate,
+  grpcio-tools,
+  huggingface-hub,
+  jinja2,
+  jsonpath-ng,
+  langchain,
+  langdetect,
+  litellm,
+  lorem,
+  markdown,
+  mistralai,
+  nemollm,
+  nltk, # also used for testing
+  numpy,
+  nvidia-riva-client,
+  ollama,
+  openai,
+  pillow,
+  python-magic,
+  rapidfuzz,
+  replicate,
+  sentencepiece,
+  stdlibs,
+  tiktoken,
+  torch,
+  tqdm,
+  transformers,
+  wn,
+  xdg-base-dirs,
+  zalgolib,
+  # optional audio
+  librosa,
+  soundfile,
+  # optional calibration
+  scipy,
+
+  # test utilities
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  writeText,
+
+  # test dependencies
+  langcodes,
+  pytest-httpserver,
+  pytest-mock,
+  requests-futures,
+  requests-mock,
+  respx,
+
+}:
+
+let
+in
+buildPythonPackage rec {
+  pname = "garak";
+  version = "0.13.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "garak";
+    rev = "v${version}";
+    hash = "sha256-saB+vBa1POXYCVUehgLBchbpgSwpa+U/EPwU8xC2OXk=";
+  };
+
+  build-system = [
+    flit-core
+  ];
+
+  pythonRelaxDeps = [
+    "avidtools"
+    "cmd2"
+    "cohere"
+    "datasets"
+    "deepl"
+    "mistralai"
+    "nvidia-riva-client"
+    "wn"
+  ];
+
+  dependencies = [
+    accelerate
+    avidtools
+    backoff
+    base2048
+    cmd2
+    cohere
+    colorama
+    datasets
+    deepl
+    ecoji
+    fschat
+    ftfy
+    google-api-python-client
+    google-cloud-translate
+    grpcio-tools
+    huggingface-hub
+    jinja2
+    jsonpath-ng
+    langchain
+    langdetect
+    litellm
+    lorem
+    markdown
+    mistralai
+    nemollm
+    nltk
+    numpy
+    nvidia-riva-client
+    ollama
+    openai
+    pillow
+    python-magic
+    rapidfuzz
+    replicate
+    sentencepiece
+    stdlibs
+    tiktoken
+    torch
+    tqdm
+    transformers
+    wn
+    xdg-base-dirs
+    zalgolib
+  ];
+
+  optional-dependencies = {
+    audio = [
+      librosa
+      soundfile
+    ];
+
+    calibration = [
+      scipy
+    ];
+  };
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+
+    pytestCheckHook
+
+    langcodes
+    pytest-httpserver
+    pytest-mock
+    requests-futures
+    requests-mock
+    respx
+  ]
+  ++ optional-dependencies.audio;
+
+  pythonImportsCheck = [ "garak" ];
+
+  # tests use localhost
+  __darwinAllowLocalNetworking = true;
+
+  passthru.test-data = {
+    nltk = nltk.dataDir (d: [
+      d.stopwords
+      d.punkt
+      d.wordnet
+    ]);
+    lexicon = {
+      name = "oewn:2023";
+      data = fetchurl {
+        url = "https://en-word.net/static/english-wordnet-2023.xml.gz";
+        hash = "sha256-T7+f+cYq/4djjiHJmNbltJJ6nz7y6YggOv7ZatuFxeU=";
+      };
+    };
+    # Wrap around `wn` python lib to load pre-fetched test lexicon.
+    # Can't just unpack to a dir since `wn` prepares an sqlite3 db.
+    # Also can't unpack to the default `data_directory` since garak changes that
+    # at runtime.
+    # https://github.com/NVIDIA/garak/blob/8fd22ee19b47613b9c2b728c35739276cd46ac6a/garak/probes/topic.py#L96
+    loadLexiconScript = writeText "load-lexicon-for-garak.py" ''
+      import sys
+      from pathlib import Path
+      from garak import _config
+      import wn
+
+      if len(sys.argv) < 2:
+          print("Error: No input provided.")
+          sys.exit(1)
+
+      lexicon_file = sys.argv[1]
+      if not isinstance(lexicon_file, str):
+          print("Error: Input is not a string.")
+          sys.exit(1)
+
+      # garak overrides the wn data_directory so use the same dir
+      wn.config.data_directory = _config.transient.cache_dir / "data" / "wn"
+      Path(wn.config.data_directory).mkdir(parents=True, exist_ok=True)
+      print("Loading lexicon", lexicon_file, "to", wn.config.data_directory)
+      wn.add(lexicon_file)
+    '';
+  };
+
+  preCheck =
+    # garak overrides nltk loading in garak/resources/api/nltk.py
+    # and doesn't respect NLTK_DATA env var
+    ''
+      mkdir -p "$HOME/.cache/data/" "$HOME/.cache/huggingface/hub" "$HOME/.cache/garak/data"
+      ln -s ${passthru.test-data.nltk} "$HOME/.cache/data/nltk_data"
+    ''
+    +
+    # prepare lexicon data via `wn` for tests/probes/test_probes_topic.py
+    ''
+      echo "Preparing ${passthru.test-data.lexicon.name} lexicon for use in testing"
+      # check TEST_LEXICON matches the one we're using
+      grep -q 'TEST_LEXICON = "${passthru.test-data.lexicon.name}"' tests/probes/test_probes_topic.py \
+        || (echo "TEST_LEXICON has been updated, fix in garak package definition" && exit 1)
+      python ${passthru.test-data.loadLexiconScript} ${passthru.test-data.lexicon.data}
+      substituteInPlace tests/probes/test_probes_topic.py \
+        --replace-fail "wn.download(TEST_LEXICON)" ""
+    '';
+
+  disabledTests = [
+    # around 77% of test runtime
+    # handy to disable for frequent testing but leave in for real build
+    # "test_repeat_token_sample_all"
+
+    # need models from huggingface
+    "test_atkgen_one_pass"
+    "test_atkgen_probe"
+    "test_atkgen_probe_translation"
+    "test_buff_load_and_transform"
+    "test_buff_results"
+    "test_dont_start_no_reverse_translation"
+    "test_dont_start_yes_reverse_translation"
+    "test_hf_detector_detection"
+    "test_hf_files_hf_repo"
+    "test_instantiate_detectors"
+    "test_local_translate_single_language"
+    "test_model"
+    "test_model_chat"
+    "test_must_contradict_NLI_detection"
+    "test_pipeline"
+    "test_run_all_active_probes"
+    "test_startswith_detect"
+    "test_Tag_attempt_descrs_translation"
+    "test_tox_safe"
+    "test_tox_unsafe"
+    "test_pipeline_chat"
+    "test_rakuland_known_package"
+
+    # runs cli, wants to fetch garak-llm/toxic-comment-model from huggingface
+    # tries to access the 8th line of the jsonl report.
+    # IndexError: list index out of range
+    "test_attempt_sticky_params"
+
+    # need images from github
+    "test_multi_modal_probe_translation"
+    "test_probe_metadata"
+    "test_probes_visual_jailbreak"
+    "test_cutoff_restriction"
+    "test_rakuland_hallucinated_package"
+
+    # needs content from windows.net
+    "test_repeat_token_single"
+
+    # need audio from huggingface, images from github
+    "test_instantiate_probes"
+
+    # outputs len = 10, generations probe calls = 1
+    "test_leakreplay_output_count"
+
+    # AttributeError: 'WordnetControversial' object has no attribute 'prompts'
+    "test_probe_prompt_translation"
+
+    # generally needs models from huggingface
+    # AssertionError: detector should return as many results as in all_outputs (maybe excluding Nones)
+    # assert 0 in (3, 4)
+    # +  where 0 = len([])
+    # +    where [] = list([])
+    "test_detector_detect"
+
+    # need datasets from huggingface for each language
+    # e.g. garak-llm/npm-20240828, garak-llm/crates-20240903, etc
+    # AssertionError: Misrecognition in core, false, or external package name validity
+    "test_javascriptnpm_case_sensitive"
+    "test_javascriptnpm_real"
+    "test_javascriptnpm_stdlib"
+    "test_javascriptnpm_weird"
+    "test_pythonpypi_case_sensitive"
+    "test_pythonpypi_pypi"
+    "test_pythonpypi_stdlib"
+    "test_pythonpypi_weird"
+    "test_result_alignment"
+    "test_rubygems_case_sensitive"
+    "test_rubygems_real"
+    "test_rubygems_stdlib"
+    "test_rubygems_weird"
+    "test_rustcrates_case_sensitive"
+    "test_rustcrates_direct_usage"
+    "test_rustcrates_real"
+    "test_rustcrates_stdlib"
+    "test_rustcrates_weird"
+
+    # get warnings from where the test causes garak/_plugins.py:273 to try open missing files
+    # e.g. /build/pytest-of-nixbld/pytest-0/test_llava_generate_returns_de0/test.png
+    "test_create"
+
+    "test_dart_known_package"
+    "test_dart_hallucinated_package"
+    "test_perl_known_package"
+    "test_perl_hallucinated_package"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook # runs ahead of checks in python builds
+  ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "LLM vulnerability scanner";
+    homepage = "https://github.com/NVIDIA/garak";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+    mainProgram = "garak";
+  };
+}

--- a/pkgs/development/python-modules/lorem/default.nix
+++ b/pkgs/development/python-modules/lorem/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+
+  setuptools,
+
+  unittestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "lorem";
+  version = "0.1.1";
+  disabled = pythonOlder "3.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sfischer13";
+    repo = "python-lorem";
+    # no tags in github
+    rev = "abf0d5b6708ea5d84fbbf46bef74907e3a7517f2";
+    hash = "sha256-fPkgNeADa5LvmEebVbJ+Rtfda9kodwvqTzbQsH26ILA=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "lorem" ];
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  meta = {
+    description = "Python library for the generation of random text that looks like Latin";
+    homepage = "https://github.com/sfischer13/python-lorem";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+  };
+}

--- a/pkgs/development/python-modules/mistralai/default.nix
+++ b/pkgs/development/python-modules/mistralai/default.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+
+  poetry-core,
+
+  eval-type-backport,
+  httpx,
+  pydantic,
+  python-dateutil,
+  typing-inspection,
+
+  authlib,
+  griffe,
+  mcp,
+
+  google-auth,
+  requests,
+
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage rec {
+  pname = "mistralai";
+  version = "1.9.3";
+  disabled = pythonOlder "3.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mistralai";
+    repo = "client-python";
+    rev = "v${version}";
+    hash = "sha256-WUmRLaXyfNEVRteZ4Qnbspo331iizOCYZx826qnuscE=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    eval-type-backport
+    httpx
+    pydantic
+    python-dateutil
+    typing-inspection
+  ];
+
+  optional-dependencies = {
+    agents = [
+      authlib
+      griffe
+      mcp
+    ];
+    gcp = [
+      google-auth
+      requests
+    ];
+  };
+
+  # pyproject wants generated README-PYPI.md using speakeasy
+  # but we can just copy existing README.md
+  preBuild = ''
+    cp README.md README-PYPI.md
+  '';
+
+  pythonImportsCheck = [ "mistralai" ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  meta = {
+    description = "Python client library for Mistral AI platform";
+    homepage = "https://github.com/mistralai/client-python";
+    changelog = "https://github.com/mistralai/client-python/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+  };
+}

--- a/pkgs/development/python-modules/nemollm/default.nix
+++ b/pkgs/development/python-modules/nemollm/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchPypi,
+
+  requests,
+  requests-futures,
+  requests-toolbelt,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "nemollm";
+  version = "0.3.5";
+  disabled = pythonOlder "3.6";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname format version;
+    dist = "py3";
+    python = "py3";
+    hash = "sha256-3jli2C1VfOXz13MUQ2G4l6GBAouOG735SATv+GXurYg=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    requests-futures
+    requests-toolbelt
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "nemollm" ];
+
+  meta = {
+    description = "Python client library for the NeMo LLM API";
+    homepage = "https://pypi.org/project/nemollm/";
+    # license isn't visible in pypi currently
+    # first ever release had MIT license in the description
+    # https://pypi.org/project/nemollm/0.1.0/
+    # and has been confirmed as MIT by NVIDIA employees in the Garak discord
+    # https://github.com/NixOS/nixpkgs/pull/429835#issuecomment-3155683784
+    license = lib.licenses.mit;
+    sourceProvenance = [
+      # python wheel
+      lib.sourceTypes.binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+  };
+}

--- a/pkgs/development/python-modules/nvidia-riva-client/default.nix
+++ b/pkgs/development/python-modules/nvidia-riva-client/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+
+  setuptools,
+  wheel,
+
+  grpcio,
+  grpcio-tools,
+
+  unittestCheckHook,
+}:
+
+let
+  version = "2.19.0";
+  # update with package
+  commonProtosSrc = fetchFromGitHub {
+    owner = "nvidia-riva";
+    repo = "common";
+    rev = "aca81234f8cd62898463742849738bf07a0d4dbb";
+    hash = "sha256-7UylSj6jZuk9RitTtb6iTfdpvQWkTskIm5gBpD2wLaY=";
+  };
+in
+buildPythonPackage {
+  pname = "nvidia-riva-client";
+  inherit version;
+  disabled = pythonOlder "3.7";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "nvidia-riva";
+    repo = "python-clients";
+    tag = "r${version}";
+    hash = "sha256-tDZoiHRzmqM6W6Q8FowmvNwWBJWQjwcLL0WEnUbnBDE=";
+  };
+
+  postPatch = ''
+    rm -rf common
+    ln -s ${commonProtosSrc} ./common
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    grpcio
+    grpcio-tools
+  ];
+
+  # there is a tests dir but seemingly unused right now
+
+  pythonImportsCheck = [ "riva" ];
+
+  meta = {
+    description = "Riva Python client API and CLI utils";
+    homepage = "https://github.com/nvidia-riva/python-clients";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+  };
+}

--- a/pkgs/development/python-modules/wn/default.nix
+++ b/pkgs/development/python-modules/wn/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pytestCheckHook,
-  pytest-benchmark,
   pythonOlder,
   hatchling,
   httpx,
   tomli,
   starlette,
+
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -37,16 +38,13 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    writableTmpDirAsHomeHook
     pytestCheckHook
-    pytest-benchmark
   ]
   ++ optional-dependencies.web;
 
-  pytestFlags = [ "--benchmark-disable" ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
+  # probably not worth spending time on plus require additional dependencies
+  disabledTestPaths = [ "bench/" ];
 
   pythonImportsCheck = [ "wn" ];
 

--- a/pkgs/development/python-modules/wn/default.nix
+++ b/pkgs/development/python-modules/wn/default.nix
@@ -53,6 +53,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/goodmami/wn";
     changelog = "https://github.com/goodmami/wn/blob/${src.tag}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ zendo ];
+    maintainers = with maintainers; [
+      zendo
+      jk
+    ];
   };
 }

--- a/pkgs/development/python-modules/wn/default.nix
+++ b/pkgs/development/python-modules/wn/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pytestCheckHook,
   pytest-benchmark,
   pythonOlder,
@@ -18,9 +18,11 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.9";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-wOaFLlFCNUo7RWWiMXRuztyVJTXpJtPvZJi9d6UmkcY=";
+  src = fetchFromGitHub {
+    owner = "goodmami";
+    repo = "wn";
+    tag = "v${version}";
+    hash = "sha256-xUraVRQmr4Oq1T/RiWgch8YJtAZR9ebOzaGBJ1NPKtw=";
   };
 
   build-system = [ hatchling ];
@@ -51,7 +53,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Modern, interlingual wordnet interface for Python";
     homepage = "https://github.com/goodmami/wn";
-    changelog = "https://github.com/goodmami/wn/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/goodmami/wn/blob/${src.tag}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ zendo ];
   };

--- a/pkgs/development/python-modules/zalgolib/default.nix
+++ b/pkgs/development/python-modules/zalgolib/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+
+  setuptools,
+}:
+
+buildPythonPackage {
+  pname = "zalgolib";
+  # no tags on github but tagged 0.2.2 on pypi
+  version = "0.2.2-unstable-2023-12-13";
+  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jivanyatra";
+    repo = "zalgolib";
+    rev = "9dbcc78cdb6612e8ff0664b4024fe28f15874b3a";
+    hash = "sha256-9hSHvFqPIQcUgxxddVnv7tEltvrxatAb6eLxt1NeBxg=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "zalgolib" ];
+
+  # no tests
+
+  meta = {
+    description = "Tools for working with Zalgo-style text";
+    homepage = "https://github.com/jivanyatra/zalgolib/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8844,6 +8844,8 @@ self: super: with self; {
 
   loqedapi = callPackage ../development/python-modules/loqedapi { };
 
+  lorem = callPackage ../development/python-modules/lorem { };
+
   loro = callPackage ../development/python-modules/loro { };
 
   losant-rest = callPackage ../development/python-modules/losant-rest { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10784,6 +10784,8 @@ self: super: with self; {
 
   nvidia-ml-py = callPackage ../development/python-modules/nvidia-ml-py { };
 
+  nvidia-riva-client = callPackage ../development/python-modules/nvidia-riva-client { };
+
   nwdiag = callPackage ../development/python-modules/nwdiag { };
 
   nxt-python = callPackage ../development/python-modules/nxt-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10413,6 +10413,8 @@ self: super: with self; {
 
   nebula3-python = callPackage ../development/python-modules/nebula3-python { };
 
+  nemollm = callPackage ../development/python-modules/nemollm { };
+
   nemosis = callPackage ../development/python-modules/nemosis { };
 
   nengo = callPackage ../development/python-modules/nengo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9439,6 +9439,8 @@ self: super: with self; {
 
   mistral-common = callPackage ../development/python-modules/mistral-common { };
 
+  mistralai = callPackage ../development/python-modules/mistralai { };
+
   mistune = callPackage ../development/python-modules/mistune { };
 
   mitmproxy = callPackage ../development/python-modules/mitmproxy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20544,6 +20544,8 @@ self: super: with self; {
 
   zadnegoale = callPackage ../development/python-modules/zadnegoale { };
 
+  zalgolib = callPackage ../development/python-modules/zalgolib { };
+
   zamg = callPackage ../development/python-modules/zamg { };
 
   zammad-py = callPackage ../development/python-modules/zammad-py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5699,6 +5699,8 @@ self: super: with self; {
 
   gaphas = callPackage ../development/python-modules/gaphas { };
 
+  garak = callPackage ../development/python-modules/garak { };
+
   gardena-bluetooth = callPackage ../development/python-modules/gardena-bluetooth { };
 
   garminconnect = callPackage ../development/python-modules/garminconnect { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4615,6 +4615,8 @@ self: super: with self; {
 
   ecoaliface = callPackage ../development/python-modules/ecoaliface { };
 
+  ecoji = callPackage ../development/python-modules/ecoji { };
+
   ecos = callPackage ../development/python-modules/ecos { };
 
   ecpy = callPackage ../development/python-modules/ecpy { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- some `python3Packages.wn` maintenance + ~update~, split for easier cherry-picking - cc: @zendo
  - `python3Packages.wn`: use original source from github
  - `python3Packages.wn`: use `writableTmpDirAsHomeHook`
  - ~`python3Packages.wn`: add optional-dependencies where deps exist~
  - ~`python3Packages.wn`: 0.11.0 -> 0.13.0~
- `python3Packages.ecoji`: init at 0.1.1
- `python3Packages.lorem`: init at 0.1.1
  - attempted to use existing `python3Packages.python-lorem` but probably sticking with `lorem`
    - related: https://github.com/NVIDIA/garak/pull/1313
- `python3Packages.mistralai`: init at 1.9.3
- `python3Packages.nemollm`: init at 0.3.5
  - ~**blocker:** currently set to `unfreeRedistributable` since there's no licensing info in PyPi~ license clarified in discord but not on pypi
  - sent an email asking what the license is or where to find original source
- `python3Packages.nvidia-riva-clients`: init at 2.19.0
- `python3Packages.zalgolib`: init at 0.2.2-unstable-2023-12-13
- `garak`: init at 0.13.1
  - pulling in an update early + relaxing numpy versions to use v2
    - could fall back to `numpy_1` but we shouldn't really add more packages with `numpy_1` and seems to work
    - related: https://github.com/NVIDIA/garak/pull/1314
  - small patch to allow garak to build with cohere v5
    - unclear if it fully functions but does allow the build to complete
    - related: https://github.com/NVIDIA/garak/pull/1252
      - would be ideal if this pr was merged as 1 commit when finalised
      - if not can take a copy `https://patch-diff.githubusercontent.com/raw/NVIDIA/garak/pull/1252.patch` when finalised or wait for next release
  - have to skip many tests as they need remote resources
    - some remote resources could be prefetched but several are also very large
    - still results in: 868 passed, 17 skipped in 15.06s

Related: #81418

~Draft due to `python3Packages.nemollm` blocker above~ confirmed as MIT by an nvidia dev, I'm personally happy with that

Future work, potentially try a NixOS test with ollama

I'm not super duper up-to-date on python packaging in nixpkgs so critical review strongly welcomed. Mostly used gramps as reference.

Tested with `./result/bin/garak --model_type ollama --generator_options '{"ollama": {"OllamaGeneratorChat": {"timeout": 300, "host": "http://my-remote-machine:11434"}}}' --model_name "gemma3:12b-it-q4_K_M" --probes dan.Ablation_Dan_11_0`

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
