### PR TITLE
python3Packages.luma-core: init at 2.5.1

### DIFF
--- a/pkgs/development/python-modules/luma-core/default.nix
+++ b/pkgs/development/python-modules/luma-core/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pillow,
+  smbus2,
+  pyftdi,
+  cbor2,
+  rpi-gpio,
+  spidev,
+}:
+buildPythonPackage rec {
+  pname = "luma-core";
+  version = "2.5.1";
+
+  src = fetchPypi {
+    pname = "luma_core";
+    inherit version;
+    hash = "sha256-m4j76GiYnsRHfiEP4pk+d0p0Jdfeg3iBQQn5i+MsplM=";
+  };
+
+  build-system = [ setuptools ];
+  pyproject = true;
+
+  dependencies = [
+    pillow
+    smbus2
+    cbor2
+  ]
+  ++ optional-dependencies.complete;
+
+  optional-dependencies = {
+    gpio = [ rpi-gpio ];
+    spi = [ spidev ];
+    ftdi = [ pyftdi ];
+    complete = with optional-dependencies; gpio ++ spi ++ ftdi;
+  };
+
+  meta = {
+    description = "Pillow-compatible drawing canvas library for SBCs";
+    longDescription = ''
+      A component library providing a Pillow-compatible drawing canvas,
+      and other functionality to support drawing primitives and text-rendering
+      capabilities for small displays on the Raspberry Pi and other single
+      board computers.
+    '';
+    homepage = "https://luma-core.readthedocs.io/";
+    changelog = "https://github.com/rm-hull/luma.core/blob/${version}/CHANGES.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eymeric ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8693,6 +8693,8 @@ self: super: with self; {
 
   luhn = callPackage ../development/python-modules/luhn { };
 
+  luma-core = callPackage ../development/python-modules/luma-core { };
+
   luna-soc = callPackage ../development/python-modules/luna-soc { };
 
   luna-usb = callPackage ../development/python-modules/luna-usb { };


### PR DESCRIPTION
## Things done

add luma-core at 2.5.1

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
