### PR TITLE
Add home assistant custom component for mitsubishi, pymitsubishi python lib

### DIFF
--- a/pkgs/development/python-modules/pymitsubishi/default.nix
+++ b/pkgs/development/python-modules/pymitsubishi/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  requests,
+  pycryptodome,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pymitsubishi";
+  version = "0.1.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pymitsubishi";
+    repo = "pymitsubishi";
+    tag = "v${version}";
+    hash = "sha256-tEmhllXvUwiJG1q7MyBrHPVVxzcZYgzTHzD8jnqfXvA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    pycryptodome
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pymitsubishi" ];
+
+  meta = {
+    description = "A Python library for controlling and monitoring Mitsubishi MAC-577IF-2E air conditioners";
+    homepage = "https://github.com/pymitsubishi/pymitsubishi";
+    changelog = "https://github.com/pymitsubishi/pymitsubishi/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ uvnikita ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  pymitsubishi,
+  pytest-cov-stub,
+  pytestCheckHook,
+  pytest-homeassistant-custom-component,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "pymitsubishi";
+  domain = "mitsubishi";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "pymitsubishi";
+    repo = "homeassistant-mitsubishi";
+    tag = "v${version}";
+    hash = "sha256-cJBhIck33gyFTITQKlLZSdKDA3VXeVJFGcQoD49BgWQ=";
+  };
+
+  dependencies = [
+    pymitsubishi
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+    pytest-homeassistant-custom-component
+  ];
+
+  meta = with lib; {
+    description = "Home Assistant Mitsubishi Air Conditioner Integration";
+    changelog = "https://github.com/pymitsubishi/homeassistant-mitsubishi/releases/tag/v${version}";
+    homepage = "https://github.com/pymitsubishi/homeassistant-mitsubishi";
+    maintainers = with maintainers; [ uvnikita ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13256,6 +13256,8 @@ self: super: with self; {
 
   pymilvus = callPackage ../development/python-modules/pymilvus { };
 
+  pymitsubishi = callPackage ../development/python-modules/pymitsubishi { };
+
   pymitv = callPackage ../development/python-modules/pymitv { };
 
   pymodbus = callPackage ../development/python-modules/pymodbus { };


### PR DESCRIPTION
- python3Packages.pymitsubishi: init at 0.1.7
- home-assistant-custom-components.mitsubishi: init at 0.1.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
