### PR TITLE
iso-image: ensure `boot.loader.grub.enable` is disabled by default

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -865,7 +865,7 @@ in
 
     # Don't build the GRUB menu builder script, since we don't need it
     # here and it causes a cyclic dependency.
-    boot.loader.grub.enable = false;
+    boot.loader.grub.enable = lib.mkImageMediaOverride false;
 
     environment.systemPackages = [
       grubPkgs.grub2


### PR DESCRIPTION
Currently `config.system.build.images.iso` will fail to evaluate if a user has enabled GRUB with default priority:

```
error: The option `boot.loader.grub.enable' has conflicting definition values:
- In `/nix/store/b1wfzqf510l49f0s40mi3ivbylzwhmmj-source/configuration.nix': true
- In `/nix/store/c60r2avfm17sc0jjgsbxidi7nb1lbl43-source/nixos/modules/installer/cd-dvd/iso-image.nix': false
```

We can use `mkImageMediaOverride` to ensure that GRUB is actually disabled if a user enables it using the default priority but still allows them to enable it using `mkForce`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
