### PR TITLE
w3m: 0.5.3+git20230121 → 0.5.4; add toastal to maintainers

### DIFF
--- a/pkgs/by-name/w3/w3m/package.nix
+++ b/pkgs/by-name/w3/w3m/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchFromSourcehut,
   fetchpatch,
   ncurses,
   boehmgc,
@@ -40,21 +40,27 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "w3m";
-  version = "0.5.3+git20230121";
+  version = "0.5.4";
 
-  src = fetchFromGitHub {
-    owner = "tats";
+  src = fetchFromSourcehut {
+    owner = "~rkta";
     repo = "w3m";
-    rev = "v${version}";
-    hash = "sha256-upb5lWqhC1jRegzTncIz5e21v4Pw912FyVn217HucFs=";
+    tag = "v${version}";
+    hash = "sha256-A11vHFiyotFncqWRiljRJbHO1wEzmWTEh1DOel803q4=";
   };
 
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isSunOS "-lsocket -lnsl";
+  env = {
+    NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isSunOS "-lsocket -lnsl";
 
-  # we must set these so that the generated files (e.g. w3mhelp.cgi) contain
-  # the correct paths.
-  PERL = "${perl}/bin/perl";
-  MAN = "${man}/bin/man";
+    # we must set these so that the generated files (e.g. w3mhelp.cgi) contain
+    # the correct paths.
+    PERL = "${perl}/bin/perl";
+    MAN = "${man}/bin/man";
+
+    # for w3mimgdisplay
+    # see: https://bbs.archlinux.org/viewtopic.php?id=196093
+    LIBS = lib.optionalString x11Support "-lX11";
+  };
 
   makeFlags = [ "AR=${stdenv.cc.bintools.targetPrefix}ar" ];
 
@@ -113,10 +119,6 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = false;
 
-  # for w3mimgdisplay
-  # see: https://bbs.archlinux.org/viewtopic.php?id=196093
-  LIBS = lib.optionalString x11Support "-lX11";
-
   passthru.tests.version = testers.testVersion {
     inherit version;
     package = w3m;
@@ -124,8 +126,8 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    homepage = "https://w3m.sourceforge.net/";
-    changelog = "https://github.com/tats/w3m/blob/v${version}/ChangeLog";
+    homepage = "https://git.sr.ht/~rkta/w3m";
+    changelog = "https://git.sr.ht/~rkta/w3m/tree/v${version}/item/NEWS";
     description = "Text-mode web browser";
     maintainers = with lib.maintainers; [
       anthonyroussel

--- a/pkgs/by-name/w3/w3m/package.nix
+++ b/pkgs/by-name/w3/w3m/package.nix
@@ -127,7 +127,10 @@ stdenv.mkDerivation rec {
     homepage = "https://w3m.sourceforge.net/";
     changelog = "https://github.com/tats/w3m/blob/v${version}/ChangeLog";
     description = "Text-mode web browser";
-    maintainers = with lib.maintainers; [ anthonyroussel ];
+    maintainers = with lib.maintainers; [
+      anthonyroussel
+      toastal
+    ];
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;
     mainProgram = "w3m";

--- a/pkgs/by-name/w3/w3m/package.nix
+++ b/pkgs/by-name/w3/w3m/package.nix
@@ -38,14 +38,14 @@ let
     '';
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "w3m";
   version = "0.5.4";
 
   src = fetchFromSourcehut {
     owner = "~rkta";
     repo = "w3m";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-A11vHFiyotFncqWRiljRJbHO1wEzmWTEh1DOel803q4=";
   };
 
@@ -120,14 +120,14 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false;
 
   passthru.tests.version = testers.testVersion {
-    inherit version;
+    inherit (finalAttrs) version;
     package = w3m;
     command = "w3m -version";
   };
 
   meta = {
     homepage = "https://git.sr.ht/~rkta/w3m";
-    changelog = "https://git.sr.ht/~rkta/w3m/tree/v${version}/item/NEWS";
+    changelog = "https://git.sr.ht/~rkta/w3m/tree/v${finalAttrs.version}/item/NEWS";
     description = "Text-mode web browser";
     maintainers = with lib.maintainers; [
       anthonyroussel
@@ -137,4 +137,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     mainProgram = "w3m";
   };
-}
+})


### PR DESCRIPTION
https://github.com/tats/w3m/issues/304

Maintainership & blessing has been handed off from tats to rtka. The code is now actively developed on SourceHut.

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project (like w3m just did!). I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
