### PR TITLE
flashrom: 1.5.1 -> 1.6.0

### DIFF
--- a/pkgs/by-name/fl/flashrom/package.nix
+++ b/pkgs/by-name/fl/flashrom/package.nix
@@ -18,11 +18,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flashrom";
-  version = "1.5.1";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "https://download.flashrom.org/releases/flashrom-v${finalAttrs.version}.tar.xz";
-    hash = "sha256-H5NLB27UnqziA2Vewkn8eGGmuOh/5K73MuR7bkhbYpM=";
+    hash = "sha256-i52zmH35tfyB5wGJ0BeQXdX2vh4UEDR/Imh6ttTJRCM=";
   };
 
   patches = [
@@ -59,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "programmer" "auto")
     (lib.mesonEnable "man-pages" true)
     (lib.mesonEnable "tests" (!stdenv.buildPlatform.isDarwin))
+    (lib.mesonEnable "generate_authors_list" false)
   ];
 
   doCheck = !stdenv.hostPlatform.isDarwin;


### PR DESCRIPTION
https://www.flashrom.org/release_notes/v_1_6.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
