### PR TITLE
conman: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8621,6 +8621,12 @@
     githubId = 10290864;
     name = "Peter Frank";
   };
+  frantathefranta = {
+    github = "frantathefranta";
+    githubId = 64412753;
+    name = "Franta Bartik";
+    email = "fb@franta.us";
+  };
   franzmondlichtmann = {
     name = "Franz Schroepf";
     email = "franz-schroepf@t-online.de";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -84,6 +84,8 @@
 
 - [paisa](https://github.com/ananthakumaran/paisa), a personal finance tracker and dashboard. Available as [services.paisa](#opt-services.paisa.enable).
 
+- [conman](https://github.com/dun/conman), a serial console management program. Available as [services.conman](#opt-services.conman.enable).
+
 ## Backward Incompatibilities {#sec-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -806,6 +806,7 @@
   ./services/misc/clipcat.nix
   ./services/misc/clipmenu.nix
   ./services/misc/confd.nix
+  ./services/misc/conman.nix
   ./services/misc/cpuminer-cryptonight.nix
   ./services/misc/db-rest.nix
   ./services/misc/devmon.nix

--- a/nixos/modules/services/misc/conman.nix
+++ b/nixos/modules/services/misc/conman.nix
@@ -1,0 +1,89 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  options = {
+    services.conman = {
+      enable = lib.mkEnableOption ''
+        Enable the conman Console manager.
+
+        Either `configFile` or `config` must be specified.
+      '';
+      package = lib.mkPackageOption pkgs "conman" { };
+
+      configFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/secrets/conman.conf";
+        description = ''
+          The absolute path to the configuration file.
+
+          Either `configFile` or `config` must be specified.
+
+          See <https://github.com/dun/conman/wiki/Man-5-conman.conf#files>.
+        '';
+      };
+      config = lib.mkOption {
+        type = lib.types.nullOr lib.types.lines;
+        default = null;
+        example = ''
+          server coredump=off
+          server keepalive=on
+          server loopback=off
+          server timestamp=1h
+
+          # global config
+          global log="/var/log/conman/%N.log"
+          global seropts="9600,8n1"
+          global ipmiopts="U:<user>,P:<password>"
+        '';
+        description = ''
+          The configuration object.
+
+          Either `configFile` or `config` must be specified.
+
+          See <https://github.com/dun/conman/wiki/Man-5-conman.conf#files>.
+        '';
+      };
+    };
+  };
+  meta.maintainers = with lib.maintainers; [
+    frantathefranta
+  ];
+
+  config =
+    let
+      cfg = config.services.conman;
+      configFile =
+        if cfg.configFile != null then
+          cfg.configFile
+        else
+          pkgs.writeTextFile {
+            name = "conman.conf";
+            text = cfg.config;
+          };
+    in
+    lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion =
+            (cfg.configFile != null) && (cfg.config == null) || (cfg.configFile == null && cfg.config != null);
+          message = "Either but not both `configFile` and `config` must be specified for conman.";
+        }
+      ];
+      environment.systemPackages = [ cfg.package ];
+      systemd.services.conmand = {
+        description = "serial console management program";
+        documentation = [ "man:conman(8)" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${cfg.package}/bin/conmand -F -c ${configFile}";
+          KillMode = "process";
+        };
+      };
+    };
+}

--- a/pkgs/by-name/co/conman/package.nix
+++ b/pkgs/by-name/co/conman/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  freeipmi,
+  autoreconfHook,
+  pkg-config,
+  fetchFromGitHub,
+  tcp_wrappers,
+  stdenv,
+  expect,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "conman";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "dun";
+    repo = "conman";
+    tag = "conman-${finalAttrs.version}";
+    hash = "sha256-CHWvHYTmTiEpEfHm3TF5aCKBOW2GsT9Vv4ehpj775NQ=";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    freeipmi # For libipmiconsole.so.2
+    tcp_wrappers # For libwrap.so.0
+    expect # For conman/*.exp scripts
+  ];
+
+  meta = {
+    description = "The Console Manager";
+    homepage = "https://github.com/dun/conman";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      frantathefranta
+    ];
+  };
+
+})


### PR DESCRIPTION
Hi, I'm adding the `conman` package as I use it fairly often on Debian and Red Hat systems. [ConMan](https://github.com/dun/conman) is a serial console management program designed to support a large number of console devices and simultaneous users. Along with the package, I'm adding a `service` module to ease the deployment. 

I've built this on my own machine and using it day-to-day.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] ~x86_64-darwin~
  - [ ] ~aarch64-darwin~
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
