### PR TITLE
mpd: move to by-name

### DIFF
--- a/pkgs/by-name/mp/mpd/package.nix
+++ b/pkgs/by-name/mp/mpd/package.nix
@@ -271,7 +271,47 @@ let
       ++ lib.optional (builtins.elem "systemd" features_) "-Dsystemd_system_unit_dir=etc/systemd/system"
       ++ lib.optional (builtins.elem "qobuz" features_) "-Dnlohmann_json=enabled";
 
-      passthru.tests.nixos = nixosTests.mpd;
+      passthru = {
+        tests.nixos = nixosTests.mpd;
+        withFeatures = run;
+        small = run {
+          features = [
+            "webdav"
+            "curl"
+            "mms"
+            "bzip2"
+            "zzip"
+            "nfs"
+            "audiofile"
+            "faad"
+            "flac"
+            "gme"
+            "mpg123"
+            "opus"
+            "vorbis"
+            "vorbisenc"
+            "lame"
+            "libsamplerate"
+            "shout"
+            "libmpdclient"
+            "id3tag"
+            "expat"
+            "pcre"
+            "sqlite"
+            "qobuz"
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            "alsa"
+            "systemd"
+            "syslog"
+            "io_uring"
+          ]
+          ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+            "mad"
+            "jack"
+          ];
+        };
+      };
 
       meta = with lib; {
         description = "Flexible, powerful daemon for playing music";
@@ -291,44 +331,4 @@ let
       };
     };
 in
-{
-  mpd = run { };
-  mpd-small = run {
-    features = [
-      "webdav"
-      "curl"
-      "mms"
-      "bzip2"
-      "zzip"
-      "nfs"
-      "audiofile"
-      "faad"
-      "flac"
-      "gme"
-      "mpg123"
-      "opus"
-      "vorbis"
-      "vorbisenc"
-      "lame"
-      "libsamplerate"
-      "shout"
-      "libmpdclient"
-      "id3tag"
-      "expat"
-      "pcre"
-      "sqlite"
-      "qobuz"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      "alsa"
-      "systemd"
-      "syslog"
-      "io_uring"
-    ]
-    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-      "mad"
-      "jack"
-    ];
-  };
-  mpdWithFeatures = run;
-}
+run { }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10317,13 +10317,8 @@ with pkgs;
 
   mkchromecast = libsForQt5.callPackage ../applications/networking/mkchromecast { };
 
-  inherit
-    (callPackages ../servers/mpd {
-    })
-    mpd
-    mpd-small
-    mpdWithFeatures
-    ;
+  mpd-small = lib.warnOnInstantiate "'mpd-small' is deprecated, please use `mpd.small` instead." mpd.small; # added 2025-08-01
+  mpdWithFeatures = lib.warnOnInstantiate "'mpdWithFeatures' is deprecated, please use `mpd.withFeatures` instead." mpd.withFeatures; # added 2025-08-01
 
   mtprotoproxy = python3.pkgs.callPackage ../servers/mtprotoproxy { };
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
