### PR TITLE
crispy-doom: refactor, add missing dependencies, add optional truecolor support, add myself as maintainer

### DIFF
--- a/pkgs/by-name/cr/crispy-doom/package.nix
+++ b/pkgs/by-name/cr/crispy-doom/package.nix
@@ -11,6 +11,8 @@
   SDL2_mixer,
   SDL2_net,
   zlib,
+
+  enableTruecolor ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     for script in $(grep -lr '^#!/usr/bin/env python3$'); do patchShebangs $script; done
   '';
+
+  configureFlags = lib.optional enableTruecolor [ "--enable-truecolor" ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/cr/crispy-doom/package.nix
+++ b/pkgs/by-name/cr/crispy-doom/package.nix
@@ -3,11 +3,14 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  libpng,
+  libsamplerate,
   pkg-config,
   python3,
   SDL2,
   SDL2_mixer,
   SDL2_net,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,9 +35,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    libpng
+    libsamplerate
     SDL2
     SDL2_mixer
     SDL2_net
+    zlib
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/cr/crispy-doom/package.nix
+++ b/pkgs/by-name/cr/crispy-doom/package.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       Gliczy
+      keenanweaver
       neonfuz
     ];
   };

--- a/pkgs/by-name/cr/crispy-doom/package.nix
+++ b/pkgs/by-name/cr/crispy-doom/package.nix
@@ -62,6 +62,9 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "crispy-doom";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ neonfuz ];
+    maintainers = with lib.maintainers; [
+      Gliczy
+      neonfuz
+    ];
   };
 })

--- a/pkgs/by-name/cr/crispy-doom/package.nix
+++ b/pkgs/by-name/cr/crispy-doom/package.nix
@@ -1,28 +1,27 @@
 {
   lib,
   stdenv,
+  fetchFromGitHub,
   autoreconfHook,
   pkg-config,
+  python3,
   SDL2,
   SDL2_mixer,
   SDL2_net,
-  fetchFromGitHub,
-  python3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "crispy-doom";
   version = "7.0";
 
   src = fetchFromGitHub {
     owner = "fabiangreffrath";
     repo = "crispy-doom";
-    rev = "crispy-doom-${version}";
-    sha256 = "sha256-+rNZsb4GAjzNcIU5xZGBpmP+nXNOP16oVg68nfecMrw=";
+    tag = "crispy-doom-${finalAttrs.version}";
+    hash = "sha256-+rNZsb4GAjzNcIU5xZGBpmP+nXNOP16oVg68nfecMrw=";
   };
 
   postPatch = ''
-    sed -e 's#/games#/bin#g' -i src{,/setup}/Makefile.am
     for script in $(grep -lr '^#!/usr/bin/env python3$'); do patchShebangs $script; done
   '';
 
@@ -31,24 +30,28 @@ stdenv.mkDerivation rec {
     pkg-config
     python3
   ];
+
   buildInputs = [
     SDL2
     SDL2_mixer
     SDL2_net
   ];
+
   enableParallelBuilding = true;
 
   strictDeps = true;
 
   meta = {
-    homepage = "http://fabiangreffrath.github.io/crispy-doom";
+    homepage = "https://fabiangreffrath.github.io/crispy-homepage";
+    changelog = "https://github.com/fabiangreffrath/crispy-doom/releases/tag/crispy-doom-${finalAttrs.version}";
     description = "Limit-removing enhanced-resolution Doom source port based on Chocolate Doom";
     longDescription = ''
       Crispy Doom is a limit-removing enhanced-resolution Doom source port based on Chocolate Doom.
       Its name means that 640x400 looks \"crisp\" and is also a slight reference to its origin.
     '';
+    mainProgram = "crispy-doom";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ neonfuz ];
   };
-}
+})


### PR DESCRIPTION
Resolves https://github.com/NixOS/nixpkgs/issues/430207.

- Added missing runtime dependencies `libpng`, `libsamplerate` and `zlid`
- Added optional and overridable truecolor support
- Updated the `meta.homepage` url, since the previous url redirects to the new url
- Removed the `sed` command in `postPatch`, it was a noop
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
