### PR TITLE
pympress: unbreak

### DIFF
--- a/pkgs/by-name/py/pympress/issue-330-gprops-iter-actually-iterable.patch
+++ b/pkgs/by-name/py/pympress/issue-330-gprops-iter-actually-iterable.patch
@@ -1,0 +1,11 @@
+--- i/pympress/builder.py
++++ w/pympress/builder.py
+@@ -76,7 +76,7 @@ class Builder(Gtk.Builder):
+         Args:
+             a_widget (:class:`~GObject.Object`): an object built by the builder, usually a widget
+         """
+-        for str_prop in (prop.name for prop in a_widget.props if prop.value_type == GObject.TYPE_STRING):
++        for str_prop in (prop.name for prop in list(a_widget.props) if prop.value_type == GObject.TYPE_STRING):
+             try:
+                 str_val = getattr(a_widget.props, str_prop)
+                 if str_val:

--- a/pkgs/by-name/py/pympress/package.nix
+++ b/pkgs/by-name/py/pympress/package.nix
@@ -30,6 +30,13 @@ python3Packages.buildPythonApplication rec {
     babel
   ];
 
+  patches = [
+    # Workaround for a bug on Python >= 3.13+ and pygobject < 3.51.
+    # This can go away once nixpkgs is using pygobject >= 3.51.
+    # See <https://github.com/Cimbali/pympress/issues/330> for details.
+    ./issue-330-gprops-iter-actually-iterable.patch
+  ];
+
   dependencies =
     with python3Packages;
     [


### PR DESCRIPTION
`pympress` currently crashes:

```console
$ pympress
Traceback (most recent call last):
  ...
  File "/usr/lib/python3.13/site-packages/pympress/builder.py", line 79, in __translate_widget_strings
    for str_prop in (prop.name for prop in a_widget.props if prop.value_type == GObject.TYPE_STRING):
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/pympress/builder.py", line 79, in <genexpr>
    for str_prop in (prop.name for prop in a_widget.props if prop.value_type == GObject.TYPE_STRING):
                                           ^^^^^^^^^^^^^^
TypeError: 'gi._gi.GPropsIter' object is not iterable
```

This isn't really a pympress bug, it's an unfortunate interaction between Python 3 and pygobject. See
<https://github.com/Cimbali/pympress/issues/330> for details.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
