### PR TITLE
eon: init at 0.2.0

### DIFF
--- a/pkgs/by-name/eo/eon/package.nix
+++ b/pkgs/by-name/eo/eon/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "eon";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "emilk";
+    repo = "eon";
+    tag = finalAttrs.version;
+    hash = "sha256-dsm4r3Or1QDA32VqERnak01vHcf7E8d/+F/S+lmMedA=";
+  };
+
+  cargoHash = "sha256-oaYykh2NtGPlDq5JSuCMaKmD65b1xZbeuGUDZD/STD0=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple and friendly config format";
+    longDescription = ''
+      The simple and friendly config format aimed to be a replacement
+      for Toml and Yaml.
+    '';
+    homepage = "https://github.com/emilk/eon";
+    changelog = "https://github.com/emilk/eon/blob/${finalAttrs.src.tag}/RELEASES.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "eon";
+  };
+})


### PR DESCRIPTION
~~TODO: should the package name be `eonfmt` instead, since that's the only executable target (for right now)?~~

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
