### PR TITLE
sesh: 2.16.0 -> 2.17.1, add randomdude to maintainers list

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21168,6 +21168,12 @@
     githubId = 5653911;
     name = "Rampoina";
   };
+  randomdude = {
+    name = "Random Dude";
+    email = "randomdude16671@proton.me";
+    github = "randomdude16671";
+    githubId = 210965013;
+  };
   rane = {
     name = "Rane";
     email = "rane+git@junkyard.systems";

--- a/pkgs/by-name/se/sesh/package.nix
+++ b/pkgs/by-name/se/sesh/package.nix
@@ -2,20 +2,27 @@
   lib,
   fetchFromGitHub,
   buildGoModule,
+  go-mockery,
   versionCheckHook,
 }:
 buildGoModule rec {
   pname = "sesh";
-  version = "2.16.0";
+  version = "2.17.1";
 
+  nativeBuildInputs = [
+    go-mockery
+  ];
   src = fetchFromGitHub {
     owner = "joshmedeski";
     repo = "sesh";
     rev = "v${version}";
-    hash = "sha256-3kD7t3lgkxrK53cL+5i9DB5w1hIYA4J/MiauLZ1Z7KQ=";
+    hash = "sha256-olt61AR/Tq8lLh65V0/+GDrWjCi9hrkNbHR9LOX7kY0=";
   };
 
-  vendorHash = "sha256-r6n0xZbOvqDU63d3WrXenvV4x81iRgpOS2h73xSlVBI=";
+  preBuild = ''
+    mockery
+  '';
+  vendorHash = "sha256-TLl8HZnsVvtx6jqusTETP0l3zTmzYmuV4NJIM958VcQ=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/se/sesh/package.nix
+++ b/pkgs/by-name/se/sesh/package.nix
@@ -34,6 +34,7 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       gwg313
+      randomdude
       t-monaghan
     ];
     mainProgram = "sesh";


### PR DESCRIPTION
## sesh update

Updated the version of the sesh terminal session manager.
from: 2.16.0 -> 2.17.1 
(this is my first contribution to nixpkgs, I apologize for any errors)

## Maintainers update

Added myself to the list of maintainers of sesh as I am willing to maintain package, the original maintainer (@gwg313) is still included in the list. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
