### PR TITLE
lib.systems, windows: Add Windows support to lib.systems and create Window team

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -120,6 +120,8 @@ let
         libc =
           if final.isDarwin then
             "libSystem"
+          else if final.isMsvc then
+            "ucrt"
           else if final.isMinGW then
             "msvcrt"
           else if final.isWasi then

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -372,6 +372,17 @@ rec {
     useLLVM = true;
   };
 
+  # Target the MSVC ABI
+  x86_64-windows = {
+    config = "x86_64-pc-windows-msvc";
+    useLLVM = true;
+  };
+
+  aarch64-windows = {
+    config = "aarch64-pc-windows-msvc";
+    useLLVM = true;
+  };
+
   # BSDs
 
   aarch64-freebsd = {

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -344,6 +344,10 @@ rec {
       kernel = kernels.windows;
       abi = abis.gnu;
     };
+    isMsvc = {
+      kernel = kernels.windows;
+      abi = abis.msvc;
+    };
     isWasi = {
       kernel = kernels.wasi;
     };

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1251,6 +1251,17 @@ with lib.maintainers;
     shortName = "coqui-ai TTS";
   };
 
+  windows = {
+    members = [
+      RossSmyth
+      eveeifyeve
+      ericson2314
+      puffnfresh
+    ];
+    scope = "Maintains the windows package set";
+    shortName = "Windows";
+  };
+
   wdz = {
     members = [
       n0emis

--- a/pkgs/os-specific/windows/cygwin-setup/default.nix
+++ b/pkgs/os-specific/windows/cygwin-setup/default.nix
@@ -66,5 +66,7 @@ stdenv.mkDerivation rec {
     homepage = "https://sourceware.org/cygwin-apps/setup.html";
     description = "Tool for installing Cygwin";
     license = lib.licenses.gpl2Plus;
+    platforms = lib.intersectLists lib.platforms.windows lib.platforms.x86;
+    teams = [ lib.teams.windows ];
   };
 }

--- a/pkgs/os-specific/windows/libgnurx/default.nix
+++ b/pkgs/os-specific/windows/libgnurx/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
+    downloadPage = "https://sourceforge.net/projects/mingw/files/Other/UserContributed/regex/";
+    description = "Regex functionality from glibc extracted into a separate library for win32";
+    license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.windows;
+    teams = [ lib.teams.windows ];
   };
 }

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -23,6 +23,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
+    downloadPage = "https://sourceforge.net/projects/mingw/files/Other/UserContributed/regex/";
+    description = "Collection of headers and libraries for building native Windows applications";
+    license = lib.licenses.publicDomain;
     platforms = lib.platforms.windows;
+    teams = [ lib.teams.windows ];
   };
 })

--- a/pkgs/os-specific/windows/msvcSdk/default.nix
+++ b/pkgs/os-specific/windows/msvcSdk/default.nix
@@ -120,5 +120,6 @@ else
       # The arm manifest is missing critical pieces.
       broken = stdenvNoCC.hostPlatform.isAarch;
       sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+      teams = [ lib.teams.windows ];
     };
   })

--- a/pkgs/os-specific/windows/pthread-w32/default.nix
+++ b/pkgs/os-specific/windows/pthread-w32/default.nix
@@ -26,11 +26,12 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "POSIX threads library for Windows";
     homepage = "https://sourceware.org/pthreads-win32";
-    license = licenses.lgpl21Plus;
-    maintainers = [ ];
-    platforms = platforms.windows;
+    license = lib.licenses.lgpl21Plus;
+    maintainers = [ lib.maintainers.RossSmyth ];
+    platforms = lib.platforms.windows;
+    teams = [ lib.teams.windows ];
   };
 }

--- a/pkgs/os-specific/windows/w32api/default.nix
+++ b/pkgs/os-specific/windows/w32api/default.nix
@@ -13,9 +13,14 @@ stdenv.mkDerivation rec {
     sha256 = "09rhnl6zikmdyb960im55jck0rdy5z9nlg3akx68ixn7khf3j8wb";
   };
 
-  meta = {
-    platforms = lib.platforms.windows;
-  };
-
   dontStrip = true;
+
+  meta = {
+    description = "Core win32 headers and libraries for MinGW";
+    downloadPage = "https://sourceforge.net/projects/mingw/files/MinGW/Base/w32api/";
+    license = lib.licenses.publicDomain;
+    maintainers = [ lib.maintainers.RossSmyth ];
+    platforms = lib.intersectLists lib.platforms.windows lib.platforms.x86;
+    teams = [ lib.teams.windows ];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8147,9 +8147,9 @@ with pkgs;
     else if libc == "musl" then
       musl
     else if libc == "msvcrt" then
-      windows.mingw_w64
+      if stdenv.hostPlatform.isMinGW then windows.mingw_w64 else windows.sdk
     else if libc == "ucrt" then
-      windows.mingw_w64
+      if stdenv.hostPlatform.isMinGW then windows.mingw_w64 else windows.sdk
     else if libc == "libSystem" then
       if stdenv.hostPlatform.useiOSPrebuilt then darwin.iosSdkPkgs.libraries else darwin.libSystem
     else if libc == "fblibc" then

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -24,6 +24,7 @@
         roundcubePlugins
         sourceHanPackages
         zabbix60
+        windows
         ;
 
       # Make sure haskell.compiler is included, so alternative GHC versions show up,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is more of an internal change setting up for more in the future.

1. Add better support in lib.systems for MSVC
2. Add selector for `windows.sdk` in top-level for the libc
3. Add a windows team to lib.teams
4. Add the windows team to a few packages
5. Add the windows package set to packages-config so search.nixos.org can index it

Notably this does not really add any support to LLVM or anything else for actually building for MSVC. That is the PR after this one. I am working on it a bit, but these changes are more meta, so I wanted to split it out so it's easier to review.

> [!note] 
> Some of these packages are broken. For example `windows.cygwinSetup`. I am going to go through each package in the set to either fix them or drop.

### Questions:

- Should all packages in the `windows` package set have the windows team applied to them? I'm not sure. If so I can just add it in `windows/default.nix` rather than each one individually. cc: @marius851000, @wegank, @shlevy 

- Should there be a GitHub NixOS/Windows team?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
