### PR TITLE
vivaldi-ffmpeg-codecs: 119293 -> 120726

### DIFF
--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
@@ -11,20 +11,19 @@
 let
   sources = {
     x86_64-linux = fetchurl {
-      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_73.snap";
-      hash = "sha256-YsAYQ/fKlrvu7IbIxLO0oVhWOtZZzUmA00lrU+z/0+s=";
+      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_85.snap";
+      hash = "sha256-77lcQFFP0eXuaxN2UdsEjFXJt22L6Mp6Fe3ZYPpKVwM=";
     };
     aarch64-linux = fetchurl {
-      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_74.snap";
-      hash = "sha256-zwCbaFeVmeHQLEp7nmD8VlEjSY9PqSVt6CdW4wPtw9o=";
+      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_85.snap";
+      hash = "sha256-77lcQFFP0eXuaxN2UdsEjFXJt22L6Mp6Fe3ZYPpKVwM=";
     };
   };
 in
-stdenv.mkDerivation rec {
-
+stdenv.mkDerivation (finalAttrs: {
   pname = "chromium-codecs-ffmpeg-extra";
 
-  version = "119293";
+  version = "120726";
 
   src = sources."${stdenv.hostPlatform.system}";
 
@@ -35,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -vD chromium-ffmpeg-${version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
+    install -vD chromium-ffmpeg-${finalAttrs.version}/chromium-ffmpeg/libffmpeg.so $out/lib/libffmpeg.so
   '';
 
   passthru = {
@@ -59,4 +58,4 @@ stdenv.mkDerivation rec {
       "aarch64-linux"
     ];
   };
-}
+})

--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/update.sh
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p common-updater-scripts coreutils grep jq squashfsTools
+#!nix-shell -i bash -p common-updater-scripts coreutils gnugrep jq squashfsTools
 
 set -eu -o pipefail
 
@@ -18,7 +18,7 @@ function update_source() {
   local url=$(echo $selectedRelease | jq -r '.download.url')
   source="$(nix-prefetch-url "$url")"
   hash=$(nix-hash --to-sri --type sha256 "$source")
-  update-source-version vivaldi-ffmpeg-codecs "$version" "$hash" "$url" --ignore-same-version --system=$platform --source-key="sources.$platform"
+  update-source-version vivaldi-ffmpeg-codecs "$version" "$hash" "$url" --ignore-same-version --system=$platform --source-key="sources.$platform" --file "package.nix"
 }
 
 x86Release="$(echo $STABLE_RELEASES | jq 'select(.channel.architecture=="amd64")')"
@@ -26,7 +26,7 @@ x86CodecVersion=$(max_version "$x86Release")
 arm64Release="$(echo $STABLE_RELEASES | jq -r 'select(.channel.architecture=="arm64")')"
 arm64CodecVersion=$(max_version "$arm64Release")
 
-currentVersion=$(nix-instantiate --eval -E "with import ./. {}; vivaldi-ffmpeg-codecs.version or (lib.getVersion vivaldi-ffmpeg-codecs)" | tr -d '"')
+currentVersion=$(grep 'version =' ./package.nix | cut -d '"' -f 2)
 
 if [[ "$currentVersion" == "$x86CodecVersion" ]]; then
   exit 0


### PR DESCRIPTION
- Updated the script it would launch.
- Update package to latest version.

Been running this patch for a few weeks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
