### PR TITLE
rendercv: init at 2.2

### DIFF
--- a/pkgs/by-name/re/rendercv/package.nix
+++ b/pkgs/by-name/re/rendercv/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "rendercv";
+  version = "2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rendercv";
+    repo = "rendercv";
+    tag = "v${version}";
+    hash = "sha256-bIEuzMGV/l8Cunc4W04ESFYTKhNH+ffkA6eXGbyu3A0=";
+  };
+
+  build-system = with python3Packages; [ hatchling ];
+
+  dependencies = with python3Packages; [
+    jinja2
+    phonenumbers
+    email-validator
+    pydantic
+    pycountry
+    pydantic-extra-types
+    ruamel-yaml
+    # full
+    typer
+    markdown
+    watchdog
+    typst
+    rendercv-fonts
+    packaging
+  ];
+
+  pythonRelaxDeps = [
+    "phonenumbers"
+    "pydantic-extra-types"
+    "pydantic"
+    "ruamel-yaml"
+  ];
+
+  pythonImportsCheck = [ "rendercv" ];
+
+  nativeCheckInputs = with python3Packages; [
+    pypdf
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    "test_are_all_the_theme_files_the_same"
+    # It needs internet to download resources
+    "test_render_a_pdf_from_typst"
+    "test_render_pngs_from_typst"
+    "test_render_command_overriding_input_file_settings"
+  ];
+
+  disabledTestPaths = [
+    # It fails due to missing internet resources
+    "tests/test_cli.py"
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Typst-based CV/resume generator";
+    homepage = "https://rendercv.com";
+    changelog = "https://docs.rendercv.com/changelog/#22-january-25-2025";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ theobori ];
+    mainProgram = "rendercv";
+  };
+}

--- a/pkgs/development/python-modules/rendercv-fonts/default.nix
+++ b/pkgs/development/python-modules/rendercv-fonts/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+  hatchling,
+}:
+
+buildPythonPackage rec {
+  pname = "rendercv-fonts";
+  version = "0.4.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "rendercv";
+    repo = "rendercv-fonts";
+    tag = "v${version}";
+    hash = "sha256-fQ9iNN3hRCrhut+1F6q3dJEWoKUQyPol0/SyTPUPK1c=";
+  };
+
+  build-system = [ hatchling ];
+
+  # pythonRelaxDeps seems not taking effect for the build-system dependencies
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'hatchling==1.26.3' 'hatchling' \
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "rendercv_fonts" ];
+
+  meta = {
+    description = "Python package with some fonts for the rendercv package";
+    homepage = "https://github.com/rendercv/rendercv-fonts";
+    changelog = "https://github.com/rendercv/rendercv-fonts/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ theobori ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15509,6 +15509,8 @@ self: super: with self; {
 
   rencode = callPackage ../development/python-modules/rencode { };
 
+  rendercv-fonts = callPackage ../development/python-modules/rendercv-fonts { };
+
   reno = callPackage ../development/python-modules/reno { };
 
   renson-endura-delta = callPackage ../development/python-modules/renson-endura-delta { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix #344244

This PR contains two nix packages:
- [x]  `rendercv` acc7ac7b71ed7e3390233b35bd771d5dec7373f0
	- [x] `rendercv-fonts` (its required Python dependency) b47ee350af73c7a1c6148eca78973446bdc3f9ec

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
