### PR TITLE
lisp-modules: set lisp attrs in passthru

### DIFF
--- a/pkgs/development/compilers/abcl/default.nix
+++ b/pkgs/development/compilers/abcl/default.nix
@@ -7,6 +7,9 @@
   jdk,
   makeWrapper,
   stripJavaArchivesHook,
+  # lisp-modules related args
+  wrapLisp,
+  packageOverrides ? (self: super: { }),
 }:
 
 let
@@ -54,7 +57,20 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = ./update.sh;
+  passthru = {
+    updateScript = ./update.sh;
+    inherit
+      (wrapLisp {
+        inherit packageOverrides;
+        pkg = finalAttrs.finalPackage;
+        faslExt = "abcl";
+      })
+      pkgs
+      withPackages
+      buildASDFSystem
+      withOverrides
+      ;
+  };
 
   meta = {
     description = "JVM-based Common Lisp implementation";

--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -17,17 +17,20 @@
   threadSupport ? true,
   useBoehmgc ? false,
   boehmgc,
+  # lisp-modules related args
+  wrapLisp,
+  packageOverrides ? (self: super: { }),
 }:
 
 let
   cc = if stdenv.cc.isClang then clang else gcc;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ecl";
   version = "24.5.10";
 
   src = fetchurl {
-    url = "https://common-lisp.net/project/ecl/static/files/release/ecl-${version}.tgz";
+    url = "https://common-lisp.net/project/ecl/static/files/release/ecl-${finalAttrs.version}.tgz";
     hash = "sha256-5Opluxhh4OSVOGv6i8ZzvQFOltPPnZHpA4+RQ1y+Yis=";
   };
 
@@ -88,6 +91,20 @@ stdenv.mkDerivation rec {
     }"
   '';
 
+  passthru = {
+    inherit
+      (wrapLisp {
+        inherit packageOverrides;
+        pkg = finalAttrs.finalPackage;
+        faslExt = "fas";
+      })
+      pkgs
+      withPackages
+      buildASDFSystem
+      withOverrides
+      ;
+  };
+
   meta = with lib; {
     description = "Lisp implementation aiming to be small, fast and easy to embed";
     homepage = "https://common-lisp.net/project/ecl/";
@@ -95,6 +112,6 @@ stdenv.mkDerivation rec {
     mainProgram = "ecl";
     teams = [ lib.teams.lisp ];
     platforms = platforms.unix;
-    changelog = "https://gitlab.com/embeddable-common-lisp/ecl/-/raw/${version}/CHANGELOG";
+    changelog = "https://gitlab.com/embeddable-common-lisp/ecl/-/raw/${finalAttrs.version}/CHANGELOG";
   };
-}
+})

--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -19,6 +19,9 @@
   # of course we can’t do that because SBCL hasn’t been built yet, so we use
   # ECL but that’s much slower.
   bootstrapLisp ? null,
+  # lisp-modules related args
+  wrapLisp,
+  packageOverrides ? (self: super: { }),
 }:
 
 let
@@ -279,6 +282,24 @@ stdenv.mkDerivation (self: {
       }
     ''
   );
+
+  passthru = {
+    inherit
+      (wrapLisp {
+        inherit packageOverrides;
+        pkg = self.finalPackage;
+        faslExt = "fasl";
+        flags = [
+          "--dynamic-space-size"
+          "3000"
+        ];
+      })
+      pkgs
+      withPackages
+      buildASDFSystem
+      withOverrides
+      ;
+  };
 
   meta = with lib; {
     description = "Common Lisp compiler";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9876,14 +9876,8 @@ with pkgs;
   };
 
   # Embeddable Common Lisp
-  ecl = wrapLisp {
-    pkg = callPackage ../development/compilers/ecl { };
-    faslExt = "fas";
-  };
-  ecl_16_1_2 = wrapLisp {
-    pkg = callPackage ../development/compilers/ecl/16.1.2.nix { };
-    faslExt = "fas";
-  };
+  ecl = callPackage ../development/compilers/ecl { };
+  ecl_16_1_2 = callPackage ../development/compilers/ecl/16.1.2.nix { };
 
   # GNU Common Lisp
   gcl = wrapLisp {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9892,38 +9892,10 @@ with pkgs;
   };
 
   # Steel Bank Common Lisp
