### PR TITLE
zoom-us: reintroduce `unset QT_PLUGIN_PATH`

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -243,6 +243,7 @@ else
     inherit (unpacked) pname version;
 
     targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
+    extraPreBwrapCmds = "unset QT_PLUGIN_PATH";
     extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
     runScript = "/opt/zoom/ZoomLauncher";
 


### PR DESCRIPTION
Fix https://github.com/NixOS/nixpkgs/issues/428434 (and possibly https://github.com/NixOS/nixpkgs/issues/429341) by partially reverting https://github.com/NixOS/nixpkgs/pull/425420 .

Notifying co-maintainers @philiptaron  @ryan4yin

Notifying issue authors @witchof0x20 @robertodr : Can you try this pull request and check if it solves your problems?  Sorry for the breakage!


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

More: Tested with Plasma5/X11/Pulseaudio on a NixOS 25.05 machine (unchecked means "not tested"):

- [x] sidebar loads (albeit empty on my installation, cf. https://github.com/NixOS/nixpkgs/issues/344931 )
- [x] audio is "detected" by zoom: microphone VU-meter shows amplitude
- [x] audio is produced: "Test speaker" generates audible ting-a-ling
- [x] other participant's audio in video conference is audible
- [x] other participants can hear me
- [x] sending camera picture in video conference works
- [x] participant's camera video is received in video conference
- [x] screen sharing sends screen to other participants
- [ ] participant's shared screen is displayed
- [x] "Participants" dialog box is shown (cf. https://github.com/NixOS/nixpkgs/issues/116355 )
- [x] settings dialog is shown/useable  (cf. https://github.com/NixOS/nixpkgs/pull/410244 )
- [x] SSO works: Zoom starts Firefox, then Firefox calls back to Zoom after login, as usual
- [x] reading team chat messages works as expected
- [ ] writing team chat messages works
- [ ] sidebar shows content
- [ ] Pipewire
- [ ] Wayland
- [ ] xdg-desktop-portal (cf. https://github.com/NixOS/nixpkgs/issues/359533 )
- [ ] Darwin

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>zoom-us</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
