### PR TITLE
graalvm-oracle_25-ea: init at 25-ea-32

### DIFF
--- a/pkgs/development/compilers/graalvm/default.nix
+++ b/pkgs/development/compilers/graalvm/default.nix
@@ -23,6 +23,11 @@ lib.makeScope pkgs.newScope (
 
     truffleruby = self.callPackage ./community-edition/truffleruby { };
 
+    graalvm-oracle_25-ea =
+      (self.callPackage ./graalvm-oracle { version = "25-ea-32"; }).overrideAttrs
+        (prev: {
+          autoPatchelfIgnoreMissingDeps = [ "libonnxruntime.so.1" ];
+        });
     graalvm-oracle_23 = self.callPackage ./graalvm-oracle { version = "23"; };
     graalvm-oracle_17 = self.callPackage ./graalvm-oracle { version = "17"; };
     graalvm-oracle = self.graalvm-oracle_23;

--- a/pkgs/development/compilers/graalvm/graalvm-oracle/hashes.nix
+++ b/pkgs/development/compilers/graalvm/graalvm-oracle/hashes.nix
@@ -4,6 +4,24 @@
 # $ rg -No "(https://.+)\"" -r '$1' pkgs/development/compilers/graalvm/graalvm-oracle/hashes.nix | \
 #   parallel -k 'echo {}; nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri $(curl -s {}.sha256)'
 {
+  "25-ea-32" = {
+    "aarch64-linux" = {
+      hash = "sha256-JO/6VHxhd8Vetpv/iLKxNCL8wHa2VAfSIs0fiWdB4QA=";
+      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.32/graalvm-jdk-25.0.0-ea.32_linux-aarch64_bin.tar.gz";
+    };
+    "x86_64-linux" = {
+      hash = "sha256-IevvXyhRnY/ujd3MriWULNcTYXOgt9h8bHhlJzkumjE=";
+      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.32/graalvm-jdk-25.0.0-ea.32_linux-x64_bin.tar.gz";
+    };
+    "x86_64-darwin" = {
+      hash = "sha256-YhMGtXud6mer7UbSd6Eyl2d1rPKzEb6zF/NFtWLIG3E=";
+      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.32/graalvm-jdk-25.0.0-ea.32_macos-x64_bin.tar.gz";
+    };
+    "aarch64-darwin" = {
+      hash = "sha256-alNurm5ieedOi636Mnyq8BqFAyOV0dBaeTtDk4c4cPQ=";
+      url = "https://github.com/graalvm/oracle-graalvm-ea-builds/releases/download/jdk-25.0.0-ea.32/graalvm-jdk-25.0.0-ea.32_macos-aarch64_bin.tar.gz";
+    };
+  };
   "23" = {
     "aarch64-linux" = {
       hash = "sha256-VlB664/l7NWFQrPE3vEJvCXkEzKEJ0ck/HNU5pGGTwU=";


### PR DESCRIPTION
This introduces a `graalvmPackages.graalvm-oracle_25-ea` package that can be used for development and testing with JDK 25 and/or native-image 25.

If the community doesn't want to merge an EA version, I will try to maintain this version in a separate flake until GaalVM 25 EA is "GA" (General Availability.)

Note that I chose to use the `-oracle` version because binary releases are provided (and I don't think they are provided for the community version.)

This is based on PR #423224 by @farnoy

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
