### PR TITLE
cardano-related: hand over packages to aciceri

### DIFF
--- a/pkgs/by-name/ai/aiken/package.nix
+++ b/pkgs/by-name/ai/aiken/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     description = "Modern smart contract platform for Cardano";
     homepage = "https://aiken-lang.org";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ t4ccer ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "aiken";
   };
 }

--- a/pkgs/by-name/ai/aiken/package.nix
+++ b/pkgs/by-name/ai/aiken/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     description = "Modern smart contract platform for Cardano";
     homepage = "https://aiken-lang.org";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ aciceri ];
     mainProgram = "aiken";
   };
 }

--- a/pkgs/by-name/op/opshin/package.nix
+++ b/pkgs/by-name/op/opshin/package.nix
@@ -43,7 +43,7 @@ python3'.pkgs.buildPythonApplication rec {
     description = "Simple pythonic programming language for Smart Contracts on Cardano";
     homepage = "https://opshin.dev";
     license = licenses.mit;
-    maintainers = with maintainers; [ t4ccer ];
+    maintainers = with maintainers; [ ];
     mainProgram = "opshin";
   };
 }

--- a/pkgs/by-name/op/opshin/package.nix
+++ b/pkgs/by-name/op/opshin/package.nix
@@ -43,7 +43,7 @@ python3'.pkgs.buildPythonApplication rec {
     description = "Simple pythonic programming language for Smart Contracts on Cardano";
     homepage = "https://opshin.dev";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ aciceri ];
     mainProgram = "opshin";
   };
 }

--- a/pkgs/development/python-modules/blockfrost-python/default.nix
+++ b/pkgs/development/python-modules/blockfrost-python/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     description = "Python SDK for the Blockfrost.io API";
     homepage = "https://github.com/blockfrost/blockfrost-python";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ aciceri ];
   };
 }

--- a/pkgs/development/python-modules/blockfrost-python/default.nix
+++ b/pkgs/development/python-modules/blockfrost-python/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     description = "Python SDK for the Blockfrost.io API";
     homepage = "https://github.com/blockfrost/blockfrost-python";
     license = licenses.asl20;
-    maintainers = with maintainers; [ t4ccer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/cardano-tools/default.nix
+++ b/pkgs/development/python-modules/cardano-tools/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     description = "Python module for interfacing with the Cardano blockchain";
     homepage = "https://gitlab.com/viperscience/cardano-tools";
     license = licenses.asl20;
-    maintainers = with maintainers; [ t4ccer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/cardano-tools/default.nix
+++ b/pkgs/development/python-modules/cardano-tools/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     description = "Python module for interfacing with the Cardano blockchain";
     homepage = "https://gitlab.com/viperscience/cardano-tools";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ aciceri ];
   };
 }

--- a/pkgs/development/python-modules/ogmios/default.nix
+++ b/pkgs/development/python-modules/ogmios/default.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     description = "Python client for Ogmios";
     homepage = "https://gitlab.com/viperscience/ogmios-python";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ t4ccer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/ogmios/default.nix
+++ b/pkgs/development/python-modules/ogmios/default.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     description = "Python client for Ogmios";
     homepage = "https://gitlab.com/viperscience/ogmios-python";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ aciceri ];
   };
 }

--- a/pkgs/development/python-modules/pluthon/default.nix
+++ b/pkgs/development/python-modules/pluthon/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Pluto-like programming language for Cardano Smart Contracts in Python";
     homepage = "https://github.com/OpShin/pluthon";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ aciceri ];
   };
 }

--- a/pkgs/development/python-modules/pluthon/default.nix
+++ b/pkgs/development/python-modules/pluthon/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Pluto-like programming language for Cardano Smart Contracts in Python";
     homepage = "https://github.com/OpShin/pluthon";
     license = licenses.mit;
-    maintainers = with maintainers; [ t4ccer ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pycardano/default.nix
+++ b/pkgs/development/python-modules/pycardano/default.nix
@@ -87,7 +87,7 @@ buildPythonPackage rec {
     description = "Lightweight Cardano library in Python";
     homepage = "https://github.com/Python-Cardano/pycardano";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ aciceri ];
     # https://github.com/Python-Cardano/pycardano/blob/v0.13.2/Makefile#L26-L39
     # cbor2 with C extensions fail tests due to differences in used sized vs unsized arrays
     # more info: https://github.com/NixOS/nixpkgs/pull/402433#issuecomment-2916520286

--- a/pkgs/development/python-modules/pycardano/default.nix
+++ b/pkgs/development/python-modules/pycardano/default.nix
@@ -87,7 +87,7 @@ buildPythonPackage rec {
     description = "Lightweight Cardano library in Python";
     homepage = "https://github.com/Python-Cardano/pycardano";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ t4ccer ];
+    maintainers = with lib.maintainers; [ ];
     # https://github.com/Python-Cardano/pycardano/blob/v0.13.2/Makefile#L26-L39
     # cbor2 with C extensions fail tests due to differences in used sized vs unsized arrays
     # more info: https://github.com/NixOS/nixpkgs/pull/402433#issuecomment-2916520286

--- a/pkgs/development/python-modules/python-secp256k1-cardano/default.nix
+++ b/pkgs/development/python-modules/python-secp256k1-cardano/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage {
     homepage = "https://github.com/OpShin/python-secp256k1";
     description = "Fork of python-secp256k1, fixing the commit hash of libsecp256k1 to a Cardano compatible version";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ aciceri ];
   };
 }

--- a/pkgs/development/python-modules/python-secp256k1-cardano/default.nix
+++ b/pkgs/development/python-modules/python-secp256k1-cardano/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage {
     homepage = "https://github.com/OpShin/python-secp256k1";
     description = "Fork of python-secp256k1, fixing the commit hash of libsecp256k1 to a Cardano compatible version";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ t4ccer ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/uplc/default.nix
+++ b/pkgs/development/python-modules/uplc/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     description = "Python implementation of untyped plutus language core";
     homepage = "https://github.com/OpShin/uplc";
     license = licenses.mit;
-    maintainers = with maintainers; [ t4ccer ];
+    maintainers = with maintainers; [ ];
     mainProgram = "opshin";
   };
 }

--- a/pkgs/development/python-modules/uplc/default.nix
+++ b/pkgs/development/python-modules/uplc/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     description = "Python implementation of untyped plutus language core";
     homepage = "https://github.com/OpShin/uplc";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ aciceri ];
     mainProgram = "opshin";
   };
 }


### PR DESCRIPTION
Handing over cardano related packages to @aciceri 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
