### PR TITLE
langgraph-cli: 0.2.10 -> 0.3.6

### DIFF
--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -4,10 +4,11 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  hatchling,
 
   # dependencies
   click,
+  langgraph-sdk,
 
   # testing
   pytest-asyncio,
@@ -20,21 +21,34 @@
 
 buildPythonPackage rec {
   pname = "langgraph-cli";
-  version = "0.2.10";
+  version = "0.3.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "cli==${version}";
-    hash = "sha256-gSiyFjk1lXiCv7JpX4J00WAPoMv4VsXDuCswbFhP2kY=";
+    hash = "sha256-tBMdFOHSRjw0PtE19XytLU4MmjR3NBLJxUqWoG4L2F8=";
   };
 
   sourceRoot = "${src.name}/libs/cli";
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
-  dependencies = [ click ];
+  dependencies = [
+    click
+    langgraph-sdk
+  ];
+
+  # Not yet. Depemnds on `langgraph-runtime-inmem` which isn't in github yet
+  # https://github.com/langchain-ai/langgraph/issues/5802
+  # optional-dependencies = {
+  #   "inmem" = [
+  #     langgraph-api
+  #     langgraph-runtime-inmem
+  #     python-dotenv
+  #   ]
+  # }
 
   nativeCheckInputs = [
     pytest-asyncio
@@ -55,8 +69,13 @@ buildPythonPackage rec {
     "test_config_to_compose_end_to_end"
     "test_config_to_compose_simple_config"
     "test_config_to_compose_watch"
-    # Tests exit value, needs to happen in a passthru test
+
+    # Tests that require docker
     "test_dockerfile_command_with_docker_compose"
+    "test_build_command_with_api_version_and_base_image"
+    "test_build_command_with_api_version"
+    "test_build_generate_proper_build_context"
+    "test_build_command_shows_wolfi_warning"
   ];
 
   passthru.updateScript = gitUpdater {


### PR DESCRIPTION
Version bump. Note the optional `inmem` dependency isn't being built yet as we're waiting for the `langgraph-runtime-inmem` library to become a regular release on github. https://github.com/langchain-ai/langgraph/issues/5802

https://github.com/langchain-ai/langgraph/releases/tag/cli%3D%3D0.3.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
