### PR TITLE
flex-ncat: 0.5-2025031901 → 0.6-20250801.0

### DIFF
--- a/pkgs/by-name/fl/flex-ncat/package.nix
+++ b/pkgs/by-name/fl/flex-ncat/package.nix
@@ -23,6 +23,7 @@ buildGoModule rec {
   meta = {
     homepage = "https://github.com/kc2g-flex-tools/nCAT";
     description = "FlexRadio remote control (CAT) via hamlib/rigctl protocol";
+    changelog = "https://github.com/kc2g-flex-tools/nCAT/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mvs ];
     mainProgram = "nCAT";

--- a/pkgs/by-name/fl/flex-ncat/package.nix
+++ b/pkgs/by-name/fl/flex-ncat/package.nix
@@ -5,14 +5,14 @@
   nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "flex-ncat";
   version = "0.6-20250801.0";
 
   src = fetchFromGitHub {
     owner = "kc2g-flex-tools";
     repo = "nCAT";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-l+A7PlckZFGwibMU5QelMzANP1WS5WPApOnQV0P+SGw=";
   };
 
@@ -23,9 +23,9 @@ buildGoModule rec {
   meta = {
     homepage = "https://github.com/kc2g-flex-tools/nCAT";
     description = "FlexRadio remote control (CAT) via hamlib/rigctl protocol";
-    changelog = "https://github.com/kc2g-flex-tools/nCAT/releases/tag/v${version}";
+    changelog = "https://github.com/kc2g-flex-tools/nCAT/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mvs ];
     mainProgram = "nCAT";
   };
-}
+})

--- a/pkgs/by-name/fl/flex-ncat/package.nix
+++ b/pkgs/by-name/fl/flex-ncat/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "flex-ncat";
-  version = "0.5-2025031901";
+  version = "0.6-20250801.0";
 
   src = fetchFromGitHub {
     owner = "kc2g-flex-tools";
     repo = "nCAT";
-    rev = "v${version}";
-    hash = "sha256-hbsrs9lgpxNqG8mmXsft01LmpX4dBpl1ncpdTWBgrUQ=";
+    tag = "v${version}";
+    hash = "sha256-l+A7PlckZFGwibMU5QelMzANP1WS5WPApOnQV0P+SGw=";
   };
 
-  vendorHash = "sha256-RqQMCP9rmdTG5AXLXkIQz0vE7qF+3RZ1BDdVRYoHHQs=";
+  vendorHash = "sha256-daMeYk64xzDPIyZl7SdXaQbu2Dvdw/yVV87/8Agvxk0=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
- Update to [latest upstream release](https://github.com/kc2g-flex-tools/nDAX/releases/tag/v0.5-20250801.0),
- provide changelog, and
- use `finalAttrs` pattern instead of `rec`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
