### PR TITLE
kdePackages.extra-cmake-modules: fix SYSTEMDUSERUNITDIR

### DIFF
--- a/pkgs/kde/frameworks/extra-cmake-modules/ecm-hook.sh
+++ b/pkgs/kde/frameworks/extra-cmake-modules/ecm-hook.sh
@@ -65,7 +65,7 @@ ecmPostHook() {
     appendToVar cmakeFlags "-DKDE_INSTALL_AUTOSTARTDIR=${!outputBin}/etc/xdg/autostart"
     appendToVar cmakeFlags "-DKDE_INSTALL_LOGGINGCATEGORIESDIR=${!outputLib}/share/qlogging-categories6"
     appendToVar cmakeFlags "-DKDE_INSTALL_SYSTEMDUNITDIR=${!outputBin}/lib/systemd"
-    appendToVar cmakeFlags "-DKDE_INSTALL_SYSTEMDUSERUNITDIR=${!outputBin}/share/systemd/user"
+    appendToVar cmakeFlags "-DKDE_INSTALL_SYSTEMDUSERUNITDIR=${!outputBin}/lib/systemd/user"
 }
 postHooks+=(ecmPostHook)
 


### PR DESCRIPTION
systemd wants user service units in `lib/systemd/user` in which case [`move-systemd-user-units.sh`](https://nixos.org/manual/nixpkgs/stable/#move-systemd-user-units.sh) will mirror them to `share/systemd/user`. Redefine `SYSTEMDUSERUNITDIR` as `lib/systemd/user` instead of `share/systemd/user`.

See [upstream documentation][KDEInstallDirs6].

Motivated by the `systemd.packages` module option only considering  `lib/systemd/*` subdirectories. ATM, I have to use a wrapper for `polkit-kde-agent-1`:
```nix
pkgs.runCommandLocal "polkit-kde-agent-1-wrapped" {} ''
  install -Dm644 {${pkgs.kdePackages.polkit-kde-agent-1}/share,$out/lib}/systemd/user/plasma-polkit-agent.service
''
```
After this PR, `plasma-polkit-agent.service` gets installed to both the `lib/systemd/user` *and* `share/systemd/user` subdirectories.

**Note:** I have only so far run `nix-build -A kdePackages.polkit-kde-agent-1`, which did succeed.

[KDEInstallDirs6]: https://api.kde.org/ecm/kde-module/KDEInstallDirs6.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
