### PR TITLE
nixos/nginx: add support connections via Multipath TCP

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -320,6 +320,19 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `mdbook-linkcheck` has been removed as it is unmaintained and incompatible with the latest version of `mdbook`. Users can instead migrate to `mdbook-linkcheck2`.
 
+- `services.nginx` now support connections via Multipath TCP (MPTCP). This requires Linux kernel since version 5.6 and the `angie` package.
+  Examlpe configuration:
+  ```
+    services.nginx = {
+      package = pkgs.angie;
+      virtualHosts."example.com" = {
+        multipath = true;
+      };
+    };
+  ```
+
+  Note: it is required to specify only once on one of the hosts.
+
 - `glibc` has been updated to version 2.42.
 
   This version no longer makes the stack executable when a shared library requires this. A symptom

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -399,6 +399,7 @@ let
                     "deferred"
                     "fastopen"
                     "http2"
+                    "multipath"
                     "proxy_protocol"
                     "so_keepalive"
                     "ssl"
@@ -415,6 +416,7 @@ let
           + optionalString (ssl && vhost.http2 && oldHTTP2) "http2 "
           + optionalString ssl "ssl "
           + optionalString vhost.default "default_server "
+          + optionalString vhost.multipath "multipath "
           + optionalString vhost.reuseport "reuseport "
           + optionalString proxyProtocol "proxy_protocol "
           + optionalString (extraParameters != [ ]) (concatStringsSep " " extraParameters)
@@ -1371,6 +1373,16 @@ in
           message = ''
             Options services.nginx.service.virtualHosts.<name>.proxyPass and
             services.nginx.virtualHosts.<name>.uwsgiPass are mutually exclusive.
+          '';
+        }
+
+        {
+          assertion =
+            cfg.package.pname != "angie" && versionAtLeast cfg.package.version "1.10.0"
+            -> all (host: !host.multipath) (attrValues virtualHosts);
+          message = ''
+             Option services.nginx.virtualHosts.<name>.multipath requires angie version
+            1.10.0 or above.
           '';
         }
 

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -274,6 +274,17 @@ with lib;
       '';
     };
 
+    multipath = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables accepting connections via Multipath TCP (MPTCP),
+        supported in the Linux kernel since version 5.6. This
+        parameter is incompatible with quic.
+        It is required to specify only once on one of the hosts.
+      '';
+    };
+
     reuseport = mkOption {
       type = types.bool;
       default = false;


### PR DESCRIPTION
Add support connections via Multipath TCP.
Currently supported only in `freenginx` and `angie` packages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
