### PR TITLE
Update jetbrains IDEs

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -11,26 +11,26 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "3bdd0cd731bcdcd15de7ebee3ec36a13b82b72f68a77f6e6e780e36d88acd51e",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2.tar.gz",
-      "build_number": "251.26094.123"
+      "version": "2025.1.4",
+      "sha256": "8d90be9d11c0f47b380f4a9f705058215817edf043bdcea2223d788d25193f78",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.4.tar.gz",
+      "build_number": "251.27812.15"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.tar.gz",
-      "version": "2025.1.3",
-      "sha256": "b672b2b50e2ae539af24e32ac7678ff32a8b207e6692e12c8b891eaf78200d24",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3.tar.gz",
-      "build_number": "251.26094.87"
+      "version": "2025.2",
+      "sha256": "5c44d4cb3e323f6913ef09a50b13028f92a7db6809b08a26763929555186df31",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.tar.gz",
+      "build_number": "252.23892.363"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "e0711b629ad45d6d051fd9796bf81689d46212fdd8f21306128a8522097ca3e9",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.1.tar.gz",
-      "build_number": "251.25410.158"
+      "version": "2025.1.2.1",
+      "sha256": "1759516154a989ad1bcbc0e0cc29eb7b50c5c96b910c1a8926ae87ea5aa07ea6",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.1.2.1.tar.gz",
+      "build_number": "251.26927.91"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
@@ -43,26 +43,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "18d4465e8c50911d8f4ecd7ba75ee1aa14cf3d05eb4df39790729cf67bf2a638",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.2.tar.gz",
-      "build_number": "251.26094.127"
+      "version": "2025.1.4",
+      "sha256": "42efe9cc97248403e868180339f403ab390e9a335a658bd7aa905b64c03c7a31",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.4.tar.gz",
+      "build_number": "251.27812.54"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "70dc870bd31fda67de30d3a132cfed543d5e67c15c7db52f6f4c4691a044930a",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.1.4.1",
+      "sha256": "34e0d7d20b6ff303cfbb97c75147b11a437221b96783687d9909adf1d56817ff",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.4.1.tar.gz",
+      "build_number": "251.27812.49"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "1e675bda1314ae914b64b31a22309ba2eba6f35e6659e53d4b291e73c2fb856b",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.1.4.1",
+      "sha256": "d1335bcdcac3746a10d6b3346f06ab6d34c9ad14c4af759322d9a93f7b428894",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.4.1.tar.gz",
+      "build_number": "251.27812.49"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -75,59 +75,59 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "229f3afde8e3466e1d262de915420f66a5fc97858788cc08f7d0f0b826c2a77b",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.2.tar.gz",
-      "build_number": "251.26094.133",
+      "version": "2025.1.4.1",
+      "sha256": "92cd8d570d0307188190761c7cd0d0f77351ff119735073c2a101e4a364292b4",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.4.1.tar.gz",
+      "build_number": "251.27812.52",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "193fbbb638235c4c671bb6c6b432f43a2d46f7f7ebd6b5f2cc8a1db7db93c5d6",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2.tar.gz",
-      "build_number": "251.26094.141"
+      "version": "2025.1.3.1",
+      "sha256": "17899a66ee4261fdb1308ee44d455675aff1e387b24165d11afdea3a88ecb244",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.3.1.tar.gz",
+      "build_number": "251.26927.90"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "4a407779c5df9728e29698eeabdb4533911e755ead224d0c1deff959876c3108",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2.tar.gz",
-      "build_number": "251.26094.141"
+      "version": "2025.1.3.1",
+      "sha256": "c8f5b42843ef21673dd94f0d565cda2d09dae595736e39cf510de9a0a8a07239",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.3.1.tar.gz",
+      "build_number": "251.26927.90"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "cdf8a824c7daa3247b09d76a29acb31cfa623b90643d3d2a814982cb0a32879d",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2.tar.gz",
-      "build_number": "251.25410.119"
+      "version": "2025.1.4",
+      "sha256": "88dc7c4b6581aab5f6a2713061ea10e7ad0f0735e92258f4a3aaba59964440ee",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.4.tar.gz",
+      "build_number": "251.26927.67"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "2d4127e0284a262acb015c9d4247b654592e045b61664043a4de56029b45174f",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2.tar.gz",
-      "build_number": "251.26094.122"
+      "version": "2025.1.4.1",
+      "sha256": "c89dcc2a6e50b3bb9e588a5109a7f1de80c2fd09576199904b386547e585d0e4",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.4.1.tar.gz",
+      "build_number": "251.27812.51"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
-      "version": "2025.1.3",
-      "sha256": "b3c4999f1d7ef7deffa56bfe75f011a012842bec5c199b0090d2ac45af78ea5e",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.3.tar.gz",
-      "build_number": "251.25410.170"
+      "version": "2025.1.5",
+      "sha256": "54eda433719c132c48e733b659b29113d362fea3b9c7dd4109497ed31da7c6f6",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.5.tar.gz",
+      "build_number": "251.26927.79"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "055510371e3c6a8d9fbfcd352645d847d2c092309c4746222babe4af240c2eac",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2.tar.gz",
-      "build_number": "251.26094.131"
+      "version": "2025.1.4.1",
+      "sha256": "f10bfc1028350a73928b49dc51db336e9c77c680b9844d29c305218e7d5db192",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.4.1.tar.gz",
+      "build_number": "251.27812.50"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -150,26 +150,26 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "911568cef55f23b134a4c316b5436214c2b51638c14a3b243785e19e354c2d4c",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.123"
+      "version": "2025.1.4",
+      "sha256": "0864c25fe8bb442b3891e51382de177ff5543bf075bbd1c12767984695f2dcaa",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.4-aarch64.tar.gz",
+      "build_number": "251.27812.15"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2025.1.3",
-      "sha256": "ca0b5a6685e8494311e3276ad22c097ea3a2f8925baff39951a45c467f3c547c",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3-aarch64.tar.gz",
-      "build_number": "251.26094.87"
+      "version": "2025.2",
+      "sha256": "fb358605d813007eea7e010cf642a822f04eea60d5808865d153429b4d5784dd",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2-aarch64.tar.gz",
+      "build_number": "252.23892.363"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.tar.gz",
-      "version": "2025.1.1",
-      "sha256": "4f7f05141bee346dd29ed48dafcea24197494aa8bbc02409df9089da1c8e0be8",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.1-aarch64.tar.gz",
-      "build_number": "251.25410.158"
+      "version": "2025.1.2.1",
+      "sha256": "a982a7e8d5b1c293b68983be792a60a885567e9af825e0fce4b2a4b6ac30c9ae",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.1.2.1-aarch64.tar.gz",
+      "build_number": "251.26927.91"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
@@ -182,26 +182,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "71f8c4addac839823b9875e6f01f8ab98d7cf77ab9acf03c09e057cc5d030757",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.127"
+      "version": "2025.1.4",
+      "sha256": "4c24dddd6babfc36d70b0287bf32857d2c01c61d3ef1d2579a29f741c71fdad0",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.4-aarch64.tar.gz",
+      "build_number": "251.27812.54"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "d98c8d7bdc3e274d278b81ba2b6c1baa38f67be9407b4bfd3bad3413c6f128f1",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.1.4.1",
+      "sha256": "e47ce26c036a7aabd4467c561bf0c9d85997f82f65b810bac314ef704a59ebac",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.4.1-aarch64.tar.gz",
+      "build_number": "251.27812.49"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "0f982a4f4424bde5a33206c20df053a7afe174fe9d590943665504814a273c9d",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.121"
+      "version": "2025.1.4.1",
+      "sha256": "5c0ba5189e4dcf114fb1b03e176780613422a71226412ea78204d1ae46bc2f52",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.4.1-aarch64.tar.gz",
+      "build_number": "251.27812.49"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -214,59 +214,59 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "2c3b703fc1d97e87fa02664bd1165ecf8439898b0a4561f522edd0252606ab5a",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.133",
+      "version": "2025.1.4.1",
+      "sha256": "3e06d34ec4a49faa88492e1d6fda8fc53c8e2d01839e553024b6b4e38e2ab9cf",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.4.1-aarch64.tar.gz",
+      "build_number": "251.27812.52",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "10e7426804d649d3c5bdbfc365cf85fe73dd7e74e67fd1e4c82645e8532d17e7",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.141"
+      "version": "2025.1.3.1",
+      "sha256": "3a648570ed0627333e7e2ef4ad0514d4b97faa4c8ed9d551ddd51c6d2b9d4482",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.3.1-aarch64.tar.gz",
+      "build_number": "251.26927.90"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "831f5563a354e617158cd88c2a63c0bda80b21c3a64fc98a3b6dc7ae22151805",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.141"
+      "version": "2025.1.3.1",
+      "sha256": "00aeea43e6a056244d278502b538babd6444c9db0e93c9a7336d20a09129ed3f",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.3.1-aarch64.tar.gz",
+      "build_number": "251.26927.90"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "c1ad139252fd3158aa86e9ac4532db5d9dd653807fc9f1dc4458170f3f1c3de6",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.25410.119"
+      "version": "2025.1.4",
+      "sha256": "42b89bf470e74807f72bab76c4a2a5e651c69d469b8d8c9b28e8763e7bc2e461",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.4-aarch64.tar.gz",
+      "build_number": "251.26927.67"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "13ed96cc82771ec49ce8e9f72179ac12829f4bc2ffae6a9ab553708aec47d4a9",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.122"
+      "version": "2025.1.4.1",
+      "sha256": "8a52fb75a9ec3a02b1351a531fcf029b97b48e7d86035fb4f0dac59e719ac6a5",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.4.1-aarch64.tar.gz",
+      "build_number": "251.27812.51"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
-      "version": "2025.1.3",
-      "sha256": "4fcd2d8560dd7fe60c3262474dd1fcea1d54b476869a62ede0de86b8d115fce9",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.3-aarch64.tar.gz",
-      "build_number": "251.25410.170"
+      "version": "2025.1.5",
+      "sha256": "9c53be6d814983852e39081db69a0ec337fd7dad77f4278fbbfd246d43f7d3e4",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.5-aarch64.tar.gz",
+      "build_number": "251.26927.79"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2025.1.2",
-      "sha256": "c182bcd17ff4d0188c0e024952677dd21415456a421c5c1aaa356870f2efa009",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2-aarch64.tar.gz",
-      "build_number": "251.26094.131"
+      "version": "2025.1.4.1",
+      "sha256": "198a70343a39ebfd07cff55f60fa8bf68ea8486d74a279a32c22fa52caedcf7a",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.4.1-aarch64.tar.gz",
+      "build_number": "251.27812.50"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -289,26 +289,26 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "f7dde8532ba52d4cfaab37828ba52fa2e159d82baf1fa555c1a0e65bb1186a86",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2.dmg",
-      "build_number": "251.26094.123"
+      "version": "2025.1.4",
+      "sha256": "73076ec3803acaf61feb0181d60a0a4a13ff33b09997995f4a57b9dc37a175ac",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.4.dmg",
+      "build_number": "251.27812.15"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}.dmg",
-      "version": "2025.1.3",
-      "sha256": "006fb7a0875c8fd205cd1d4204dee3be87d1fe359375b75e20ee6e0d21ca7d00",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3.dmg",
-      "build_number": "251.26094.87"
+      "version": "2025.2",
+      "sha256": "241a87b39b88b1e6e03ee3296f7839807ae926cc5bef9d1783bbab17d5951299",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.dmg",
+      "build_number": "252.23892.363"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}.dmg",
-      "version": "2025.1.1",
-      "sha256": "a0b3bd8513f98e448a90132dfb61b221cab22938d8a3992627f9cb141cf71926",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.1.dmg",
-      "build_number": "251.25410.158"
+      "version": "2025.1.2.1",
+      "sha256": "21915425a004b9148ab5fb634ab919d328a692847f3229bcd060fc46c2b91e76",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.1.2.1.dmg",
+      "build_number": "251.26927.91"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
@@ -321,26 +321,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "6d3c732fb3aadc7dad9bb6dafd294be04c82a4dd994223e4982b77213bf9a4b6",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.2.dmg",
-      "build_number": "251.26094.127"
+      "version": "2025.1.4",
+      "sha256": "4b9ec3bf0cf040dd076b028f68f91815664cfdd11f51c68c54a60cbf1df3af25",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.4.dmg",
+      "build_number": "251.27812.54"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "c64c7ff7fe2e73d7552f1727d912bb5f901d040c7269b4292f94190475580c2b",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.1.4.1",
+      "sha256": "c4adb3c4cac8ff7ae1f86898c73f4946410af849df056e6dc05e8e9fc2943c49",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.4.1.dmg",
+      "build_number": "251.27812.49"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "bacfa3bcf48d57d8e8ca8d352895025ffc42ce395b9b0074b3b566dc217324c9",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.1.4.1",
+      "sha256": "d3ee0f157d3a342efe067d7dd782b0c6ca6ca4bd3c253f93e47a7c713c8de94f",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.4.1.dmg",
+      "build_number": "251.27812.49"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -353,59 +353,59 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "18b63995efa4e5ef555f08089c998694b4e3fcda84013155e970524f92c1b90e",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.2.dmg",
-      "build_number": "251.26094.133",
+      "version": "2025.1.4.1",
+      "sha256": "ce91ad25859ce7081c2181468aa57fef76e4f394049cb90da5ab69f34d9d9209",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.4.1.dmg",
+      "build_number": "251.27812.52",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "38283e62677079d7d830217087c563ac6daf5e71422c03e56082bde9572e3908",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2.dmg",
-      "build_number": "251.26094.141"
+      "version": "2025.1.3.1",
+      "sha256": "cfef4f5a640ed3f3edf61d8b4b4d0f6cc1d0696b2764da32e1d8b507260dcbad",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.3.1.dmg",
+      "build_number": "251.26927.90"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "41c6187f4f044522d02749f979cef8f127337b2945772070a0ba44c53a6ebf0c",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2.dmg",
-      "build_number": "251.26094.141"
+      "version": "2025.1.3.1",
+      "sha256": "c90758075f01428a69c18f9962762d069a9a982d2f483c3834d7f2a2cee11117",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.3.1.dmg",
+      "build_number": "251.26927.90"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "23f3479d1cff5ee1726726bea866ff755b08930e9da43b7ad250e6cb620c1dcf",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2.dmg",
-      "build_number": "251.25410.119"
+      "version": "2025.1.4",
+      "sha256": "e0eb853c15bcf4eab5f06a009090fa83697cc513fbd0d68d6639d88ecd850630",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.4.dmg",
+      "build_number": "251.26927.67"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "059d3d4c089b9277089bd7d64b8f6eedcf039fe791cddc694af434a1c5ad88c8",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2.dmg",
-      "build_number": "251.26094.122"
+      "version": "2025.1.4.1",
+      "sha256": "80ac67a3f982b66abdae447f361c974dd2b3b086ca52ba62dc538df7002df60a",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.4.1.dmg",
+      "build_number": "251.27812.51"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
-      "version": "2025.1.3",
-      "sha256": "2ed48a8d1f0afb13a5a2d59a1f478128bff406028f82290db1f9b2847a1e6ade",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.3.dmg",
-      "build_number": "251.25410.170"
+      "version": "2025.1.5",
+      "sha256": "320183fdab31207bf56396e97ba4c15549feec71885f5f390a70a1c1cd81ecc7",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.5.dmg",
+      "build_number": "251.26927.79"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2025.1.2",
-      "sha256": "c33853a8d8a2dd47ce3a795202e2d802a9f1888b2c998c91cdfc9bc66f9bb19a",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2.dmg",
-      "build_number": "251.26094.131"
+      "version": "2025.1.4.1",
+      "sha256": "d77d8a8547cd0ca8a97dc8e4164f169e470d26bfe51274d0a4456ed4d856d226",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.4.1.dmg",
+      "build_number": "251.27812.50"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -428,26 +428,26 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "9a47d3d86f2465f4b741408ad3a792d63a4dff486a05103825e479dae4d63932",
-      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.123"
+      "version": "2025.1.4",
+      "sha256": "85e0f764787a3d910d92f3f61ea4b6b3ff46712c674154adbccafc45640e1ff2",
+      "url": "https://download.jetbrains.com/cpp/CLion-2025.1.4-aarch64.dmg",
+      "build_number": "251.27812.15"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://download.jetbrains.com/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2025.1.3",
-      "sha256": "83da07ddd46fe95aed36d98cbb61c7f81097dc38abe5515933653746859b396c",
-      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.1.3-aarch64.dmg",
-      "build_number": "251.26094.87"
+      "version": "2025.2",
+      "sha256": "86a4851e0ab9a74bb1c12c829752dc04b1e15b1ba668f7712ea6a0ecb5be058b",
+      "url": "https://download.jetbrains.com/datagrip/datagrip-2025.2-aarch64.dmg",
+      "build_number": "252.23892.363"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://download.jetbrains.com/python/dataspell-{version}-aarch64.dmg",
-      "version": "2025.1.1",
-      "sha256": "65bbf4da47e5ceecfab5e19f80bec7ddd5f66bfcdc8dc75691cad98958e72af1",
-      "url": "https://download.jetbrains.com/python/dataspell-2025.1.1-aarch64.dmg",
-      "build_number": "251.25410.158"
+      "version": "2025.1.2.1",
+      "sha256": "97588c238523b2c492a322a0751173f908f31eb27e0d38f81dd51f670690a9a5",
+      "url": "https://download.jetbrains.com/python/dataspell-2025.1.2.1-aarch64.dmg",
+      "build_number": "251.26927.91"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
@@ -460,26 +460,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "a30940d1b2659487ababc3a9ad8e4770236e90ad6c732cb1fd0c24690829a0ce",
-      "url": "https://download.jetbrains.com/go/goland-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.127"
+      "version": "2025.1.4",
+      "sha256": "3a49552e2c3a0a08b1758f9ab7ad2b119ca3fd1b5067b2432ac438537f53d5c8",
+      "url": "https://download.jetbrains.com/go/goland-2025.1.4-aarch64.dmg",
+      "build_number": "251.27812.54"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "61a64b8abf0b350cb14f963975fc87ec574bc4b50ae7944980c43c816ffad5a8",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.1.4.1",
+      "sha256": "656f9fb857afbfc56494b005fad390f1c4cb69deb911cc0ffcf5bb94c52e2f94",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2025.1.4.1-aarch64.dmg",
+      "build_number": "251.27812.49"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "1c1afc32c8edcf1d2057a505f7f0b0dd1f1a20a6859172c1dd6a91a311a3167b",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.121"
+      "version": "2025.1.4.1",
+      "sha256": "dd36c36e7ef1bd14db16bfd9feb85ae37a7eb8bd11e532689567de168adc61dd",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2025.1.4.1-aarch64.dmg",
+      "build_number": "251.27812.49"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -492,59 +492,59 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "0437ba56e1b12b1781ba132d10f9f66c6375cb0609b4755982c7edd1778a3a3b",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.133",
+      "version": "2025.1.4.1",
+      "sha256": "69dbad250e42863c3b3bf724734d4428ff148c73cab39f8faf946ae44f9437a3",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2025.1.4.1-aarch64.dmg",
+      "build_number": "251.27812.52",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "cdcdea2e167c3621f5b5ea8e0150c62d24495192edd2282616676d3f53b06063",
-      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.141"
+      "version": "2025.1.3.1",
+      "sha256": "177359e1861e691eef0c64bec343212453d3e2cd72eeb1ccee05477dcb74aadb",
+      "url": "https://download.jetbrains.com/python/pycharm-community-2025.1.3.1-aarch64.dmg",
+      "build_number": "251.26927.90"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://download.jetbrains.com/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "89a463c896e4e7f6cf6a624b78305d881756b2a350780bfcecd15d6cb766e54b",
-      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.141"
+      "version": "2025.1.3.1",
+      "sha256": "850b9336d1d41600a0a9e53924c98abf30a138c9d6085b9a5a16b6c47727906a",
+      "url": "https://download.jetbrains.com/python/pycharm-professional-2025.1.3.1-aarch64.dmg",
+      "build_number": "251.26927.90"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "ab6645bba503f0a9d67b2838d1dd88a81ad81dd34e6015ccaea30400c35659e4",
-      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.2-aarch64.dmg",
-      "build_number": "251.25410.119"
+      "version": "2025.1.4",
+      "sha256": "b42644a5fcf1c107d8582eb0f74a8a54e03fb88f029b5d5eb53902721c305ec0",
+      "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2025.1.4-aarch64.dmg",
+      "build_number": "251.26927.67"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "1da265fa947d5d1cf3075495414b9e65ec519a5bd9bee5ca2fa7df67bafdc352",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.122"
+      "version": "2025.1.4.1",
+      "sha256": "859f72e3acab761bc5ddd2c8cb9d16d8497494dbd41873dd883981fa9a24bdcd",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2025.1.4.1-aarch64.dmg",
+      "build_number": "251.27812.51"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2025.1.3",
-      "sha256": "552145a2d550cfcb2dc59530605dbe4af179102a99dab4b69acb80d9504d0ef3",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.3-aarch64.dmg",
-      "build_number": "251.25410.170"
+      "version": "2025.1.5",
+      "sha256": "9386f41063a209d4634098bc14e8e63d3cf030b3f8b83524b61d99bf992905d1",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2025.1.5-aarch64.dmg",
+      "build_number": "251.26927.79"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2025.1.2",
-      "sha256": "298d53fcd1a979e6910f97d9a29ac9bc0ed12386838a93a6d279bb415cf4708f",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.2-aarch64.dmg",
-      "build_number": "251.26094.131"
+      "version": "2025.1.4.1",
+      "sha256": "6840c346c133f3d1ed0eb41ba2f0195b32a70eb69884c66af408c51ebdb6825a",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2025.1.4.1-aarch64.dmg",
+      "build_number": "251.27812.50"
     },
     "writerside": {
       "update-channel": "Writerside EAP",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -16,18 +16,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip"
       },
       "name": "ideavim"
     },
