### PR TITLE
forge-mtg: 1.6.65 -> 2.0.05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10597,6 +10597,18 @@
     githubId = 51162078;
     name = "IceDBorn";
   };
+  icetan = {
+    name = "Christopher Fredén";
+    email = "me@icetan.org";
+    matrix = "@icetan:matrix.org";
+    github = "icetan";
+    githubId = 839982;
+    keys = [
+      {
+        fingerprint = "D572 2356 FAE3 D9C5 3753  C464 E4A6 9EDB E76F 692E";
+      }
+    ];
+  };
   icewind1991 = {
     name = "Robin Appelman";
     email = "robin@icewind.nl";

--- a/pkgs/by-name/fo/forge-mtg/no-launch4j.patch
+++ b/pkgs/by-name/fo/forge-mtg/no-launch4j.patch
@@ -1,396 +1,85 @@
-diff --git a/forge-adventure/pom.xml b/forge-adventure/pom.xml
-index b35356ea76..b7ab1c775b 100644
---- a/forge-adventure/pom.xml
-+++ b/forge-adventure/pom.xml
-@@ -47,131 +47,6 @@
-                 </configuration>
-             </plugin>
- 
--            <plugin>
--                    <groupId>com.akathist.maven.plugins.launch4j</groupId>
--                    <artifactId>launch4j-maven-plugin</artifactId>
--                    <version>1.7.25</version>
--                    <executions>
--                        <execution>
--                            <id>l4j-adv</id>
--                            <phase>package</phase>
--                            <goals>
--                                <goal>launch4j</goal>
--                            </goals>
--                            <configuration>
--                                <headerType>gui</headerType>
--                                <outfile>${project.build.directory}/forge-adventure-editor-java8.exe</outfile>
--                                <jar>${project.build.finalName}-jar-with-dependencies.jar</jar>
--                                <dontWrapJar>true</dontWrapJar>
--                                <errTitle>forge</errTitle>
--                                <icon>src/main/config/forge-adventure-editor.ico</icon>
--                                <classPath>
--                                    <mainClass>forge.adventure.Main</mainClass>
--                                    <addDependencies>false</addDependencies>
--                                    <preCp>anything</preCp>
--                                </classPath>
--                                <jre>
--                                    <minVersion>1.8.0</minVersion>
--                                    <maxHeapSize>4096</maxHeapSize>
--                                    <opts>
--                                        <opt>-Dfile.encoding=UTF-8</opt>
--                                    </opts>
--                                </jre>
--                                <versionInfo>
--                                    <fileVersion>
--                                        1.0.0.0
--                                    </fileVersion>
--                                    <txtFileVersion>
--                                        1.0.0.0
--                                    </txtFileVersion>
--                                    <fileDescription>Forge</fileDescription>
--                                    <copyright>Forge</copyright>
--                                    <productVersion>
--                                        1.0.0.0
--                                    </productVersion>
--                                    <txtProductVersion>
--                                        1.0.0.0
--                                    </txtProductVersion>
--                                    <productName>forge-adventure-editor</productName>
--                                    <internalName>forge-adventure-editor</internalName>
--                                    <originalFilename>forge-adventure-editor-java8.exe</originalFilename>
--                                </versionInfo>
--                            </configuration>
--                        </execution>
--                        <!--extra-->
--                        <execution>
--                            <id>l4j-adv2</id>
--                            <phase>package</phase>
--                            <goals>
--                                <goal>launch4j</goal>
--                            </goals>
--                            <configuration>
--                                <headerType>gui</headerType>
--                                <outfile>${project.build.directory}/forge-adventure-editor.exe</outfile>
--                                <jar>${project.build.finalName}-jar-with-dependencies.jar</jar>
--                                <dontWrapJar>true</dontWrapJar>
--                                <errTitle>forge</errTitle>
--                                <downloadUrl>https://www.oracle.com/java/technologies/downloads/</downloadUrl>
--                                <icon>src/main/config/forge-adventure-editor.ico</icon>
--                                <classPath>
--                                    <mainClass>forge.adventure.Main</mainClass>
--                                    <addDependencies>false</addDependencies>
--                                    <preCp>anything</preCp>
--                                </classPath>
--                                <jre>
--                                    <minVersion>11.0.1</minVersion>
--                                    <jdkPreference>jdkOnly</jdkPreference>
--                                    <maxHeapSize>4096</maxHeapSize>
--                                    <opts>
--                                        <opt>-Dfile.encoding=UTF-8</opt>
--                                        <opt>--add-opens java.base/java.lang=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.base/java.math=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.base/jdk.internal.misc=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.base/java.nio=ALL-UNNAMED</opt>
--                                        <opt>--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.base/java.util=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.base/java.lang.reflect=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.base/java.text=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/java.awt=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/java.awt.font=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/java.awt.image=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/java.awt.color=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/sun.awt.image=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/javax.swing=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/javax.swing.border=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/javax.swing.event=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/sun.swing=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.desktop/java.beans=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.base/java.util.concurrent=ALL-UNNAMED</opt>
--                                        <opt>--add-opens java.base/java.net=ALL-UNNAMED</opt>
--                                        <opt>-Dio.netty.tryReflectionSetAccessible=true</opt>
--                                    </opts>
--                                </jre>
--                                <versionInfo>
--                                    <fileVersion>
--                                        1.0.0.0
--                                    </fileVersion>
--                                    <txtFileVersion>
--                                        1.0.0.0
--                                    </txtFileVersion>
--                                    <fileDescription>Forge</fileDescription>
--                                    <copyright>Forge</copyright>
--                                    <productVersion>
--                                        1.0.0.0
--                                    </productVersion>
--                                    <txtProductVersion>
--                                        1.0.0.0
--                                    </txtProductVersion>
--                                    <productName>forge-adventure-editor</productName>
--                                    <internalName>forge-adventure-editor</internalName>
--                                    <originalFilename>forge-adventure-editor.exe</originalFilename>
--                                </versionInfo>
--                            </configuration>
--                        </execution>
--                        <!--extra-->
--                    </executions>
--            </plugin>
--
-             <plugin>
-                 <groupId>com.google.code.maven-replacer-plugin</groupId>
-                 <artifactId>replacer</artifactId>
-diff --git a/forge-gui-desktop/pom.xml b/forge-gui-desktop/pom.xml
-index 3b74663b04..f0e324b69c 100644
---- a/forge-gui-desktop/pom.xml
-+++ b/forge-gui-desktop/pom.xml
-@@ -282,59 +282,6 @@
-             <id>windows-linux-release</id>
-             <build>
-                 <plugins>
--                    <plugin>
--                        <groupId>com.akathist.maven.plugins.launch4j</groupId>
--                        <artifactId>launch4j-maven-plugin</artifactId>
--                        <version>2.1.2</version>
--                        <executions>
--                            <execution>
--                                <id>l4j-gui</id>
--                                <phase>package</phase>
--                                <goals>
--                                    <goal>launch4j</goal>
--                                </goals>
--                                <configuration>
--                                    <headerType>gui</headerType>
--                                    <outfile>${project.build.directory}/forge-java8.exe</outfile>
--                                    <jar>${project.build.finalName}-jar-with-dependencies.jar</jar>
--                                    <dontWrapJar>true</dontWrapJar>
--                                    <errTitle>forge</errTitle>
--                                    <icon>src/main/config/forge.ico</icon>
--                                    <classPath>
--                                        <mainClass>forge.view.Main</mainClass>
--                                        <addDependencies>false</addDependencies>
--                                        <preCp>anything</preCp>
--                                    </classPath>
--                                    <jre>
--                                        <minVersion>1.8.0</minVersion>
--                                        <maxHeapSize>4096</maxHeapSize>
--                                        <opts>
--                                            <opt>-Dfile.encoding=UTF-8</opt>
--                                        </opts>
--                                    </jre>
--                                    <versionInfo>
--                                        <fileVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </fileVersion>
--                                        <txtFileVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </txtFileVersion>
--                                        <fileDescription>Forge</fileDescription>
--                                        <copyright>Forge</copyright>
--                                        <productVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </productVersion>
--                                        <txtProductVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </txtProductVersion>
--                                        <productName>Forge</productName>
--                                        <internalName>forge</internalName>
--                                        <originalFilename>forge-java8.exe</originalFilename>
--                                    </versionInfo>
--                                </configuration>
--                            </execution>
--                        </executions>
--                    </plugin>
- 
-                     <plugin>
-                         <groupId>org.apache.maven.plugins</groupId>
-@@ -447,130 +394,6 @@
-             <id>windows-linux</id>
-             <build>
-                 <plugins>
--                    <plugin>
--                        <groupId>com.akathist.maven.plugins.launch4j</groupId>
--                        <artifactId>launch4j-maven-plugin</artifactId>
--                        <version>2.1.2</version>
--                        <executions>
--                            <execution>
--                                <id>l4j-gui</id>
--                                <phase>package</phase>
--                                <goals>
--                                    <goal>launch4j</goal>
--                                </goals>
--                                <configuration>
--                                    <headerType>gui</headerType>
--                                    <outfile>${project.build.directory}/forge-java8.exe</outfile>
--                                    <jar>${project.build.finalName}-jar-with-dependencies.jar</jar>
--                                    <dontWrapJar>true</dontWrapJar>
--                                    <errTitle>forge</errTitle>
--                                    <icon>src/main/config/forge.ico</icon>
--                                    <classPath>
--                                        <mainClass>forge.view.Main</mainClass>
--                                        <addDependencies>false</addDependencies>
--                                        <preCp>anything</preCp>
--                                    </classPath>
--                                    <jre>
--                                        <minVersion>1.8.0</minVersion>
--                                        <maxHeapSize>4096</maxHeapSize>
--                                        <opts>
--                                            <opt>-Dfile.encoding=UTF-8</opt>
--                                        </opts>
--                                    </jre>
--                                    <versionInfo>
--                                        <fileVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </fileVersion>
--                                        <txtFileVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </txtFileVersion>
--                                        <fileDescription>Forge</fileDescription>
--                                        <copyright>Forge</copyright>
--                                        <productVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </productVersion>
--                                        <txtProductVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </txtProductVersion>
--                                        <productName>Forge</productName>
--                                        <internalName>forge</internalName>
--                                        <originalFilename>forge-java8.exe</originalFilename>
--                                    </versionInfo>
--                                </configuration>
--                            </execution>
--                            <!--extra-->
--                            <execution>
--                                <id>l4j-gui2</id>
--                                <phase>package</phase>
--                                <goals>
--                                    <goal>launch4j</goal>
--                                </goals>
--                                <configuration>
--                                    <headerType>gui</headerType>
--                                    <outfile>${project.build.directory}/forge.exe</outfile>
--                                    <jar>${project.build.finalName}-jar-with-dependencies.jar</jar>
--                                    <dontWrapJar>true</dontWrapJar>
--                                    <errTitle>forge</errTitle>
--                                    <downloadUrl>https://www.oracle.com/java/technologies/downloads/</downloadUrl>
--                                    <icon>src/main/config/forge.ico</icon>
--                                    <classPath>
--                                        <mainClass>forge.view.Main</mainClass>
--                                        <addDependencies>false</addDependencies>
--                                        <preCp>anything</preCp>
--                                    </classPath>
--                                    <jre>
--                                        <minVersion>11.0.1</minVersion>
--                                        <jdkPreference>jdkOnly</jdkPreference>
--                                        <maxHeapSize>4096</maxHeapSize>
--                                        <opts>
--                                            <opt>-Dfile.encoding=UTF-8</opt>
--                                            <opt>--add-opens java.base/java.lang=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.base/java.math=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.base/jdk.internal.misc=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.base/java.nio=ALL-UNNAMED</opt>
--                                            <opt>--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.base/java.util=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.base/java.lang.reflect=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.base/java.text=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/java.awt=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/java.awt.font=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/java.awt.image=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/java.awt.color=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/sun.awt.image=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/javax.swing=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/javax.swing.border=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/javax.swing.event=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/sun.swing=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.desktop/java.beans=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.base/java.util.concurrent=ALL-UNNAMED</opt>
--                                            <opt>--add-opens java.base/java.net=ALL-UNNAMED</opt>
--                                            <opt>-Dio.netty.tryReflectionSetAccessible=true</opt>
--                                        </opts>
--                                    </jre>
--                                    <versionInfo>
--                                        <fileVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </fileVersion>
--                                        <txtFileVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </txtFileVersion>
--                                        <fileDescription>Forge</fileDescription>
--                                        <copyright>Forge</copyright>
--                                        <productVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </productVersion>
--                                        <txtProductVersion>
--                                            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
--                                        </txtProductVersion>
--                                        <productName>Forge</productName>
--                                        <internalName>forge</internalName>
--                                        <originalFilename>forge.exe</originalFilename>
--                                    </versionInfo>
--                                </configuration>
--                            </execution>
--                            <!--extra-->
--                        </executions>
--                    </plugin>
- 
-                     <plugin>
-                         <groupId>org.apache.maven.plugins</groupId>
-diff --git a/forge-gui-mobile-dev/pom.xml b/forge-gui-mobile-dev/pom.xml
-index e7439c1e3a..de0cbc16a1 100644
---- a/forge-gui-mobile-dev/pom.xml
-+++ b/forge-gui-mobile-dev/pom.xml
-@@ -64,130 +64,6 @@
-                     </replacements>
-                 </configuration>
+diff --git i/forge-gui-desktop/pom.xml w/forge-gui-desktop/pom.xml
+index dfe902e6..6fe3382f 100644
+--- i/forge-gui-desktop/pom.xml
++++ w/forge-gui-desktop/pom.xml
+@@ -70,62 +70,6 @@
+                     </execution>
+                 </executions>
              </plugin>
 -            <plugin>
 -                <groupId>com.akathist.maven.plugins.launch4j</groupId>
 -                <artifactId>launch4j-maven-plugin</artifactId>
--                <version>1.7.25</version>
+-                <version>2.5.1</version>
 -                <executions>
 -                    <execution>
--                        <id>l4j-adv</id>
+-                        <id>l4j-gui</id>
 -                        <phase>package</phase>
 -                        <goals>
 -                            <goal>launch4j</goal>
 -                        </goals>
 -                        <configuration>
 -                            <headerType>gui</headerType>
--                            <outfile>${project.build.directory}/forge-adventure-java8.exe</outfile>
+-                            <outfile>${project.build.directory}/forge.exe</outfile>
 -                            <jar>${project.build.finalName}-jar-with-dependencies.jar</jar>
 -                            <dontWrapJar>true</dontWrapJar>
 -                            <errTitle>forge</errTitle>
--                            <icon>src/main/config/forge-adventure.ico</icon>
+-                            <downloadUrl>https://bell-sw.com/pages/downloads/#jdk-17-lts</downloadUrl>
+-                            <icon>src/main/config/forge.ico</icon>
 -                            <classPath>
--                                <mainClass>forge.app.Main</mainClass>
+-                                <mainClass>forge.view.Main</mainClass>
 -                                <addDependencies>false</addDependencies>
 -                                <preCp>anything</preCp>
 -                            </classPath>
 -                            <jre>
--                                <minVersion>1.8.0</minVersion>
+-                                <minVersion>17</minVersion>
+-                                <requiresJdk>true</requiresJdk>
 -                                <maxHeapSize>4096</maxHeapSize>
 -                                <opts>
--                                    <opt>-Dfile.encoding=UTF-8</opt>
+-                                    <opt>${mandatory.java.args}</opt>
+-                                    <opt>${addopen.java.args}</opt>
 -                                </opts>
 -                            </jre>
 -                            <versionInfo>
 -                                <fileVersion>
--                                    1.0.0.0
+-                                    ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
 -                                </fileVersion>
 -                                <txtFileVersion>
--                                    1.0.0.0
+-                                    ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
 -                                </txtFileVersion>
 -                                <fileDescription>Forge</fileDescription>
 -                                <copyright>Forge</copyright>
 -                                <productVersion>
--                                    1.0.0.0
+-                                    ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
 -                                </productVersion>
 -                                <txtProductVersion>
--                                    1.0.0.0
+-                                    ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.0
 -                                </txtProductVersion>
--                                <productName>forge-adventure</productName>
--                                <internalName>forge-adventure</internalName>
--                                <originalFilename>forge-adventure-java8.exe</originalFilename>
+-                                <productName>Forge</productName>
+-                                <internalName>forge</internalName>
+-                                <originalFilename>forge.exe</originalFilename>
 -                            </versionInfo>
 -                        </configuration>
 -                    </execution>
--                    <!--extra-->
+-                </executions>
+-            </plugin>
+             <plugin>
+                 <groupId>com.google.code.maven-replacer-plugin</groupId>
+                 <artifactId>replacer</artifactId>
+diff --git i/forge-gui-mobile-dev/pom.xml w/forge-gui-mobile-dev/pom.xml
+index 8d5f2687..a65bb4d4 100644
+--- i/forge-gui-mobile-dev/pom.xml
++++ w/forge-gui-mobile-dev/pom.xml
+@@ -60,57 +60,6 @@
+                     <target>17</target>
+                 </configuration>
+             </plugin>
+-            <plugin>
+-                <groupId>com.akathist.maven.plugins.launch4j</groupId>
+-                <artifactId>launch4j-maven-plugin</artifactId>
+-                <version>2.5.1</version>
+-                <executions>
 -                    <execution>
--                        <id>l4j-adv2</id>
+-                        <id>l4j-adv</id>
 -                        <phase>package</phase>
 -                        <goals>
 -                            <goal>launch4j</goal>
@@ -401,40 +90,14 @@ index e7439c1e3a..de0cbc16a1 100644
 -                            <jar>${project.build.finalName}-jar-with-dependencies.jar</jar>
 -                            <dontWrapJar>true</dontWrapJar>
 -                            <errTitle>forge</errTitle>
--                            <downloadUrl>https://www.oracle.com/java/technologies/downloads/</downloadUrl>
+-                            <downloadUrl>https://bell-sw.com/pages/downloads/#jdk-17-lts</downloadUrl>
 -                            <icon>src/main/config/forge-adventure.ico</icon>
--                            <classPath>
--                                <mainClass>forge.app.Main</mainClass>
--                                <addDependencies>false</addDependencies>
--                                <preCp>anything</preCp>
--                            </classPath>
 -                            <jre>
--                                <minVersion>11.0.1</minVersion>
--                                <jdkPreference>jdkOnly</jdkPreference>
+-                                <minVersion>17</minVersion>
+-                                <requiresJdk>true</requiresJdk>
 -                                <maxHeapSize>4096</maxHeapSize>
 -                                <opts>
--                                    <opt>-Dfile.encoding=UTF-8</opt>
--                                    <opt>--add-opens java.base/java.lang=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.base/java.math=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.base/jdk.internal.misc=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.base/java.nio=ALL-UNNAMED</opt>
--                                    <opt>--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.base/java.util=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.base/java.lang.reflect=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.base/java.text=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/java.awt=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/java.awt.font=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/java.awt.image=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/java.awt.color=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/sun.awt.image=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/javax.swing=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/javax.swing.border=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/javax.swing.event=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/sun.swing=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.desktop/java.beans=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.base/java.util.concurrent=ALL-UNNAMED</opt>
--                                    <opt>--add-opens java.base/java.net=ALL-UNNAMED</opt>
--                                    <opt>-Dio.netty.tryReflectionSetAccessible=true</opt>
+-                                    <opt>${mandatory.java.args}</opt>
 -                                </opts>
 -                            </jre>
 -                            <versionInfo>
@@ -462,5 +125,5 @@ index e7439c1e3a..de0cbc16a1 100644
 -                </executions>
 -            </plugin>
              <plugin>
-                 <artifactId>maven-assembly-plugin</artifactId>
-                 <configuration>
+                 <groupId>com.google.code.maven-replacer-plugin</groupId>
+                 <artifactId>replacer</artifactId>

--- a/pkgs/by-name/fo/forge-mtg/package.nix
+++ b/pkgs/by-name/fo/forge-mtg/package.nix
@@ -5,17 +5,18 @@
   lib,
   maven,
   makeWrapper,
+  nix-update-script,
   openjdk,
 }:
 
 let
