### PR TITLE
[Backport release-25.05] changie: 1.21.1 -> 1.22.1

### DIFF
--- a/pkgs/by-name/ch/changie/package.nix
+++ b/pkgs/by-name/ch/changie/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "changie";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchFromGitHub {
     owner = "miniscruff";
     repo = "changie";
     rev = "v${version}";
-    hash = "sha256-tq29L9YlzhjbHkUfE0ZZhSrH+rcAwgYjcEAUjP/lHm8=";
+    hash = "sha256-JXVrOZKm8whmc3LkCDsbZkNcYMgiolp9dgnZFPYCtAs=";
   };
 
-  vendorHash = "sha256-nAwBVa+UssbfFbcOWFcsWUllBTeW89xPcgS+ofXDPf0=";
+  vendorHash = "sha256-bUopfHd6/0dd3OuxQMW9ZNsZtVqnRSDRqZLkfaQq12I=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/ch/changie/package.nix
+++ b/pkgs/by-name/ch/changie/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "changie";
-  version = "1.21.1";
+  version = "1.22.0";
 
   src = fetchFromGitHub {
     owner = "miniscruff";
     repo = "changie";
     rev = "v${version}";
-    hash = "sha256-zLRMH5TxEz/fspMOPAMTEqO19fj9PZsRh6zddbTqSXM=";
+    hash = "sha256-tq29L9YlzhjbHkUfE0ZZhSrH+rcAwgYjcEAUjP/lHm8=";
   };
 
-  vendorHash = "sha256-LWf10MM9SBU9sHb59c6ILlsHs8E8ETYAR34296aeHlI=";
+  vendorHash = "sha256-nAwBVa+UssbfFbcOWFcsWUllBTeW89xPcgS+ofXDPf0=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Manual backport of #413090 #428925 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
