### PR TITLE
cypress: 14.5.2 -> 14.5.3

### DIFF
--- a/pkgs/by-name/cy/cypress/package.nix
+++ b/pkgs/by-name/cy/cypress/package.nix
@@ -19,19 +19,19 @@ let
   availableBinaries = {
     x86_64-linux = {
       platform = "linux-x64";
-      hash = "sha256-LcpIiPQWH4ny31abrjL7fYZ4coWphRVCGJlJibt5iqQ=";
+      hash = "sha256-3zuKJ99/AJ2bG2MWs6J4YPznNeW+Cf5vkdM+wpfFZb0=";
     };
     aarch64-linux = {
       platform = "linux-arm64";
-      hash = "sha256-4eGIklTtF08WLdYanjQPvWX+vEUalhMV1WwiJpVayfc=";
+      hash = "sha256-73MtXLJLPUdrYKpdna4869f9JjDYhjlCkjKrv9qw5yk=";
     };
     aarch64-darwin = {
       platform = "darwin-arm64";
-      hash = "sha256-C8TknPDv0NwHzDJzIHHBfpMB0mSsXTnXkUxO3l5v5zY=";
+      hash = "sha256-c8acBIdTVInl6C+BCegu91jTfc5Ug1hG7yXAvDnyuuQ=";
     };
     x86_64-darwin = {
       platform = "darwin-x64";
-      hash = "sha256-fvZT7bBV331iVuzvwosIvh8C/XMHLvCvQpQyeM3bt2E=";
+      hash = "sha256-7pGw2AP2T4PtYhQdWzdP0oKzDCPiJqnkR70cj8382Y4=";
     };
   };
   inherit (stdenv.hostPlatform) system;
@@ -41,7 +41,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cypress";
-  version = "14.5.2";
+  version = "14.5.3";
 
   src = fetchzip {
     url = "https://cdn.cypress.io/desktop/${version}/${platform}/cypress.zip";


### PR DESCRIPTION
https://docs.cypress.io/app/references/changelog#14-5-3

This release addresses CVE-2025-7783 and includes other bugfixes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
