### PR TITLE
ustreamer: add withPython option

### DIFF
--- a/pkgs/by-name/us/ustreamer/package.nix
+++ b/pkgs/by-name/us/ustreamer/package.nix
@@ -16,8 +16,10 @@
   nixosTests,
   systemdLibs,
   which,
+  python3Packages,
   withSystemd ? true,
   withJanus ? true,
+  withPython ? true,
 }:
 stdenv.mkDerivation rec {
   pname = "ustreamer";
@@ -36,6 +38,15 @@ stdenv.mkDerivation rec {
     libjpeg
     libdrm
   ]
+  ++ lib.optionals withPython (
+    with python3Packages;
+    [
+      python
+      setuptools
+      build
+      pip
+    ]
+  )
   ++ lib.optionals withSystemd [
     systemdLibs
   ]
@@ -56,6 +67,9 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "WITH_V4P=1"
+  ]
+  ++ lib.optionals withPython [
+    "WITH_PYTHON=1"
   ]
   ++ lib.optionals withSystemd [
     "WITH_SYSTEMD=1"


### PR DESCRIPTION
## Things done

Add the option withpython to ustreamer and set the cmake flag when the option is enabled + add python deps.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
@tfc 
@MatthewCroughan 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
