### PR TITLE
flashback: init at 2.30.0

### DIFF
--- a/pkgs/by-name/fl/flashback/package.nix
+++ b/pkgs/by-name/fl/flashback/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "flashback";
+  version = "2.30.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cachebag";
+    repo = "flashback";
+    tag = "v${version}";
+    hash = "sha256-hZpsLI/diCnw/ORjDLt3VzyTJcl519TH2bOoHL8bODY=";
+  };
+
+  build-system = with python3Packages; [ hatchling ];
+
+  dependencies = with python3Packages; [
+    click
+    colorama
+    google-api-python-client
+    platformdirs
+    python-dotenv
+    tabulate
+    textual
+  ];
+
+  optional-dependencies.dev = with python3Packages; [
+    black
+    flake8
+    mypy
+    pytest
+  ];
+
+  meta = {
+    description = "Find old YouTube gems that the algorithm hides";
+    longDescription = ''
+      A YouTube search tool that helps you find older content by
+      searching videos from specific years.  Available as both a
+      Terminal User Interface (TUI - Thanks to Textual) and Command
+      Line Interface (CLI).
+    '';
+    homepage = "https://github.com/cachebag/flashback";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "flashback";
+  };
+}


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
