### PR TITLE
etcd_3_4: 3.4.28 -> 3.4.37

### DIFF
--- a/pkgs/servers/etcd/3_4/default.nix
+++ b/pkgs/servers/etcd/3_4/default.nix
@@ -6,33 +6,41 @@
 
 buildGoModule rec {
   pname = "etcd";
-  version = "3.4.28";
+  version = "3.4.37";
 
   src = fetchFromGitHub {
     owner = "etcd-io";
     repo = "etcd";
     rev = "v${version}";
-    hash = "sha256-M0iD05Wk3pC56kGKeIb0bfMUpy9idMKin0+DYhBo/cw=";
+    hash = "sha256-PZ+8hlxSwayR1yvjHmStMDur9e1uc2s+YB8qdz+42mA=";
   };
 
-  vendorHash = "sha256-DbDIz/cbXqYHaGqNqP+wYpuiaFiZYElRXmQwBXnCbMk=";
+  proxyVendor = true;
+  vendorHash = "sha256-VeB0A+freNwgETQMIokiOPWovGq1FANUexnzxVg2aRA=";
+
+  preBuild = ''
+    go mod tidy
+  '';
 
   buildPhase = ''
+    runHook preBuild
     patchShebangs .
     ./build
     ./functional/build
+    runHook postBuild
   '';
 
   doCheck = false;
 
-  installPhase = ''
+  postInstall = ''
     install -Dm755 bin/* bin/functional/cmd/* -t $out/bin
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Distributed reliable key-value store for the most critical data of a distributed system";
-    license = licenses.asl20;
+    downloadPage = "https://github.com/etcd-io/etcd/";
+    license = lib.licenses.asl20;
     homepage = "https://etcd.io/";
-    maintainers = with maintainers; [ offline ];
+    maintainers = with lib.maintainers; [ offline ];
   };
 }

--- a/pkgs/servers/etcd/3_4/default.nix
+++ b/pkgs/servers/etcd/3_4/default.nix
@@ -41,6 +41,6 @@ buildGoModule rec {
     downloadPage = "https://github.com/etcd-io/etcd/";
     license = lib.licenses.asl20;
     homepage = "https://etcd.io/";
-    maintainers = with lib.maintainers; [ offline ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10043,7 +10043,7 @@ with pkgs;
   };
 
   etcd = etcd_3_5;
-  etcd_3_4 = callPackage ../servers/etcd/3.4.nix { };
+  etcd_3_4 = callPackage ../servers/etcd/3_4 { };
   etcd_3_5 = callPackage ../servers/etcd/3_5 {
     buildGoModule = buildGo123Module;
   };


### PR DESCRIPTION
etcd_3_4: 3.4.28 -> 3.4.37

- Release: https://github.com/etcd-io/etcd/releases/tag/v3.4.37
- Changelog: https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.4.md

* etcd_3_4: remove offline from maintainers for inactivity

CC @offlinehacker 