### PR TITLE
python3Packages.m2crypto: fixup darwin build

### DIFF
--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -40,6 +40,7 @@ buildPythonPackage rec {
       "-Wno-error=implicit-function-declaration"
       "-Wno-error=incompatible-pointer-types"
     ]);
+    OPENSSL_PATH = lib.optionalString stdenv.hostPlatform.isDarwin "${openssl.dev}";
   }
   // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
     CPP = "${stdenv.cc.targetPrefix}cpp";


### PR DESCRIPTION
darwin builds would fail with the following output:
```
INFO:spawn:swig -python -Isystem_shadowing -Isystem_shadowing -I/nix/store/03yi1jcbkpb693las8rkq4wmakg5m8yx-apple-sdk-11.3/Platf
orms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include -I/nix/store/riv3i1wrig5kaf89wgpx46581f71gfqb-python3-3.13.5/incl
ude/python3.13 -I/usr/include/openssl -cpperraswarn -includeall -builtin -outdir build/lib.macosx-11.3-arm64-cpython-313/M2Crypt
o -o src/SWIG/_m2crypto_wrap.c src/SWIG/_m2crypto.i
src/SWIG/_m2crypto.i:62: Error: Unable to find 'openssl/opensslv.h'
src/SWIG/_m2crypto.i:68: Error: Unable to find 'openssl/safestack.h'
src/SWIG/_evp.i:12: Error: Unable to find 'openssl/opensslconf.h'
src/SWIG/_rc4.i:5: Error: Unable to find 'openssl/opensslconf.h'
src/SWIG/_ec.i:7: Error: Unable to find 'openssl/opensslconf.h'
error: command '/nix/store/mhpryadgkrbvbslrgc6lbcz2b5yzcprq-swig-4.3.1/bin/swig' failed with exit code 1
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
