### PR TITLE
odic-agent: 5.3.2 -> 5.3.3; Fix insecure dependencies

### DIFF
--- a/pkgs/by-name/oi/oidc-agent/package.nix
+++ b/pkgs/by-name/oi/oidc-agent/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   curl,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
   libmicrohttpd,
   libsecret,
   qrencode,
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "oidc-agent";
-  version = "5.3.2";
+  version = "5.3.3";
 
   src = fetchFromGitHub {
     owner = "indigo-dc";
     repo = "oidc-agent";
     rev = "v${version}";
-    hash = "sha256-G2E6/mMP8d9s6JsIlFwMQ8sm4FCF8Gm8OqrsTPjPUrA=";
+    hash = "sha256-PV1aswfvEMtsgHWKfdtIo/BV+MHKKdul2vjFdyoT2Ic=";
   };
 
   nativeBuildInputs = [
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     curl
-    webkitgtk_4_0
+    webkitgtk_4_1
     libmicrohttpd
     libsecret
     qrencode
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
     "BIN_PATH=$(out)"
     "PROMPT_BIN_PATH=$(out)"
     "LIB_PATH=$(out)/lib"
+    "WEBKITGTK=webkit2gtk-4.1"
   ];
 
   installTargets = [
@@ -56,7 +57,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     # Override with patched binary to be used by help2man
     cp -r $out/bin/* bin
-    make install_man PREFIX=$out MAN_PATH=$out/share/man PROMPT_MAN_PATH=$out/share/man
+    make install_man PREFIX=$out MAN_PATH=$out/share/man PROMPT_MAN_PATH=$out/share/man WEBKITGTK=webkit2gtk-4.1
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -68,3 +69,4 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
   };
 }
+

--- a/pkgs/by-name/oi/oidc-agent/package.nix
+++ b/pkgs/by-name/oi/oidc-agent/package.nix
@@ -69,4 +69,3 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
   };
 }
-


### PR DESCRIPTION
- Updated from 5.3.2 to 5.3.3
- Fixed the insecure `libsoup-2.74.3` dependency by forcing the `webkitgtk_4_1` via the `WEBKITGTK` make variable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
