### PR TITLE
linuxPackages.yt6801: 1.0.29-20240812 -> 1.0.30-20250430; fix build

### DIFF
--- a/pkgs/os-specific/linux/yt6801/default.nix
+++ b/pkgs/os-specific/linux/yt6801/default.nix
@@ -12,7 +12,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "yt6801";
-  version = "1.0.29-20240812";
+  version = "1.0.30-20250430";
 
   src =
     let
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     fetchzip {
       stripRoot = false;
       url = "https://www.motor-comm.com/Public/Uploads/uploadfile/files/${uploadDate}/yt6801-linux-driver-${versionName}.zip";
-      sha256 = "sha256-oz6CeOUN6QWKXxe3WUZljhGDTFArsknjzBuQ4IchGeU=";
+      sha256 = "sha256-6HeU3bbTaKOCy3X+nMpC9/bBc+0c4Ip5TdG+LGUGTKk=";
     };
 
   nativeBuildInputs = kernel.moduleBuildDependencies ++ [ kmod ];

--- a/pkgs/os-specific/linux/yt6801/default.nix
+++ b/pkgs/os-specific/linux/yt6801/default.nix
@@ -28,9 +28,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = kernel.moduleBuildDependencies ++ [ kmod ];
 
-  patches = lib.optionals (lib.versionAtLeast kernel.version "6.15") [
-    ./kernel_6.15_fix.patch
-  ];
+  patches =
+    lib.optionals (lib.versionAtLeast kernel.version "6.15") [
+      ./kernel_6.15_fix.patch
+    ]
+    ++ lib.optionals (lib.versionAtLeast kernel.version "6.16") [
+      ./kernel_6_16_fix.patch
+    ];
 
   postPatch = ''
     substituteInPlace src/Makefile \

--- a/pkgs/os-specific/linux/yt6801/kernel_6_16_fix.patch
+++ b/pkgs/os-specific/linux/yt6801/kernel_6_16_fix.patch
@@ -1,0 +1,33 @@
+--- a/src/fuxi-gmac-phy.c	2025-08-03 00:00:00.000000000 +0000
++++ b/src/fuxi-gmac-phy.c	2025-08-03 00:00:00.000000000 +0000
+@@ -322,8 +322,10 @@
+ static void fxgmac_phy_link_poll(unsigned long data)
+ #endif
+ {
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0))
++    struct fxgmac_pdata *pdata = container_of(t, struct fxgmac_pdata, expansion.phy_poll_tm);
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0))
+     struct fxgmac_pdata *pdata = from_timer(pdata, t, expansion.phy_poll_tm);
+ #else
+     struct fxgmac_pdata *pdata = (struct fxgmac_pdata*)data;
+ #endif
+@@ -350,13 +352,17 @@
+
+ int fxgmac_phy_timer_init(struct fxgmac_pdata *pdata)
+ {
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0))
++    timer_setup(&pdata->expansion.phy_poll_tm, fxgmac_phy_link_poll, 0);
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0))
+     init_timer_key(&pdata->expansion.phy_poll_tm, NULL, 0, "fuxi_phy_link_update_timer", NULL);
+ #else
+     init_timer_key(&pdata->expansion.phy_poll_tm, 0, "fuxi_phy_link_update_timer", NULL);
+ #endif
+     pdata->expansion.phy_poll_tm.expires = jiffies + HZ / 2;
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,16,0))
+     pdata->expansion.phy_poll_tm.function = (void *)(fxgmac_phy_link_poll);
++#endif
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,15,0))
+     pdata->expansion.phy_poll_tm.data = (unsigned long)pdata;
+ #endif


### PR DESCRIPTION
Closes #430466

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
