### PR TITLE
uv: add manual entry

### DIFF
--- a/doc/packages/index.md
+++ b/doc/packages/index.md
@@ -32,5 +32,6 @@ urxvt.section.md
 vcpkg.section.md
 weechat.section.md
 xorg.section.md
+uv.section.md
 build-support.md
 ```

--- a/doc/packages/uv.section.md
+++ b/doc/packages/uv.section.md
@@ -1,0 +1,22 @@
+# uv {#sec-uv}
+
+`uv` is an extremely fast Python package installer and resolver, written in Rust.
+It manages project dependencies and environments, with support for lockfiles, workspaces, and more.
+
+Due to `uv` being unaware that it is running on a NixOS system, by default, it will fetch dynamically-linked Python executables that will fail to run, as NixOS cannot run executables intended for generic Linux environments out of the box.
+To learn more on this, please visit
+https://nix.dev/guides/faq.html#how-to-run-non-nix-executables
+
+There are two ways to mitigate this:
+
+1. Provide `uv` with a statically-linked Python executable (ideally from `nixpkgs`) via the [`UV_PYTHON` environment variable](https://docs.astral.sh/uv/reference/environment/#uv_python). Alternatively, the `--python` flag can also be used, but this is easy to forget. It is also helpful to forbid `uv` from downloading any Python binaries via the [`UV_PYTHON_DOWNLOADS` environment variable](https://docs.astral.sh/uv/reference/environment/#uv_python_downloads) by setting it to `never`.
+These variables can be set in `shell.nix` and `.env` files, which can be redistributed with the project to ensure other NixOS machines can execute the project.
+
+2. Add `programs.nix-ld.enable = true` to your NixOS config. While functional, the previous option is to be preferred, as this is the "works on my machine" option, because redistributing Python projects that use `uv` to another NixOS machine that does not have `nix-ld` enabled will cause the same errors to occur.
+
+Additionally, there is the issue of modules from PyPI vendoring dynamically-linked libraries, such as `numpy`, which will also fail to work.
+This topic is not local to `uv`, but is deserving of documentation nonetheless.
+Setting `LD_LIBRARY_PATH` should be the solution of choice here. Either:
+
+1. Use `lib.makeLibraryPath` to set `LD_LIBRARY_PATH` from a `shell.nix`, e.g. `LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.openssl pkgs.zlib pkgs.curl ]`
+2. (If you have already enabled `nix-ld`) set `LD_LIBRARY_PATH` to `NIX_LD_LIBRARY_PATH`. Be aware this is not a silver bullet solution, as this simply provides a list of commonly used libraries, as is shown in `nixos/modules/programs/nix-ld.nix`.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -4594,6 +4594,9 @@
   "sec-interop.cylonedx-fod": [
     "index.html#sec-interop.cylonedx-fod"
   ],
+  "sec-uv": [
+    "index.html#sec-uv"
+  ],
   "module-system-module-argument-_prefix": [
     "index.html#module-system-module-argument-_prefix"
   ],

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -69,6 +69,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Extremely fast Python package installer and resolver, written in Rust";
+    longDescription = ''
+      `uv` manages project dependencies and environments, with support for lockfiles, workspaces, and more.
+
+      Due to `uv`'s (over)eager fetching of dynamically-linked Python executables,
+      as well as vendoring of dynamically-linked libraries within Python modules distributed via PyPI,
+      NixOS users can run into issues when managing Python projects.
+      See the Nixpkgs Reference Manual entry for `uv` for information on how to mitigate these issues:
+      https://nixos.org/manual/nixpkgs/unstable/#sec-uv.
+
+      For building Python projects with `uv` and Nix outside of nixpkgs, check out `uv2nix` at https://github.com/pyproject-nix/uv2nix.
+    '';
     homepage = "https://github.com/astral-sh/uv";
     changelog = "https://github.com/astral-sh/uv/blob/${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [


### PR DESCRIPTION
Using `uv run` on NixOS systems can lead to unexpected results.
Use `meta.longDescription` to recommend specifying `UV_PYTHON` and `--python` where necessary.

Additionally recommend `uv2nix` for building Python projects outside of nixpkgs.

See https://github.com/NixOS/nixpkgs/pull/429813 for further context


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
