### PR TITLE
etcd_3_6: init 3.6.4

### DIFF
--- a/pkgs/by-name/et/etcd_3_6/package.nix
+++ b/pkgs/by-name/et/etcd_3_6/package.nix
@@ -1,0 +1,148 @@
+{
+  applyPatches,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchpatch,
+  installShellFiles,
+  k3s,
+  lib,
+  nixosTests,
+  stdenv,
+  symlinkJoin,
+}:
+
+let
+  version = "3.6.4";
+  etcdSrcHash = "sha256-otz+06cOD2MVnMZWKId1GN+MeZfnDbdudiYfVCKdzuo=";
+  etcdCtlVendorHash = "sha256-kTH+s/SY+xwo6kt6iPJ7XDhin0jPk0FBr0eOe/717bE=";
+  etcdUtlVendorHash = "sha256-P0yx9YMMD9vT7N6LOlo26EAOi+Dj33p3ZjAYEoaL19A=";
+  etcdServerVendorHash = "sha256-kgbCT1JxI98W89veCItB7ZfW4d9D3/Ip3tOuFKEX9v4=";
+
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "etcd-io";
+      repo = "etcd";
+      tag = "v${version}";
+      hash = etcdSrcHash;
+    };
+    patches = [
+      (fetchpatch {
+        url = "https://github.com/etcd-io/etcd/commit/31650ab0c8df43af05fc4c13b48ffee59271eec7.patch";
+        hash = "sha256-Q94HOLFx2fnb61wMQsAUT4sIBXfxXqW9YEayukQXX18=";
+      })
+    ];
+  };
+
+  env = {
+    CGO_ENABLED = 0;
+  };
+
+  meta = {
+    description = "Distributed reliable key-value store for the most critical data of a distributed system";
+    downloadPage = "https://github.com/etcd-io/etcd";
+    license = lib.licenses.asl20;
+    homepage = "https://etcd.io/";
+    maintainers = with lib.maintainers; [ dtomvan ];
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+  };
+
+  etcdserver = buildGoModule {
+    pname = "etcdserver";
+
+    inherit
+      env
+      meta
+      src
+      version
+      ;
+
+    vendorHash = etcdServerVendorHash;
+
+    __darwinAllowLocalNetworking = true;
+
+    modRoot = "./server";
+
+    preInstall = ''
+      mv $GOPATH/bin/{server,etcd}
+    '';
+
+    # We set the GitSHA to `GitNotFound` to match official build scripts when
+    # git is unavailable. This is to avoid doing a full Git Checkout of etcd.
+    # User facing version numbers are still available in the binary, just not
+    # the sha it was built from.
+    ldflags = [ "-X go.etcd.io/etcd/api/v3/version.GitSHA=GitNotFound" ];
+  };
+
+  etcdutl = buildGoModule {
+    pname = "etcdutl";
+
+    inherit
+      env
+      meta
+      src
+      version
+      ;
+
+    vendorHash = etcdUtlVendorHash;
+
+    __darwinAllowLocalNetworking = true;
+
+    modRoot = "./etcdutl";
+
+    nativeBuildInputs = [ installShellFiles ];
+
+    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      for shell in bash fish zsh; do
+        installShellCompletion --cmd etcdutl \
+          --$shell <($out/bin/etcdutl completion $shell)
+      done
+    '';
+  };
+
+  etcdctl = buildGoModule {
+    pname = "etcdctl";
+
+    inherit
+      env
+      meta
+      src
+      version
+      ;
+
+    vendorHash = etcdCtlVendorHash;
+
+    modRoot = "./etcdctl";
+
+    nativeBuildInputs = [ installShellFiles ];
+
+    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      for shell in bash fish zsh; do
+        installShellCompletion --cmd etcdctl \
+          --$shell <($out/bin/etcdctl completion $shell)
+      done
+    '';
+  };
+in
+symlinkJoin {
+  name = "etcd-${version}";
+
+  inherit meta version;
+
+  passthru = {
+    deps = {
+      inherit etcdserver etcdutl etcdctl;
+    };
+    # Fix-Me: Tests for etcd 3.6 needs work.
+    # tests = {
+    #   inherit (nixosTests) etcd etcd-cluster;
+    #   k3s = k3s.passthru.tests.etcd;
+    # };
+    updateScript = ./update.sh;
+  };
+
+  paths = [
+    etcdserver
+    etcdutl
+    etcdctl
+  ];
+}

