### PR TITLE
python3Packages.snapshot-restore-py: init at 1.0.0; python3Packages.awslambdaric: 3.0.0 -> 3.1.1

### DIFF
--- a/pkgs/development/python-modules/awslambdaric/default.nix
+++ b/pkgs/development/python-modules/awslambdaric/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitHub,
@@ -14,10 +13,11 @@
   perl,
   setuptools,
   simplejson,
+  snapshot-restore-py,
 }:
 buildPythonPackage rec {
   pname = "awslambdaric";
-  version = "3.0.0";
+  version = "3.1.1";
   pyproject = true;
 
   disabled = isPy27;
@@ -29,7 +29,10 @@ buildPythonPackage rec {
     sha256 = "sha256-pUVWd4zpmTygndPIy76uVk7+sLCmwQqulLaUI7B0fQc=";
   };
 
-  propagatedBuildInputs = [ simplejson ];
+  propagatedBuildInputs = [
+    simplejson
+    snapshot-restore-py
+  ];
 
   nativeBuildInputs = [
     autoconf271
@@ -55,7 +58,6 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64;
     description = "AWS Lambda Runtime Interface Client for Python";
     homepage = "https://github.com/aws/aws-lambda-python-runtime-interface-client";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/snapshot-restore-py/default.nix
+++ b/pkgs/development/python-modules/snapshot-restore-py/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  isPy27,
+  pytestCheckHook,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "snapshot-restore-py";
+  version = "1.0.0";
+  pyproject = true;
+
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "snapshot-restore-py";
+    tag = "v${version}";
+    hash = "sha256-sixVSQcEqLTUrKxYAM13gzqttWnbXPMII0V/gtXM1IE=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "snapshot_restore_py" ];
+
+  meta = {
+    description = "Snapshot Restore for Python library which can be used for registering runtime hooks in Snapstart enabled Python Lambda functions";
+    homepage = "https://github.com/aws/snapshot-restore-py";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ austinbutler ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16687,6 +16687,8 @@ self: super: with self; {
 
   snappy-manifolds = callPackage ../development/python-modules/snappy-manifolds { };
 
+  snapshot-restore-py = callPackage ../development/python-modules/snapshot-restore-py { };
+
   snapshottest = callPackage ../development/python-modules/snapshottest { };
 
   snaptime = callPackage ../development/python-modules/snaptime { };


### PR DESCRIPTION
- Fixes https://github.com/NixOS/nixpkgs/issues/429067
  - As of 3.x, `snapshot-restore-py` is [a new dependency of `awslambdaric`](https://github.com/aws/aws-lambda-python-runtime-interface-client/compare/2.2.1...3.0.0#diff-0940fec0afe21798f617cc4522db676f15769ae28a72992b8d19216ef7b1c3b5)
- [Upgrades](https://github.com/aws/aws-lambda-python-runtime-interface-client/compare/3.0.0...3.1.1) `awslambdaric` to latest version



## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc