### PR TITLE
python3Packages.docling-jobkit: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/docling-jobkit/default.nix
+++ b/pkgs/development/python-modules/docling-jobkit/default.nix
@@ -95,6 +95,10 @@ buildPythonPackage rec {
     "test_convert_url"
     "test_convert_file"
     "test_convert_warmup"
+
+    # Flaky due to comparison with magic object
+    # https://github.com/docling-project/docling-jobkit/issues/45
+    "test_options_validator"
   ];
 
   meta = {


### PR DESCRIPTION
Test failure when building `python3Packages.docling-jobkit`:

```sh
FAILED tests/test_options.py::test_options_validator - AssertionError: assert InlineVlmOpti...w_tokens=4096) == InlineVlmOpti...w_tokens=4096)
```

Inspection of the output shows `repo_id='ds4sd/SmolDocling-256M-preview-mlx-bf16'` vs. `repo_id='ds4sd/SmolDocling-256M-preview'`.

Disabled the test. Filed https://github.com/docling-project/docling-jobkit/issues/45

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
