### PR TITLE
gnome-commander: fix build

### DIFF
--- a/pkgs/by-name/gn/gnome-commander/package.nix
+++ b/pkgs/by-name/gn/gnome-commander/package.nix
@@ -29,13 +29,29 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-rSaj1Fg2seZKlzlERZZmz80kxJT1vZ+INiJlWfZ9m6g=";
   };
 
-  # hard-coded schema paths
-  postPatch = ''
-    substituteInPlace src/gnome-cmd-data.cc plugins/fileroller/file-roller-plugin.cc \
-      --replace-fail \
-        '/share/glib-2.0/schemas' \
-        '/share/gsettings-schemas/${finalAttrs.finalPackage.name}/glib-2.0/schemas'
-  '';
+  postPatch =
+    # hard-coded schema paths
+    ''
+      substituteInPlace src/gnome-cmd-data.cc plugins/fileroller/file-roller-plugin.cc \
+        --replace-fail \
+          '/share/glib-2.0/schemas' \
+          '/share/gsettings-schemas/${finalAttrs.finalPackage.name}/glib-2.0/schemas'
+    ''
+    # Fix missing semicolon in file-list sort_by_owner / sort_by_group
+    + ''
+      substituteInPlace src/gnome-cmd-file-list.cc \
+        --replace-fail "GetGfileAttributeString(G_FILE_ATTRIBUTE_OWNER_USER), raising)" \
+                 "GetGfileAttributeString(G_FILE_ATTRIBUTE_OWNER_USER), raising);" \
+        --replace-fail "GetGfileAttributeString(G_FILE_ATTRIBUTE_OWNER_GROUP), raising)" \
+                 "GetGfileAttributeString(G_FILE_ATTRIBUTE_OWNER_GROUP), raising);"
+    ''
+    # Update C/C++ language standards to C17 and C++17 to meet GTest 1.10+ requirements and ensure consistency across tests
+    + ''
+      substituteInPlace meson.build \
+        --replace-fail "'cpp_std=gnu++11', 'build.cpp_std=gnu++11'" "'cpp_std=gnu++17', 'build.cpp_std=gnu++17'"
+      substituteInPlace tests/meson.build \
+        --replace-fail "'c_std=c14', 'cpp_std=c++14'" "'c_std=c17', 'cpp_std=c++17'"
+    '';
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
