### PR TITLE
rewaita: init at 1.0.1

### DIFF
--- a/pkgs/by-name/re/rewaita/package.nix
+++ b/pkgs/by-name/re/rewaita/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  ninja,
+  meson,
+  pkg-config,
+  wrapGAppsHook4,
+  glib,
+  gtk4,
+  desktop-file-utils,
+  appstream-glib,
+  blueprint-compiler,
+  libadwaita,
+  nix-update-script,
+}:
+let
+  version = "1.0.1";
+in
+python3Packages.buildPythonApplication {
+  pname = "rewaita";
+  inherit version;
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "SwordPuffin";
+    repo = "Rewaita";
+    tag = "v${version}";
+    hash = "sha256-adSXq+DFw3IQxNuUkP1FcKlIh9h4Zb0tJKswYs3S92E=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    glib
+    gtk4
+    desktop-file-utils
+    appstream-glib
+    blueprint-compiler
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+  ];
+
+  buildInputs = [
+    libadwaita
+    gtk4
+  ];
+
+  dontWrapGApps = true;
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Bring color to Adwaita";
+    homepage = "https://github.com/SwordPuffin/Rewaita";
+    changelog = "https://github.com/SwordPuffin/Rewaita/releases/tag/v${version}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "rewaita";
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.awwpotato ];
+  };
+}


### PR DESCRIPTION
https://github.com/SwordPuffin/Rewaita
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
