### PR TITLE
mprime: fix fatal error with -march=znver1

### DIFF
--- a/pkgs/by-name/mp/mprime/package.nix
+++ b/pkgs/by-name/mp/mprime/package.nix
@@ -81,14 +81,18 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   buildPhase = ''
+    runHook preBuild
     make -C gwnum -f ${gwnum} ''${enableParallelBuilding:+-j$NIX_BUILD_CORES}
     make -C ${srcDir} ''${enableParallelBuilding:+-j$NIX_BUILD_CORES}
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     install -Dm555 -t $out/bin ${srcDir}/mprime
 
     install -Dm444 -t $out/${docDir} license.txt readme.txt stress.txt undoc.txt
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/mp/mprime/package.nix
+++ b/pkgs/by-name/mp/mprime/package.nix
@@ -28,6 +28,8 @@ let
     ."${stdenv.hostPlatform.system}" or throwSystem;
 
   docDir = "share/mprime/doc";
+  ccArch = stdenv.hostPlatform.gcc.arch or "x86-64";
+
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mprime";
@@ -66,6 +68,15 @@ stdenv.mkDerivation (finalAttrs: {
     hwloc
     gmp
   ];
+
+  env = {
+    NIX_CFLAGS_COMPILE = toString (
+      # The following is needed because compiling with stdenv.hostPlatform.gcc.arch
+      # set to something like "znver1" causes fatal errors during runtime due to
+      # rounding issues
+      lib.optional (stdenv.hostPlatform.isx86_64 && ccArch != "x86-64") "-march=x86-64"
+    );
+  };
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Compiling for recent architectures causes rounding issues:

FATAL ERROR: Rounding was 0.4977243728, expected less than 0.4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