@@ -36,7 +36,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/631/766544/python-251.26094.121.zip"
+        "251.27812.49": "https://plugins.jetbrains.com/files/631/805177/python-251.27812.49.zip"
       },
       "name": "python"
     },
@@ -46,8 +46,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.26094.121": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/1347/806838/scala-intellij-bin-2025.1.32.zip"
       },
       "name": "scala"
     },
@@ -67,18 +67,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
       },
       "name": "string-manipulation"
     },
@@ -98,18 +98,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip"
       },
       "name": "handlebars-mustache"
     },
@@ -129,18 +129,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.119": null,
-        "251.25410.170": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.141": null,
-        "251.26094.87": null
+        "251.25410.129": null,
+        "251.26927.67": null,
+        "251.26927.79": null,
+        "251.26927.90": null,
+        "251.27812.15": null,
+        "251.27812.49": null,
+        "251.27812.50": null,
+        "251.27812.51": null,
+        "251.27812.52": null,
+        "251.27812.54": null,
+        "252.23892.363": "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip"
       },
       "name": "kotlin"
     },
@@ -160,18 +160,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/6981/724264/ini-251.23774.466.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip"
+        "251.23774.423": null,
+        "251.25410.129": null,
+        "251.26927.67": "https://plugins.jetbrains.com/files/6981/782326/ini-251.26927.70.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/6981/782326/ini-251.26927.70.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/6981/782326/ini-251.26927.70.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/6981/811158/ini-252.23892.374.zip"
       },
       "name": "ini"
     },
