### PR TITLE
casilda: 0.9.1 -> 0.9.2; cambalache: 0.94.1 -> 0.97.6-unstable-2025-07-29

### DIFF
--- a/pkgs/by-name/ca/cambalache/package.nix
+++ b/pkgs/by-name/ca/cambalache/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitLab,
+  fetchurl,
   python3,
   meson,
   ninja,
@@ -19,11 +20,13 @@
   webkitgtk_6_0,
   nix-update-script,
   casilda,
+  libxml2,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication {
   pname = "cambalache";
-  version = "0.94.1";
+  # need https://gitlab.gnome.org/jpu/cambalache/-/commit/cbe5a6ab11b621f428a09954b3e0bc8c24b8a922
+  version = "0.97.6-unstable-2025-07-29";
   pyproject = false;
 
   # Did not fetch submodule since it is only for tests we don't run.
@@ -31,8 +34,8 @@ python3.pkgs.buildPythonApplication rec {
     domain = "gitlab.gnome.org";
     owner = "jpu";
     repo = "cambalache";
-    tag = version;
-    hash = "sha256-dX9YiBCBG/ALWX0W1CjvdUlOCQ6UulnQCiYUscRMKWk=";
+    rev = "4375049d89cc719976ea9a578846ac554e9b7ea9";
+    hash = "sha256-JZRN8/qzxUKM85msHRMXd2T6FJnZBcCwRr3P9GbMqK0=";
   };
 
   nativeBuildInputs = [
@@ -46,7 +49,20 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   pythonPath = with python3.pkgs; [
-    pygobject3
+    (pygobject3.overrideAttrs (
+      oldAttrs:
+      let
+        version = "3.52.3";
+      in
+      {
+        inherit version;
+
+        src = fetchurl {
+          url = "mirror://gnome/sources/pygobject/${lib.versions.majorMinor version}/pygobject-${version}.tar.gz";
+          hash = "sha256-AOQn0pHpV0Yqj61lmp+ci+d2/4Kot2vfQC8eruwIbYI=";
+        };
+      }
+    ))
     lxml
   ];
 
@@ -57,6 +73,7 @@ python3.pkgs.buildPythonApplication rec {
     gtksourceview5
     webkitgtk_4_1
     webkitgtk_6_0
+    libxml2
     # For extra widgets support.
     libadwaita
     libhandy

--- a/pkgs/by-name/ca/casilda/package.nix
+++ b/pkgs/by-name/ca/casilda/package.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "casilda";
-  version = "0.9.1";
+  version = "0.9.2";
 
   outputs = [
     "out"
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "jpu";
     repo = "casilda";
     tag = finalAttrs.version;
-    hash = "sha256-7A3XzfUALsmkykwOqF/8fg7T7LoVzwk1+7TmRkh1Wys=";
+    hash = "sha256-AvbgFUahZUdcV5MTEthcrXNt3HmEfd7tyi0YeeBFr14=";
   };
 
   depsBuildBuild = [ pkg-config ];

--- a/pkgs/by-name/ca/casilda/package.nix
+++ b/pkgs/by-name/ca/casilda/package.nix
@@ -14,6 +14,7 @@
   wayland-scanner,
   wlroots_0_18,
   libxkbcommon,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -55,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = [ gtk4 ];
 
   strictDeps = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://gitlab.gnome.org/jpu/casilda";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://gitlab.gnome.org/jpu/casilda/-/compare/0.9.1...0.9.2
https://gitlab.gnome.org/jpu/cambalache/-/compare/0.94.1...4375049d89cc719976ea9a578846ac554e9b7ea9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
