### PR TITLE
netpeek: init at 0.2.3.1

### DIFF
--- a/pkgs/by-name/ne/netpeek/package.nix
+++ b/pkgs/by-name/ne/netpeek/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  appstream,
+  desktop-file-utils,
+  gobject-introspection,
+  wrapGAppsHook4,
+  pkg-config,
+  libadwaita,
+  libportal-gtk4,
+  gnome,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "netpeek";
+  version = "0.2.3.1";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "ZingyTomato";
+    repo = "NetPeek";
+    tag = "v${version}";
+    hash = "sha256-3PbGK8e/W4pHlXwIvW6kmyeBMvzBIS2DrV0pxafgJOY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    appstream
+    desktop-file-utils
+    gobject-introspection
+    wrapGAppsHook4
+    pkg-config
+  ];
+
+  buildInputs = [
+    libadwaita
+    libportal-gtk4
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    ping3
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = {
+    description = "Modern network scanner for GNOME";
+    homepage = "https://github.com/ZingyTomato/NetPeek";
+    changelog = "https://github.com/ZingyTomato/NetPeek/releases/tag/${src.tag}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ Cameo007 ];
+    mainProgram = "netpeek";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
NetPeek is a libadwaita network scanner which scans for machines and their open ports.

[https://github.com/ZingyTomato/NetPeek](https://github.com/ZingyTomato/NetPeek)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
