### PR TITLE
proton-authenticator: init at 1.0.0

### DIFF
--- a/pkgs/by-name/pr/proton-authenticator/package.nix
+++ b/pkgs/by-name/pr/proton-authenticator/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  glib-networking,
+  wrapGAppsHook4,
+  webkitgtk_4_1,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "proton-authenticator";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://proton.me/download/authenticator/linux/ProtonAuthenticator_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-Ri6U7tuQa5nde4vjagQKffWgGXbZtANNmeph1X6PFuM=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 usr/bin/proton-authenticator $out/bin/${finalAttrs.meta.mainProgram}
+    cp -r usr/share $out
+
+    wrapProgram "$out/bin/${finalAttrs.meta.mainProgram}" \
+      --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Two-factor authentication manager with optional sync";
+    homepage = "https://proton.me/authenticator";
+    license = lib.licenses.unfree; # source not yet published
+    maintainers = with lib.maintainers; [ felschr ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "proton-authenticator";
+  };
+})


### PR DESCRIPTION
Packages Proton Authenticator, a two-factor authentication manager.

It's a redistribution of the official binary release from https://proton.me/authenticator/download

It was built with Tauri, so once the source is accessible (I could only find Android & iOS sources so far), we can probably switch quite easily to building it from source.

https://proton.me/authenticator
https://proton.me/blog/authenticator-app

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
