### PR TITLE
stdenv: Remove extra merge operator in meta

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -26,7 +26,6 @@ let
     isAttrs
     isString
     mapAttrs
-    filterAttrs
     ;
 
   inherit (lib.lists)
@@ -576,6 +575,8 @@ let
     let
       outputs = attrs.outputs or [ "out" ];
       hasOutput = out: builtins.elem out outputs;
+      maintainersPosition = builtins.unsafeGetAttrPos "maintainers" (attrs.meta or { });
+      teamsPosition = builtins.unsafeGetAttrPos "teams" (attrs.meta or { });
     in
     {
       # `name` derivation attribute includes cross-compilation cruft,
@@ -604,19 +605,17 @@ let
         )
       ]
       ++ optional (hasOutput "man") "man";
-    }
-    // (filterAttrs (_: v: v != null) {
+
       # CI scripts look at these to determine pings. Note that we should filter nulls out of this,
       # or nix-env complains: https://github.com/NixOS/nix/blob/2.18.8/src/nix-env/nix-env.cc#L963
-      maintainersPosition = builtins.unsafeGetAttrPos "maintainers" (attrs.meta or { });
-      teamsPosition = builtins.unsafeGetAttrPos "teams" (attrs.meta or { });
-    })
-    // attrs.meta or { }
-    # Fill `meta.position` to identify the source location of the package.
-    // optionalAttrs (pos != null) {
-      position = pos.file + ":" + toString pos.line;
+      ${if maintainersPosition == null then null else "maintainersPosition"} = maintainersPosition;
+      ${if teamsPosition == null then null else "teamsPosition"} = teamsPosition;
     }
+    // attrs.meta or { }
     // {
+      # Fill `meta.position` to identify the source location of the package.
+      ${if pos == null then null else "position"} = pos.file + ":" + toString pos.line;
+
       # Maintainers should be inclusive of teams.
       # Note that there may be external consumers of this API (repology, for instance) -
       # if you add a new maintainer or team attribute please ensure that this expectation is still met.

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -622,8 +622,7 @@ let
       # if you add a new maintainer or team attribute please ensure that this expectation is still met.
       maintainers =
         attrs.meta.maintainers or [ ] ++ concatMap (team: team.members or [ ]) attrs.meta.teams or [ ];
-    }
-    // {
+
       # Expose the result of the checks for everyone to see.
       unfree = hasUnfreeLicense attrs;
       broken = isMarkedBroken attrs;


### PR DESCRIPTION
This operator merges two attrsets without any conditions, and leads to more operations and allocations.

Extract from the Eval / compare job [summary](https://github.com/NixOS/nixpkgs/actions/runs/16676844191/attempts/1#summary-47205772636):

| metric | mean_before | mean_after | mean_diff | mean_%_change | p_value | t_stat |
| - | - | - | - | - | - | - |
| cpuTime | 36.8319 | 35.9723 | -0.8596 | -2.0140 | 0.0002 | -4.0792 |
| gc.cycles | 10.0455 | 10.0227 | -0.0227 | -0.1623 | 0.3229 | -1.0000 |
| gc.heapSize | 3258545524.3636 | 3256257629.0909 | -2287895.2727 | -0.1905 | 0.6364 | -0.4762 |
| gc.totalBytes | 5852793058.9091 | 5839663730.9091 | -13129328.0000 | -0.2349 | 0.0000 | -12.9536 |
| nrExprs | 1735737.0455 | 1735735.0455 | -2.0000 | -0.0001 | - | -inf |
| nrOpUpdateValuesCopied | 100875413.1591 | 100260153.1136 | -615260.0455 | -0.6539 | 0.0000 | -12.9458 |
| nrOpUpdates | 4137372.5909 | 4034829.2500 | -102543.3409 | -2.4710 | 0.0000 | -12.9458 |
| sets.bytes | 2241343462.5455 | 2228217914.9091 | -13125547.6364 | -0.6294 | 0.0000 | -12.9458 |
| sets.elements | 132069782.6818 | 131454522.6364 | -615260.0455 | -0.5011 | 0.0000 | -12.9458 |
| sets.number | 8014183.7273 | 7809097.0455 | -205086.6818 | -2.7824 | 0.0000 | -12.9458 |
| time.cpu | 36.8319 | 35.9723 | -0.8596 | -2.0140 | 0.0002 | -4.0792 |
| time.gc | 7.1009 | 6.7456 | -0.3553 | -3.1433 | 0.0086 | -2.7559 |
| time.gcFraction | 0.2112 | 0.2084 | -0.0028 | -1.2720 | 0.1663 | -1.4081 |

All these metrics went down, all other metrics didn't change.

Especially note -2% of CPU and -3% of GC time, -2.7% of sets and -2.4% of update ops.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
