### PR TITLE
apkg: 0.5.0 -> 0.6.1

### DIFF
--- a/pkgs/by-name/ap/apkg/package.nix
+++ b/pkgs/by-name/ap/apkg/package.nix
@@ -10,7 +10,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "apkg";
-  version = "0.5.0";
+  version = "0.6.1";
   format = "pyproject";
 
   src = fetchFromGitLab {
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
     owner = "packaging";
     repo = "apkg";
     tag = "v${version}";
-    hash = "sha256-VQNUzbWIDo/cbCdtx8JxN5UUMBW3mQ2B42In4b3AA+A=";
+    hash = "sha256-rFcHgNaZBTKO0tU7O8fz2eOD731sLHWxhh0x5mMo9uw=";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -35,7 +35,9 @@ python3Packages.buildPythonApplication rec {
     toml # config files
   ];
 
-  nativeBuildInputs = with python3Packages; [ hatchling ];
+  nativeBuildInputs = with python3Packages; [
+    setuptools # required for build
+  ];
 
   makeWrapperArgs = [
     # deps for `srcpkg` operation for other distros; could be optional
@@ -52,7 +54,6 @@ python3Packages.buildPythonApplication rec {
 
   nativeCheckInputs = with python3Packages; [
     pytest
-    dunamai
   ];
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
https://gitlab.nic.cz/packaging/apkg/-/blob/v0.6.1/docs/news.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable: N/A
- N/A Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
