### PR TITLE
keyspersecond: build with gradle_8, remove gradle_7

### DIFF
--- a/pkgs/by-name/ke/keyspersecond/gradleShadowJar.patch
+++ b/pkgs/by-name/ke/keyspersecond/gradleShadowJar.patch
@@ -1,0 +1,27 @@
+diff --git a/build.gradle b/build.gradle
+index 6adb040..f442496 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -56,8 +56,10 @@ sourceCompatibility = 1.8
+ javadoc.options.memberLevel = JavadocMemberLevel.PRIVATE
+ group = 'dev.roanh.kps'
+ ext.artifact = 'keyspersecond'
+-shadowJar.archiveName = 'KeysPerSecond-v' + version + '.jar'
+-application.mainClassName = 'dev.roanh.kps.Main'
++shadowJar.archiveBaseName = 'KeysPerSecond'
++shadowJar.archiveVersion = 'v' + version
++shadowJar.archiveClassifier = ''
++application.mainClass = 'dev.roanh.kps.Main'
+
+ test{
+ 	useJUnitPlatform()
+@@ -129,7 +131,7 @@ shadowJar{
+
+ launch4j{
+ 	jarTask = project.tasks.shadowJar
+-	mainClassName = application.mainClassName
++	mainClassName = application.mainClass
+ 	icon = "${projectDir}/kps.ico"
+ 	jreMinVersion = project.sourceCompatibility
+ 	bundledJrePath = "%JAVA_HOME%"
+--

--- a/pkgs/by-name/ke/keyspersecond/package.nix
+++ b/pkgs/by-name/ke/keyspersecond/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gradle_7,
+  gradle_8,
   copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
@@ -17,7 +17,7 @@
 }:
 
 let
-  gradle = gradle_7;
+  gradle = gradle_8;
 
   libPath = lib.makeLibraryPath [
     # used by the Java2D OpenGL backend
@@ -41,6 +41,13 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-DGpXbCInq+RS56Ae5Y6xzyWqwXAm26c0vOYrFqDvl+8=";
   };
+
+  patches = [
+    # deprecated shadowJar.archiveName, application.mainClassName
+    # patches already in `master` branch, but no new release yet
+    # and would be spread along multiple cherry-picks
+    ./gradleShadowJar.patch
+  ];
 
   sourceRoot = "${finalAttrs.src.name}/KeysPerSecond";
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
