### PR TITLE
hashcat: 6.2.6 -> 7.0.0

### DIFF
--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -194,7 +194,7 @@ stdenv'.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "-DLIBDIR=/does-not-exist"
-    "-DSSE2NEON_INCLUDE_DIR=${sse2neon}/lib"
+    "-DSSE2NEON_INCLUDE_DIR=${sse2neon}/include"
   ]
   ++ lib.optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS=" # Clang doesn't support "-export-dynamic"
   ++ lib.optionals cudaSupport [

--- a/pkgs/by-name/ha/hashcat/package.nix
+++ b/pkgs/by-name/ha/hashcat/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   addDriverRunpath,
   config,
-  cudaPackages_12_4 ? { },
+  cudaPackages ? { },
   cudaSupport ? config.cudaSupport,
   fetchurl,
   makeWrapper,
@@ -13,6 +13,7 @@
   xxHash,
   zlib,
   libiconv,
+  sse2neon,
 }:
 
 stdenv.mkDerivation rec {
@@ -46,6 +47,7 @@ stdenv.mkDerivation rec {
     opencl-headers
     xxHash
     zlib
+    sse2neon
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
@@ -83,7 +85,7 @@ stdenv.mkDerivation rec {
           "${ocl-icd}/lib"
         ]
         ++ lib.optionals cudaSupport [
-          "${cudaPackages_12_4.cudatoolkit}/lib"
+          "${cudaPackages.cudatoolkit}/lib"
         ]
       );
     in

--- a/pkgs/by-name/ss/sse2neon/package.nix
+++ b/pkgs/by-name/ss/sse2neon/package.nix
@@ -27,13 +27,13 @@ stdenv.mkDerivation (finalAttrs: {
   # use postBuild instead of installPhase, because the build
   # in itself doesn't produce any ($out) output
   postBuild = ''
-    mkdir -p $out/lib
-    install -m444 sse2neon.h $out/lib/
+    mkdir -p $out/include
+    install -m444 sse2neon.h $out/include/
   '';
 
   meta = {
-    description = "Mono library that provides a GDI+-compatible API on non-Windows operating systems";
-    homepage = "https://www.mono-project.com/docs/gui/libgdiplus/";
+    description = "Translator from Intel SSE intrinsics to Arm/Aarch64 NEON implementation";
+    homepage = "https://github.com/DLTcollab/sse2neon";
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.gador ];


### PR DESCRIPTION
- this PR also includes fix in output path of sse2neon

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
