### PR TITLE
inngest: init at 1.11.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12568,6 +12568,12 @@
     githubId = 5352661;
     name = "James Cleverley-Prance";
   };
+  jpwilliams = {
+    email = "jpwilliamsphotography@gmail.com";
+    github = "jpwilliams";
+    githubId = 1736957;
+    name = "Jack Williams";
+  };
   jqueiroz = {
     email = "nixos@johnjq.com";
     github = "jqueiroz";

--- a/pkgs/by-name/in/inngest/package.nix
+++ b/pkgs/by-name/in/inngest/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "inngest";
+  version = "1.11.2";
+
+  src = fetchFromGitHub {
+    owner = "inngest";
+    repo = "inngest";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5biiAozUwQlZn5VPHvon1aEOL1pc9MGFfhyCqUtvQFw=";
+  };
+
+  vendorHash = null;
+
+  subPackages = [ "cmd" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/inngest/inngest/pkg/inngest/version.Version=${finalAttrs.version}"
+  ];
+
+  # Match goreleaser env: CGO_ENABLED=0
+  env.CGO_ENABLED = 0;
+
+  # Rename binary to match goreleaser config: binary: inngest
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/inngest
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "The developer platform for easily building reliable workflows";
+    homepage = "https://www.inngest.com/";
+    license = lib.licenses.sspl;
+    maintainers = with lib.maintainers; [ jpwilliams ];
+    mainProgram = "inngest";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the Inngest CLI (https://www.inngest.com), a tool used to spin up an Inngest Dev Server to locally run and test durable workflows.

Can also be used to self-host Inngest.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