@@ -191,18 +191,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -222,18 +222,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
       },
       "name": "grep-console"
     },
@@ -253,18 +253,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip"
       },
       "name": "file-watchers"
     },
@@ -274,8 +274,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip"
       },
       "name": "maven-helper"
     },
@@ -295,18 +295,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip"
       },
       "name": "cucumber-for-java"
     },
@@ -316,8 +316,8 @@
         "phpstorm"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip"
+        "251.27812.49": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip"
       },
       "name": "symfony-plugin"
     },
@@ -327,8 +327,8 @@
         "phpstorm"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip"
+        "251.27812.49": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip"
       },
       "name": "php-annotations"
     },
@@ -345,15 +345,15 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.25410.119": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/7322/782358/python-ce-251.26927.70.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7322/782358/python-ce-251.26927.70.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/7322/782358/python-ce-251.26927.70.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7322/809016/python-ce-252.23892.360.zip"
       },
       "name": "python-community-edition"
     },
@@ -373,18 +373,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip"
       },
       "name": "asciidoc"
     },
@@ -404,18 +404,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26927.67": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.26927.90": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.50": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.51": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
       },
       "name": "wakatime"
     },
@@ -435,18 +435,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip"
       },
       "name": "gittoolbox"
     },
@@ -466,18 +466,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/7724/724240/clouds-docker-impl-251.23774.466.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip"
+        "251.23774.423": null,
+        "251.25410.129": null,
+        "251.26927.67": "https://plugins.jetbrains.com/files/7724/782341/clouds-docker-impl-251.26927.70.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/7724/782341/clouds-docker-impl-251.26927.70.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/7724/782341/clouds-docker-impl-251.26927.70.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/7724/811134/clouds-docker-impl-252.23892.374.zip"
       },
       "name": "docker"
     },
