### PR TITLE
platformio: Add new dependencies

### DIFF
--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -71,8 +71,10 @@ buildPythonApplication rec {
     click-completion
     colorama
     git
+    intelhex
     lockfile
     marshmallow
+    pip
     pyelftools
     pyserial
     requests
@@ -82,6 +84,7 @@ buildPythonApplication rec {
     starlette
     tabulate
     uvicorn
+    wheel
     wsproto
     zeroconf
   ]


### PR DESCRIPTION
esphome is currently broken as it looks for `pip` which is not installed:

```
/nix/store/8fmw29099ppmcxc2zbjff4xlghgsm97h-python3-3.13.5-env/bin/python3.13: No module named pip
CalledProcessError: Command '['/nix/store/8fmw29099ppmcxc2zbjff4xlghgsm97h-python3-3.13.5-env/bin/python3.13', '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check']' returned non-zero exit status 1.:
  File "/nix/store/f5sb0xk20vvm2dp9yxsxr6i3ihl2ckff-platformio-6.1.18/lib/python3.13/site-packages/platformio/builder/main.py", line 173:
    env.SConscript("$BUILD_SCRIPT")
  File "/home/polyfloyd/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 620:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/home/polyfloyd/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 280:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/home/polyfloyd/.platformio/platforms/espressif32/builder/main.py", line 366:
    target_elf = env.BuildProgram()
  File "/home/polyfloyd/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Util/envs.py", line 252:
    return self.method(*nargs, **kwargs)
  File "/nix/store/f5sb0xk20vvm2dp9yxsxr6i3ihl2ckff-platformio-6.1.18/lib/python3.13/site-packages/platformio/builder/tools/piobuild.py", line 62:
    env.ProcessProgramDeps()
  File "/home/polyfloyd/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Util/envs.py", line 252:
    return self.method(*nargs, **kwargs)
  File "/nix/store/f5sb0xk20vvm2dp9yxsxr6i3ihl2ckff-platformio-6.1.18/lib/python3.13/site-packages/platformio/builder/tools/piobuild.py", line 142:
    env.BuildFrameworks(env.get("PIOFRAMEWORK"))
  File "/home/polyfloyd/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Util/envs.py", line 252:
    return self.method(*nargs, **kwargs)
  File "/nix/store/f5sb0xk20vvm2dp9yxsxr6i3ihl2ckff-platformio-6.1.18/lib/python3.13/site-packages/platformio/builder/tools/piobuild.py", line 352:
    SConscript(env.GetFrameworkScript(name), exports="env")
  File "/home/polyfloyd/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 684:
    return method(*args, **kw)
  File "/home/polyfloyd/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 620:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/home/polyfloyd/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 280:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/home/polyfloyd/.platformio/platforms/espressif32/builder/frameworks/arduino.py", line 135:
    install_python_deps()
  File "/home/polyfloyd/.platformio/platforms/espressif32/builder/frameworks/arduino.py", line 108:
    installed_packages = _get_installed_pip_packages()
  File "/home/polyfloyd/.platformio/platforms/espressif32/builder/frameworks/arduino.py", line 82:
    pip_output = subprocess.check_output(
  File "/nix/store/9yh9ak97gn659bk4d3n411fx6c0ng7s2-python3-3.13.5/lib/python3.13/subprocess.py", line 472:
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/nix/store/9yh9ak97gn659bk4d3n411fx6c0ng7s2-python3-3.13.5/lib/python3.13/subprocess.py", line 577:
    raise CalledProcessError(retcode, process.args,
```

Afterwards, it does seem to work but spits out an error complaining about a RO filesystem as it uses pip to install intelhex and wheel:
```
Installing collected packages: intelhex, wheel
ERROR: Could not install packages due to an OSError: [Errno 30] Read-only file system: '/nix/store/8fmw29099ppmcxc2zbjff4xlghgsm97h-python3-3.13.5-env/lib/python3.13/site-packages/intelhex'
```
Adding these packages to the environment resolves the error.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
