### PR TITLE
vscode: add FHS dependencies for extensions with embedded headless browsers

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -96,6 +96,31 @@ stdenv.mkDerivation (
 
             # mono
             krb5
+
+            # Needed for headless browser-in-vscode based plugins such as
+            # anything based on Puppeteer https://pptr.dev .
+            # e.g. Roo Code
+            glib
+            nspr
+            nss
+            dbus
+            at-spi2-atk
+            cups
+            expat
+            libxkbcommon
+            xorg.libX11
+            xorg.libXcomposite
+            xorg.libXdamage
+            xorg.libxcb
+            xorg.libXext
+            xorg.libXfixes
+            xorg.libXrandr
+            cairo
+            pango
+            alsa-lib
+            libgbm
+            udev
+            libudev0-shim
           ])
           ++ additionalPkgs pkgs;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I imagine this could be quite contentious, but going to chuck this out here to see what people's opinions are.

Adds libraries needed for extensions that require running a standalone headless browser within vscode. For example, plugins that use the Puppeteer library for automation such as Roo Code.

Includes X11, graphics, and audio libraries required for headless browser functionality.

Minimal set of dependencies was determined via trial and error by finding packages containing the missing dependencies with `nix run github:nix-community/nix-index-database` until things worked.

<img width="420" alt="image" src="https://github.com/user-attachments/assets/f31aa237-07ac-49cc-90f3-22d7b831416f" />

(Example of Puppeteer in Roo Code in VSCode)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - N/A [NixOS tests] in [nixos/tests].
  - N/A [Package tests] at `passthru.tests`.
  - N/A Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