@@ -497,18 +497,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip"
       },
       "name": "graphql"
     },
@@ -527,17 +527,17 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.119": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.141": null,
-        "251.26094.87": null
+        "251.25410.129": null,
+        "251.26927.67": null,
+        "251.26927.90": null,
+        "251.27812.15": null,
+        "251.27812.49": null,
+        "251.27812.50": null,
+        "251.27812.51": null,
+        "251.27812.52": null,
+        "251.27812.54": null,
+        "252.23892.363": null
       },
       "name": "-deprecated-rust"
     },
@@ -556,17 +556,17 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
         "251.23774.423": null,
-        "251.25410.119": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.141": null,
-        "251.26094.87": null
+        "251.25410.129": null,
+        "251.26927.67": null,
+        "251.26927.90": null,
+        "251.27812.15": null,
+        "251.27812.49": null,
+        "251.27812.50": null,
+        "251.27812.51": null,
+        "251.27812.52": null,
+        "251.27812.54": null,
+        "252.23892.363": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -586,18 +586,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/8195/715934/toml-251.23774.429.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip"
+        "251.23774.423": null,
+        "251.25410.129": null,
+        "251.26927.67": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/8195/809304/toml-252.23892.361.zip"
       },
       "name": "toml"
     },
@@ -607,8 +607,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/8327/809293/Minecraft_Development-2025.1-1.8.6.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/8327/809293/Minecraft_Development-2025.1-1.8.6.zip"
       },
       "name": "minecraft-development"
     },
@@ -628,18 +628,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
-        "251.23774.423": "https://plugins.jetbrains.com/files/8554/716074/featuresTrainer-251.23774.436.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip"
+        "251.23774.423": null,
+        "251.25410.129": "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/8554/811140/featuresTrainer-252.23892.374.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -659,18 +659,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
       },
       "name": "nixidea"
     },
@@ -690,18 +690,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip"
       },
       "name": "gherkin"
     },
@@ -721,18 +721,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip"
       },
       "name": "-env-files"
     },
@@ -742,8 +742,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "251.26094.121": "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip"
+        "251.27812.49": "https://plugins.jetbrains.com/files/9568/802993/go-plugin-251.27812.12.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9568/802993/go-plugin-251.27812.12.zip"
       },
       "name": "go"
     },
@@ -763,18 +763,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9707/702582/ANSI_Highlighter_Premium-24.3.4.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26927.67": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.26927.90": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.49": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.50": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.51": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar"
       },
       "name": "ansi-highlighter-premium"
     },
@@ -794,18 +794,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
     },
@@ -825,18 +825,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip"
       },
       "name": "randomness"
     },
@@ -856,18 +856,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
       },
       "name": "csv-editor"
     },
@@ -887,18 +887,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip"
       },
       "name": "rainbow-brackets"
     },
@@ -918,18 +918,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
     },
@@ -949,18 +949,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
       },
       "name": "hocon"
     },
@@ -979,17 +979,17 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip"
       },
       "name": "go-template"
     },
@@ -1009,18 +1009,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip"
       },
       "name": "extra-icons"
     },
@@ -1040,18 +1040,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/11349/768106/aws-toolkit-jetbrains-standalone-3.74.243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1060,7 +1060,7 @@
         "rider"
       ],
       "builds": {
-        "251.25410.119": "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip"
+        "251.26927.67": "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip"
       },
       "name": "cognitivecomplexity"
     },
@@ -1080,18 +1080,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip"
       },
       "name": "vscode-keymap"
     },
@@ -1111,18 +1111,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -1142,18 +1142,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
     },
@@ -1173,18 +1173,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -1204,18 +1204,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
     },
@@ -1235,18 +1235,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip"
       },
       "name": "protocol-buffers"
     },
@@ -1266,18 +1266,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26927.67": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.26927.90": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.49": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.50": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.51": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -1297,18 +1297,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26927.67": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.26927.90": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.49": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.50": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.51": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
     },
@@ -1328,18 +1328,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "251.23774.423": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar"
+        "251.25410.129": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26927.67": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.26927.90": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.49": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.50": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.51": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar"
       },
       "name": "which-key"
     },
@@ -1359,18 +1359,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1390,18 +1390,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip"
       },
       "name": "github-copilot"
     },
@@ -1421,18 +1421,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1452,18 +1452,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1483,18 +1483,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18824/694222/CodeGlancePro-1.9.7-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip"
       },
       "name": "codeglance-pro"
     },
@@ -1514,18 +1514,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.23774.423": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.25410.119": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.25410.170": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.121": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.122": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.123": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.127": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.131": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.133": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.141": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar",
-        "251.26094.87": "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar"
+        "251.23774.423": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.25410.129": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.26927.67": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.26927.79": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.26927.90": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.27812.15": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.27812.49": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.27812.50": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.27812.51": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.27812.52": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "251.27812.54": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar",
+        "252.23892.363": "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1545,18 +1545,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
     },
@@ -1576,18 +1576,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
       },
       "name": "mermaid"
     },
@@ -1607,18 +1607,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
     },
@@ -1638,18 +1638,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "252.23892.363": null
       },
       "name": "code-complexity"
     },
@@ -1669,18 +1669,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1696,14 +1696,14 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.119": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip"
+        "251.26927.67": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip"
       },
       "name": "dev-containers"
     },
@@ -1714,9 +1714,9 @@
         "rust-rover"
       ],
       "builds": {
-        "251.25410.170": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip"
+        "251.26927.79": "https://plugins.jetbrains.com/files/22407/786178/intellij-rust-251.26927.79.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/22407/786178/intellij-rust-251.26927.79.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/22407/786178/intellij-rust-251.26927.79.zip"
       },
       "name": "rust"
     },
@@ -1736,18 +1736,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip"
       },
       "name": "continue"
     },
@@ -1767,18 +1767,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": null,
         "251.23774.423": "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/22857/810975/vcs-gitlab-IU-252.23892.364-IU.zip"
       },
       "name": "gitlab"
     },
@@ -1798,18 +1798,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip"
       },
       "name": "catppuccin-icons"
     },
@@ -1829,18 +1829,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "251.23774.423": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
     },
