### PR TITLE
lib.modules: Add hint when using `config` in `imports`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -652,7 +652,13 @@ let
       # evaluation of the option.
       context = name: ''while evaluating the module argument `${name}' in "${key}":'';
       extraArgs = mapAttrs (
-        name: _: addErrorContext (context name) (args.${name} or config._module.args.${name})
+        name: _:
+        addErrorContext (context name) (
+          args.${name} or (addErrorContext
+            "noting that argument `${name}` is not externally provided, so querying `_module.args` instead, requiring `config`"
+            config._module.args.${name}
+          )
+        )
       ) (functionArgs f);
 
       # Note: we append in the opposite order such that we can add an error

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -258,7 +258,7 @@ let
                     ;
                   _class = class;
                   _prefix = prefix;
-                  config = addErrorContext "if you get an infinite recursion here, you probably reference `config` in `imports`. This is not possible. If you are trying to achieve a conditional behavior dependent on `config`, consider importing unconditionally, and using `mkEnableOption` and `mkIf` to control its effect." config;
+                  config = addErrorContext "if you get an infinite recursion here, you probably reference `config` in `imports`. If you are trying to achieve a conditional import behavior dependent on `config`, consider importing unconditionally, and using `mkEnableOption` and `mkIf` to control its effect." config;
                 }
                 // specialArgs
               );

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -254,11 +254,12 @@ let
                   inherit
                     lib
                     options
-                    config
                     specialArgs
                     ;
                   _class = class;
                   _prefix = prefix;
+                  config = builtins.addErrorContext "If you get an infinite recursion here, you probably reference `config`
+              in `imports`. This is not supported; consider using mkEnableOption." config;
                 }
                 // specialArgs
               );
@@ -637,15 +638,6 @@ let
     key: f:
     args@{ config, ... }:
     let
-      importHint =
-        name:
-        if name == "config" then
-          "\n\n"
-          + ''
-            … If you get an infinite recursion here, you probably reference `config`
-              in `imports`. This is not supported; consider using mkEnableOption.''
-        else
-          "";
       # Module arguments are resolved in a strict manner when attribute set
       # deconstruction is used.  As the arguments are now defined with the
       # config._module.args option, the strictness used on the attribute
@@ -658,7 +650,7 @@ let
       # a module will resolve strictly the attributes used as argument but
       # not their values.  The values are forwarding the result of the
       # evaluation of the option.
-      context = name: ''while evaluating the module argument `${name}' in "${key}":${importHint name}'';
+      context = name: ''while evaluating the module argument `${name}' in "${key}":'';
       extraArgs = mapAttrs (
         name: _: addErrorContext (context name) (args.${name} or config._module.args.${name})
       ) (functionArgs f);

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -258,8 +258,7 @@ let
                     ;
                   _class = class;
                   _prefix = prefix;
-                  config = builtins.addErrorContext "If you get an infinite recursion here, you probably reference `config`
-              in `imports`. This is not supported; consider using mkEnableOption." config;
+                  config = addErrorContext "if you get an infinite recursion here, you probably reference `config` in `imports`. This is not possible. If you are trying to achieve a conditional behavior dependent on `config`, consider importing unconditionally, and using `mkEnableOption` and `mkIf` to control its effect." config;
                 }
                 // specialArgs
               );

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -637,6 +637,15 @@ let
     key: f:
     args@{ config, ... }:
     let
+      importHint =
+        name:
+        if name == "config" then
+          "\n\n"
+          + ''
+            … If you get an infinite recursion here, you probably reference `config`
+              in `imports`. This is not supported; consider using mkEnableOption.''
+        else
+          "";
       # Module arguments are resolved in a strict manner when attribute set
       # deconstruction is used.  As the arguments are now defined with the
       # config._module.args option, the strictness used on the attribute
@@ -649,7 +658,7 @@ let
       # a module will resolve strictly the attributes used as argument but
       # not their values.  The values are forwarding the result of the
       # evaluation of the option.
-      context = name: ''while evaluating the module argument `${name}' in "${key}":'';
+      context = name: ''while evaluating the module argument `${name}' in "${key}":${importHint name}'';
       extraArgs = mapAttrs (
         name: _: addErrorContext (context name) (args.${name} or config._module.args.${name})
       ) (functionArgs f);

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -82,6 +82,30 @@ checkConfigOutput() {
     fi
 }
 
+invertIfUnset() {
+    gate="$1"
+    shift
+    if [[ -n "${!gate:-}" ]]; then
+        "$@"
+    else
+        ! "$@"
+    fi
+}
+
+globalErrorLogCheck() {
+    invertIfUnset "REQUIRE_INFINITE_RECURSION_HINT" \
+      grep -i 'if you get an infinite recursion here' \
+      <<<"$err" >/dev/null \
+      || {
+        if [[ -n "${REQUIRE_INFINITE_RECURSION_HINT:-}" ]]; then
+            echo "Unexpected infinite recursion hint"
+        else
+            echo "Expected infinite recursion hint, but none found"
+        fi
+        return 1
+      }
+}
+
 checkConfigError() {
     local errorContains=$1
     local err=""
@@ -94,6 +118,14 @@ checkConfigError() {
         logFailure
         logEndFailure
     else
+        if ! globalErrorLogCheck "$err"; then
+            logStartFailure
+            echo "LOG:"
+            reportFailure "$@"
+            echo "GLOBAL ERROR LOG CHECK FAILED"
+            logFailure
+            logEndFailure
+        fi
         if echo "$err" | grep -zP --silent "$errorContains" ; then
             ((++pass))
         else
@@ -488,7 +520,7 @@ checkConfigOutput '^"bar"$' config.nest.bar ./freeform-attrsOf.nix ./freeform-ne
 checkConfigOutput '^null$' config.foo ./freeform-attrsOf.nix ./freeform-str-dep-unstr.nix
 checkConfigOutput '^"24"$' config.foo ./freeform-attrsOf.nix ./freeform-str-dep-unstr.nix ./define-value-string.nix
 # Check whether an freeform-typed value can depend on a declared option, this can only work with lazyAttrsOf
-checkConfigError 'infinite recursion encountered' config.foo ./freeform-attrsOf.nix ./freeform-unstr-dep-str.nix
+REQUIRE_INFINITE_RECURSION_HINT=1 checkConfigError 'infinite recursion encountered' config.foo ./freeform-attrsOf.nix ./freeform-unstr-dep-str.nix
 checkConfigError 'The option .* was accessed but has no value defined. Try setting the option.' config.foo ./freeform-lazyAttrsOf.nix ./freeform-unstr-dep-str.nix
 checkConfigOutput '^"24"$' config.foo ./freeform-lazyAttrsOf.nix ./freeform-unstr-dep-str.nix ./define-value-string.nix
 # submodules in freeformTypes should have their locations annotated

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -315,8 +315,8 @@ checkConfigOutput '^true$' "$@" ./define-_module-args-custom.nix
 # Check that using _module.args on imports cause infinite recursions, with
 # the proper error context.
 set -- "$@" ./define-_module-args-custom.nix ./import-custom-arg.nix
-checkConfigError 'while evaluating the module argument .*custom.* in .*import-custom-arg.nix.*:' "$@"
-checkConfigError 'infinite recursion encountered' "$@"
+REQUIRE_INFINITE_RECURSION_HINT=1 checkConfigError 'while evaluating the module argument .*custom.* in .*import-custom-arg.nix.*:' "$@"
+REQUIRE_INFINITE_RECURSION_HINT=1 checkConfigError 'infinite recursion encountered' "$@"
 
 # Check _module.check.
 set -- config.enable ./declare-enable.nix ./define-enable.nix ./define-attrsOfSub-foo.nix


### PR DESCRIPTION
Minor change: Add a hint for when this happens. I've been asked a couple of times why this gets an infinite recursion; why not add a helpful error message to explain it automatically?

```
nix-repl> (lib.evalModules { modules = [ (
  {config, ...}: {
    imports = if config.x then ["a"] else ["b"];
  }
) ]; }).config

error:
       … while evaluating the attribute 'config'
         at /home/lexi/git/nixpkgs/lib/modules.nix:360:9:
          359|         options = checked options;
          360|         config = checked (removeAttrs config [ "_module" ]);
             |         ^
          361|         _module = checked (config._module);

       … while calling the 'seq' builtin
         at /home/lexi/git/nixpkgs/lib/modules.nix:360:18:
          359|         options = checked options;
          360|         config = checked (removeAttrs config [ "_module" ]);
             |                  ^
          361|         _module = checked (config._module);

       … while evaluating the module argument `config' in ":anon-1":

       … If you get an infinite recursion here, you probably reference `config`
         in `imports`. This is not supported; consider using mkEnableOption.

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: infinite recursion encountered
       at /home/lexi/git/nixpkgs/lib/modules.nix:257:21:
          256|                     options
          257|                     config
             |                     ^
          258|                     specialArgs

nix-repl> 
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
