### PR TITLE
Cinnamon updates 2025-08-01

### DIFF
--- a/pkgs/by-name/bu/bulky/package.nix
+++ b/pkgs/by-name/bu/bulky/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bulky";
-  version = "3.7";
+  version = "3.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "bulky";
     rev = version;
-    hash = "sha256-8sSn/EXLs7UC4M6cNKtVUNwrHeV4dt3mvUCxQQQRaj0=";
+    hash = "sha256-LVrVgfYCcfaIFDPQu8cFr2+KkzXboDSjPwM5UIP4G9c=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fo/folder-color-switcher/package.nix
+++ b/pkgs/by-name/fo/folder-color-switcher/package.nix
@@ -8,14 +8,14 @@
 
 stdenvNoCC.mkDerivation {
   pname = "folder-color-switcher";
-  version = "1.6.7";
+  version = "1.6.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "folder-color-switcher";
     # They don't really do tags, this is just a named commit.
-    rev = "5bd94d3ffdb9585c09832f0beabb14f0e67e8d58";
-    hash = "sha256-77+b7yVcTvBjtmXGOUIrh88IaxvCiBNM+hbZoN0+zoI=";
+    rev = "d135f29d688d89a0e7b48acec9e08738c7976ee1";
+    hash = "sha256-3EFnQxTYcJLGjfAzZNS7pgVDUwuU3juOAwUyaKOHemI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-online-accounts-gtk/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts-gtk/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-online-accounts-gtk";
-  version = "3.50.6";
+  version = "3.50.7";
 
   src = fetchFromGitHub {
     owner = "xapp-project";
     repo = "gnome-online-accounts-gtk";
     rev = finalAttrs.version;
-    hash = "sha256-/d6ezujW/yeZV95zv/12ttUEUliZARtEGFoCXe6Dp/I=";
+    hash = "sha256-CFPaCx3tfOIoovm9AXofBdZzl/Rxiz5RVOrVKCuxZbI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/hy/hypnotix/package.nix
+++ b/pkgs/by-name/hy/hypnotix/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "hypnotix";
-  version = "5.0";
+  version = "5.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "hypnotix";
     rev = version;
-    hash = "sha256-nBt+eGzUQaRO2IaEkvhdEZcVuKpZFEqIYSdVKSO1l4M=";
+    hash = "sha256-XXfZDFvHrGk+RFSQPldI/G4xhPm8lafZyBVCDtzvyoI=";
   };
 
   patches = [

--- a/pkgs/by-name/li/lightdm-slick-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-slick-greeter/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "2.2.0";
+  version = "2.2.1";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    hash = "sha256-xuNUCS8v8XXidXNT/DP+sckdadUTeflFK34ZDpF1iyc=";
+    hash = "sha256-AErY8Gy1AkYY/vpXoSE8zhyJd/nboMw+9BO3j6N7CNc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pi/pix/package.nix
+++ b/pkgs/by-name/pi/pix/package.nix
@@ -34,13 +34,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pix";
-  version = "3.4.5";
+  version = "3.4.6";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "pix";
     rev = version;
-    hash = "sha256-c/+NQHvscW/XE49Twmg1Rk1IfsjReCtRQWffobZtgTs=";
+    hash = "sha256-jlaqlA3akRNnBPTdtkWl+0NXqFbYw9uJKRfE/oTJMSg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/st/sticky/package.nix
+++ b/pkgs/by-name/st/sticky/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sticky";
-  version = "1.25";
+  version = "1.26";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "sticky";
     rev = version;
-    hash = "sha256-lM9R89CNj8ZXeOciwn/ax9wcsf3J4yPmzrgAntp8Fsg=";
+    hash = "sha256-pwY5MO3xKgRQa1zYfcO02z6kOMofOFWqTUrwEYzkAEo=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/wa/warpinator/package.nix
+++ b/pkgs/by-name/wa/warpinator/package.nix
@@ -39,13 +39,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "warpinator";
-  version = "1.8.9";
+  version = "1.8.10";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "warpinator";
     rev = version;
-    hash = "sha256-/BRL0TT0zLjrL3ZcDnNqlHHMizirx8wQd9R4NT+fMqI=";
+    hash = "sha256-OSZYjCnFIHmWCwVcWP1MLmezt5HL4Njf0WMyCRmPP58=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xa/xapp/package.nix
+++ b/pkgs/by-name/xa/xapp/package.nix
@@ -24,7 +24,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xapp";
-  version = "2.8.9";
+  version = "2.8.11";
 
   outputs = [
     "out"
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     owner = "linuxmint";
     repo = "xapp";
     rev = version;
-    hash = "sha256-ub5OwtB+LR86gt17342cmgvoWJu2kYzkWhl9V1QVCzQ=";
+    hash = "sha256-dmMjGWjq0s4MkobeqssbG5G3+gHRqA6lmu95uJX3RJY=";
   };
 
   # Recommended by upstream, which enables the build of xapp-debug.

--- a/pkgs/by-name/xe/xed-editor/package.nix
+++ b/pkgs/by-name/xe/xed-editor/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xed-editor";
-  version = "3.8.2";
+  version = "3.8.3";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xed";
     rev = version;
-    hash = "sha256-LSAOo6lPm6CQdTNxfAIthul9I9VnWpbEo1vOnKN7SNU=";
+    hash = "sha256-bNnxQOYDBS/pNaBwvmrt/VAya/m7t5H40lJkFevufUE=";
   };
 
   patches = [

--- a/pkgs/by-name/xr/xreader/package.nix
+++ b/pkgs/by-name/xr/xreader/package.nix
@@ -36,13 +36,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xreader";
-  version = "4.2.7";
+  version = "4.2.8";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xreader";
     rev = version;
-    hash = "sha256-APBVrrvLS5CFtfi0UlIDtYyg4pfCS8qLc2a4KDOU1Zk=";
+    hash = "sha256-Q/Hx43B+LmoAWzHPcz+kETjLzKyrO0Sn4gu9PmGfyUI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xv/xviewer/package.nix
+++ b/pkgs/by-name/xv/xviewer/package.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xviewer";
-  version = "3.4.9";
+  version = "3.4.10";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "xviewer";
     rev = version;
-    hash = "sha256-WYGX57PUX+WUVVZ1F+oE3QNwKB7ii5FlJdQ/3j5heUA=";
+    hash = "sha256-ELjr6W1Hqpvc7ChOrLhVUw9YPRoS/JjXQMNBrCn7JOQ=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
View list of changes: https://github.com/bobby285271/what-changed/blob/950bba2a5b1350a615901be1d64469fbf4aafd25/003-cinnamon.md

**tldr:** The only non-trivial commit is https://github.com/linuxmint/xapp/commit/b6fefa1da74c0841dfe1db08f08a97a66972cc4d. I expect the commit no-op with switcheroo-control we ship. All other updates are translation only.

<!---

xed-editor: 3.8.2 -> 3.8.3
sticky: 1.25 -> 1.26
lightdm-slick-greeter: 2.2.0 -> 2.2.1
hypnotix: 5.0 -> 5.1
xviewer: 3.4.9 -> 3.4.10
xreader: 4.2.7 -> 4.2.8
xapp: 2.8.9 -> 2.8.11
warpinator: 1.8.9 -> 1.8.10
pix: 3.4.5 -> 3.4.6
folder-color-switcher: 1.6.7 -> 1.6.8
bulky: 3.7 -> 3.8
gnome-online-accounts-gtk: 3.50.6 -> 3.50.7

--->


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

