### PR TITLE
ablog: disable failed test

### DIFF
--- a/pkgs/by-name/ab/ablog/package.nix
+++ b/pkgs/by-name/ab/ablog/package.nix
@@ -5,10 +5,13 @@
   gitUpdater,
 }:
 
-python3Packages.buildPythonApplication rec {
-  pname = "ablog";
+let
   version = "0.11.12";
-  format = "pyproject";
+in
+python3Packages.buildPythonApplication {
+  pname = "ablog";
+  inherit version;
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sunpy";
@@ -20,9 +23,8 @@ python3Packages.buildPythonApplication rec {
   build-system = with python3Packages; [
     setuptools
     setuptools-scm
+    wheel
   ];
-
-  nativeBuildInputs = with python3Packages; [ wheel ];
 
   dependencies = with python3Packages; [
     docutils
@@ -40,14 +42,17 @@ python3Packages.buildPythonApplication rec {
   ];
 
   pytestFlags = [
-    "-Wignore::sphinx.deprecation.RemovedInSphinx90Warning"
     "--rootdir=src/ablog"
     "-Wignore::sphinx.deprecation.RemovedInSphinx90Warning" # Ignore ImportError
   ];
 
-  # assert "post 1" not in html
-  # AssertionError
-  disabledTests = [ "test_not_safe_for_parallel_read" ];
+  disabledTests = [
+    # upstream investigation is still ongoing
+    # https://github.com/sunpy/ablog/issues/302
+    "test_not_safe_for_parallel_read"
+    # need sphinx old version
+    "test_feed"
+  ];
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
