### PR TITLE
systemd: remove bash

### DIFF
--- a/pkgs/by-name/li/libpcap/package.nix
+++ b/pkgs/by-name/li/libpcap/package.nix
@@ -4,6 +4,8 @@
   fetchurl,
   flex,
   bison,
+  bash,
+  bashNonInteractive,
   bluez,
   libnl,
   libxcrypt,
@@ -26,13 +28,25 @@ stdenv.mkDerivation rec {
   pname = "libpcap";
   version = "1.10.5";
 
+  __structuredAttrs = true;
+
   src = fetchurl {
     url = "https://www.tcpdump.org/release/${pname}-${version}.tar.gz";
     hash = "sha256-N87ZChmjAqfzLkWCJKAMNlwReQXCzTWsVEtogKgUiPA=";
   };
 
-  buildInputs =
-    lib.optionals stdenv.hostPlatform.isLinux [ libnl ] ++ lib.optionals withRemote [ libxcrypt ];
+  outputs = [
+    "out"
+    "lib"
+  ];
+
+  strictDeps = true;
+
+  buildInputs = [
+    bash
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ libnl ]
+  ++ lib.optionals withRemote [ libxcrypt ];
 
   nativeBuildInputs = [
     flex
@@ -61,6 +75,11 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  outputChecks.lib.disallowedRequisites = [
+    bash
+    bashNonInteractive
+  ];
 
   passthru.tests = {
     inherit

--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -9,6 +9,8 @@
   ninja,
   audit,
   libxcrypt,
+  bash,
+  bashNonInteractive,
   nixosTests,
   meson,
   pkg-config,
@@ -31,7 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "linux-pam";
     tag = "v${finalAttrs.version}";
     hash = "sha256-kANcwxifQz2tYPSrSBSFiYNTm51Gr10L/zroCqm8ZHQ=";
+
   };
+
+  __structuredAttrs = true;
 
   # patching unix_chkpwd is required as the nix store entry does not have the necessary bits
   postPatch = ''
@@ -43,8 +48,11 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "doc"
     "man"
+    "scripts"
     # "modules"
   ];
+
+  strictDeps = true;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [
@@ -65,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     db4
     libxcrypt
+    bash
   ]
   ++ lib.optionals stdenv.buildPlatform.isLinux [
     audit
@@ -89,7 +98,17 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "examples" false)
   ];
 
+  postInstall = ''
+    moveToOutput sbin/pam_namespace_helper $scripts
+    moveToOutput etc/security/namespace.init $scripts
+  '';
+
   doCheck = false; # fails
