### PR TITLE
python313Packages.qbusmqttapi: 1.3.0 -> 1.4.2

### DIFF
--- a/pkgs/development/python-modules/qbusmqttapi/default.nix
+++ b/pkgs/development/python-modules/qbusmqttapi/default.nix
@@ -2,22 +2,35 @@
   buildPythonPackage,
   fetchFromGitHub,
   lib,
-  setuptools,
+  hatchling,
+  aiohttp,
+  yarl,
 }:
 
 buildPythonPackage rec {
   pname = "qbusmqttapi";
-  version = "1.3.0";
+  version = "1.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Qbus-iot";
     repo = "qbusmqttapi";
     tag = "v${version}";
-    hash = "sha256-1Srp1FOnTw7TwE0OTY+q6R1d/M7/LH9leCUZMADE++Y=";
+    hash = "sha256-8TNtfBxJcSwlcAgKF6Gvn+e4NGbOIE3JWBAgFKmNyKA=";
   };
 
-  build-system = [ setuptools ];
+  postPatch = ''
+    # Upstream uses a placeholder version in pyproject.toml
+    substituteInPlace pyproject.toml \
+      --replace-fail '"0.0.0"' '"${version}"'
+  '';
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    aiohttp
+    yarl
+  ];
 
   pythonImportsCheck = [ "qbusmqttapi" ];
 
@@ -27,6 +40,7 @@ buildPythonPackage rec {
   meta = {
     description = "MQTT API for Qbus Home Automation";
     homepage = "https://github.com/Qbus-iot/qbusmqttapi";
+    changelog = "https://github.com/Qbus-iot/qbusmqttapi/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };


### PR DESCRIPTION
Changelog: https://github.com/Qbus-iot/qbusmqttapi/releases/tag/v1.4.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
