### PR TITLE
python310Packages.pip: fix build failure caused by sphinx-8.2.3

### DIFF
--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   installShellFiles,
@@ -51,20 +52,24 @@ let
       installShellFiles
       setuptools
       wheel
-
+    ]
+    ++ lib.optionals (pythonAtLeast "3.11") [
       # docs
+      # (sphinx requires Python 3.11)
       sphinx
       sphinx-issues
     ];
 
     outputs = [
       "out"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.11") [
       "man"
     ];
 
     # pip uses a custom sphinx extension and unusual conf.py location, mimic the internal build rather than attempting
     # to fit sphinxHook see https://github.com/pypa/pip/blob/0778c1c153da7da457b56df55fb77cbba08dfb0c/noxfile.py#L129-L148
-    postBuild = ''
+    postBuild = lib.optionalString (pythonAtLeast "3.11") ''
       cd docs
 
       # remove references to sphinx extentions only required for html doc generation


### PR DESCRIPTION
fixes #394105

_I am pushing this small changes to upstream as to patch pip on python3.10 and it also takes a while to build this locally._

Shout outs to [@FliegendeWurst](https://github.com/FliegendeWurst) for the suggestions and I will be assigning them as reviewer for this PR. Check out #394105. 
As per the suggested changes, this patch will route pip not to include sphinx dependency for python versions lower than 3.11. This caused a build failure on python 3.10.
I have built and tested this change on NixOS 25.05. Please check the attached screenshot.

<img width="1159" height="497" alt="image" src="https://github.com/user-attachments/assets/8e7bb58f-6239-4a13-b30f-47ab9a31ca57" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
