### PR TITLE
nixos/borgmatic: add support for ZFS, BTRFS and LVM snapshots

### DIFF
--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -57,6 +57,7 @@ let
     });
 
   requireZfs = s: s ? zfs;
+  requireBtrfs = s: s ? btrfs;
 
   repository =
     with lib.types;
@@ -128,7 +129,9 @@ let
     requireSudo cfg.settings || lib.any requireSudo (lib.attrValues cfg.configurations);
   anycfgRequiresZfs =
     requireZfs cfg.settings || lib.any requireZfs (lib.attrValues cfg.configurations);
-  anycfgSnapshots = anycfgRequiresZfs;
+  anycfgRequiresBtrfs =
+    requireBtrfs cfg.settings || lib.any requireBtrfs (lib.attrValues cfg.configurations);
+  anycfgSnapshots = anycfgRequiresZfs || anycfgRequiresBtrfs;
 in
 {
   options.services.borgmatic = {
@@ -194,7 +197,8 @@ in
         pkgs.coreutils
       ]
       ++ lib.optional anycfgSnapshots pkgs.util-linux
-      ++ lib.optional anycfgRequiresZfs config.boot.zfs.package;
+      ++ lib.optional anycfgRequiresZfs config.boot.zfs.package
+      ++ lib.optional anycfgRequiresBtrfs pkgs.btrfs-progs;
 
       systemd.services.borgmatic.serviceConfig = lib.mkMerge [
         (lib.mkIf anycfgRequiresSudo {

--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -56,6 +56,8 @@ let
       ) s.mysql_databases;
     });
 
+  requireZfs = s: s ? zfs;
+
   repository =
     with lib.types;
     submodule {
@@ -124,6 +126,9 @@ let
 
   anycfgRequiresSudo =
     requireSudo cfg.settings || lib.any requireSudo (lib.attrValues cfg.configurations);
+  anycfgRequiresZfs =
+    requireZfs cfg.settings || lib.any requireZfs (lib.attrValues cfg.configurations);
+  anycfgSnapshots = anycfgRequiresZfs;
 in
 {
   options.services.borgmatic = {
@@ -185,11 +190,40 @@ in
       environment.etc = configFiles;
 
       systemd.packages = [ pkgs.borgmatic ];
-      systemd.services.borgmatic.path = [ pkgs.coreutils ];
-      systemd.services.borgmatic.serviceConfig = lib.optionalAttrs anycfgRequiresSudo {
-        NoNewPrivileges = false;
-        CapabilityBoundingSet = "CAP_DAC_READ_SEARCH CAP_NET_RAW CAP_SETUID CAP_SETGID";
-      };
+      systemd.services.borgmatic.path = [
+        pkgs.coreutils
+      ]
+      ++ lib.optional anycfgSnapshots pkgs.util-linux
+      ++ lib.optional anycfgRequiresZfs config.boot.zfs.package;
+
+      systemd.services.borgmatic.serviceConfig = lib.mkMerge [
+        (lib.mkIf anycfgRequiresSudo {
+          NoNewPrivileges = false;
+          CapabilityBoundingSet = [
+            "CAP_DAC_READ_SEARCH"
+            "CAP_NET_RAW"
+            "CAP_SETUID"
+            "CAP_SETGID"
+          ];
+        })
+        (lib.mkIf anycfgSnapshots {
+          NoNewPrivileges = false;
+          CapabilityBoundingSet = [ "CAP_SYS_ADMIN" ];
+          # this next line is included in the latest upstream unit and should become unnecessary
+          SystemCallFilter = [
+            "@system-service"
+            "@mount"
+          ];
+        })
+        (lib.mkIf anycfgRequiresZfs {
+          PrivateDevices = false;
+          CapabilityBoundingSet = [
+            "CAP_SYS_RAWIO"
+            "CAP_DAC_OVERRIDE"
+          ];
+          ReadWritePaths = [ "/etc/zfs" ];
+        })
+      ];
 
       # Workaround: https://github.com/NixOS/nixpkgs/issues/81138
       systemd.timers.borgmatic.wantedBy = [ "timers.target" ];


### PR DESCRIPTION
Closes #430233.

Borgmatic includes support for [ snapshots](https://torsion.org/borgmatic/docs/how-to/snapshot-your-filesystems/) with ZFS, BRTFS, and LVM. However, the upstream systemd unit does not support these features by default. This PR detects whether filesystem snapshots are configured and makes necessary edits to the unit.

I have personally tested this change with ZFS; the BTRFS/LVM changes are currently untested best-guesses.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
