### PR TITLE
nixos/eval-config: move pkgsModule into baseModules

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -19,7 +19,28 @@ evalConfigArgs@{
   # !!! what do we gain by making this configurable?
   #     we can add modules that are included in specialisations, regardless
   #     of inheritParentConfig.
-  baseModules ? import ../modules/module-list.nix,
+  baseModules ? (
+    let
+      pkgsModule = rec {
+        _file = ./eval-config.nix;
+        key = _file;
+        config = lib.mkMerge (
+          (lib.optional (system != null) {
+            # Explicit `nixpkgs.system` or `nixpkgs.localSystem` should override
+            # this.  Since the latter defaults to the former, the former should
+            # default to the argument. That way this new default could propagate all
+            # they way through, but has the last priority behind everything else.
+            nixpkgs.system = lib.mkDefault system;
+          })
+          ++ (lib.optional (pkgs != null) {
+            # This should be default priority, so it conflicts with any user-defined pkgs.
+            nixpkgs.pkgs = pkgs;
+          })
+        );
+      };
+    in
+    import ../modules/module-list.nix ++ [ pkgsModule ]
+  ),
   # !!! See comment about args in lib/modules.nix
   extraArgs ? { },
   # !!! See comment about args in lib/modules.nix
@@ -57,9 +78,7 @@ evalConfigArgs@{
         e
     ),
 }:
-
 let
-  inherit (lib) optional;
 
   evalModulesMinimal =
     (import ./default.nix {
@@ -67,24 +86,6 @@ let
       # Implicit use of feature is noted in implementation.
       featureFlags.minimalModules = { };
     }).evalModules;
-
-  pkgsModule = rec {
-    _file = ./eval-config.nix;
-    key = _file;
-    config = lib.mkMerge (
-      (optional (system != null) {
-        # Explicit `nixpkgs.system` or `nixpkgs.localSystem` should override
-        # this.  Since the latter defaults to the former, the former should
-        # default to the argument. That way this new default could propagate all
-        # they way through, but has the last priority behind everything else.
-        nixpkgs.system = lib.mkDefault system;
-      })
-      ++ (optional (pkgs != null) {
-        # This should be default priority, so it conflicts with any user-defined pkgs.
-        nixpkgs.pkgs = pkgs;
-      })
-    );
-  };
 
   withWarnings =
     x:
@@ -135,7 +136,6 @@ let
       baseModules
       ++ extraModules
       ++ [
-        pkgsModule
         modulesModule
       ];
   });


### PR DESCRIPTION
#430335 calling eval-config with empty baseModules should be possible Currently the 'pkgsModule' defines 'config.nixpkgs' with no matching declaration when the module list is empty. Leading to a failing evaluation

This should fix the following:

```nix
  import (pkgs.path + "/nixos/lib/eval-config.nix") {
    baseModules = [];
    modules = [
      {  }
    ];
  };
```
=> 
```
       error: The option `nixpkgs' does not exist. Definition values:
       - In `nixpkgs/nixos/lib/eval-config.nix':
           {
             system = {
               _type = "override";
               content = "x86_64-linux";
               priority = 1000;
 ```
 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
