### PR TITLE
hashcat: 6.2.6 -> 7.0.0

### DIFF
--- a/pkgs/by-name/ha/hashcat/package.nix
+++ b/pkgs/by-name/ha/hashcat/package.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "hashcat";
-  version = "6.2.6";
+  version = "7.0.0";
 
   src = fetchurl {
     url = "https://hashcat.net/files/hashcat-${version}.tar.gz";
-    sha256 = "sha256-sl4Qd7zzSQjMjxjBppouyYsEeyy88PURRNzzuh4Leyo=";
+    sha256 = "sha256-hCtx0NNLAgAFiCR6rp/smg/BMnfyzTpqSSWw8Jszv3U=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ha/hashcat/package.nix
+++ b/pkgs/by-name/ha/hashcat/package.nix
@@ -61,6 +61,9 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform) [
     "IS_APPLE_SILICON='${if stdenv.hostPlatform.isAarch64 then "1" else "0"}'"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+    "IS_AARCH64=1"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates hashcat from v6.2.6 to [v7.0.0](https://github.com/hashcat/hashcat/releases/tag/v7.0.0), superseding https://github.com/NixOS/nixpkgs/pull/430363.

Overrides the `IS_AARCH64` make flag such that sse2neon is linked correctly, as [`arch`](https://github.com/hashcat/hashcat/blob/483efe2f9d600dded0fcd0232b9b7337028db589/src/Makefile#L91) can not detect it automatically.

The [release notes](https://github.com/hashcat/hashcat/blob/9727714cf25424b3a04990b34992298f0423b8a3/docs/changes.txt#L20) contain many new features, enhancements and fixes, but no large breaking changes as far as I can see.

Tested and benchmarked with `-m 34000`, one of the new algorithms in this release, on aarch64-darwin with Metal and x86_64-linux with ROCM.

--- 
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `e9aa1c19b02838571a37040f000ffb5fb287ffe3`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>hashcat</li>
    <li>wifite2</li>
    <li>wifite2.dist</li>
  </ul>
</details>

### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>hashcat</li>
  </ul>
</details>



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
