### PR TITLE
nixosTests.ly: use TTY1

### DIFF
--- a/nixos/tests/ly.nix
+++ b/nixos/tests/ly.nix
@@ -39,8 +39,8 @@ in
     ''
       start_all()
 
-      machine.wait_until_tty_matches("2", "password:")
-      machine.send_key("ctrl-alt-f2")
+      machine.wait_until_tty_matches("1", "password:")
+      machine.send_key("ctrl-alt-f1")
       machine.sleep(1)
       machine.screenshot("ly")
       machine.send_chars("alice")
@@ -52,8 +52,8 @@ in
       machine.wait_for_window("^IceWM ")
       machine.screenshot("icewm")
 
-      machineNoX11.wait_until_tty_matches("2", "password:")
-      machineNoX11.send_key("ctrl-alt-f2")
+      machineNoX11.wait_until_tty_matches("1", "password:")
+      machineNoX11.send_key("ctrl-alt-f1")
       machineNoX11.sleep(1)
       machineNoX11.screenshot("ly-no-x11")
       machineNoX11.send_chars("alice")


### PR DESCRIPTION
adopt test to changes from https://github.com/NixOS/nixpkgs/pull/428972


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