+
+  outputChecks.out.disallowedRequisites = [
+    bash
+    bashNonInteractive
+  ];
 
   passthru = {
     tests = {

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -6,6 +6,7 @@
   byacc, # can also use bison, but byacc has fewer dependencies
   keyutils,
   openssl,
+  bashNonInteractive,
   perl,
   pkg-config,
 
@@ -33,6 +34,8 @@
 stdenv.mkDerivation rec {
   pname = "krb5";
   version = "1.21.3";
+
+  __structuredAttrs = true;
 
   src = fetchurl {
     url = "https://kerberos.org/dist/krb5/${lib.versions.majorMinor version}/krb5-${version}.tar.gz";
@@ -73,6 +76,8 @@ stdenv.mkDerivation rec {
     "ac_cv_printf_positional=yes"
   ];
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     byacc
     perl
@@ -83,6 +88,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     openssl
+    bashNonInteractive # cannot use bashInteractive because of a dependency cycle
   ]
   ++ lib.optionals (
     stdenv.hostPlatform.isLinux
@@ -116,7 +122,7 @@ stdenv.mkDerivation rec {
   # options don't give us enough granularity to specify that, so we have to override the generated
   # Makefiles manually.
   postConfigure = ''
-    find $libFolders -type f -name Makefile -print0 | while IFS= read -rd "" f; do
+    find "''${libFolders[@]}" -type f -name Makefile -print0 | while IFS= read -rd "" f; do
       substituteInPlace "$f" --replace-fail "$out" "$lib"
     done
   '';
@@ -125,9 +131,11 @@ stdenv.mkDerivation rec {
     mkdir -p "$lib"/{bin,sbin,lib/pkgconfig,share/{et,man/man1}}
   '';
 
-  # not via outputBin, due to reference from libkrb5.so
   postInstall = ''
+    # not via outputBin, due to reference from libkrb5.so
     moveToOutput bin/krb5-config "$dev"
+    moveToOutput sbin/krb5-send-pr "$out"
+    moveToOutput bin/compile_et "$out"
   '';
 
   # Disable _multioutDocs in stdenv by overriding it to be a no-op.
@@ -140,6 +148,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
   doCheck = false; # fails with "No suitable file for testing purposes"
+
+  outputChecks.lib.disallowedRequisites = [
+    # bash cannot be here because of a dependency cycle
+    bashNonInteractive
+  ];
 
   meta = with lib; {
     description = "MIT Kerberos 5";

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -12,6 +12,8 @@
   libnfnetlink,
   libnftnl,
   libpcap,
+  bash,
+  bashNonInteractive,
   nftablesCompat ? true,
   gitUpdater,
 }:
@@ -20,6 +22,8 @@ stdenv.mkDerivation rec {
   version = "1.8.11";
   pname = "iptables";
 
+  __structuredAttrs = true;
+
   src = fetchurl {
     url = "https://www.netfilter.org/projects/${pname}/files/${pname}-${version}.tar.xz";
     sha256 = "2HMD1V74ySvK1N0/l4sm0nIBNkKwKUJXdfW60QCf57I=";
@@ -27,9 +31,12 @@ stdenv.mkDerivation rec {
 
   outputs = [
     "out"
+    "lib"
     "dev"
     "man"
   ];
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     autoreconfHook
@@ -45,6 +52,7 @@ stdenv.mkDerivation rec {
     libnfnetlink
     libnftnl
     libpcap
+    bash
   ];
 
   configureFlags = [
@@ -67,6 +75,11 @@ stdenv.mkDerivation rec {
     ln -sv xtables-nft-multi $out/bin/ip6tables-restore
     ln -sv xtables-nft-multi $out/bin/ip6tables-save
   '';
+
+  outputChecks.lib.disallowedRequisites = [
+    bash
+    bashNonInteractive
+  ];
 
   passthru = {
     updateScript = gitUpdater {

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -8,6 +8,8 @@
   coreutils,
   libuuid,
   libaio,
+  bash,
+  bashNonInteractive,
   replaceVars,
   enableCmdlib ? false,
   enableDmeventd ? false,
@@ -39,6 +41,8 @@ stdenv.mkDerivation rec {
     + lib.optionalString enableVDO "-with-vdo";
   inherit version;
 
+  __structuredAttrs = true;
+
   src = fetchurl {
     urls = [
       "https://mirrors.kernel.org/sourceware/lvm2/LVM2.${version}.tgz"
@@ -47,9 +51,12 @@ stdenv.mkDerivation rec {
     inherit hash;
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals udevSupport [ udevCheckHook ];
   buildInputs = [
     libaio
+    bash
   ]
   ++ lib.optionals udevSupport [
     udev
@@ -70,12 +77,20 @@ stdenv.mkDerivation rec {
     "--with-systemd-run=/run/current-system/systemd/bin/systemd-run"
     "--with-default-profile-subdir=profile.d"
   ]
-  ++ lib.optionals (!enableCmdlib && !onlyLib) [
-    "--bindir=${placeholder "bin"}/bin"
-    "--sbindir=${placeholder "bin"}/bin"
-    "--libdir=${placeholder "lib"}/lib"
-    "--with-libexecdir=${placeholder "lib"}/libexec"
-  ]
+  ++ lib.optionals (!onlyLib) (
+    if enableCmdlib then
+      [
+        "--bindir=${placeholder "out"}/bin"
+        "--sbindir=${placeholder "out"}/bin"
+      ]
+    else
+      [
+        "--bindir=${placeholder "bin"}/bin"
+        "--sbindir=${placeholder "bin"}/bin"
+        "--libdir=${placeholder "lib"}/lib"
+        "--with-libexecdir=${placeholder "lib"}/libexec"
+      ]
+  )
   ++ lib.optional enableCmdlib "--enable-cmdlib"
   ++ lib.optionals enableDmeventd [
     "--enable-dmeventd"
@@ -92,6 +107,7 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals enableVDO [
     "--enable-vdo"
+    "--with-vdo-format=${vdo}/bin/vdoformat"
   ]
   ++ lib.optionals stdenv.hostPlatform.isStatic [
     "--enable-static_link"
@@ -173,15 +189,35 @@ stdenv.mkDerivation rec {
   ++ lib.optionals (!onlyLib) [
     "dev"
     "man"
+    "scripts"
   ]
   ++ lib.optionals (!onlyLib && !enableCmdlib) [
     "bin"
     "lib"
   ];
 
-  postInstall = lib.optionalString (enableCmdlib != true) ''
-    moveToOutput lib/libdevmapper.so $lib
-  '';
+  postInstall =
+    lib.optionalString (!onlyLib) ''
+      moveToOutput bin/fsadm $scripts
+      moveToOutput bin/blkdeactivate $scripts
+      moveToOutput bin/lvmdump $scripts
+      moveToOutput bin/lvm_import_vdo $scripts
+      moveToOutput libexec/lvresize_fs_helper $scripts/lib
+    ''
+    + lib.optionalString (!enableCmdlib) ''
+      moveToOutput lib/libdevmapper.so $lib
+    '';
+
+  outputChecks = lib.optionalString (!enableVDO) {
+    out.disallowedRequisites = [
+      bash
+      bashNonInteractive
+    ];
+    lib.disallowedRequisites = [
+      bash
+      bashNonInteractive
+    ];
+  };
 
   passthru.tests = {
     installer = nixosTests.installer.lvm;

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -114,7 +114,6 @@
   withHostnamed ? true,
   withHwdb ? true,
   withImportd ? !stdenv.hostPlatform.isMusl,
-  withIptables ? true,
   withKmod ? true,
   withLibBPF ?
     lib.versionAtLeast buildPackages.llvmPackages.clang.version "10.0"
@@ -427,7 +426,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withKmod kmod
   ++ lib.optional withLibidn2 libidn2
   ++ lib.optional withLibseccomp libseccomp
-  ++ lib.optional withIptables iptables
   ++ lib.optional withPam pam
   ++ lib.optional withPCRE2 pcre2
   ++ lib.optional withSelinux libselinux
@@ -566,7 +564,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "libcurl" wantCurl)
     (lib.mesonEnable "libidn" false)
     (lib.mesonEnable "libidn2" withLibidn2)
-    (lib.mesonEnable "libiptc" withIptables)
+    (lib.mesonEnable "libiptc" false)
     (lib.mesonEnable "repart" withRepart)
     (lib.mesonEnable "sysupdate" withSysupdate)
     (lib.mesonEnable "sysupdated" withSysupdate)

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -63,7 +63,6 @@
   libseccomp,
   withKexectools ? lib.meta.availableOn stdenv.hostPlatform kexec-tools,
   kexec-tools,
-  bashInteractive,
   bash,
   libmicrohttpd,
   libfido2,
@@ -400,7 +399,6 @@ stdenv.mkDerivation (finalAttrs: {
     (if withPam then libcap else libcap.override { usePam = false; })
     libuuid
     linuxHeaders
-    bashInteractive # for patch shebangs
   ]
 
   ++ lib.optionals withGcrypt [
@@ -517,6 +515,10 @@ stdenv.mkDerivation (finalAttrs: {
     # SSH
     (lib.mesonOption "sshconfdir" "")
     (lib.mesonOption "sshdconfdir" "no")
+
+    # RPM
+    # This stops building/installing RPM specific tools.
+    (lib.mesonOption "rpmmacrosdir" "no")
 
     # Features
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -464,10 +464,13 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "version-tag" version)
     (lib.mesonOption "mode" "release")
     (lib.mesonOption "tty-gid" "3") # tty in NixOS has gid 3
-    (lib.mesonOption "debug-shell" "${bashInteractive}/bin/bash")
     (lib.mesonOption "pamconfdir" "${placeholder "out"}/etc/pam.d")
     (lib.mesonOption "shellprofiledir" "${placeholder "out"}/etc/profile.d")
     (lib.mesonOption "kmod-path" "${kmod}/bin/kmod")
+
+    # /bin/sh is also the upstream default. Explicitly set this so that we're
+    # independent of upstream changes to the default.
+    (lib.mesonOption "debug-shell" "/bin/sh")
 
     # Attempts to check /usr/sbin and that fails in macOS sandbox because
     # permission is denied. If /usr/sbin is not a symlink, it defaults to true.

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -64,6 +64,7 @@
   withKexectools ? lib.meta.availableOn stdenv.hostPlatform kexec-tools,
   kexec-tools,
   bash,
+  bashNonInteractive,
   libmicrohttpd,
   libfido2,
   p11-kit,
@@ -907,6 +908,11 @@ stdenv.mkDerivation (finalAttrs: {
           builtins.map (p: p.__spliced.buildHost or p) finalAttrs.nativeBuildInputs
         )
       );
+
+  disallowedRequisites = [
+    bash
+    bashNonInteractive
+  ];
 
   passthru = {
     # The `interfaceVersion` attribute below points out the incompatibilities

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11099,7 +11099,6 @@ with pkgs;
     withHomed = false;
     withHwdb = false;
     withImportd = false;
-    withIptables = false;
     withLibBPF = false;
     withLibidn2 = false;
     withLocaled = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12544,6 +12544,10 @@ with pkgs;
 
   kbibtex = libsForQt5.callPackage ../applications/office/kbibtex { };
 
+  kbdCompressed = callPackage ../by-name/kb/kbd/package.nix {
+    compress = true;
+  };
+
   kexi = libsForQt5.callPackage ../applications/office/kexi { };
 
   kiwix = libsForQt5.callPackage ../applications/misc/kiwix { };


### PR DESCRIPTION
Enforce that the closure of systemd remains bashless.

See the individual commits for more reasoning.

Review commit-by-commit.

Depended on (already merged):
- https://github.com/NixOS/nixpkgs/pull/429797
- https://github.com/NixOS/nixpkgs/pull/429438

Part of https://github.com/NixOS/nixpkgs/issues/428908

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
