### PR TITLE
python3Packages.intel-extension-for-pytorch: init at 2.7.0

### DIFF
--- a/pkgs/development/python-modules/intel-extension-for-pytorch/default.nix
+++ b/pkgs/development/python-modules/intel-extension-for-pytorch/default.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cmake,
+  ninja,
+  setuptools,
+
+  gitMinimal,
+
+  libgcc,
+  llvmPackages,
+
+  # dependencies
+  expecttest,
+  hypothesis,
+  packaging,
+  psutil,
+  torch,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "intel-extension-for-pytorch";
+  version = "2.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "intel-extension-for-pytorch";
+    tag = "v${version}+cpu";
+    fetchSubmodules = true;
+    # leaveDotGit = true;
+    deepClone = true;
+    # hash = "sha256-WpexEAAQFF95sANpFz6sk0qJ0td1kM+4Q68vSA0H8iY=";
+    # hash = "sha256-3wgVSBdsLh+QUu09o8IgRobw9omqLYZMmrtwLcLiSa4=";
+    hash = "sha256-rRtRmTlx/18WvbdMIrhskcwDRfDL7pB9RVZsteteB+M=";
+  };
+
+  build-system = [
+    cmake
+    ninja
+    setuptools
+  ];
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    gitMinimal
+  ];
+
+  buildInputs = [
+    (lib.getDev llvmPackages.openmp)
+    (lib.getDev libgcc)
+  ];
+
+  dependencies = [
+    expecttest
+    hypothesis
+    packaging
+    psutil
+    setuptools
+    torch
+  ];
+
+  pythonImportsCheck = [ "intel_extension_for_pytorch" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Python package for extending the official PyTorch that can easily obtain performance on Intel platform";
+    homepage = "https://github.com/intel/intel-extension-for-pytorch";
+    changelog = "https://github.com/intel/intel-extension-for-pytorch/releases/tag/v${version}%2Bcpu";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7037,6 +7037,10 @@ self: super: with self; {
 
   intbitset = callPackage ../development/python-modules/intbitset { };
 
+  intel-extension-for-pytorch =
+    callPackage ../development/python-modules/intel-extension-for-pytorch
+      { };
+
   intelhex = callPackage ../development/python-modules/intelhex { };
 
   intellifire4py = callPackage ../development/python-modules/intellifire4py { };


### PR DESCRIPTION
## Things done

Adds [intel-extension-for-pytorch](https://github.com/intel/intel-extension-for-pytorch), a python package for extending the official PyTorch that can easily obtain performance on Intel platform.

This is a dependency of `python3Packages.vllm` that we are currently not shipping.

cc @NickCao

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
