### PR TITLE
linux: add a hook into moduleBuildDependencies to add makeFlags

### DIFF
--- a/pkgs/os-specific/linux/kernel/add-linux-make-flags-hook.sh
+++ b/pkgs/os-specific/linux/kernel/add-linux-make-flags-hook.sh
@@ -1,0 +1,5 @@
+addLinuxMakeFlags() {
+    prependToVar makeFlags @commonMakeFlags@
+}
+
+preConfigureHooks+=(addLinuxMakeFlags)

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildPackages,
+  makeSetupHook,
   runCommand,
   bc,
   bison,
@@ -166,6 +167,10 @@ lib.makeOverridable (
           elfutils
           # module makefiles often run uname commands to find out the kernel version
           (buildPackages.deterministic-uname.override { inherit modDirVersion; })
+          (makeSetupHook {
+            name = "add-linux-make-flags-hook";
+            substitutions = { inherit commonMakeFlags; };
+          } ./add-linux-make-flags-hook.sh)
         ]
         ++ optional (lib.versionAtLeast version "5.13") zstd
         ++ optionals withRust [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR adds a hook into moduleBuildDependencies to add makeFlags for kernel modules. Probably fixes build failures of kernel modules on LLVM stdenv.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
