### PR TITLE
meson: 1.8.3 -> 1.9.0

### DIFF
--- a/pkgs/by-name/me/meson/001-fix-rpath.patch
+++ b/pkgs/by-name/me/meson/001-fix-rpath.patch
@@ -1,10 +1,11 @@
---- a/mesonbuild/backend/backends.py
-+++ b/mesonbuild/backend/backends.py
-@@ -723,6 +723,21 @@
-     @staticmethod
-     def get_rpath_dirs_from_link_args(args: T.List[str]) -> T.Set[str]:
+diff --git a/mesonbuild/build.py b/mesonbuild/build.py
+index 9014d09fb..4dda63a96 100644
+--- a/mesonbuild/build.py
++++ b/mesonbuild/build.py
+@@ -1888,6 +1888,20 @@ class BuildTarget(Target):
+     def get_rpath_dirs_from_link_args(cls, args: T.List[str]) -> T.Set[str]:
          dirs: T.Set[str] = set()
-+
+ 
 +        nix_ldflags = os.environ.get('NIX_LDFLAGS', '').split()
 +        next_is_path = False
 +        # Try to add rpaths set by user or ld-wrapper so that they are not removed.
@@ -19,6 +20,6 @@
 +                    dirs.add(flag)
 +                next_is_path = False
 +
-         # Match rpath formats:
-         # -Wl,-rpath=
-         # -Wl,-rpath,
+         for arg in args:
+             if not arg.startswith('-Wl,'):
+                 continue

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -16,14 +16,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meson";
-  version = "1.8.3";
+  version = "1.9.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "mesonbuild";
     repo = "meson";
     tag = version;
-    hash = "sha256-Htjr/gZ4G53XY/kuGsbToZOo+ptDoNA737aaqDT1AUo=";
+    hash = "sha256-VMLcGtyJIH3jsTkHrIUhCpjwm6ljsRSyRECYhaafjD8=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
