### PR TITLE
remove-references-to: Fix sanitizing headers when filenames have spaces in

### DIFF
--- a/pkgs/build-support/nuke-references/nuke-refs.sh
+++ b/pkgs/build-support/nuke-references/nuke-refs.sh
@@ -27,7 +27,7 @@ for i in "$@"; do
         mv "$i.tmp" "$i"
 
         for hook in "${fixupHooks[@]}"; do
-            eval "$hook" "$i"
+            "$hook" "$i"
         done
     fi
 done

--- a/pkgs/build-support/remove-references-to/remove-references-to.sh
+++ b/pkgs/build-support/remove-references-to/remove-references-to.sh
@@ -32,6 +32,6 @@ done
 
 for region in "${regions[@]}"; do
     for hook in "${fixupHooks[@]}"; do
-        eval "$hook" "$region"
+        "$hook" "$region"
     done
 done


### PR DESCRIPTION
sanitiseHeaderPathsHook uses remove-references-to, where `eval "$hook" "$region"` is trying to call `signIfRequired` with a file path. However, `eval "signIfRequired" "foo bar"` actually calls signIfRequired with two arguments "foo" and "bar".

This was causing boost builds to fail on darwin with:

```
sanitiseHeaderPaths: sanitising header path in /nix/store/cisfk7wp3llzicrrxdg031c7y6dl8qfs-boost-1.82.0-dev/include/boost/serialization/collection_size_type copy.hpp
libc++abi: terminating due to uncaught exception of type std::runtime_error: opening input file: No such file or directory
/nix/store/w3q1nvfb44cmc0a3pdky0654ll7nca7n-signing-utils: line 24: 64192 Abort trap: 6           /nix/store/dqrpsqnanf3cr9nalcnl7pvbdwrqrwfk-sigtool-0.1.3/bin/sigtool --file "$file" check-requires-signature
Unexpected exit status from sigtool: 134
```

Or, with extra debugging:

```
+ eval signIfRequired '/nix/store/053hs64698lvs5wf5m0ydcqjpnip8vqg-boost-1.77.0-dev/include/boost/serialization/collection_size_type copy.hpp'
++ signIfRequired /nix/store/053hs64698lvs5wf5m0ydcqjpnip8vqg-boost-1.77.0-dev/include/boost/serialization/collection_size_type copy.hpp
++ local file=/nix/store/053hs64698lvs5wf5m0ydcqjpnip8vqg-boost-1.77.0-dev/include/boost/serialization/collection_size_type
++ checkRequiresSignature /nix/store/053hs64698lvs5wf5m0ydcqjpnip8vqg-boost-1.77.0-dev/include/boost/serialization/collection_size_type
++ local file=/nix/store/053hs64698lvs5wf5m0ydcqjpnip8vqg-boost-1.77.0-dev/include/boost/serialization/collection_size_type
++ local rc=0
++ /nix/store/lqhw9siq8a9xa3yp79cn17i56ngx5y5l-sigtool-0.1.3/bin/sigtool --file /nix/store/053hs64698lvs5wf5m0ydcqjpnip8vqg-boost-1.77.0-dev/include/boost/serialization/collection_size_type check-requires-signature
libc++abi: terminating due to uncaught exception of type std::runtime_error: opening input file: No such file or directory
/nix/store/qa2phyrw78sg8axqcqrh0mqi04bqpk9i-signing-utils: line 24: 88164 Abort trap: 6           /nix/store/lqhw9siq8a9xa3yp79cn17i56ngx5y5l-sigtool-0.1.3/bin/sigtool --file "$file" check-requires-signature
++ rc=134
++ '[' 134 -eq 0 ']'
++ '[' 134 -eq 1 ']'
++ echo 'Unexpected exit status from sigtool: 134'
```

I don't think eval is actually necessary here, remove it.

_Please sanity check me on this - I find it hard to believe this is the first time we've needed to call remove-references-to on a path with spaces_


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


Fixes #426934