### PR TITLE
crush: init at 0.1.10

### DIFF
--- a/pkgs/by-name/cr/crush/package.nix
+++ b/pkgs/by-name/cr/crush/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "crush";
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "charmbracelet";
+    repo = "crush";
+    rev = "v${version}";
+    hash = "sha256-XHdudkll+NUksT+Rdvx3M8SKDpgx4z7M14gIWAY6/hI=";
+  };
+
+  vendorHash = "sha256-P+2m3RogxqSo53vGXxLO4sLF5EVsG66WJw3Bb9+rvT8=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/charmbracelet/crush/internal/version.Version=${version}"
+  ];
+
+  # doCheck = false;
+  checkFlags = [ "-skip=TestMain" ];
+
+  meta = {
+    description = "The glamourous AI coding agent for your favourite terminal";
+    homepage = "https://github.com/charmbracelet/crush";
+    changelog = "https://github.com/charmbracelet/crush/releases/tag/v${version}";
+    license = lib.licenses.fsl11Mit;
+    maintainers = with lib.maintainers; [ kiara ];
+    mainProgram = "crush";
+  };
+}

--- a/pkgs/by-name/cr/crush/package.nix
+++ b/pkgs/by-name/cr/crush/package.nix
@@ -26,6 +26,11 @@ buildGoModule rec {
   # doCheck = false;
   checkFlags = [ "-skip=TestMain" ];
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "The glamourous AI coding agent for your favourite terminal";
     homepage = "https://github.com/charmbracelet/crush";

--- a/pkgs/by-name/cr/crush/package.nix
+++ b/pkgs/by-name/cr/crush/package.nix
@@ -2,6 +2,8 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 buildGoModule rec {

--- a/pkgs/by-name/cr/crush/package.nix
+++ b/pkgs/by-name/cr/crush/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "charmbracelet";
     repo = "crush";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-XHdudkll+NUksT+Rdvx3M8SKDpgx4z7M14gIWAY6/hI=";
   };
 


### PR DESCRIPTION
adds https://github.com/charmbracelet/crush.

<details>
<summary>
note that i had yet to manage to get the test skip to work, meaning that without `doCheck = false` it would fail as follows.
</summary>

```
this derivation will be built:
  /nix/store/zwbzkrydqwwp76m203jmmqd62vdxs89b-crush-0.1.10.drv
building '/nix/store/zwbzkrydqwwp76m203jmmqd62vdxs89b-crush-0.1.10.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/5fvx0yki2haync201b9p2spb7a0q4afm-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: buildPhase
Building subPackage .
Building subPackage ./internal/ansiext
Building subPackage ./internal/app
Building subPackage ./internal/cmd
Building subPackage ./internal/config
Building subPackage ./internal/csync
Building subPackage ./internal/db
Building subPackage ./internal/diff
Building subPackage ./internal/env
Building subPackage ./internal/format
Building subPackage ./internal/fsext
Building subPackage ./internal/history
Building subPackage ./internal/llm/agent
Building subPackage ./internal/llm/prompt
Building subPackage ./internal/llm/provider
Building subPackage ./internal/llm/tools
Building subPackage ./internal/log
Building subPackage ./internal/lsp
Building subPackage ./internal/lsp/protocol
Building subPackage ./internal/lsp/util
Building subPackage ./internal/lsp/watcher
Building subPackage ./internal/message
Building subPackage ./internal/permission
Building subPackage ./internal/pubsub
Building subPackage ./internal/session
Building subPackage ./internal/shell
Building subPackage ./internal/tui
Building subPackage ./internal/tui/components/anim
Building subPackage ./internal/tui/components/anim/example
Building subPackage ./internal/tui/components/chat
Building subPackage ./internal/tui/components/chat/editor
Building subPackage ./internal/tui/components/chat/header
Building subPackage ./internal/tui/components/chat/messages
Building subPackage ./internal/tui/components/chat/sidebar
Building subPackage ./internal/tui/components/chat/splash
Building subPackage ./internal/tui/components/completions
Building subPackage ./internal/tui/components/core
Building subPackage ./internal/tui/components/core/layout
Building subPackage ./internal/tui/components/core/status
Building subPackage ./internal/tui/components/dialogs
Building subPackage ./internal/tui/components/dialogs/commands
Building subPackage ./internal/tui/components/dialogs/compact
Building subPackage ./internal/tui/components/dialogs/filepicker
Building subPackage ./internal/tui/components/dialogs/models
Building subPackage ./internal/tui/components/dialogs/permissions
Building subPackage ./internal/tui/components/dialogs/quit
Building subPackage ./internal/tui/components/dialogs/sessions
Building subPackage ./internal/tui/components/image
Building subPackage ./internal/tui/components/logo
Building subPackage ./internal/tui/exp/diffview
Building subPackage ./internal/tui/exp/list
Building subPackage ./internal/tui/highlight
Building subPackage ./internal/tui/page
Building subPackage ./internal/tui/page/chat
Building subPackage ./internal/tui/styles
Building subPackage ./internal/tui/util
Building subPackage ./internal/version
buildPhase completed in 33 seconds
Running phase: checkPhase
ok      github.com/charmbracelet/crush/internal/config  0.005s
ok      github.com/charmbracelet/crush/internal/csync   0.106s
ok      github.com/charmbracelet/crush/internal/env     0.003s
ok      github.com/charmbracelet/crush/internal/llm/prompt      0.004s
panic: Failed to initialize config: failed to load providers: failed to load providers

goroutine 1 [running]:
github.com/charmbracelet/crush/internal/llm/provider.TestMain(0xc0002e5ea0)
        /build/source/internal/llm/provider/openai_test.go:22 +0x79
main.main()
        _testmain.go:47 +0xa8
FAIL    github.com/charmbracelet/crush/internal/llm/provider    0.010s
FAIL
error: builder for '/nix/store/zwbzkrydqwwp76m203jmmqd62vdxs89b-crush-0.1.10.drv' failed with exit code 1;
       last 25 log lines:
       > Building subPackage ./internal/tui/components/image
       > Building subPackage ./internal/tui/components/logo
       > Building subPackage ./internal/tui/exp/diffview
       > Building subPackage ./internal/tui/exp/list
       > Building subPackage ./internal/tui/highlight
       > Building subPackage ./internal/tui/page
       > Building subPackage ./internal/tui/page/chat
       > Building subPackage ./internal/tui/styles
       > Building subPackage ./internal/tui/util
       > Building subPackage ./internal/version
       > buildPhase completed in 33 seconds
       > Running phase: checkPhase
       > ok         github.com/charmbracelet/crush/internal/config  0.005s
       > ok      github.com/charmbracelet/crush/internal/csync   0.106s
       > ok      github.com/charmbracelet/crush/internal/env     0.003s
       > ok      github.com/charmbracelet/crush/internal/llm/prompt      0.004s
       > panic: Failed to initialize config: failed to load providers: failed to load providers
       >
       > goroutine 1 [running]:
       > github.com/charmbracelet/crush/internal/llm/provider.TestMain(0xc0002e5ea0)
       >   /build/source/internal/llm/provider/openai_test.go:22 +0x79
       > main.main()
       >       _testmain.go:47 +0xa8
       > FAIL     github.com/charmbracelet/crush/internal/llm/provider    0.010s
       > FAIL
       For full logs, run 'nix log /nix/store/zwbzkrydqwwp76m203jmmqd62vdxs89b-crush-0.1.10.drv'.
```

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