@@ -1860,18 +1860,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23806/664310/Oxocarbon-1.4.5.zip",
-        "251.23774.423": null,
-        "251.25410.119": null,
-        "251.25410.170": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.141": null,
-        "251.26094.87": null
+        "251.23774.423": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip",
+        "252.23892.363": null
       },
       "name": "oxocarbon"
     },
@@ -1891,18 +1891,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip"
       },
       "name": "extra-ide-tweaks"
     },
@@ -1922,18 +1922,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.23774.423": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip"
+        "251.23774.423": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.25410.129": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip",
+        "252.23892.363": "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip"
       },
       "name": "extra-tools-pack"
     },
@@ -1950,15 +1950,15 @@
         "webstorm"
       ],
       "builds": {
-        "251.25410.119": null,
-        "251.25410.170": null,
-        "251.26094.121": null,
-        "251.26094.122": null,
-        "251.26094.123": null,
-        "251.26094.127": null,
-        "251.26094.131": null,
-        "251.26094.133": null,
-        "251.26094.87": null
+        "251.26927.67": null,
+        "251.26927.79": null,
+        "251.27812.15": null,
+        "251.27812.49": null,
+        "251.27812.50": null,
+        "251.27812.51": null,
+        "251.27812.52": null,
+        "251.27812.54": null,
+        "252.23892.363": null
       },
       "name": "nix-lsp"
     },
