### PR TITLE
keymap-drawer: 0.22.0 -> 0.22.1

### DIFF
--- a/pkgs/development/python-modules/keymap-drawer/default.nix
+++ b/pkgs/development/python-modules/keymap-drawer/default.nix
@@ -60,6 +60,7 @@ buildPythonPackage {
   meta = {
     description = "Module and CLI tool to help parse and draw keyboard layouts";
     homepage = "https://github.com/caksoylar/keymap-drawer";
+    changelog = "https://github.com/caksoylar/keymap-drawer/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       MattSturgeon

--- a/pkgs/development/python-modules/keymap-drawer/default.nix
+++ b/pkgs/development/python-modules/keymap-drawer/default.nix
@@ -18,7 +18,7 @@
   versionCheckHook,
 }:
 let
-  version = "0.22.0";
+  version = "0.22.1";
 in
 buildPythonPackage {
   inherit version;
@@ -30,10 +30,14 @@ buildPythonPackage {
     owner = "caksoylar";
     repo = "keymap-drawer";
     tag = "v${version}";
-    hash = "sha256-SPnIfrUA0M9xznjEe60T+0VHh9lCmY4cni9hyqFlZqM=";
+    hash = "sha256-X3O5yspEdey03YQ6JsYN/DE9NUiq148u1W6LQpUQ3ns=";
   };
 
   build-system = [ poetry-core ];
+
+  pythonRelaxDeps = [
+    "tree-sitter-devicetree"
+  ];
 
   dependencies = [
     pcpp


### PR DESCRIPTION
Changelog: https://github.com/caksoylar/keymap-drawer/releases/tag/v0.22.1

Relax the `tree-sitter-devicetree` dependency that is pinned to 0.14.0 upstream, but is packaged as 0.25.6 in nixpkgs.
IIUC, nixpkgs maintains its own tree-sitter python bindings, so package versions do not match up with the PyPi equivalent. In this release, upstream fixed _their_ version pinning, so now we need to relax the version check.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Tested the binary via my [Glove80 keymap](https://github.com/MattSturgeon/glove80-config)'s "draw" script
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
