### PR TITLE
[Backport release-25.05] ansible-lint: 25.4.0 -> 25.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21235,6 +21235,13 @@
     githubId = 1069318;
     name = "Robin Lambertz";
   };
+  robsliwi = {
+    email = "r@sliwi.org";
+    github = "robsliwi";
+    githubId = 14806293;
+    keys = [ { fingerprint = "37F4 9AB8 340B AAE2 4DB8  4322 08BD 6076 8CCE 08F1"; } ];
+    name = "Robert Sliwinski";
+  };
   robwalt = {
     email = "robwalter96@gmail.com";
     github = "robwalt";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9630,6 +9630,13 @@
     name = "Martin Hardselius";
     keys = [ { fingerprint = "3F35 E4CA CBF4 2DE1 2E90  53E5 03A6 E6F7 8693 6619"; } ];
   };
+  HarisDotParis = {
+    name = "Haris";
+    email = "nix.dev@haris.paris";
+    matrix = "@haris:haris.paris";
+    github = "HarisDotParis";
+    githubId = 67912527;
+  };
   harryposner = {
     email = "nixpkgs@harryposner.com";
     github = "harryposner";

--- a/pkgs/by-name/an/ansible-lint/package.nix
+++ b/pkgs/by-name/an/ansible-lint/package.nix
@@ -95,6 +95,9 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/ansible/ansible-lint";
     changelog = "https://github.com/ansible/ansible-lint/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ sengaya ];
+    maintainers = with lib.maintainers; [
+      sengaya
+      HarisDotParis
+    ];
   };
 }

--- a/pkgs/by-name/an/ansible-lint/package.nix
+++ b/pkgs/by-name/an/ansible-lint/package.nix
@@ -8,13 +8,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ansible-lint";
-  version = "25.5.0";
+  version = "25.6.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "ansible_lint";
-    hash = "sha256-QYJSDyM+70JIvEz0tgdOJc2vW+Ic+b6USqvIXfVAfpw=";
+    hash = "sha256-ah3St6nz8gLJ6SpsgClv8zyoYzSMOs+Xj4D7DUU23OQ=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/an/ansible-lint/package.nix
+++ b/pkgs/by-name/an/ansible-lint/package.nix
@@ -8,13 +8,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ansible-lint";
-  version = "25.4.0";
+  version = "25.5.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "ansible_lint";
-    hash = "sha256-8vKzGtGZklsjQ/ZgVS+5Rolw8WwsXVfan+rnDsTuyn0=";
+    hash = "sha256-QYJSDyM+70JIvEz0tgdOJc2vW+Ic+b6USqvIXfVAfpw=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/an/ansible-lint/package.nix
+++ b/pkgs/by-name/an/ansible-lint/package.nix
@@ -98,6 +98,7 @@ python3Packages.buildPythonApplication rec {
     maintainers = with lib.maintainers; [
       sengaya
       HarisDotParis
+      robsliwi
     ];
   };
 }

--- a/pkgs/by-name/an/ansible-lint/package.nix
+++ b/pkgs/by-name/an/ansible-lint/package.nix
@@ -8,13 +8,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ansible-lint";
-  version = "25.6.1";
+  version = "25.7.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "ansible_lint";
-    hash = "sha256-ah3St6nz8gLJ6SpsgClv8zyoYzSMOs+Xj4D7DUU23OQ=";
+    hash = "sha256-mvz0GZl84f/FesqjpW83e86M7rnbEOarhP1WXQm+QIs=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Manual backport of #413135 #419706 #422235 #423853 #429747 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.