### PR TITLE
claude-code: 1.0.65 -> 1.0.67

### DIFF
--- a/pkgs/by-name/cl/claude-code/package-lock.json
+++ b/pkgs/by-name/cl/claude-code/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@anthropic-ai/claude-code": "^1.0.65"
+        "@anthropic-ai/claude-code": "^1.0.67"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.65.tgz",
-      "integrity": "sha512-MUpHFOzdx8EKw3DogQObsL5nseXbMInGHInqRyMVBf2/aLnD4IHEFOuyR5SfnINI9E8lEiqIOy0p3muu60j3uA==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.67.tgz",
+      "integrity": "sha512-r7CfhbKBXgaL5Wo0BIh08SOahFYQPcbHCNnMLtse7iDd2IVBWeOxqoiqQvzRQ0wTCiqLTshRbnmLWHyP4AbuyQ==",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -7,16 +7,16 @@
 
 buildNpmPackage rec {
   pname = "claude-code";
-  version = "1.0.65";
+  version = "1.0.67";
 
   nodejs = nodejs_20; # required for sandboxed Nix builds on Darwin
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-    hash = "sha256-Ch55xuJZJ0LXDTIlC7Ya381jqeGJzYC5IDEY0hS76/M=";
+    hash = "sha256-NZgv0nGsq+RuPTJcX0GsE1NWs/PFge2A0ek3BL1fJeY=";
   };
 
-  npmDepsHash = "sha256-iekpD6RTMRHaV2ifogoestwpq3W+JkesjGVlhtGwHQQ=";
+  npmDepsHash = "sha256-v994F0x0LCh+QbIfCywk5agxn7tNhhi+uo/3ka5Iuww=";
 
   postPatch = ''
     cp ${./package-lock.json} package-lock.json


### PR DESCRIPTION
Changelog: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

Updated claude-code from version 1.0.65 to 1.0.67, bringing the latest improvements and bug fixes.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
