### PR TITLE
windows: Various clean-ups

### DIFF
--- a/pkgs/by-name/li/libpfm/package.nix
+++ b/pkgs/by-name/li/libpfm/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
   env.CONFIG_PFMLIB_SHARED = if enableShared then "y" else "n";
 
-  buildInputs = lib.optional stdenv.hostPlatform.isWindows windows.libgnurx;
+  buildInputs = lib.optional stdenv.hostPlatform.isMinGW windows.libgnurx;
 
   meta = with lib; {
     description = "Helper library to program the performance monitoring events";

--- a/pkgs/os-specific/windows/libgnurx/default.nix
+++ b/pkgs/os-specific/windows/libgnurx/default.nix
@@ -3,16 +3,13 @@
   stdenv,
   fetchurl,
 }:
-
-let
-  version = "2.5.1";
-in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libgnurx";
-  inherit version;
+  version = "2.5.1";
+
   src = fetchurl {
-    url = "mirror://sourceforge/mingw/Other/UserContributed/regex/mingw-regex-${version}/mingw-${pname}-${version}-src.tar.gz";
-    sha256 = "0xjxcxgws3bblybw5zsp9a4naz2v5bs1k3mk8dw00ggc0vwbfivi";
+    url = "mirror://sourceforge/mingw/Other/UserContributed/regex/mingw-regex-${finalAttrs.version}/mingw-libgnurx-${finalAttrs.version}-src.tar.gz";
+    hash = "sha256-cUe3+AbsPQB4Q7OOGfQqW3xliUpX/8KXp2sNzV9nXXY=";
   };
 
   # file looks for libgnurx.a when compiling statically
@@ -27,4 +24,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.windows;
     teams = [ lib.teams.windows ];
   };
-}
+})

--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ windows.mingw_w64_headers ];
+  buildInputs = [ mingw_w64_headers ];
   hardeningDisable = [
     "stackprotector"
     "fortify"

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -4,7 +4,10 @@
   fetchurl,
   crt ? stdenvNoCC.hostPlatform.libc,
 }:
-
+assert lib.assertOneOf "crt" crt [
+  "msvcrt"
+  "ucrt"
+];
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mingw_w64-headers";
   version = "12.0.0";
@@ -23,9 +26,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    downloadPage = "https://sourceforge.net/projects/mingw/files/Other/UserContributed/regex/";
+    homepage = "https://www.mingw-w64.org/";
+    downloadPage = "https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/";
     description = "Collection of headers and libraries for building native Windows applications";
-    license = lib.licenses.publicDomain;
+    license = with lib.licenses; [
+      # Primarily under
+      zpl21
+      # A couple files
+      mit
+      # Certain headers imported from Wine
+      lgpl21Plus
+    ];
     platforms = lib.platforms.windows;
     teams = [ lib.teams.windows ];
   };

--- a/pkgs/os-specific/windows/pthread-w32/default.nix
+++ b/pkgs/os-specific/windows/pthread-w32/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   src = fetchzip {
     url = "https://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.tar.gz";
-    sha256 = "1s8iny7g06z289ahdj0kzaxj0cd3wvjbd8j3bh9xlg7g444lhy9w";
+    hash = "sha256-PHlICSHvPNoTXEOituTmozEgu/oTyAZVQuIb8I63Eek=";
   };
 
   makeFlags = [

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     updateAutotoolsGnuConfigScriptsHook
   ]
   ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
-  buildInputs = [ zlib ] ++ lib.optional stdenv.hostPlatform.isWindows libgnurx;
+  buildInputs = [ zlib ] ++ lib.optional stdenv.hostPlatform.isMinGW libgnurx;
 
   # https://bugs.astron.com/view.php?id=382
   doCheck = !stdenv.buildPlatform.isMusl;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Cleanup the libgnurx derivation
2. Change all gates for libgnurx to be behind mingw and not windows.
3. Clean up the windows.pthreads derivation
4. Clean up windows.mingw_w64 derivatoin ad meta block

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
