### PR TITLE
ip2asn: init at 0.1.2

### DIFF
--- a/pkgs/by-name/ip/ip2asn/package.nix
+++ b/pkgs/by-name/ip/ip2asn/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ip2asn";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "x123";
+    repo = "ip2asn";
+    tag = finalAttrs.version;
+    hash = "sha256-2wuxBwllrkPdmmBCt7DPQ38E2k3igAjbICun51bhopY=";
+  };
+
+  cargoHash = "sha256-fYg0aIU8usueMg6cMWUcwMIFCinHdm6H7k9ywZGYfg8=";
+
+  passthru.updateScript = nix-update-script { };
+
+  cargoBuildFlags = [
+    "-p"
+    "ip2asn-cli"
+  ];
+
+  # disable network based tests that download data
+  cargoTestFlags = [
+    "-p"
+    "ip2asn-cli"
+    "--"
+    "--skip"
+    "auto_update_tests::test_auto_update_triggers_download"
+    "--skip"
+    "auto_update_tests::test_auto_update_skips_check_for_recent_cache"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  meta = {
+    description = "CLI tool for mapping IP addresses to Autonomous System information";
+    homepage = "https://github.com/x123/ip2asn/tree/master/ip2asn-cli";
+    changelog = "https://github.com/x123/ip2asn/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ x123 ];
+    mainProgram = "ip2asn";
+  };
+})


### PR DESCRIPTION
adds ip2asn utility for enriching IP addresses with ASN information:

```
$ ip2asn 8.8.8.8 1.1.1.1
15169 | 8.8.8.8 | 8.8.8.0/24 | GOOGLE | US
13335 | 1.1.1.1 | 1.1.1.0/24 | CLOUDFLARENET | US
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
