### PR TITLE
gamma-launcher: init at 2.5

### DIFF
--- a/pkgs/by-name/ga/gamma-launcher/package.nix
+++ b/pkgs/by-name/ga/gamma-launcher/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "gamma-launcher";
+  version = "2.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Mord3rca";
+    repo = "gamma-launcher";
+    tag = "v${version}";
+    hash = "sha256-qzjfgDFimEL6vtsJBubY6fHsokilDB248WwHJt3F7fI=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    beautifulsoup4
+    cloudscraper
+    gitpython
+    platformdirs
+    py7zr
+    python-unrar
+    requests
+    tenacity
+    tqdm
+  ];
+
+  nativeCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Python cli to download S.T.A.L.K.E.R. GAMMA";
+    changelog = "https://github.com/Mord3rca/gamma-launcher/releases/tag/v${version}";
+    homepage = "https://github.com/Mord3rca/gamma-launcher";
+    mainProgram = "gamma-launcher";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ DrymarchonShaun ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/python-unrar/default.nix
+++ b/pkgs/development/python-modules/python-unrar/default.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  lib,
+  replaceVars,
+  buildPythonPackage,
+  fetchPypi,
+  unrar,
+  pytestCheckHook,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "python-unrar";
+  version = "0.4";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "unrar";
+    inherit version;
+    hash = "sha256-skRHpbkwJL5gDvglVmi6I6MPRRF2V3tpFVnqE1n30WQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  patches = [
+    (replaceVars ./use_nix_unrar_path.patch {
+      unrar_lib_path = "${unrar}/lib/libunrar${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "unrar" ];
+
+  meta = {
+    homepage = "http://github.com/matiasb/python-unrar";
+    changelog = "https://github.com/matiasb/python-unrar/releases/tag/v${version}";
+    description = "Wrapper for UnRAR library, plus a rarfile module on top of it";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ DrymarchonShaun ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/python-unrar/use_nix_unrar_path.patch
+++ b/pkgs/development/python-modules/python-unrar/use_nix_unrar_path.patch
@@ -1,0 +1,13 @@
+diff --git a/unrar/unrarlib.py b/unrar/unrarlib.py
+index 06df081..22c1dde 100644
+--- a/unrar/unrarlib.py
++++ b/unrar/unrarlib.py
+@@ -31,7 +31,7 @@ __all__ = ["RAROpenArchiveDataEx", "RARHeaderDataEx", "RAROpenArchiveEx",
+            "dostime_to_timetuple"]
+ 
+ 
+-lib_path = os.environ.get('UNRAR_LIB_PATH', None)
++lib_path = "@unrar_lib_path@"
+ 
+ # find and load unrar library
+ unrarlib = None

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15367,6 +15367,8 @@ self: super: with self; {
 
   python-ulid = callPackage ../development/python-modules/python-ulid { };
 
+  python-unrar = callPackage ../development/python-modules/python-unrar { inherit (pkgs) unrar; };
+
   python-utils = callPackage ../development/python-modules/python-utils { };
 
   python-vagrant = callPackage ../development/python-modules/python-vagrant { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [gamma-launcher](https://github.com/Mord3rca/gamma-launcher), a reimplementation of the Windows-only (due to use of .NET/powershell scripts) Stalker G.A.M.M.A. launcher

also initializes `python-unrar`, a required dependency for the launcher



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
