### PR TITLE
 marytts: use Gradle 8

### DIFF
--- a/pkgs/by-name/ma/marytts/gradle-8.patch
+++ b/pkgs/by-name/ma/marytts/gradle-8.patch
@@ -1,0 +1,28 @@
+From 5cda42b687a2271f5be52466c39d18e974beaa30 Mon Sep 17 00:00:00 2001
+From: Tomodachi94 <tomodachi94@protonmail.com>
+Date: Sun, 20 Apr 2025 02:22:16 +0000
+Subject: [PATCH] gradle(installDist): explicitly depend on
+ installerGuiStartScripts
+
+This allows us to use Gradle 8.
+
+Closes #1112
+---
+ applicationLogic.gradle | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/applicationLogic.gradle b/applicationLogic.gradle
+index 0d4a4c7dc..a4f6a571c 100644
+--- a/applicationLogic.gradle
++++ b/applicationLogic.gradle
+@@ -129,6 +129,10 @@ def testStartScriptsTask = tasks.register('testStartScripts') {
+     }
+ }
+ 
++tasks.named('installDist') {
++    dependsOn tasks.named('installerGuiStartScripts')
++}
++
+ tasks.named('check') {
+     dependsOn testStartScriptsTask
+ }

--- a/pkgs/by-name/ma/marytts/package.nix
+++ b/pkgs/by-name/ma/marytts/package.nix
@@ -2,9 +2,8 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  # Gradle 8 complains about implicit task dependencies when using `installDist`.
-  # See https://github.com/marytts/marytts/issues/1112
-  gradle_7,
+  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
+  gradle_8,
   makeWrapper,
   jdk,
   nixosTests,
@@ -20,12 +19,19 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-jGpsD6IwJ67nDLnulBn8DycXCyowssSnDCkQXBIfOH8=";
   };
 
+  patches = [
+    # Gradle 8 complains about implicit task dependencies when using `installDist`,
+    # so let's patch it.
+    # See https://github.com/marytts/marytts/issues/1112
+    ./gradle-8.patch
+  ];
+
   nativeBuildInputs = [
-    gradle_7
+    gradle_8
     makeWrapper
   ];
 
-  mitmCache = gradle_7.fetchDeps {
+  mitmCache = gradle_8.fetchDeps {
     inherit (finalAttrs) pname;
     data = ./deps.json;
   };


### PR DESCRIPTION
 Part of #358845.

 Inlined from https://github.com/marytts/marytts/pull/1120


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
