### PR TITLE
discord: add equicord support; equicord: 2025-07-25 -> 2025-08-24

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -17,6 +17,8 @@
   openasar,
   withVencord ? false,
   vencord,
+  withEquicord ? false,
+  equicord,
   withMoonlight ? false,
   moonlight,
   commandLineArgs ? "",
@@ -81,7 +83,12 @@ stdenv.mkDerivation {
       echo '{"name":"discord","main":"index.js"}' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json
       echo 'require("${vencord}/patcher.js")' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/index.js
     ''
-
+    + lib.strings.optionalString withEquicord ''
+      mv $out/Applications/${desktopName}.app/Contents/Resources/app.asar $out/Applications/${desktopName}.app/Contents/Resources/_app.asar
+      mkdir $out/Applications/${desktopName}.app/Contents/Resources/app.asar
+      echo '{"name":"discord","main":"index.js"}' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json
+      echo 'require("${equicord}/patcher.js")' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/index.js
+    ''
     + lib.strings.optionalString withMoonlight ''
       mv $out/Applications/${desktopName}.app/Contents/Resources/app.asar $out/Applications/${desktopName}.app/Contents/Resources/_app.asar
       mkdir $out/Applications/${desktopName}.app/Contents/Resources/app.asar

--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -24,11 +24,14 @@
   commandLineArgs ? "",
 }:
 
-assert lib.assertMsg (
-  !(withMoonlight && withVencord)
-) "discord: Moonlight and Vencord can not be enabled at the same time";
-
 let
+  discordMods = [
+    withVencord
+    withEquicord
+    withMoonlight
+  ];
+  enabledDiscordModsCount = builtins.length (lib.filter (x: x) discordMods);
+
   disableBreakingUpdates =
     runCommand "disable-breaking-updates.py"
       {
@@ -43,6 +46,9 @@ let
         chmod +x $out/bin/disable-breaking-updates.py
       '';
 in
+assert lib.assertMsg (
+  enabledDiscordModsCount <= 1
+) "discord: Only one of Vencord, Equicord or Moonlight can be enabled at the same time";
 stdenv.mkDerivation {
   inherit
     pname

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -73,10 +73,15 @@
   disableUpdates ? true,
   commandLineArgs ? "",
 }:
-assert lib.assertMsg (
-  !(withMoonlight && withVencord)
-) "discord: Moonlight and Vencord can not be enabled at the same time";
+
 let
+  discordMods = [
+    withVencord
+    withEquicord
+    withMoonlight
+  ];
+  enabledDiscordModsCount = builtins.length (lib.filter (x: x) discordMods);
+
   disableBreakingUpdates =
     runCommand "disable-breaking-updates.py"
       {
@@ -91,6 +96,9 @@ let
         chmod +x $out/bin/disable-breaking-updates.py
       '';
 in
+assert lib.assertMsg (
+  enabledDiscordModsCount <= 1
+) "discord: Only one of Vencord, Equicord or Moonlight can be enabled at the same time";
 stdenv.mkDerivation rec {
   inherit
     pname

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -61,6 +61,8 @@
   openasar,
   withVencord ? false,
   vencord,
+  withEquicord ? false,
+  equicord,
   withMoonlight ? false,
   moonlight,
   withTTS ? true,
@@ -207,6 +209,12 @@ stdenv.mkDerivation rec {
       mkdir $out/opt/${binaryName}/resources/app.asar
       echo '{"name":"discord","main":"index.js"}' > $out/opt/${binaryName}/resources/app.asar/package.json
       echo 'require("${vencord}/patcher.js")' > $out/opt/${binaryName}/resources/app.asar/index.js
+    ''
+    + lib.strings.optionalString withEquicord ''
+      mv $out/opt/${binaryName}/resources/app.asar $out/opt/${binaryName}/resources/_app.asar
+      mkdir $out/opt/${binaryName}/resources/app.asar
+      echo '{"name":"discord","main":"index.js"}' > $out/opt/${binaryName}/resources/app.asar/package.json
+      echo 'require("${equicord}/desktop/patcher.js")' > $out/opt/${binaryName}/resources/app.asar/index.js
     ''
     + lib.strings.optionalString withMoonlight ''
       mv $out/opt/${binaryName}/resources/app.asar $out/opt/${binaryName}/resources/_app.asar

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -3,7 +3,7 @@
   git,
   lib,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   stdenv,
   nix-update-script,
   buildWebExtension ? false,
@@ -14,25 +14,25 @@ stdenv.mkDerivation (finalAttrs: {
   # the Equicord repository. Dates as tags (and automatic releases) were the compromise
   # we came to with upstream. Please do not change the version schema (e.g., to semver)
   # unless upstream changes the tag schema from dates.
-  version = "2025-07-25";
+  version = "2025-08-24";
 
   src = fetchFromGitHub {
     owner = "Equicord";
     repo = "Equicord";
     tag = "${finalAttrs.version}";
-    hash = "sha256-6p7lfdRaxQusqZf86a1qclal2E0LusYYT1y3BPkOSKY=";
+    hash = "sha256-BK0Mvy0Bp0Q6wj4aECEtyGsW56hqbLkkELZ9yN+QRw8=";
   };
 
-  pnpmDeps = pnpm_9.fetchDeps {
+  pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-LXbr/qh1QZXQ/Na5180Im2WW8KbWU78Oo0O12SiNMWg=";
+    hash = "sha256-xVnryPA7+gnRvpMzuFJl4YeEPOky2+iOu76V3Rf6bow=";
   };
 
   nativeBuildInputs = [
     git
     nodejs
-    pnpm_9.configHook
+    pnpm_10.configHook
   ];
 
   env = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- [x] Depends on https://github.com/NixOS/nixpkgs/pull/428217

Fixes https://github.com/NixOS/nixpkgs/issues/384446

For people coming from the issue, this is how to use Equicord with Discord with this PR:

```nix
{
  environment.systemPackages = with pkgs; [
    (discord.override {
      withEquicord = true;
    })
  ];
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