@@ -1977,120 +1977,118 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.119": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.25410.170": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.121": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.122": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.123": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.127": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.131": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.133": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.141": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip",
-        "251.26094.87": "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip"
+        "251.25410.129": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.26927.67": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.26927.79": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.26927.90": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.15": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.49": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.50": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.51": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.52": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "251.27812.54": "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip",
+        "252.23892.363": null
       },
       "name": "markdtask"
     }
   },
   "files": {
     "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip": "sha256-frvQ+Dm1ueID6+vNlja0HtecGyn+ppq9GTgmU3kQ+58=",
-    "https://plugins.jetbrains.com/files/10080/739688/intellij-rainbow-brackets-2024.2.11-241.zip": "sha256-ekeCyyUhzP32v8nu+U/LS0a/eW6onhBX0qCQmNQ/pgg=",
+    "https://plugins.jetbrains.com/files/10080/811169/intellij-rainbow-brackets-2025.3.2.zip": "sha256-X02u3BiuX9V2pQqgrs4qcKbN2IlcXhuVb56knZKMwzU=",
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
-    "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip": "sha256-Bnnvy+HDNkx2DQM7N+JUa8hQzIA3H/5Y0WpWAjPmhUI=",
     "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip": "sha256-GO0bXJsHx9O1A6M9NUCv9m4JwKHs5plwSssgx+InNqE=",
-    "https://plugins.jetbrains.com/files/10581/629973/go-template-243.21565.122.zip": "sha256-6pZ8vHw8C08IUvU76meMTGShoSMntQABv/KBX4BRDYs=",
     "https://plugins.jetbrains.com/files/10581/711019/go-template-251.23774.318.zip": "sha256-zX1nEdq84wwQvGhV664V5bNBPVTI4zWo306JtjXcGkE=",
-    "https://plugins.jetbrains.com/files/11058/734948/Extra_Icons-2025.1.5.zip": "sha256-trVQyV4PcxI1BeLtIg3fP1dOITiFRheIGpxU3GuA83w=",
-    "https://plugins.jetbrains.com/files/11349/768106/aws-toolkit-jetbrains-standalone-3.74.243.zip": "sha256-eWAEs18QSUate1bvO1412v+XniVEhjykgNsEn/rhGH0=",
-    "https://plugins.jetbrains.com/files/11349/768108/aws-toolkit-jetbrains-standalone-3.74.251.zip": "sha256-yklhTCVPh6vJo/ppVh3W6d7Cy8mfzfHbfOiXZT/vyI4=",
+    "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip": "sha256-XKv4jEKOk2O++VdHycGoLgICsusULbWRlQ0J5p+KgAE=",
+    "https://plugins.jetbrains.com/files/11058/812798/Extra_Icons-2025.1.11.zip": "sha256-c2ICvJaEt4xyblIb5LOuLxaLGzuV/uHENiJO+4t0ves=",
+    "https://plugins.jetbrains.com/files/11349/795849/aws-toolkit-jetbrains-standalone-3.86.251.zip": "sha256-7IaINi15gpltTpT52KpHAu5CG/eLVHJBrEGGPsBau4Q=",
     "https://plugins.jetbrains.com/files/12024/667413/ReSharperPlugin.CognitiveComplexity-2025.1.0-eap01.zip": "sha256-SWIXjxnwAf9dju1oOgzePrTY0lPNNX54Afp5OIkGGi4=",
-    "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
     "https://plugins.jetbrains.com/files/12062/711097/keymap-vscode-251.23774.318.zip": "sha256-obbLL8n6gK8oFw8NnJbdAylPHfTv4GheBDnVFOUpwL0=",
-    "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip": "sha256-/g1ucT18ywVJnCePH7WyMWKgM9umowBz5wFObmO7cws=",
+    "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip": "sha256-V3Vk6UYLUSiSmypD+g0DCX1sPw3/wZqvLxFhbkTqY34=",
     "https://plugins.jetbrains.com/files/12559/711714/keymap-eclipse-251.23774.329.zip": "sha256-HC1s5FqSLVgPNKc5Wiw0RFC6KpozxmjKzbh9rS9nFwc=",
+    "https://plugins.jetbrains.com/files/12559/796343/keymap-eclipse-252.23892.201.zip": "sha256-VotPAC/wcz5QveJMlgzGZktKHRpqW/KalckEMRU66cU=",
     "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip": "sha256-Q+gqKG/2bHD49Xtn9MNlYJQGtNF/7tIay9F7ndi8uwA=",
-    "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip": "sha256-VQqK0Cm9ddXN63KYIqimuGOh7EB9VvdlErp/VrWx8SA=",
     "https://plugins.jetbrains.com/files/13017/711726/keymap-visualStudio-251.23774.329.zip": "sha256-DKkgt0z/ui0bOLSbnKy51RL7+9HIqeriroi2otZ64mQ=",
+    "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip": "sha256-5qDjLRMNwn+1QVN8cKUYlakQ8aBRiTyGuA7se3l9BI0=",
     "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip": "sha256-eKwDE+PMtYhrGbDDZPS5cimssH+1xV4GF6RXXg/3urU=",
     "https://plugins.jetbrains.com/files/1347/770332/scala-intellij-bin-2025.1.25.zip": "sha256-h9GNGjqTc+h+x/0TRilKmqGoPsxhPmXIKoGC/s4/PKg=",
-    "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip": "sha256-Tgu8CfDhO6KugfuLNhmxe89dMm+Qo3fmAg/8hwjUaoc=",
+    "https://plugins.jetbrains.com/files/1347/806838/scala-intellij-bin-2025.1.32.zip": "sha256-Bmix+OZ1Q5P0X8uGdu2kX70OJOq3CPDx+2Tmh4lDVg8=",
     "https://plugins.jetbrains.com/files/14004/711000/protoeditor-251.23774.318.zip": "sha256-ZYn365EY8+VP1TKM4wBotMj1hYbSSr4J1K5oIZlE2SE=",
+    "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip": "sha256-WK9ukN6g2tCmeljFXwv3F+xFI/VZKlIeFs8DXqPcIKA=",
+    "https://plugins.jetbrains.com/files/14004/803006/protoeditor-251.27812.12.zip": "sha256-EPL6bUZmdBXrkfeGyx7uf73kWGM/drxic/poSXJinS8=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar": "sha256-mB09zvUg1hLXl9lgW1NEU+DyVel1utZv6s+mFykckYY=",
-    "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar": "sha256-2FlEaHf2rO6xgG3LnZIPt/XKgRGjpLSiEXCncfAf3bI=",
     "https://plugins.jetbrains.com/files/15976/762630/IDEA_Which-Key-0.11.1.jar": "sha256-Z3q0d4jCqeBwzW0jSSM3q4MTAPaTqQuwnV3ZVHfOMR4=",
-    "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip": "sha256-yKpWQZGxfsKwPVTJLHpF4KGJ5ANCd73uxHlfdFE4Qf4=",
-    "https://plugins.jetbrains.com/files/164/756054/IdeaVIM-2.25.1.zip": "sha256-W5CtJqmejx2braLiJEYGPU29fCSOZNSQG0HZxqdOJIk=",
-    "https://plugins.jetbrains.com/files/16604/734947/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.7.zip": "sha256-9DLY2HIyQR2w8xPVVKa2l7OZWqfoTvHkLGZYEnDV7/A=",
-    "https://plugins.jetbrains.com/files/17718/765945/github-copilot-intellij-1.5.46-243.zip": "sha256-GKCOuZJerzhkhbl4zXWukonkygCT/Dm/tV4zRxFAP+g=",
+    "https://plugins.jetbrains.com/files/164/789514/IdeaVIM-2.26.0.zip": "sha256-6YPspMAtSM0L3nbvnloeO65Xp5HTXgqx9DHxItvf2NY=",
+    "https://plugins.jetbrains.com/files/16604/812796/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.11.zip": "sha256-YmbPcb3ghZbzzOlF3bGUNLY8HgfvQPLOFXl48VsH48I=",
+    "https://plugins.jetbrains.com/files/17718/803946/github-copilot-intellij-1.5.52-243.zip": "sha256-rP2PplN9rOnKGWMdmXphdMeV0AqoauT0aIoKkgM7Hjw=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/18682/744076/Catppuccin_Theme-3.4.2.zip": "sha256-fa9GiD/PNGy8AEao99vW3DBF1FKSulu3t+wO7mdr5fk=",
-    "https://plugins.jetbrains.com/files/18824/694222/CodeGlancePro-1.9.7-signed.zip": "sha256-8RjKjmadd1o/M+WTLtKPn354bbKgEht4nvWnMcRPN9w=",
     "https://plugins.jetbrains.com/files/18824/736403/CodeGlancePro-1.9.8-signed.zip": "sha256-/1lyQq7JANhcKmIaaBHZ8ZCR4p23sLjLTTq9/68Fz+c=",
-    "https://plugins.jetbrains.com/files/18922/767365/GerryThemes.jar": "sha256-NjhQX8TY9B+aOPm3RrR42OyPM2GnZ5d0/+L83fcaGM0=",
+    "https://plugins.jetbrains.com/files/18922/812139/GerryThemes.jar": "sha256-uROFg0GA7C3cpY3X5nrNccgGLuDDIIg4jz+GOUiZ6VI=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
-    "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip": "sha256-jGWRU0g120qYvvFiUFI10zvprTsemuIq3XmIjYxZGts=",
-    "https://plugins.jetbrains.com/files/20146/717659/Mermaid-0.0.25_IJ.243.zip": "sha256-QqEjnN6lUUtHkDRFWPeV3vqgGB/ZfWGVDqtk8gwJEqY=",
+    "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip": "sha256-QTh77pyi4lh7V0DGPFx9kERjFCop219d76wTDwD0SYY=",
     "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip": "sha256-N66Bh0AwHmg5N9PNguRAGtpJ/dLMWMp3rxjTgz9poFo=",
     "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip": "sha256-TZPup3EJ0cBv4i2eVAQwVmmzy0rmt4KptEsk3C7baEM=",
     "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip": "sha256-2qDeC2Fxp4/IfiLPL1JDquJDCzONCp4m92Ht2fnCn/M=",
     "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip": "sha256-lOPUSxlbgagD0SuXTw+fEdwTxxfUHP1Kl6L+u/oa4fs=",
     "https://plugins.jetbrains.com/files/21962/732363/clouds-docker-gateway-251.25410.75.zip": "sha256-kfXB36mIOn82pq+22ryztxY9K6CgwwNarNKcLuIH9G4=",
-    "https://plugins.jetbrains.com/files/22407/757316/intellij-rust-251.25410.170.zip": "sha256-drL4D+lWFdKkmjMHDsPl8nJ+0oMldR6fs4MpyuiVWYg=",
-    "https://plugins.jetbrains.com/files/22707/762617/continue-intellij-extension-1.0.21.zip": "sha256-Jdt7S5goBdA8kf09pjDdLLyRXi3AVy2BdnC1zUDm46Y=",
+    "https://plugins.jetbrains.com/files/22407/786178/intellij-rust-251.26927.79.zip": "sha256-+mxjAEsOdotjp8w/9gkun4VbASFIp5JM7efVkHWiqk0=",
+    "https://plugins.jetbrains.com/files/22707/800990/continue-intellij-extension-1.0.30.zip": "sha256-UxVzxs2ToLkq1/q6s44pggUMNFoObdxNbJdPJVUTNBA=",
     "https://plugins.jetbrains.com/files/22857/716106/vcs-gitlab-IU-251.23774.435-IU.zip": "sha256-zNNFPPPnYLkSzXX3CA1IMA0cjeXMcPY58+v80/KjVkg=",
     "https://plugins.jetbrains.com/files/22857/742106/vcs-gitlab-IU-251.25410.159-IU.zip": "sha256-PwxExt+Dlq11Y5UdEwFr/2BJPST3EYY7r/3gsXoxGzo=",
-    "https://plugins.jetbrains.com/files/22857/764755/vcs-gitlab-IU-251.26094.114-IU.zip": "sha256-0x7t3Lo29Bwmo5pItUD/D+na2yIfd2shPiAVCZp9j/w=",
+    "https://plugins.jetbrains.com/files/22857/780560/vcs-gitlab-IU-251.26927.54-IU.zip": "sha256-pLB6vIl7bgtu2tu/7OpcnAkMFEc+iEVyRJgxmSl35hk=",
+    "https://plugins.jetbrains.com/files/22857/810975/vcs-gitlab-IU-252.23892.364-IU.zip": "sha256-ubzjpn46yI0oP1xZKH/Hz6ag+4WXghVpOWmK05WgthA=",
     "https://plugins.jetbrains.com/files/23029/764814/Catppuccin_Icons-1.12.0.zip": "sha256-TZNCi4kRc7NNcV89j2UhT6y1+l1L512xTN/yTztjQfY=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
-    "https://plugins.jetbrains.com/files/23806/664310/Oxocarbon-1.4.5.zip": "sha256-zF89Q1LE6xwBeDKv4FSQ6H6cbABjz74Z/qGwddRWp7M=",
-    "https://plugins.jetbrains.com/files/23927/734950/Extra_IDE_Tweaks-2025.1.5.zip": "sha256-bwZSaUkfJ2D6XLr0e7EoismsTmvNCyRzGd4OWu6u9n0=",
-    "https://plugins.jetbrains.com/files/24559/734949/Extra_Tools_Pack-2025.1.6.zip": "sha256-SC8IMca0EYEmZFrMsaK3oadaemM4FQnYiTxOTt1zQGg=",
-    "https://plugins.jetbrains.com/files/26084/745003/markdtask-2025.1.2.zip": "sha256-rRSyr7nShG1q9tVSO7VRo3KoGnBcrND4D4+38gNBtqI=",
-    "https://plugins.jetbrains.com/files/631/766544/python-251.26094.121.zip": "sha256-gj3s+D04AcmPxzhKDWdYFED8Ab+iHIp6fpZhxasofUQ=",
-    "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip": "sha256-pFKAZ8xFNfUh7/Hi4NYPDQAhRRYm4WKTpCQELqBfb40=",
+    "https://plugins.jetbrains.com/files/23806/784029/Oxocarbon-1.4.6.zip": "sha256-+cLKIu8abGXZqJ3GutQsoQQg3s0wkmk5qKosW0O8RII=",
+    "https://plugins.jetbrains.com/files/23927/812793/Extra_IDE_Tweaks_Subscription-2025.1.10.zip": "sha256-b+1tyiMuQ3g/adLBfRnB/8tmUxlpqemI0O3VZmTzIWk=",
+    "https://plugins.jetbrains.com/files/24559/812799/Extra_Tools_Pack-2025.1.13.zip": "sha256-eOUdDQDEaxDxEx9Osa8elZiBEqhWs3grGiS4Z/iY7IE=",
+    "https://plugins.jetbrains.com/files/26084/804883/markdtask-2025.2.zip": "sha256-2Vrm9k4ZqqpWl/EgDrAFNTpUeBhDSYt48JhAWlSWY1A=",
+    "https://plugins.jetbrains.com/files/631/805177/python-251.27812.49.zip": "sha256-pDjETptVpOSEVFmw/bKtQND6NAMEZxDvBzyClV4WQvo=",
     "https://plugins.jetbrains.com/files/6884/711128/handlebars-251.23774.318.zip": "sha256-34s7pOsqMaGoVYhCuAZtylNwplQOtNQJUppepsl4F4Q=",
-    "https://plugins.jetbrains.com/files/6981/724264/ini-251.23774.466.zip": "sha256-CnoNNfcsbP9IipuqsBV1OZu+l3h7Yrs6MSofriDvI34=",
-    "https://plugins.jetbrains.com/files/6981/724294/ini-251.25410.24.zip": "sha256-dcFDO0/mzbjkrsgM+RdHBAA5davTqD5is2D7JYQiTxc=",
-    "https://plugins.jetbrains.com/files/6981/771136/ini-251.26094.141.zip": "sha256-pyB9/Rutax3lp69NcvbVKy4b4OpZZ3cJst6UrrsQCho=",
+    "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip": "sha256-iWKLgk+eWhUmv/lH9+B2HI97d++EYvLwGgtRsJf4aSE=",
+    "https://plugins.jetbrains.com/files/6954/809234/Kotlin-252.23892.360-IJ.zip": "sha256-pQGVguF7zzzasLm2tlmtvqiPtdFN4Q5NKRwYx1r62fM=",
+    "https://plugins.jetbrains.com/files/6981/782326/ini-251.26927.70.zip": "sha256-SWxabTcZDL1HoF9ou62ABvHOjK9vPQG+1S60kXskuwk=",
+    "https://plugins.jetbrains.com/files/6981/806736/ini-251.27812.54.zip": "sha256-olPIXYib4IUF/qmTzTOmEEXq01I8ji7no4dqSTJvqhY=",
+    "https://plugins.jetbrains.com/files/6981/811158/ini-252.23892.374.zip": "sha256-eZJ95qzzpwlj5zJZlX+iAwkgxiKjykVaELiGudxDUTg=",
     "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip": "sha256-BW47ZEUINVnhV0RZ1np7Dkf3lfyrtKoZ9ej/SVct2Xs=",
     "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip": "sha256-KY5VRiLJJwa9OVVog1W3MboZjwVboYwYm+i4eqooo44=",
-    "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip": "sha256-8IHS3kmmbL8uQYnaMW7NgBIpBKT+XDJ4QDiiPZa5pzo=",
     "https://plugins.jetbrains.com/files/7177/711086/fileWatcher-251.23774.318.zip": "sha256-jNHP/vaCaolmvNUQRGmIgSR1ykjDtKqyJ69UIn5cz70=",
+    "https://plugins.jetbrains.com/files/7177/796349/fileWatcher-252.23892.201.zip": "sha256-ac4h2uwF6h2L5Cax40t36wTBNFzQn38EVGEL2gts8jQ=",
     "https://plugins.jetbrains.com/files/7179/767851/MavenHelper-4.30.0-IJ2022.2.zip": "sha256-Xsw4P/KddgOuwcNBzT3UWkaQBYXLqGop+fQhoL65Dfg=",
-    "https://plugins.jetbrains.com/files/7212/636678/cucumber-java-243.22562.13.zip": "sha256-q8LjYzKuTK5da+A/29Z2+bHhWKmvsIUVG1MprbsIoLM=",
     "https://plugins.jetbrains.com/files/7212/711023/cucumber-java-251.23774.318.zip": "sha256-I7gwjCnW8OXzM5eioM7h6RW9qYaQX0MWJPfHOOL9KJA=",
+    "https://plugins.jetbrains.com/files/7212/809131/cucumber-java-252.23892.360.zip": "sha256-ypJOPmcl4881TpMboomVvmspJ3I1sfm5a26l54cfFpo=",
     "https://plugins.jetbrains.com/files/7219/770179/Symfony_Plugin-2025.1.280.zip": "sha256-SgldikXjVx6hUw3LqcN8/NxLLBfnr/LUc/SrIIACl7k=",
     "https://plugins.jetbrains.com/files/7320/718466/PHP_Annotations-12.0.0.zip": "sha256-HfTd3zT/7sOrYutEkEzpFAu6AijrFrpHJg1ftP3N87Y=",
     "https://plugins.jetbrains.com/files/7322/737802/python-ce-251.25410.129.zip": "sha256-gN9XqO/x41scgJ9dzTdC4i4hIZJpwSeR7OjU2BG8gzU=",
-    "https://plugins.jetbrains.com/files/7322/766528/python-ce-251.26094.121.zip": "sha256-8om1u4KfXRkMUV8YzXWa1cgMeqTCRKSvDUh86ZBzPTE=",
-    "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip": "sha256-3RJ7YVFtynyqeLIzdrirCMbWNZmUkJ+DT/9my71H0Dk=",
-    "https://plugins.jetbrains.com/files/7391/763266/asciidoctor-intellij-plugin-0.44.7.zip": "sha256-//bXaBJI+eIAYCuXek0pl9h7Utmrtui68QC1vrxPY8c=",
+    "https://plugins.jetbrains.com/files/7322/782358/python-ce-251.26927.70.zip": "sha256-Lole5M9TXN6tuEb4Y39qqhQ0RwGZaCLyPnzBtfH2XGk=",
+    "https://plugins.jetbrains.com/files/7322/805188/python-ce-251.27812.49.zip": "sha256-53cIBQbvP13Py0nN5ZXJBLH3xA5/tz2ba4hhVWRaFSM=",
+    "https://plugins.jetbrains.com/files/7322/809016/python-ce-252.23892.360.zip": "sha256-51js6gSLK0cIzLxx5LFjdsQIHiSNZdyGO+ATiQcxA3k=",
+    "https://plugins.jetbrains.com/files/7391/807449/asciidoctor-intellij-plugin-0.44.8.zip": "sha256-6VpRIidsf8iWJeR3OarwwgS1NDXj9j6bLnxU/YBskeY=",
     "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar": "sha256-DobKZKokueqq0z75d2Fo3BD8mWX9+LpGdT9C7Eu2fHc=",
-    "https://plugins.jetbrains.com/files/7499/721170/gittoolbox-600.1.2_243-signed.zip": "sha256-cnVK5tsExjEAqP3cuh1PgNjrZYt2dVGQ/RL/jr89Zew=",
-    "https://plugins.jetbrains.com/files/7724/724240/clouds-docker-impl-251.23774.466.zip": "sha256-2o1CaX3Xe86ZksIMW9ZqvnuvfvnqSddDDxEU/SFWER8=",
-    "https://plugins.jetbrains.com/files/7724/731335/clouds-docker-impl-251.25410.67.zip": "sha256-p+7U17bTsrxGFVR+Kguma43FOHW0d3NQKRjwxONqL1g=",
-    "https://plugins.jetbrains.com/files/7724/771131/clouds-docker-impl-251.26094.141.zip": "sha256-+WJP3tXjIC4eGkssPrNf+tGEIKGQeLP3CcFtyXYUlQg=",
-    "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip": "sha256-rr2pO0mIsqWXYZgwEhcQJlk0lQabxnIPxqRCGdTFaTw=",
+    "https://plugins.jetbrains.com/files/7499/810633/gittoolbox-600.1.7_243-signed.zip": "sha256-lSgPEqhTvr+xm+9Or01IQABgjNugoUZHLUgUFZaOLs0=",
+    "https://plugins.jetbrains.com/files/7724/782341/clouds-docker-impl-251.26927.70.zip": "sha256-jEiC6Ro30ZGR3d5ODZ7lzHjwdzarxVVdWmFOKinIhW4=",
+    "https://plugins.jetbrains.com/files/7724/805402/clouds-docker-impl-251.27812.52.zip": "sha256-irzstm3qMkiJSVsXGunYdMvThvPX1KU4Cf85ZDf3/9o=",
+    "https://plugins.jetbrains.com/files/7724/811134/clouds-docker-impl-252.23892.374.zip": "sha256-faFrInr51uyQUMUTAc4dHBWjQVJH9lWPEdV98sGPLFA=",
     "https://plugins.jetbrains.com/files/8097/711188/graphql-251.23774.318.zip": "sha256-O+gSW36MwqQqUiZBQl8J4NFNK+jFowtT9k1ykhSraxM=",
-    "https://plugins.jetbrains.com/files/8097/747099/graphql-251.26094.37.zip": "sha256-5QQ3zmfgtcy4cSyGale9GvENuiWV8cQmzTEfxPkox2A=",
-    "https://plugins.jetbrains.com/files/8195/715934/toml-251.23774.429.zip": "sha256-cNWs+ycKlqednnqJAm4AkqF3LTdMt8jhwWWiEDdKQE4=",
-    "https://plugins.jetbrains.com/files/8195/740008/toml-251.25410.140.zip": "sha256-DYgGpnlqpr/d/hJXD6uYsa2tzErM4uCofgok/3WayYs=",
-    "https://plugins.jetbrains.com/files/8195/763535/toml-251.26094.108.zip": "sha256-l1dKtjk1YkO2Bd5H/4MDIGAyqi3tNMsDIrVNoMDwzEs=",
-    "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip": "sha256-4c1nxjbEsNs9twmQnJllk1OIVmm0nnUYZ0R7f/6bJt4=",
-    "https://plugins.jetbrains.com/files/8327/770049/Minecraft_Development-2025.1-1.8.5.zip": "sha256-JD/OcG0B/KUMNmNsnRmiWzZ3QWVcFjaqNnQW8WbV1zc=",
-    "https://plugins.jetbrains.com/files/8554/716074/featuresTrainer-251.23774.436.zip": "sha256-P6ux6UgbjeJW3lF4w696bZ73zumY8hEm1iM98IsKgTQ=",
+    "https://plugins.jetbrains.com/files/8097/780447/graphql-251.26927.39.zip": "sha256-zPSBubfibs8dTxOLzJusinLn0ejkHNwEO1E4Ryi72HI=",
+    "https://plugins.jetbrains.com/files/8097/796399/graphql-252.23892.201.zip": "sha256-eLh0p5vDNG7fUV7pqbIbkL30dpPj19NE9JbwcDwxZXs=",
+    "https://plugins.jetbrains.com/files/8097/802996/graphql-251.27812.12.zip": "sha256-Pju+Kre4EKRoKYEPsj74+JFvd+VyXSb7EMDo00eCz10=",
+    "https://plugins.jetbrains.com/files/8195/780518/toml-251.26927.47.zip": "sha256-WGGDyxE1ElguDMm7dONA2f0k3u+Tl1vZp3HMLkr5bFw=",
+    "https://plugins.jetbrains.com/files/8195/809304/toml-252.23892.361.zip": "sha256-g4+qrB99G6l8CZce6X1fd6jt3fTtJXgb+ITZHiwu/SQ=",
+    "https://plugins.jetbrains.com/files/8327/809293/Minecraft_Development-2025.1-1.8.6.zip": "sha256-mePVZa+63bheH85ylkbX9oOX1Nq/IYLAGHHseOJx520=",
     "https://plugins.jetbrains.com/files/8554/740850/featuresTrainer-251.25410.148.zip": "sha256-iK3cy0Nf87rLV0m/t3LJv65Klij/9L5l9ad2UW9O00w=",
     "https://plugins.jetbrains.com/files/8554/768764/featuresTrainer-251.26094.133.zip": "sha256-qcMxLM2Y/Q18r718VasRMAlKppbH+ra/6eKCkmVL88s=",
-    "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip": "sha256-OFisV6Vs/xlbDvchxfrREDVgVh7wcfGnot+zUrgQU6M=",
-    "https://plugins.jetbrains.com/files/9164/636661/gherkin-243.22562.13.zip": "sha256-aG15ecfrsvNkpLjHclJEVKEW95GvBH+dEaqa+VCRkUo=",
+    "https://plugins.jetbrains.com/files/8554/811140/featuresTrainer-252.23892.374.zip": "sha256-wodhIhiPRsuBqfzYSEJo4reSrwh0yJbPu0W/kaoTUOE=",
+    "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip": "sha256-JShheBoOBiWM9HubMUJvBn4H3DnWykvqPyrmetaCZiM=",
     "https://plugins.jetbrains.com/files/9164/710996/gherkin-251.23774.318.zip": "sha256-Boy61dRieXmWrnTMfqqYZbdG/DNQ24KdguKN2fcZ+eg=",
-    "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip": "sha256-hR7hC2phDJnHXxPy80WlEDFAhZHtMCu7nqYvAb0VeTI=",
+    "https://plugins.jetbrains.com/files/9164/796366/gherkin-252.23892.201.zip": "sha256-KrC3EK4wYLSxWywF8I8nVx6tkclr1wAMya1Z1XF0QY8=",
     "https://plugins.jetbrains.com/files/9525/711041/dotenv-251.23774.318.zip": "sha256-0c/2qbuu+M6z0gvpme+Mkv23JlQKNTUU+9GL9mh2IFw=",
-    "https://plugins.jetbrains.com/files/9568/766540/go-plugin-251.26094.121.zip": "sha256-P6XLFObtTrnxNWvNZag73hFVVY82t3+YQ2G31cwAVgg=",
+    "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip": "sha256-N0DNEtF3FDcRirfjfSCCVUbDIA4SB35F/9XY1tPXXmg=",
+    "https://plugins.jetbrains.com/files/9568/802993/go-plugin-251.27812.12.zip": "sha256-7U44Ri396isqwV2s9E6WnlyWTLKdAwFVZ/qpW3lagto=",
     "https://plugins.jetbrains.com/files/9707/702581/ANSI_Highlighter_Premium-25.1.5.jar": "sha256-XYCD4kOHDeIKhti0T175xhBHR8uscaFN4c9CNlUaCDs=",
-    "https://plugins.jetbrains.com/files/9707/702582/ANSI_Highlighter_Premium-24.3.4.jar": "sha256-STDhSOshNJU8YOjd1ZMxNl4WaHEp81t9TimFVQGZgWw=",
+    "https://plugins.jetbrains.com/files/9707/767822/ANSI_Highlighter_Premium-25.2.1.jar": "sha256-mp1k2BdksxbGH4zUp/7DnjcGi5OXJ7UekCfX6dWZOtU=",
     "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip": "sha256-Mzmmq0RzMKZeKfBSo7FHvzeEtPGIrwqEDLAONQEsR1M=",
-    "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip": "sha256-ArwC2HO2cHlTcFKXQBuKzZTuOiiIDEc/SGDsDQUCZmI="
+    "https://plugins.jetbrains.com/files/9836/803254/intellij-randomness-3.4.0.zip": "sha256-mg0xdvhe/CSKJqmwACKHfk9zoRqfSz6xNPRP1njFClg="
   }
 }


### PR DESCRIPTION
Updated Jetbrains IDEs

## Things done

Ran `./bin/update_bin.py` in `/pkgs/applications/editors/jetbrains`, as per instructed in its README.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
