### PR TITLE
Partially revert "nixos/kernel: Allow controlling modules with attrsets"

### DIFF
--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -202,18 +202,15 @@ in
     };
 
     boot.kernelModules = mkOption {
-      type = attrNamesToTrue;
-      default = { };
+      type = types.listOf types.str;
+      default = [ ];
       description = ''
         The set of kernel modules to be loaded in the second stage of
         the boot process.  Note that modules that are needed to
         mount the root file system should be added to
         {option}`boot.initrd.availableKernelModules` or
         {option}`boot.initrd.kernelModules`.
-
-        ${modulesTypeDesc}
       '';
-      apply = mods: lib.attrNames (lib.filterAttrs (_: v: v) mods);
     };
 
     boot.initrd.availableKernelModules = mkOption {
@@ -244,14 +241,9 @@ in
     };
 
     boot.initrd.kernelModules = mkOption {
-      type = attrNamesToTrue;
-      default = { };
-      description = ''
-        Set of modules that are always loaded by the initrd.
-
-        ${modulesTypeDesc}
-      '';
-      apply = mods: lib.attrNames (lib.filterAttrs (_: v: v) mods);
+      type = types.listOf types.str;
+      default = [ ];
+      description = "List of modules that are always loaded by the initrd.";
     };
 
     boot.initrd.includeDefaultModules = mkOption {


### PR DESCRIPTION
This partially reverts commit https://github.com/NixOS/nixpkgs/commit/98652f9a901aac50c1d7780ea3507439803a3408.

Specifically, `boot.initrd.kernelModules` and `boot.kernelModules` need to retain their list ordering, so those are not able to be attrsets.

Fixes https://github.com/NixOS/nixpkgs/issues/420419


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