--- a/pkgs/by-name/et/etcd_3_6/update.sh
+++ b/pkgs/by-name/et/etcd_3_6/update.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq nurl
+
+set -x -eu -o pipefail
+
+MAJOR_VERSION=3
+MINOR_VERSION=6
+
+ETCD_PATH="$(dirname "$0")"
+ETCD_VERSION_MAJOR_MINOR=${MAJOR_VERSION}.${MINOR_VERSION}
+ETCD_PKG_NAME=etcd_${MAJOR_VERSION}_${MINOR_VERSION}
+NIXPKGS_PATH="$(git rev-parse --show-toplevel)"
+
+LATEST_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} \
+    --silent https://api.github.com/repos/etcd-io/etcd/releases \
+    | jq -r 'map(select(.prerelease == false))' \
+    | jq -r 'map(.tag_name)' \
+    | grep "v${ETCD_VERSION_MAJOR_MINOR}." \
+    | sed 's|[", ]||g' \
+    | sort -rV | head -n1 )
+
+LATEST_VERSION=$(echo ${LATEST_TAG} | sed 's/^v//')
+
+OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_PATH {}; \
+    $ETCD_PKG_NAME.version or (builtins.parseDrvName $ETCD_PKG_NAME.name).version" | tr -d '"')"
+
+if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
+    echo "Attempting to update etcd from $OLD_VERSION to $LATEST_VERSION"
+    ETCD_SRC_HASH=$(nix-prefetch-url --quiet --unpack https://github.com/etcd-io/etcd/archive/refs/tags/${LATEST_TAG}.tar.gz)
+    ETCD_SRC_HASH=$(nix hash to-sri --type sha256 $ETCD_SRC_HASH)
+
+    setKV () {
+        sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "$ETCD_PATH/default.nix"
+    }
+
+    setKV version $LATEST_VERSION
+    setKV etcdSrcHash $ETCD_SRC_HASH
+
+    getAndSetVendorHash () {
+        local EMPTY_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" # Hash from lib.fakeHash
+        local VENDOR_HASH=$EMPTY_HASH
+        local PKG_KEY=$1
+        local INNER_PKG=$2
+
+        setKV $PKG_KEY $EMPTY_HASH
+
+        set +e
+        VENDOR_HASH=$(nurl -e "(import ${NIXPKGS_PATH}/. {}).$ETCD_PKG_NAME.passthru.deps.$INNER_PKG.goModules")
+        set -e
+
+        if [ -n "${VENDOR_HASH:-}" ]; then
+            setKV $PKG_KEY $VENDOR_HASH
+        else
+            echo "Update failed. $PKG_KEY is empty."
+            exit 1
+        fi
+    }
+
+    getAndSetVendorHash etcdServerVendorHash etcdserver
+    getAndSetVendorHash etcdUtlVendorHash etcdutl
+    getAndSetVendorHash etcdCtlVendorHash etcdctl
+
+    # `git` flag here is to be used by local maintainers to speed up the bump process
+    if [ $# -eq 1 ] && [ "$1" = "git" ]; then
+        git switch -c "package-$ETCD_PKG_NAME-$LATEST_VERSION"
+        git add "$ETCD_PATH"/default.nix
+        git commit -m "$ETCD_PKG_NAME: $OLD_VERSION -> $LATEST_VERSION
+
+Release: https://github.com/etcd-io/etcd/releases/tag/$LATEST_TAG"
+    fi
+
+else
+    echo "etcd is already up-to-date at $OLD_VERSION"
+fi


### PR DESCRIPTION
etcd_3_6: init 3.6.4

Release: https://github.com/etcd-io/etcd/releases/tag/v3.6.4

Changelog: https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md

Migration notes: https://etcd.io/docs/v3.6/upgrades/upgrade_3_6/

Known future/pending work:
- Etcd 3.6 tests needs work and is pending. (I don't have a solution for it yet.)
  - Updating latest etcd version should happen after etcd_3_6 is fully tested.

CC @dtomvan