### PR TITLE
sratoolkit: fix build due to undefined ATTRIBUTE_UNUSED

### DIFF
--- a/pkgs/by-name/sr/sratoolkit/attribute_unused.patch
+++ b/pkgs/by-name/sr/sratoolkit/attribute_unused.patch
@@ -1,0 +1,14 @@
+diff --git a/libs/kxml/xml.c b/libs/kxml/xml.c
+index ce445424..41e21612 100644
+--- a/libs/kxml/xml.c
++++ b/libs/kxml/xml.c
+@@ -46,6 +46,9 @@ struct s_KNodeNamelist;
+ #include <assert.h>
+ #include <string.h>
+ 
++#ifndef ATTRIBUTE_UNUSED
++#define ATTRIBUTE_UNUSED
++#endif
+ 
+ #define XML_DEBUG(msg) DBGMSG (DBG_XML, DBG_FLAG(DBG_XML_XML), msg)
+ 

--- a/pkgs/by-name/sr/sratoolkit/package.nix
+++ b/pkgs/by-name/sr/sratoolkit/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OeM4syv9c1rZn2ferrhXyKJu68ywVYwnHoqnviWBZy4=";
   };
 
+  patches = [ ./attribute_unused.patch ];
+
   cmakeFlags = [
     "-DVDB_INCDIR=${ncbi-vdb}/include"
     "-DVDB_LIBDIR=${ncbi-vdb}/lib"


### PR DESCRIPTION
Closes #429951

I'm not sure what exactly caused the breakage and due to unfree license it is not built on hydra and my laptop doesn't have a capacity to run git bisect on nixpkgs. Probably libxml bump stopped exporting the macro.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
