### PR TITLE
[Backport release-25.05] caido: 0.48.0 -> 0.50.1

### DIFF
--- a/pkgs/by-name/ca/caido/package.nix
+++ b/pkgs/by-name/ca/caido/package.nix
@@ -15,14 +15,14 @@ let
     "cli"
     "desktop"
   ];
-  version = "0.48.1";
+  version = "0.49.0";
   cli = fetchurl {
     url = "https://caido.download/releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
-    hash = "sha256-UdeC3BZmQVUdWmwQTC27ptF0+lZgCXpF8yXaf8Bjpbo=";
+    hash = "sha256-pPFTN/KjwZZXJvFHttw3dQr7AQnIIEkyxlsWEx61Kbc=";
   };
   desktop = fetchurl {
     url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
-    hash = "sha256-4KQpgO8Cb+TkKuDOK+bAE0nOhlwjkSUVXLHJmHaj6NQ=";
+    hash = "sha256-bvK2SdFrIpX/cJghwW0QJ6wkTndRIZZ3qf7dHqeZTgY=";
   };
   appimageContents = appimageTools.extractType2 {
     inherit pname version;

--- a/pkgs/by-name/ca/caido/package.nix
+++ b/pkgs/by-name/ca/caido/package.nix
@@ -15,14 +15,14 @@ let
     "cli"
     "desktop"
   ];
-  version = "0.49.0";
+  version = "0.50.0";
   cli = fetchurl {
     url = "https://caido.download/releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
-    hash = "sha256-pPFTN/KjwZZXJvFHttw3dQr7AQnIIEkyxlsWEx61Kbc=";
+    hash = "sha256-Hb+Ul/DAK+ciay4N56r/lX4q43u0gWrJv5o03rmoqhk=";
   };
   desktop = fetchurl {
     url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
-    hash = "sha256-bvK2SdFrIpX/cJghwW0QJ6wkTndRIZZ3qf7dHqeZTgY=";
+    hash = "sha256-GLEtAm2XQCYjgYeZpQUTd46sPbsxdDoanLBYNpHT1Do=";
   };
   appimageContents = appimageTools.extractType2 {
     inherit pname version;

--- a/pkgs/by-name/ca/caido/package.nix
+++ b/pkgs/by-name/ca/caido/package.nix
@@ -15,14 +15,14 @@ let
     "cli"
     "desktop"
   ];
-  version = "0.48.0";
+  version = "0.48.1";
   cli = fetchurl {
     url = "https://caido.download/releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
-    hash = "sha256-9481W8AsgxCCvdTkCy2kXH6CG72xP5S3kejjxcXLVkg=";
+    hash = "sha256-UdeC3BZmQVUdWmwQTC27ptF0+lZgCXpF8yXaf8Bjpbo=";
   };
   desktop = fetchurl {
     url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
-    hash = "sha256-XIRjuvBxmfdHnizbVOh7kWKHm4OkUDwuSSNYzjJW/dA=";
+    hash = "sha256-4KQpgO8Cb+TkKuDOK+bAE0nOhlwjkSUVXLHJmHaj6NQ=";
   };
   appimageContents = appimageTools.extractType2 {
     inherit pname version;

--- a/pkgs/by-name/ca/caido/package.nix
+++ b/pkgs/by-name/ca/caido/package.nix
@@ -15,14 +15,14 @@ let
     "cli"
     "desktop"
   ];
-  version = "0.50.0";
+  version = "0.50.1";
   cli = fetchurl {
     url = "https://caido.download/releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
-    hash = "sha256-Hb+Ul/DAK+ciay4N56r/lX4q43u0gWrJv5o03rmoqhk=";
+    hash = "sha256-mHB0nyU0nQg7duPcQf3NNz5vcnIfZcPLkAc+LoWdH58=";
   };
   desktop = fetchurl {
     url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
-    hash = "sha256-GLEtAm2XQCYjgYeZpQUTd46sPbsxdDoanLBYNpHT1Do=";
+    hash = "sha256-mVK/valleYH3qZdxRBCbmC7MTEE/Cn6MJwZviMgHL08=";
   };
   appimageContents = appimageTools.extractType2 {
     inherit pname version;


### PR DESCRIPTION
Changelog (https://github.com/caido/caido/releases) doesn't seem to me to have breaking changes.

Manual backport of #408651 #421690 #428422 #429443 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.