### PR TITLE
windows.mingw_w64: 12.0.0 -> 13.0.0

### DIFF
--- a/pkgs/os-specific/windows/mingw-w64/default.nix
+++ b/pkgs/os-specific/windows/mingw-w64/default.nix
@@ -7,11 +7,6 @@
   crt ? stdenv.hostPlatform.libc,
 }:
 
-assert lib.assertOneOf "crt" crt [
-  "msvcrt"
-  "ucrt"
-];
-
 stdenv.mkDerivation {
   pname = "mingw-w64";
   inherit (mingw_w64_headers) version src meta;

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -1,13 +1,10 @@
 {
   lib,
+  nixosTests,
   stdenvNoCC,
   fetchurl,
   crt ? stdenvNoCC.hostPlatform.libc,
 }:
-assert lib.assertOneOf "crt" crt [
-  "msvcrt"
-  "ucrt"
-];
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mingw_w64-headers";
   version = "12.0.0";
@@ -24,6 +21,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   preConfigure = ''
     cd mingw-w64-headers
   '';
+
+  passthru = {
+    tests = {
+      inherit (nixosTests) wine;
+    };
+    updateScript = ./update.nu;
+  };
 
   meta = {
     homepage = "https://www.mingw-w64.org/";

--- a/pkgs/os-specific/windows/mingw-w64/headers.nix
+++ b/pkgs/os-specific/windows/mingw-w64/headers.nix
@@ -7,11 +7,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mingw_w64-headers";
-  version = "12.0.0";
+  version = "13.0.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/mingw-w64/mingw-w64-v${finalAttrs.version}.tar.bz2";
-    hash = "sha256-zEGJiqxLbo3Vz/1zMbnZUVuRLfRCCjphK16ilVu+7S8=";
+    hash = "sha256-Wv6CKvXE7b9n2q9F7sYdU49J7vaxlSTeZIl8a5WCjK8=";
   };
 
   configureFlags = [

--- a/pkgs/os-specific/windows/mingw-w64/update.nu
+++ b/pkgs/os-specific/windows/mingw-w64/update.nu
@@ -1,0 +1,77 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i nu -p nushell nix
+
+use std/log
+
+def replace [ p: path old: string new: string ] {
+  open $p
+  | str replace $old $new
+  | save -f $p
+}
+
+def eval [ attr: string ] {
+  with-env {
+    NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM: 1
+  } {
+    nix eval -f ./. $attr --json
+  }
+  | from json
+}
+
+def main [] {
+  # List of all the link in the RSS feed for
+  # https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/
+  let links = http get https://sourceforge.net/projects/mingw-w64/rss?path=/mingw-w64/mingw-w64-release/
+  | from xml
+  | get content.content.0
+  | where tag == item
+  | get content
+  | flatten
+  | where tag == title
+  | get content
+  | flatten
+  | get content
+
+  # Select only files ending in "tar.bz2", then select the largest value
+  # We only consider values with at least two digits cause they are at
+  # 13.0 and sorting strings doesn't work well if they aren't the same length
+  let newest = $links
+    | where { ($in | str ends-with "tar.bz2") and ($in =~ v[0-9][0-9]\.) }
+    | sort -r
+    | get 0
+
+  # Extract the newest version out of the URL
+  let new_version = $newest
+    | split column /
+    | get column4.0
+    | split column -
+    | get column3.0
+    | str replace .tar.bz2 ""
+    | str trim -c v
+
+  # Get the current version in the drv
+  let current_version = eval "windows.mingw_w64_headers.version"
+
+  if $new_version == $current_version {
+    log info "Current mingw-w64 version matches the latest, exiting..."
+    return
+  } else {
+    log info $"Current version is ($current_version)\nLatest version is ($new_version)"
+  }
+
+  # Get the current hash
+  let current_hash = eval "windows.mingw_w64_headers.src.outputHash"
+
+  # Set to the new version
+  replace ./pkgs/os-specific/windows/mingw-w64/headers.nix $current_version $new_version
+
+  # The nix derivation creates the URL from the version, so just grab that.
+  let new_url = eval "windows.mingw_w64_headers.src.url"
+
+  # Prefetch to get the new hash
+  let new_hash = nix-prefetch-url --type sha256 $new_url
+  | nix hash to-sri --type sha256 $in
+
+  # Set the hash
+  replace ./pkgs/os-specific/windows/mingw-w64/headers.nix $current_hash $new_hash
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Add updateScript
2. Add passthru test
3. Update mingw

I ran the test on my computer and it was fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