-  sbcl_2_4_6 = wrapLisp {
-    pkg = callPackage ../development/compilers/sbcl { version = "2.4.6"; };
-    faslExt = "fasl";
-    flags = [
-      "--dynamic-space-size"
-      "3000"
-    ];
-  };
-  sbcl_2_4_10 = wrapLisp {
-    pkg = callPackage ../development/compilers/sbcl { version = "2.4.10"; };
-    faslExt = "fasl";
-    flags = [
-      "--dynamic-space-size"
-      "3000"
-    ];
-  };
-  sbcl_2_5_4 = wrapLisp {
-    pkg = callPackage ../development/compilers/sbcl { version = "2.5.4"; };
-    faslExt = "fasl";
-    flags = [
-      "--dynamic-space-size"
-      "3000"
-    ];
-  };
-  sbcl_2_5_5 = wrapLisp {
-    pkg = callPackage ../development/compilers/sbcl { version = "2.5.5"; };
-    faslExt = "fasl";
-    flags = [
-      "--dynamic-space-size"
-      "3000"
-    ];
-  };
+  sbcl_2_4_6 = callPackage ../development/compilers/sbcl { version = "2.4.6"; };
+  sbcl_2_4_10 = callPackage ../development/compilers/sbcl { version = "2.4.10"; };
+  sbcl_2_5_4 = callPackage ../development/compilers/sbcl { version = "2.5.4"; };
+  sbcl_2_5_5 = callPackage ../development/compilers/sbcl { version = "2.5.5"; };
   sbcl = sbcl_2_5_5;
 
   sbclPackages = recurseIntoAttrs sbcl.pkgs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9836,13 +9836,10 @@ with pkgs;
   wrapLisp = callPackage ../development/lisp-modules/nix-cl.nix { };
 
   # Armed Bear Common Lisp
-  abcl = wrapLisp {
-    pkg = callPackage ../development/compilers/abcl {
-      # https://armedbear.common-lisp.dev/ lists OpenJDK 17 as the highest
-      # supported JDK.
-      jdk = openjdk17;
-    };
-    faslExt = "abcl";
+  abcl = callPackage ../development/compilers/abcl {
+    # https://armedbear.common-lisp.dev/ lists OpenJDK 17 as the highest
+    # supported JDK.
+    jdk = openjdk17;
   };
 
   # Clozure Common Lisp


### PR DESCRIPTION
Hey, @NixOS/lisp 

What do you think about adding the`pkgs`, `withPackages` etc. attributes within each packages' `passthru` instead of in `all-packages`?

It would make `(ecl.overrideAttrs { version = "20250731-trunk"; src = fetchzip { ... }; }).pkgs` work without having to re-wrap with `wrapLisp`. 

(Currently, `overrideAttrs` "loses" the `pkgs`, `withPackages` attrs added by `wrapLisp` to `abcl`, `ecl`, `ccl` etc. That can be surprising/unexpected, see: https://github.com/NixOS/nixpkgs/pull/360320#issuecomment-2537065930)

On the aesthetic side, the assignments in `all-packages` don't stand out anymore. The passthru inside each CL isn't pretty, though, but see _PS_.

Maybe that's too much, but I also thoguth to add an attribute (`packageOverrides`) a'la `python3`/`lua` for e.g. `ecl.override { packageOverrides = (self: super: { ... }); }` (though one can use the existing `ecl.withOverrides (self: super: { ... })`). What do you think, does adding that reduces friction? (i.e. someone would expect such an `override` for a `pkgs`-kind of a package, but it isn't there currently).

If that works, I can do the remaining CLs and document it a bit.

_PS. The weird thing with `inherit` instead of just `wrapLisp { ... } // { updateScript = ... }` is because attribute *names* returned by something that uses `finalAttrs.finalPackage` cause an infinite recursion in the interpreter - only values are allowed like this._

