### PR TITLE
nixos/homer: fix escape docstring

### DIFF
--- a/nixos/modules/services/web-apps/homer.nix
+++ b/nixos/modules/services/web-apps/homer.nix
@@ -49,7 +49,7 @@ in
 
         To add files such as icons or backgrounds, you can reference them in line such as
         ```nix
-        icon = "$\{./icon.png}";
+        icon = "''${./icon.png}";
         ```
         This will add the file to the nix store upon build, referencing it by file path as expected by Homer.
       '';


### PR DESCRIPTION
The option `services.homer.settings` contains a wrongly escaped `$`. When the documentation is currently viewed at [search.nixos.org](https://search.nixos.org/options?channel=25.05&show=services.homer.settings&from=0&size=1&sort=relevance&type=packages&query=services.homer.settings), it contains this code snippet under "description": `icon = "$\{./icon.png}";`.

I think this is by accident and fixed the docstring so that it gets rendered to: `icon = "${./icon.png}";`

You are the maintainer @Stunkymonkey, could you please review this?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
