### PR TITLE
nixos/oci-containers: Minor docs improvements

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -98,20 +98,16 @@ let
           type = with types; listOf str;
           default = [ ];
           description = "Commandline arguments to pass to the image's entrypoint.";
-          example = literalExpression ''
-            ["--port=9000"]
-          '';
+          example = [ "--port=9000" ];
         };
 
         labels = mkOption {
           type = with types; attrsOf str;
           default = { };
           description = "Labels to attach to the container at runtime.";
-          example = literalExpression ''
-            {
-              "traefik.https.routers.example.rule" = "Host(`example.container`)";
-            }
-          '';
+          example = {
+            "traefik.https.routers.example.rule" = "Host(`example.container`)";
+          };
         };
 
         entrypoint = mkOption {
@@ -125,24 +121,20 @@ let
           type = with types; attrsOf str;
           default = { };
           description = "Environment variables to set for this container.";
-          example = literalExpression ''
-            {
-              DATABASE_HOST = "db.example.com";
-              DATABASE_PORT = "3306";
-            }
-          '';
+          example = {
+            DATABASE_HOST = "db.example.com";
+            DATABASE_PORT = "3306";
+          };
         };
 
         environmentFiles = mkOption {
           type = with types; listOf path;
           default = [ ];
           description = "Environment files for this container.";
-          example = literalExpression ''
-            [
-              /path/to/.env
-              /path/to/.env.secret
-            ]
-          '';
+          example = [
+            /path/to/.env
+            /path/to/.env.secret
+          ];
         };
 
         log-driver = mkOption {
@@ -223,12 +215,10 @@ let
             field; please refer to the
             [docker engine documentation](https://docs.docker.com/engine/storage/volumes/) for details.
           '';
-          example = literalExpression ''
-            [
-              "volume_name:/path/inside/container"
-              "/path/on/host:/path/inside/container"
-            ]
-          '';
+          example = [
+            "volume_name:/path/inside/container"
+            "/path/on/host:/path/inside/container"
+          ];
         };
 
         workdir = mkOption {
@@ -277,9 +267,7 @@ let
           type = with types; listOf str;
           default = [ ];
           description = "Extra options for {command}`${defaultBackend} run`.";
-          example = literalExpression ''
-            ["--network=host"]
-          '';
+          example = [ "--network=host" ];
         };
 
         autoStart = mkOption {
@@ -352,12 +340,10 @@ let
             When set to false, capability is dropped from the container.
             When null, default runtime settings apply.
           '';
-          example = literalExpression ''
-            {
-              SYS_ADMIN = true;
-              SYS_WRITE = false;
-            {
-          '';
+          example = {
+            SYS_ADMIN = true;
+            SYS_WRITE = false;
+          };
         };
 
         devices = mkOption {
@@ -366,11 +352,9 @@ let
           description = ''
             List of devices to attach to this container.
           '';
-          example = literalExpression ''
-            [
-              "/dev/dri:/dev/dri"
-            ]
-          '';
+          example = [
+            "/dev/dri:/dev/dri"
+          ];
         };
 
         privileged = mkOption {

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -239,10 +239,8 @@ let
           example = literalExpression ''
             virtualisation.oci-containers.containers = {
               node1 = {};
-              node2 = {
-                dependsOn = [ "node1" ];
-              }
-            }
+              node2.dependsOn = [ "node1" ];
+            };
           '';
         };
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Manually inspected the built manual, using the following to get a locally-hosted copy:
```sh
python3 -m http.server -d $(nix-build nixos/release.nix -A manual.x86_64-linux)/share/doc/nixos
```
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
