### PR TITLE
jetbrains.jdk-no-jcef-17: enable `--disable-warnings-as-errors`.

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/17.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/17.nix
@@ -87,7 +87,7 @@ openjdk17.overrideAttrs (oldAttrs: rec {
         -i jb/project/tools/linux/scripts/mkimages_${arch}.sh
 
     patchShebangs .
-    ./jb/project/tools/linux/scripts/mkimages_${arch}.sh ${build} ${
+    ./jb/project/tools/linux/scripts/mkimages_${arch}.sh -w ${build} ${
       if debugBuild then "fd" else (if withJcef then "jcef" else "nomod")
     }
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The jetbrains.jdk-no-jcef-17 build on aarch64 is broken right now due to the following error:

```
jetbrains-jdk> In member function 'void Assembler::set_current(Instruction_aarch64*)',
jetbrains-jdk>     inlined from 'void Assembler::sbfm(Register, Register, unsigned int, unsigned int)' at /build/source/src/hotspot/cpu/aarch64/assembler_aarch64.hpp:866:3:
jetbrains-jdk> /build/source/src/hotspot/cpu/aarch64/assembler_aarch64.hpp:700:54: error: storing the address of local variable 'do_not_use' in '*this.Assembler::current' [-Werror=dangling-pointer=]
jetbrains-jdk>   700 |   void set_current(Instruction_aarch64* i) { current = i; }
jetbrains-jdk>       |                                              ~~~~~~~~^~~
jetbrains-jdk> /build/source/src/hotspot/cpu/aarch64/assembler_aarch64.hpp: In function 'void Assembler::sbfm(Register, Register, unsigned int, unsigned int)':
jetbrains-jdk> /build/source/src/hotspot/cpu/aarch64/assembler_aarch64.hpp:316:36: note: 'do_not_use' declared here
jetbrains-jdk>   316 | #define starti Instruction_aarch64 do_not_use(this); set_current(&do_not_use)
jetbrains-jdk>       |                                    ^~~~~~~~~~
jetbrains-jdk> /build/source/src/hotspot/cpu/aarch64/assembler_aarch64.hpp:857:5: note: in expansion of macro 'starti'
jetbrains-jdk>   857 |     starti;                                                             \
jetbrains-jdk>       |     ^~~~~~
jetbrains-jdk> /build/source/src/hotspot/cpu/aarch64/assembler_aarch64.hpp:866:3: note: in expansion of macro 'INSN'
jetbrains-jdk>   866 |   INSN(sbfm,  0b1001001101, 1);
jetbrains-jdk>       |   ^~~~
jetbrains-jdk> /build/source/src/hotspot/cpu/aarch64/assembler_aarch64.hpp:856:67: note: 'this' declared here
jetbrains-jdk>   856 |   void NAME(Register Rd, Register Rn, unsigned immr, unsigned imms) {   \
jetbrains-jdk>       |                                                                   ^
jetbrains-jdk> /build/source/src/hotspot/cpu/aarch64/assembler_aarch64.hpp:866:3: note: in expansion of macro 'INSN'
jetbrains-jdk>   866 |   INSN(sbfm,  0b1001001101, 1);
jetbrains-jdk>       |   ^~~~
```

This is probably caused by gcc version updates. This patch temporary fixes the build by disabling the warning as error until the upstream addresses this issue. 


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
