### PR TITLE
fallout2-ce: fix patch hash

### DIFF
--- a/pkgs/games/fallout-ce/fallout2-ce.nix
+++ b/pkgs/games/fallout-ce/fallout2-ce.nix
@@ -20,7 +20,7 @@ callPackage ./build.nix rec {
     # Fix case-sensitive filesystems issue when save/load games
     (fetchpatch2 {
       url = "https://github.com/alexbatalov/fallout2-ce/commit/d843a662b3ceaf01ac363e9abb4bfceb8b805c36.patch";
-      sha256 = "sha256-u4E9+DE6sGYikIGwKDmSBj3ErCfIo6YzIw2eMiqXw/E=";
+      sha256 = "sha256-r4sfl1JolWRNd2xcf4BMCxZw3tbN21UJW4TdyIbQzgs=";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

The hash for the patch used in `fallout2-ce` no longer matches, likely due to upstream changes in GitHub's patch rendering.

This PR updates the patch hash to the correct one, fixing the build.

###### Things done

- [x] Built on x86_64-linux
- [ ] Tested execution of binary (not applicable)
- [x] Ensured the patch still applies cleanly
- [x] Ran `nixpkgs-review` (optional, but useful)

###### Notes

Let me know if maintainers want this patch to be vendored instead of fetched via `fetchpatch2`.

---

cc maintainers of the package (if any listed)
