### PR TITLE
prosody: 0.12.4 -> 13.0.2, fix nixos test

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16655,6 +16655,12 @@
     githubId = 1776903;
     name = "Andrew Abbott";
   };
+  mirror230469 = {
+    email = "mirror230469@disroot.org";
+    github = "mirror230469";
+    githubId = 215964377;
+    name = "mirror";
+  };
   mirrorwitch = {
     email = "mirrorwitch@transmom.love";
     github = "mirrorwitch";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -107,6 +107,14 @@
 
 - The `dovecot` systemd service was renamed from `dovecot2` to `dovecot`. The former is now just an alias. Update any overrides on the systemd unit to the new name.
 
+- `Prosody` has been updated to major release 13 which removed some obsoleted modules and brought a couple of major and breaking changes:
+  - The `http_files` module is now disabled by default because it now requires `http_files_dir` to be configured.
+  - The `vcard_muc` module has been removed and got replaced by the inbuilt `muc_vcard` module.
+  - The `http_upload` module has been removed and you must migrate to the `http_file_share` module to stay XEP-0423 compliant. The `httpFileShare` options got expanded to better facility that.
+  - The `admin_shell` module is now always being loaded to make `prosodyctl` functional.
+  - The `mime_types_file` setting is now set to `"${pkgs.mailcap}/etc/mime.types"` to prevent errors.
+  For a complete list of changes, please see [their announcement](https://blog.prosody.im/prosody-13.0.0-released/).
+
 - The `yeahwm` package and `services.xserver.windowManager.yeahwm` module were removed due to the package being broken and unmaintained upstream.
 
 - The `services.postgresql` module now sets up a systemd unit `postgresql.target`. Depending on `postgresql.target` guarantees that postgres is in read-write mode and initial/ensure scripts were executed. Depending on `postgresql.service` only guarantees a read-only connection.

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -1000,6 +1000,7 @@ in
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
           Restart = "on-abnormal";
 
+          AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
           MemoryDenyWriteExecute = true;
           PrivateDevices = true;
           PrivateMounts = true;

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -524,6 +524,7 @@ let
       admins = ${toLua cfg.admins}
 
       modules_enabled = {
+        "admin_shell";  -- for prosodyctl
         ${lib.concatStringsSep "\n  " (
           lib.mapAttrsToList (name: val: optionalString val "${toLua name};") cfg.modules
         )}

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -182,7 +182,7 @@ let
 
     http_files = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = "Serve static files from a directory over HTTP";
     };
 

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -920,6 +920,9 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
+    # prevent error if not all certs are configured by the user
+    environment.etc."prosody/certs/.dummy".text = "";
+
     environment.etc."prosody/prosody.cfg.lua".source =
       if cfg.checkConfig then
         pkgs.runCommandLocal "prosody.cfg.lua"

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -559,7 +559,7 @@ let
 
       ${lib.concatMapStrings (muc: ''
         Component ${toLua muc.domain} "muc"
-            modules_enabled = { "muc_mam"; ${optionalString muc.allowners_muc ''"muc_allowners";''}  }
+            modules_enabled = {${optionalString cfg.modules.mam ''" muc_mam";''}${optionalString muc.allowners_muc ''" muc_allowners";''} }
             name = ${toLua muc.name}
             restrict_room_creation = ${toLua muc.restrictRoomCreation}
             max_history_messages = ${toLua muc.maxHistoryMessages}

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -993,11 +993,12 @@ in
         {
           User = cfg.user;
           Group = cfg.group;
-          Type = "forking";
+          Type = "simple";
           RuntimeDirectory = [ "prosody" ];
           PIDFile = "/run/prosody/prosody.pid";
-          ExecStart = "${cfg.package}/bin/prosodyctl start";
+          ExecStart = "${lib.getExe cfg.package} -F";
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+          Restart = "on-abnormal";
 
           MemoryDenyWriteExecute = true;
           PrivateDevices = true;

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -567,7 +567,7 @@ let
 
       ${lib.concatMapStrings (muc: ''
         Component ${toLua muc.domain} "muc"
-            modules_enabled = {${optionalString cfg.modules.mam ''" muc_mam";''}${optionalString muc.allowners_muc ''" muc_allowners";''} }
+            modules_enabled = {${optionalString cfg.modules.mam ''" muc_mam",''}${optionalString muc.allowners_muc ''" muc_allowners",''} }
             name = ${toLua muc.name}
             restrict_room_creation = ${toLua muc.restrictRoomCreation}
             max_history_messages = ${toLua muc.maxHistoryMessages}

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -552,6 +552,8 @@ let
       http_ports = ${toLua cfg.httpPorts}
       https_ports = ${toLua cfg.httpsPorts}
 
+      mime_types_file = "${pkgs.mailcap}/etc/mime.types"
+
       ${cfg.extraConfig}
 
       ${lib.concatMapStrings (muc: ''

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -524,7 +524,6 @@ let
       admins = ${toLua cfg.admins}
 
       modules_enabled = {
-
         ${lib.concatStringsSep "\n  " (
           lib.mapAttrsToList (name: val: optionalString val "${toLua name};") cfg.modules
         )}
@@ -590,7 +589,6 @@ let
         '') cfg.virtualHosts
       )}
     '';
-
 in
 {
   options = {

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -369,11 +369,6 @@ let
           kick other. Useful in jitsi-meet to kick ghosts.
         '';
       };
-      vcard_muc = mkOption {
-        type = types.bool;
-        default = true;
-        description = "Adds the ability to set vCard for Multi User Chat rooms";
-      };
 
       # Extra parameters. Defaulting to prosody default values.
       # Adding them explicitly to make them visible from the options
@@ -579,7 +574,7 @@ let
 
       ${lib.concatMapStrings (muc: ''
         Component ${toLua muc.domain} "muc"
-            modules_enabled = { "muc_mam"; ${optionalString muc.vcard_muc ''"vcard_muc";''} ${optionalString muc.allowners_muc ''"muc_allowners";''}  }
+            modules_enabled = { "muc_mam"; ${optionalString muc.allowners_muc ''"muc_allowners";''}  }
             name = ${toLua muc.name}
             restrict_room_creation = ${toLua muc.restrictRoomCreation}
             max_history_messages = ${toLua muc.maxHistoryMessages}

--- a/nixos/tests/xmpp/prosody.nix
+++ b/nixos/tests/xmpp/prosody.nix
@@ -15,8 +15,7 @@ let
   # test interactively.
   createUsers =
     pkgs:
-    pkgs.writeScriptBin "create-prosody-users" ''
-      #!${pkgs.bash}/bin/bash
+    pkgs.writeShellScriptBin "create-prosody-users" ''
       set -e
       prosodyctl register cthon98 example.com nothunter2
       prosodyctl register azurediamond example.com hunter2
@@ -24,8 +23,7 @@ let
   # Deletes the test users.
   delUsers =
     pkgs:
-    pkgs.writeScriptBin "delete-prosody-users" ''
-      #!${pkgs.bash}/bin/bash
+    pkgs.writeShellScriptBin "delete-prosody-users" ''
       set -e
       prosodyctl deluser cthon98@example.com
       prosodyctl deluser azurediamond@example.com

--- a/nixos/tests/xmpp/prosody.nix
+++ b/nixos/tests/xmpp/prosody.nix
@@ -2,7 +2,8 @@ let
   cert =
     pkgs:
     pkgs.runCommand "selfSignedCerts" { buildInputs = [ pkgs.openssl ]; } ''
-      openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -subj '/CN=example.com/CN=uploads.example.com/CN=conference.example.com' -days 36500
+      openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -days 365 \
+        -subj '/C=GB/CN=example.com' -addext "subjectAltName = DNS:example.com,DNS:uploads.example.com,DNS:conference.example.com"
       mkdir -p $out
       cp key.pem cert.pem $out
     '';

--- a/nixos/tests/xmpp/prosody.nix
+++ b/nixos/tests/xmpp/prosody.nix
@@ -7,33 +7,26 @@ let
       mkdir -p $out
       cp key.pem cert.pem $out
     '';
+
+  # Creates and set password for the 2 xmpp test users.
+  #
+  # Doing that in a bash script instead of doing that in the test
+  # script allow us to easily provision the users when running that
+  # test interactively.
   createUsers =
     pkgs:
     pkgs.writeScriptBin "create-prosody-users" ''
       #!${pkgs.bash}/bin/bash
       set -e
-
-      # Creates and set password for the 2 xmpp test users.
-      #
-      # Doing that in a bash script instead of doing that in the test
-      # script allow us to easily provision the users when running that
-      # test interactively.
-
       prosodyctl register cthon98 example.com nothunter2
       prosodyctl register azurediamond example.com hunter2
     '';
+  # Deletes the test users.
   delUsers =
     pkgs:
     pkgs.writeScriptBin "delete-prosody-users" ''
       #!${pkgs.bash}/bin/bash
       set -e
-
-      # Deletes the test users.
-      #
-      # Doing that in a bash script instead of doing that in the test
-      # script allow us to easily provision the users when running that
-      # test interactively.
-
       prosodyctl deluser cthon98@example.com
       prosodyctl deluser azurediamond@example.com
     '';
@@ -45,7 +38,6 @@ import ../make-test-python.nix {
       {
         nodes,
         pkgs,
-        config,
         ...
       }:
       {
@@ -60,6 +52,7 @@ import ../make-test-python.nix {
           (pkgs.callPackage ./xmpp-sendmessage.nix { connectTo = "example.com"; })
         ];
       };
+
     server =
       { config, pkgs, ... }:
       {
@@ -97,16 +90,14 @@ import ../make-test-python.nix {
       };
   };
 
-  testScript =
-    { nodes, ... }:
-    ''
-      # Check with sqlite storage
-      start_all()
-      server.wait_for_unit("prosody.service")
-      server.succeed('prosodyctl status | grep "Prosody is running"')
+  testScript = _: ''
+    # Check with sqlite storage
+    start_all()
+    server.wait_for_unit("prosody.service")
+    server.succeed('prosodyctl status | grep "Prosody is running"')
 
-      server.succeed("create-prosody-users")
-      client.succeed("send-message")
-      server.succeed("delete-prosody-users")
-    '';
+    server.succeed("create-prosody-users")
+    client.succeed("send-message")
+    server.succeed("delete-prosody-users")
+  '';
 }

--- a/nixos/tests/xmpp/prosody.nix
+++ b/nixos/tests/xmpp/prosody.nix
@@ -89,7 +89,7 @@ import ../make-test-python.nix {
               domain = "conference.example.com";
             }
           ];
-          uploadHttp = {
+          httpFileShare = {
             domain = "uploads.example.com";
           };
         };

--- a/nixos/tests/xmpp/prosody.nix
+++ b/nixos/tests/xmpp/prosody.nix
@@ -40,7 +40,6 @@ import ../make-test-python.nix {
       }:
       {
         security.pki.certificateFiles = [ "${cert pkgs}/cert.pem" ];
-        console.keyMap = "fr-bepo";
         networking.extraHosts = ''
           ${nodes.server.config.networking.primaryIPAddress} example.com
           ${nodes.server.config.networking.primaryIPAddress} conference.example.com
@@ -55,7 +54,6 @@ import ../make-test-python.nix {
       { config, pkgs, ... }:
       {
         security.pki.certificateFiles = [ "${cert pkgs}/cert.pem" ];
-        console.keyMap = "fr-bepo";
         networking.extraHosts = ''
           ${config.networking.primaryIPAddress} example.com
           ${config.networking.primaryIPAddress} conference.example.com

--- a/nixos/tests/xmpp/prosody.nix
+++ b/nixos/tests/xmpp/prosody.nix
@@ -41,9 +41,9 @@ import ../make-test-python.nix {
       {
         security.pki.certificateFiles = [ "${cert pkgs}/cert.pem" ];
         networking.extraHosts = ''
-          ${nodes.server.config.networking.primaryIPAddress} example.com
-          ${nodes.server.config.networking.primaryIPAddress} conference.example.com
-          ${nodes.server.config.networking.primaryIPAddress} uploads.example.com
+          ${nodes.server.networking.primaryIPAddress} example.com
+          ${nodes.server.networking.primaryIPAddress} conference.example.com
+          ${nodes.server.networking.primaryIPAddress} uploads.example.com
         '';
         environment.systemPackages = [
           (pkgs.callPackage ./xmpp-sendmessage.nix { connectTo = "example.com"; })

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
   # default setup.
   nixosModuleDeps = [
     "cloud_notify"
-    "vcard_muc"
     "http_upload"
   ];
 

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -36,7 +36,7 @@ let
   );
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "0.12.5"; # also update communityModules
+  version = "13.0.2"; # also update communityModules
   pname = "prosody";
   # The following community modules are necessary for the nixos module
   # prosody module to comply with XEP-0423 and provide a working
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   src = fetchurl {
     url = "https://prosody.im/downloads/source/prosody-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-d4+3cHoPEDmVlbp6ucZt0qIojArjp/5Kt4+X1GK9OZ8=";
+    hash = "sha256-PmG9OW83ylJF3r/WvkmkemGRMy8Pqi1O5fAPuwQK3bA=";
   };
 
   # A note to all those merging automated updates: Please also update this
@@ -56,8 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
   # version.
   communityModules = fetchhg {
     url = "https://hg.prosody.im/prosody-modules";
-    rev = "fc521fb5ffa0";
-    hash = "sha256-Ci52Xkx1xd3GW9lBPKgWFBB52SocxKyj8f/Hq3hZeak=";
+    rev = "a4d7fefa4a8b";
+    hash = "sha256-lPxKZlIVyAt1Nx+PQ0ru0qihJ1ecBbvO0fMk+5D+NzE=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -114,6 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     homepage = "https://prosody.im";
     platforms = platforms.linux;
+    mainProgram = "prosody";
     maintainers = with maintainers; [
       toastal
       mirror230469

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -35,7 +35,7 @@ let
     ++ withExtraLuaPackages p
   );
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "0.12.5"; # also update communityModules
   pname = "prosody";
   # The following community modules are necessary for the nixos module
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     "http_upload"
   ];
   src = fetchurl {
-    url = "https://prosody.im/downloads/source/${pname}-${version}.tar.gz";
+    url = "https://prosody.im/downloads/source/prosody-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-d4+3cHoPEDmVlbp6ucZt0qIojArjp/5Kt4+X1GK9OZ8=";
   };
 
@@ -93,9 +93,13 @@ stdenv.mkDerivation rec {
   postInstall = ''
     ${lib.concatMapStringsSep "\n"
       (module: ''
-        cp -r $communityModules/mod_${module} $out/lib/prosody/modules/
+        cp -r ${finalAttrs.communityModules}/mod_${module} $out/lib/prosody/modules/
       '')
-      (lib.lists.unique (nixosModuleDeps ++ withCommunityModules ++ withOnlyInstalledCommunityModules))
+      (
+        lib.lists.unique (
+          finalAttrs.nixosModuleDeps ++ withCommunityModules ++ withOnlyInstalledCommunityModules
+        )
+      )
     }
     make -C tools/migration install
   '';
@@ -115,4 +119,4 @@ stdenv.mkDerivation rec {
       mirror230469
     ];
   };
-}
+})

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -36,8 +36,14 @@ let
   );
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "13.0.2"; # also update communityModules
   pname = "prosody";
+  version = "13.0.2"; # also update communityModules
+
+  src = fetchurl {
+    url = "https://prosody.im/downloads/source/prosody-${finalAttrs.version}.tar.gz";
+    hash = "sha256-PmG9OW83ylJF3r/WvkmkemGRMy8Pqi1O5fAPuwQK3bA=";
+  };
+
   # The following community modules are necessary for the nixos module
   # prosody module to comply with XEP-0423 and provide a working
   # default setup.
@@ -46,10 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     "vcard_muc"
     "http_upload"
   ];
-  src = fetchurl {
-    url = "https://prosody.im/downloads/source/prosody-${finalAttrs.version}.tar.gz";
-    hash = "sha256-PmG9OW83ylJF3r/WvkmkemGRMy8Pqi1O5fAPuwQK3bA=";
-  };
 
   # A note to all those merging automated updates: Please also update this
   # attribute as some modules might not be compatible with a newer prosody
@@ -61,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [ makeWrapper ];
+
   buildInputs = [
     luaEnv
     libidn
@@ -77,6 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--c-compiler=${stdenv.cc.targetPrefix}cc"
     "--linker=${stdenv.cc.targetPrefix}cc"
   ];
+
   configurePlatforms = [ ];
 
   postBuild = ''

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -110,6 +110,9 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     homepage = "https://prosody.im";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ toastal ];
+    maintainers = with maintainers; [
+      toastal
+      mirror230469
+    ];
   };
 }

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
   # default setup.
   nixosModuleDeps = [
     "cloud_notify"
-    "http_upload"
   ];
 
   # A note to all those merging automated updates: Please also update this

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -123,5 +123,6 @@ stdenv.mkDerivation (finalAttrs: {
       toastal
       mirror230469
     ];
+    teams = with lib.teams; [ c3d2 ];
   };
 })


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
