### PR TITLE
timeshift: 24.06.6 -> 25.07.4

### DIFF
--- a/pkgs/applications/backup/timeshift/default.nix
+++ b/pkgs/applications/backup/timeshift/default.nix
@@ -3,6 +3,7 @@
   btrfs-progs,
   coreutils,
   cron,
+  debianutils,
   grubPackage,
   mount,
   psmisc,
@@ -17,6 +18,7 @@ in
   btrfs-progs
   coreutils
   cron
+  debianutils
   grubPackage
   mount
   psmisc

--- a/pkgs/applications/backup/timeshift/unwrapped.nix
+++ b/pkgs/applications/backup/timeshift/unwrapped.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "timeshift";
-  version = "24.06.6";
+  version = "25.07.4";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "timeshift";
     rev = version;
-    hash = "sha256-umMekxP9bvV01KzfIh2Zxa9Xb+tR5x+tG9dOnBIOkjY=";
+    hash = "sha256-yrLpEhSt7QB0qWCXjIjTVeXKRpgue2pVdV+6hSixeuA=";
   };
 
   postPatch = ''
@@ -37,10 +37,8 @@ stdenv.mkDerivation rec {
       --replace-fail "/usr/share" "$out/share"
 
     # Substitute app_command to look for the `timeshift-gtk` in $out.
-    # Substitute the `pkexec ...` as a hack to run a GUI application like Timeshift as root without setting up the corresponding pkexec policy.
     substituteInPlace ./src/timeshift-launcher \
-      --replace-fail "app_command='timeshift-gtk'" "app_command=$out/bin/timeshift-gtk" \
-      --replace-fail ${lib.escapeShellArg ''pkexec ''${app_command}''} ${lib.escapeShellArg ''pkexec env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" "''${app_command}"''}
+      --replace-fail "app_command='timeshift-gtk'" "app_command=$out/bin/timeshift-gtk"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/linuxmint/timeshift/compare/24.06.6...25.07.4

The timeshift-launcher substitution upstreamed:
https://github.com/linuxmint/timeshift/commit/98af1049992693599be78528029abba5421c4f19

run-parts introduced in:
https://github.com/linuxmint/timeshift/commit/b20c307d455a04df3d8bcd2cf9eee01c26b5b999




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

