### PR TITLE
typescript: 5.8.3 -> 5.9.2 with adding patch for ags_1

### DIFF
--- a/pkgs/by-name/ag/ags_1/package.nix
+++ b/pkgs/by-name/ag/ags_1/package.nix
@@ -59,6 +59,11 @@ buildNpmPackage (finalAttrs: {
     upower
   ];
 
+  patches = [
+    # Workaround for TypeScript 5.9: https://github.com/Aylur/ags/issues/725#issuecomment-3070009695
+    ./ts59.patch
+  ];
+
   postPatch = ''
     chmod u+x ./post_install.sh && patchShebangs ./post_install.sh
   '';

--- a/pkgs/by-name/ag/ags_1/ts59.patch
+++ b/pkgs/by-name/ag/ags_1/ts59.patch
@@ -1,0 +1,19 @@
+diff --git a/src/service/greetd.ts b/src/service/greetd.ts
+index 10a475e..621a427 100644
+--- a/src/service/greetd.ts
++++ b/src/service/greetd.ts
+@@ -101,8 +101,12 @@ export class Greetd extends Service {
+             ostream.put_int32(json.length, null);
+             ostream.put_string(json, null);
+ 
+-            const data = await istream.read_bytes_async(4, GLib.PRIORITY_DEFAULT, null);
+-            const length = new Uint32Array(data.get_data()?.buffer || [0])[0];
++            const data = (
++                await istream.read_bytes_async(4, GLib.PRIORITY_DEFAULT, null)
++            ).get_data();
++            const length = data
++                ? new DataView(data.buffer, data.byteOffset, data.byteLength).getUint32(0, true)
++                : 0;
+             const res = await istream.read_bytes_async(length, GLib.PRIORITY_DEFAULT, null);
+             return JSON.parse(this._decoder.decode(res.get_data()!)) as Response;
+         } finally {

--- a/pkgs/by-name/ty/typescript/package-lock.json
+++ b/pkgs/by-name/ty/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript",
-  "version": "5.8.3",
+  "version": "5.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript",
-      "version": "5.8.3",
+      "version": "5.9.2",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/pkgs/by-name/ty/typescript/package.nix
+++ b/pkgs/by-name/ty/typescript/package.nix
@@ -14,7 +14,7 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "typescript";
-  version = "5.8.3";
+  version = "5.9.2";
 
   # Prefer npmjs over the GitHub repository for source code.
   # The TypeScript project typically publishes stable, versioned code to npmjs,
@@ -24,7 +24,7 @@ buildNpmPackage (finalAttrs: {
   #   - https://github.com/microsoft/TypeScript/pull/60150#issuecomment-2648791588, 5.8.3 includes this 5.9 breaking change
   src = fetchurl {
     url = "https://registry.npmjs.org/typescript/-/typescript-${finalAttrs.version}.tgz";
-    hash = "sha256-cuddvrksLm65o0y1nXT6tcLubzKgMkqJQF9hZdWgg3Q=";
+    hash = "sha256-Z6O8gugiuPRfZTqA/DqXMNIyFNNsg7qF3X9avr7oIGI=";
   };
 
   # The upstream GitHub repository's package-lock.json differs from the package.json in the npmjs tarball.
@@ -40,7 +40,7 @@ buildNpmPackage (finalAttrs: {
     mkdir -p node_modules
   '';
 
-  npmDepsHash = "sha256-f/7Dxwoz0qv7T3Ez4jeRvmu7PxhzObwczjO7JcEcCr4=";
+  npmDepsHash = "sha256-dyN94wmEA/jtiJCsEs/MoDSd6AFsaq2r25a/FeuqQ5k=";
   forceEmptyCache = true;
 
   dontNpmBuild = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Supersedes and closes #429915

The error in `ags_1` was discussed in https://github.com/NixOS/nixpkgs/pull/411350#issuecomment-2912620761.
I've applied the workaround from https://github.com/Aylur/ags/issues/725#issuecomment-3070009695.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @JohnRTitor @foo-dogsquared

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
