### PR TITLE
renoise: use LuaLS from nixpkgs

### DIFF
--- a/pkgs/by-name/re/renoise/package.nix
+++ b/pkgs/by-name/re/renoise/package.nix
@@ -13,6 +13,7 @@
   libXtst,
   mpg123,
   pipewire,
+  lua-language-server,
   releasePath ? null,
 }:
 
@@ -91,6 +92,16 @@ stdenv.mkDerivation rec {
     cp Installer/renoise-48.png $out/share/icons/hicolor/48x48/apps/renoise.png
     cp Installer/renoise-64.png $out/share/icons/hicolor/64x64/apps/renoise.png
     cp Installer/renoise-128.png $out/share/icons/hicolor/128x128/apps/renoise.png
+
+    # Internal scripting editor
+    LuaLS="$out/3rdParty/LuaLS"
+
+    rm -r $LuaLS
+    mkdir -p $LuaLS/bin
+
+    ln -s ${lib.getExe lua-language-server} $LuaLS/bin/lua-language-server-linux_${
+      platforms.${stdenv.system}.archSuffix
+    }
   '';
 
   postFixup = ''


### PR DESCRIPTION
Renoise bundles a lua language server for its internal scripting editor. This PR implements logic that replaces vendored LuaLS with a package from nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
