### PR TITLE
yamlfmt: correct commit reference in version flag and add versionCheckHook

### DIFF
--- a/pkgs/by-name/ya/yamlfmt/package.nix
+++ b/pkgs/by-name/ya/yamlfmt/package.nix
@@ -14,7 +14,12 @@ buildGoModule (finalAttrs: {
     owner = "google";
     repo = "yamlfmt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EYOtxb2Xq4bQpWbITmPieVMqJz3/2chgNirZEjiyjAY=";
+    hash = "sha256-WSw4WhWNyvkCwRCQYFAKhtkvOSSCrSlX3+i6cMHRtOQ=";
+    leaveDotGit = true;
+    postFetch = ''
+      git -C "$out" rev-parse --short HEAD > "$out/.git_head"
+      rm -rf "$out/.git"
+    '';
   };
 
   vendorHash = "sha256-Cy1eBvKkQ90twxjRL2bHTk1qNFLQ22uFrOgHKmnoUIQ=";
@@ -23,8 +28,11 @@ buildGoModule (finalAttrs: {
     "-s"
     "-w"
     "-X=main.version=${finalAttrs.version}"
-    "-X=main.commit=${finalAttrs.src.rev}"
   ];
+
+  preBuild = ''
+    ldflags+=" -X=main.commit=$(<.git_head)"
+  '';
 
   # Test failure in vendored yaml package, see:
   # https://github.com/google/yamlfmt/issues/256

--- a/pkgs/by-name/ya/yamlfmt/package.nix
+++ b/pkgs/by-name/ya/yamlfmt/package.nix
@@ -2,8 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  testers,
-  yamlfmt,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -38,9 +37,11 @@ buildGoModule (finalAttrs: {
   # https://github.com/google/yamlfmt/issues/256
   checkFlags = [ "-run=!S/TestNodeRoundtrip" ];
 
-  passthru.tests.version = testers.testVersion {
-    package = yamlfmt;
-  };
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Extensible command line tool or library to format yaml files";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## [Official GitHub release](https://github.com/google/yamlfmt/releases/download/v0.17.2/yamlfmt_0.17.2_Linux_x86_64.tar.gz)

```console
> ./yamlfmt --version
yamlfmt 0.17.2 (398e72a)
```

## [nixpkgs(nixos-unstable)](https://github.com/NixOS/nixpkgs/tree/94def634a20494ee057c76998843c015909d6311)

```console
> nix run github:NixOS/nixpkgs/94def634a20494ee057c76998843c015909d6311#yamlfmt -- --version
yamlfmt 0.17.2 (refs/tags/v0.17.2)
```

## After this change

```console
> nix run .#yamlfmt -- --version
yamlfmt 0.17.2 (398e72a)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
