### PR TITLE
forgejo-runner: 8.0.1 -> 9.0.1

### DIFF
--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -13,21 +13,45 @@ let
   disabledTests = [
     "Test_runCreateRunnerFile"
     "Test_ping"
+
+    # The following tests were introduced in 9.x with the inclusion of act
+    # the pkgs/by-name/ac/act/package.nix just sets doCheck = false;
+
+    # Requires running docker install
+    "TestDocker"
+    "TestJobExecutor"
+    "TestRunner"
+    "Test_validateCmd"
+
+    # Docker network request for image
+    "TestImageExistsLocally"
+
+    # Reaches out to different websites
+    "TestFindGitRemoteURL"
+    "TestGitFindRef"
+    "TestGitCloneExecutor"
+    "TestCloneIfRequired"
+    "TestActionCache"
+    "TestRunContext_GetGitHubContext"
+
+    # These tests rely on outbound IP address
+    "TestHandler"
+    "TestHandler_gcCache"
   ];
 in
 buildGoModule rec {
   pname = "forgejo-runner";
-  version = "8.0.1";
+  version = "9.0.1";
 
   src = fetchFromGitea {
     domain = "code.forgejo.org";
     owner = "forgejo";
     repo = "runner";
     rev = "v${version}";
-    hash = "sha256-6FTJYs1dqIAHPxMzRNOHHZQv4be9LaR1wxMJsW3t5kg=";
+    hash = "sha256-3VurTHOM7FMRJzmQ5tBmW4E0mw7hePCnff0vhxPsKfE=";
   };
 
-  vendorHash = "sha256-NykeBR2dnWQaqJuY73i9KLIqehLHniaMqf9oTqUDstQ=";
+  vendorHash = "sha256-7R42Aa04wCba90xLTX2p6oNX58OpfDDKegqwDw3Ycbk=";
 
   # See upstream Makefile
   # https://code.forgejo.org/forgejo/runner/src/branch/main/Makefile
@@ -39,7 +63,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X code.forgejo.org/forgejo/runner/internal/pkg/ver.version=${src.rev}"
+    "-X code.forgejo.org/forgejo/runner/v9/internal/pkg/ver.version=${src.rev}"
   ];
 
   checkFlags = [


### PR DESCRIPTION
changelog: https://code.forgejo.org/forgejo/runner/releases/tag/v9.0.0
changelog: https://code.forgejo.org/forgejo/runner/releases/tag/v9.0.1


9.x introduces `act` code directly which has a number of integration tests that reach out to the internet and/or docker socket. These are skipped, the official `act` package gets around this by completely disabling the `check` phase. This seemed better.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
