### PR TITLE
tauno-monitor: 0.2.11 -> 0.2.13

### DIFF
--- a/pkgs/by-name/ta/tauno-monitor/package.nix
+++ b/pkgs/by-name/ta/tauno-monitor/package.nix
@@ -13,14 +13,14 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "tauno-monitor";
-  version = "0.2.11";
+  version = "0.2.13";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "taunoe";
     repo = "tauno-monitor";
     tag = "v${version}";
-    hash = "sha256-FoNn+A0zqFf/Nl0MrK9/X5mwaq8mJBRH0uGnemDC0is=";
+    hash = "sha256-DAP+ddWD0K6EpK7OpO0ErnECS7293nPJpE2B8PWopyU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update tauno-monitor to v0.2.13.

Changelog: [https://github.com/taunoe/tauno-monitor/releases/tag/v0.2.13](https://github.com/taunoe/tauno-monitor/releases/tag/v0.2.13)

[https://github.com/taunoe/tauno-monitor/compare/v0.2.11...v0.2.13](https://github.com/taunoe/tauno-monitor/compare/v0.2.11...v0.2.13)

However I noticed a warning on startup without any device being attached. It is not a crash or error but I want to check if it is an upstream "issue" before merging.
This warning shows up since v0.2.9 (don't know why I didn't see it).

```
/nix/store/wyqiskrzyvy5p9ka2lxpwqa34whan4wi-tauno-monitor-0.2.13/share/tauno-monitor/tauno_monitor/usb_db.py:22790: SyntaxWarning: invalid escape sequence '\R'
  "1400": " CD\RW 40X",
Name          : ttyS3
Description   : n/a
HWID          : n/a
VID           : None
PID           : None
Serial Number : None
Location      : None
Manufacturer  : None
Product       : None
Interface     : None
```

Ok in [line 22790](https://github.com/taunoe/tauno-monitor/blob/main/src/usb_db.py#L22790) there is actually this dict value: `" CD\RW 40X"`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
