### PR TITLE
magic-wormhole: 0.19.2 -> 0.20.0

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   setuptools,
   autobahn,
   twisted,
@@ -18,6 +19,15 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-kS2DXaIbESZsdxEdybXlgAJj/AuY8KF5liJn30GBnow=";
   };
+
+  patches = [
+    # TODO: drop when updating beyond version 0.4.0
+    (fetchpatch {
+      name = "stock-Twisted-testing-reactor-seems-to-work.patch";
+      url = "https://github.com/magic-wormhole/magic-wormhole-transit-relay/commit/3abb80fd5e55bd0ba8ee66278ccf76be5f904622.patch";
+      hash = "sha256-qMaJ58kPWvEfnSZiFzxO6GlkBiyVMsgGDEa1deITZco=";
+    })
+  ];
 
   postPatch = ''
     # Passing the environment to twistd is necessary to preserve Python's site path.

--- a/pkgs/development/python-modules/magic-wormhole/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   installShellFiles,
 
   # build-system
@@ -41,15 +42,24 @@
 
 buildPythonPackage rec {
   pname = "magic-wormhole";
-  version = "0.19.2";
+  version = "0.20.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "magic-wormhole";
     repo = "magic-wormhole";
     tag = version;
-    hash = "sha256-5Tipcood5RktXY05p20hQpWhSMMnZm67I4iybjV8TcA=";
+    hash = "sha256-YjzdznZZ/0YTU83f3jlOr6+yOWQ++R1wU9IZDrfAMpo=";
   };
+
+  patches = [
+    # TODO: drop when updating beyond version 0.20.0
+    (fetchpatch {
+      name = "SubchannelDemultiplex._pending_opens-fix-type.patch";
+      url = "https://github.com/magic-wormhole/magic-wormhole/commit/6d7f48786b5506df5b6a254bc4e37f6bf5d75593.patch";
+      hash = "sha256-28YH3enyQ9rTT56OU7FfFonb9l8beJ9QRgPoItzrgu4=";
+    })
+  ];
 
   postPatch =
     # enable tests by fixing the location of the wormhole binary
@@ -104,16 +114,17 @@ buildPythonPackage rec {
   ++ optional-dependencies.dilation
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ unixtools.locale ];
 
-  enabledTestPaths = [ "src/wormhole/test" ];
-
   __darwinAllowLocalNetworking = true;
 
   postInstall = ''
     install -Dm644 docs/wormhole.1 $out/share/man/man1/wormhole.1
+
+    # https://github.com/magic-wormhole/magic-wormhole/issues/619
     installShellCompletion --cmd ${meta.mainProgram} \
       --bash wormhole_complete.bash \
       --fish wormhole_complete.fish \
       --zsh wormhole_complete.zsh
+    rm $out/wormhole_complete.*
   '';
 
   passthru.updateScript = gitUpdater { };


### PR DESCRIPTION
https://github.com/magic-wormhole/magic-wormhole/blob/refs/tags/0.20.0/NEWS.md
https://github.com/magic-wormhole/magic-wormhole/compare/refs/tags/0.19.2...refs/tags/0.20.0

close #429602

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `c4a50e0b164ca543963e81808129e9d2aa4f54e6`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>magic-wormhole (python313Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python313Packages.magic-wormhole.dist)</li>
    <li>python312Packages.magic-wormhole</li>
    <li>python312Packages.magic-wormhole.dist</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc