### PR TITLE
python3Packages.docling-core: 2.38.1 -> 2.44.1

### DIFF
--- a/pkgs/development/python-modules/docling-core/default.nix
+++ b/pkgs/development/python-modules/docling-core/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "docling-core";
-  version = "2.38.1";
+  version = "2.44.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-core";
     tag = "v${version}";
-    hash = "sha256-zfpinXjZrGp5SF5IXLSP/A9Kb1WzqXXtIhhk/G3nY4k=";
+    hash = "sha256-vZTQE8UACMdMPPvNM2FVu+Sq9uJByt443N3ScNXsjGc=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/docling-ibm-models/default.nix
+++ b/pkgs/development/python-modules/docling-ibm-models/default.nix
@@ -7,6 +7,7 @@
   poetry-core,
 
   # dependencies
+  accelerate,
   docling-core,
   huggingface-hub,
   jsonlines,
@@ -29,14 +30,14 @@
 
 buildPythonPackage rec {
   pname = "docling-ibm-models";
-  version = "3.8.1";
+  version = "3.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-ibm-models";
     tag = "v${version}";
-    hash = "sha256-Yogg71CXQTdF5OUbdbma1rQxtLudTLjyOIFe2LS9CpI=";
+    hash = "sha256-UmgxEPEm6fNf4FbZ7CIcSEIaJg4sReI0pnkWwPdrJvQ=";
   };
 
   build-system = [
@@ -44,6 +45,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    accelerate
     docling-core
     huggingface-hub
     jsonlines

--- a/pkgs/development/python-modules/docling-parse/default.nix
+++ b/pkgs/development/python-modules/docling-parse/default.nix
@@ -33,6 +33,14 @@ buildPythonPackage rec {
     hash = "sha256-1vl5Ij25NXAwhoXLJ35lcr5r479jrdKd9DxWhYbCApw=";
   };
 
+  patches = [
+    # Fixes test_parse unit tests
+    # export_to_textlines in docling-core >= 2.38.2 includes text direction
+    # by default, which is not included in upstream's groundtruth data.
+    # TODO: remove when docling-core version gets bumped in upstream's uv.lock
+    ./test_parse.patch
+  ];
+
   dontUseCmakeConfigure = true;
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/docling-parse/test_parse.patch
+++ b/pkgs/development/python-modules/docling-parse/test_parse.patch
@@ -1,0 +1,20 @@
+diff --git a/tests/test_parse.py b/tests/test_parse.py
+index 84e17ae..e1eb6ae 100644
+--- a/tests/test_parse.py
++++ b/tests/test_parse.py
+@@ -242,6 +242,7 @@ def test_reference_documents_from_filenames():
+                         cell_unit=unit,
+                         add_fontkey=True,
+                         add_fontname=False,
++                        add_text_direction=False,
+                     )
+                     _fname = fname + f".{unit}.txt"
+                     with open(_fname, "w") as fw:
+@@ -254,6 +255,7 @@ def test_reference_documents_from_filenames():
+                         cell_unit=unit,
+                         add_fontkey=True,
+                         add_fontname=False,
++                        add_text_direction=False,
+                     )
+ 
+                     _fname = fname + f".{unit}.txt"

--- a/pkgs/development/python-modules/docling/default.nix
+++ b/pkgs/development/python-modules/docling/default.nix
@@ -52,14 +52,14 @@
 
 buildPythonPackage rec {
   pname = "docling";
-  version = "2.38.1";
+  version = "2.42.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling";
     tag = "v${version}";
-    hash = "sha256-ITRpWO7PEtfg5kM9LF3koZgzuPtLxoGFhorMlXlwSdI=";
+    hash = "sha256-9HUomW55Yg5N7u3Wb4imzRUYECeGkb3lkHPLEGzuAnA=";
   };
 
   build-system = [


### PR DESCRIPTION
This PR bumps docling-core to 2.44.1, and serve as the root cause fix for #426428. Close #427342.

Since docling-core 2.38.2 (commit https://github.com/docling-project/docling-core/commit/425b191a90ef48c186567ef4c3bfe605938273bb), `export_to_textlines` would include text direction by default. However, docking-parse's ground truth data is still generated by docling-core 2.38.0 as seen in uv.lock, causing failures in unit tests. This PR mitigates it by patching docling-parse's failing unit test to specify `add_text_direction=False` explicitly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