-  version = "1.6.65";
 
+  version = "2.0.05";
   src = fetchFromGitHub {
     owner = "Card-Forge";
     repo = "forge";
     rev = "forge-${version}";
-    hash = "sha256-MCJl3nBHbX/O24bzD4aQ12eMWxYY2qJC5vomvtsIBek=";
+    hash = "sha256-71CZBI4FvN5X7peDjhv+0cdTYv8hWwzM8ePdvQSb6QI=";
   };
 
   # launch4j downloads and runs a native binary during the package phase.
@@ -26,7 +27,7 @@ maven.buildMavenPackage {
   pname = "forge-mtg";
   inherit version src patches;
 
-  mvnHash = "sha256-ouF0Ja3oGrlUCcT0PzI5i9FQ+oLdEhE/LvhJ0QGErvI=";
+  mvnHash = "sha256-HEcKPvNttQsG7Vip/N/sduK4uEDpQe8GsQwkOcATa38=";
 
   doCheck = false; # Needs a running Xorg
 
@@ -40,15 +41,15 @@ maven.buildMavenPackage {
       forge-gui-desktop/target/forge-gui-desktop-${version}-jar-with-dependencies.jar \
       forge-gui-mobile-dev/target/forge-adventure.sh \
       forge-gui-mobile-dev/target/forge-gui-mobile-dev-${version}-jar-with-dependencies.jar \
-      forge-adventure/target/forge-adventure-editor.sh \
-      forge-adventure/target/forge-adventure-${version}-jar-with-dependencies.jar \
+      adventure-editor/target/adventure-editor.sh \
+      adventure-editor/target/adventure-editor-jar-with-dependencies.jar \
       forge-gui/res \
       $out/share/forge
     runHook postInstall
   '';
 
   preFixup = ''
-    for commandToInstall in forge forge-adventure forge-adventure-editor; do
+    for commandToInstall in forge forge-adventure adventure-editor; do
       chmod 555 $out/share/forge/$commandToInstall.sh
       makeWrapper $out/share/forge/$commandToInstall.sh $out/bin/$commandToInstall \
         --prefix PATH : ${
@@ -63,10 +64,17 @@ maven.buildMavenPackage {
     done
   '';
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=forge-(.*)" ];
+  };
+
   meta = with lib; {
     description = "Magic: the Gathering card game with rules enforcement";
     homepage = "https://www.slightlymagic.net/forum/viewforum.php?f=26";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ eigengrau ];
+    maintainers = with maintainers; [
+      eigengrau
+      icetan
+    ];
   };
 }


### PR DESCRIPTION
Updates to the `forge-mtg` package:

- Regenerate the patch that removes the `launch4j` dependency from the projects `pom.xml`
- Update `installPhase` and `preFixup` scripts to reflect name change to the `adventure-editor` executable
- Add `passthru.updateScript`  attribute set to the `nix-update-script` with a version regex

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
