### PR TITLE
onedrivegui: 1.1.1a -> 1.2.1, modernize, add self as maintainer

### DIFF
--- a/pkgs/by-name/on/onedrivegui/package.nix
+++ b/pkgs/by-name/on/onedrivegui/package.nix
@@ -8,6 +8,8 @@
   makeDesktopItem,
   makeWrapper,
   onedrive,
+
+  nix-update-script,
 }:
 
 let
@@ -99,6 +101,8 @@ python3Packages.buildPythonApplication rec {
       } \
       --add-flags $out/${python3Packages.python.sitePackages}/OneDriveGUI.py
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/bpozdena/OneDriveGUI";

--- a/pkgs/by-name/on/onedrivegui/package.nix
+++ b/pkgs/by-name/on/onedrivegui/package.nix
@@ -109,7 +109,7 @@ python3Packages.buildPythonApplication rec {
     description = "Simple GUI for Linux OneDrive Client, with multi-account support";
     mainProgram = "onedrivegui";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ philipdb ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/on/onedrivegui/package.nix
+++ b/pkgs/by-name/on/onedrivegui/package.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "1.1.1a";
+  version = "1.2.1";
 
   setupPy = writeText "setup.py" ''
     from setuptools import setup
@@ -28,14 +28,18 @@ in
 python3Packages.buildPythonApplication rec {
   pname = "onedrivegui";
   inherit version;
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bpozdena";
     repo = "OneDriveGUI";
-    rev = "v${version}";
-    hash = "sha256-pcY1JOi74pePvkIMRuHv5mlE4F68NzuBLJTCtgjUFRw=";
+    tag = "v${version}";
+    hash = "sha256-QCSCJ1m/PKSpkfseq8fyDEHFyIt156Lp15JC04NY0ps=";
   };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
 
   nativeBuildInputs = [
     copyDesktopItems
@@ -48,7 +52,7 @@ python3Packages.buildPythonApplication rec {
     qt6.qtwayland
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     pyside6
     requests
   ];
@@ -58,7 +62,7 @@ python3Packages.buildPythonApplication rec {
   dontWrapQtApps = true;
 
   doCheck = false; # No tests defined
-  pythonImportsCheck = [ "OneDriveGUI" ];
+  # pythonImportsCheck = [ "OneDriveGUI" ]; # requires a display
 
   desktopItems = [
     (makeDesktopItem {
@@ -74,8 +78,8 @@ python3Packages.buildPythonApplication rec {
   ];
 
   postPatch = ''
-    # Patch OneDriveGUI.py so DIR_PATH points to shared files location
-    sed -i src/OneDriveGUI.py -e "s@^DIR_PATH =.*@DIR_PATH = '$out/share/OneDriveGUI'@"
+    # Patch global_config.py so DIR_PATH points to shared files location
+    sed -i src/global_config.py -e "s@^DIR_PATH =.*@DIR_PATH = '$out/share/OneDriveGUI'@"
     cp ${setupPy} ${setupPy.name}
   '';
 
@@ -91,17 +95,17 @@ python3Packages.buildPythonApplication rec {
       ''${qtWrapperArgs[@]} \
       --prefix PATH : ${lib.makeBinPath [ onedrive ]} \
       --prefix PYTHONPATH : ${
-        python3Packages.makePythonPath (propagatedBuildInputs ++ [ (placeholder "out") ])
+        python3Packages.makePythonPath (dependencies ++ [ (placeholder "out") ])
       } \
       --add-flags $out/${python3Packages.python.sitePackages}/OneDriveGUI.py
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/bpozdena/OneDriveGUI";
     description = "Simple GUI for Linux OneDrive Client, with multi-account support";
     mainProgram = "onedrivegui";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/bpozdena/OneDriveGUI/compare/v1.1.1a...v1.2.1
Also did some cleanup and modernizations and made myself maintainer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I did remove the Python imports check due to it resulting in the following error:
```
Check whether the following modules can be imported: OneDriveGUI
qt.qpa.xcb: could not connect to display 
qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: minimal, linuxfb, vkkhrdisplay, minimalegl, eglfs, offscreen, vnc, xcb.
```
This seemed like a bit of a strange error to have for me. The application itself seems to work fine as well. I don't know of a fix for this. The problem does not seem to be that the correct libs are unavailable, just that in this scenario the import goes wrong. Or that's how I understand it now.
But please let me know if this should be changed or what approaches can be tried.


Closes: #429947

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
