### PR TITLE
cynthion: build gateware bitstreams and moondancer firmware

### DIFF
--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -119,6 +119,7 @@ rec {
         "armv6l-netbsd"
         "mipsel-netbsd"
         "riscv64-netbsd"
+        "riscv32-none"
         "x86_64-redox"
         "wasm32-wasi"
       ];

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -118,6 +118,7 @@ rec {
         "armv6l-netbsd"
         "mipsel-netbsd"
         "riscv64-netbsd"
+        "riscv32-none"
         "x86_64-redox"
         "wasm32-wasi"
       ];

--- a/pkgs/development/python-modules/cynthion/build-gateware.sh
+++ b/pkgs/development/python-modules/cynthion/build-gateware.sh
@@ -1,0 +1,62 @@
+echo "Sourcing build-gateware-hook"
+
+_buildGatewareHook() {
+    echo "Building gateware"
+    # find site-packages
+    echo "site_packages" "$out/@pythonSitePackages@"
+
+    # generate the list of platforms
+    local -a luna_platforms
+    mapfile -t luna_platforms < <(python <<EOS
+import inspect
+import cynthion.gateware.platform
+for name, obj in inspect.getmembers(cynthion.gateware.platform):
+    if inspect.isclass(obj):
+        print(name)
+EOS
+)
+    echo "building for platforms" "${luna_platforms[@]}"
+
+    # run the builds in parallel
+    local -a bitstreams pids
+    bitstreams=(analyzer facedancer selftest)
+    pids=()
+
+    local N i j k
+    local platform bitstream platform_folder bitstream_out_path job_pid
+    N=${enableParallelBuilding:+${NIX_BUILD_CORES}}
+    N=${N:-1}
+    echo "Running ${N} parallel builds ${enableParallelBuilding} ${NIX_BUILD_CORES}"
+    for i in "${!luna_platforms[@]}"; do
+        platform="${luna_platforms[i]}"
+        platform_folder="$out/@pythonSitePackages@/cynthion/assets/${luna_platforms[i]}"
+        mkdir -p "$platform_folder"
+        for j in "${!bitstreams[@]}"; do
+            k=$((i*${#bitstreams[@]}+j))
+            bitstream="${bitstreams[j]}"
+
+            export LUNA_PLATFORM="cynthion.gateware.platform:${platform}"
+            out_path="${platform_folder}/${bitstream}.bit"
+            python -m cynthion.gateware.${bitstream}.top --output "${out_path}" &
+            job_pid=$!
+            pids+=($job_pid)
+
+            echo Build $k is for: $platform/$bitstream with PID $job_pid
+
+            if [[ $(( (k+1)%N )) == 0 ]]; then
+                for pid in "${pids[@]}"; do
+                    echo "Waiting for PID $pid"
+                    wait $pid || exit 1
+                done
+                pids=()
+            fi
+        done
+    done
+
+    for pid in "${pids[@]}"; do
+        echo "Waiting for PID $pid"
+        wait $pid || exit 1
+    done
+}
+
+postInstallHooks+=(_buildGatewareHook)

--- a/pkgs/development/python-modules/cynthion/build_gateware.py
+++ b/pkgs/development/python-modules/cynthion/build_gateware.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+# Builds the FPGA bitstreams `cynthion flash` needs, one set per revision, into
+# assets/<CynthionPlatformRevXDY>/{analyzer,facedancer,selftest}.bit
+
+import asyncio
+import inspect
+import logging
+import os
+import sys
+from pathlib import Path
+
+import cynthion.gateware.platform
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(name)32s:%(message)s")
+
+logger = logging.getLogger("build-gateware")
+
+BITSTREAMS = ["analyzer", "facedancer", "selftest"]
+
+# Pin the nextpnr placer seed so place-and-route is deterministic. Some
+# bitstreams (e.g. CynthionPlatformRev1D3/analyzer) are marginal on timing, and
+# without a fixed seed a build can non-deterministically miss the constraint.
+NEXTPNR_SEED = 0
+
+
+async def build_bitstream(
+    semaphore: asyncio.Semaphore, assets_dir: Path, platform: str, bitstream: str
+) -> None:
+    async with semaphore:
+        log = logging.getLogger(f"build-gateware.{platform}.{bitstream}")
+        log.info("build started")
+
+        env = os.environ.copy()
+        env["LUNA_PLATFORM"] = f"cynthion.gateware.platform:{platform}"
+        env["AMARANTH_nextpnr_opts"] = f"--seed {NEXTPNR_SEED}"
+
+        out_dir = assets_dir / platform
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{bitstream}.bit"
+
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            f"cynthion.gateware.{bitstream}.top",
+            "--output",
+            str(out_path),
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+
+        stdout, _ = await process.communicate()
+        log.info("\n%s", stdout.decode("utf-8", errors="replace"))
+
+        if process.returncode != 0:
+            raise RuntimeError(
+                f"{platform}/{bitstream} failed with exit code {process.returncode}"
+            )
+        log.info("build complete")
+
+
+def collect_platforms() -> set[str]:
+    platforms = {
+        name
+        for name, obj in inspect.getmembers(cynthion.gateware.platform)
+        if inspect.isclass(obj) and name.startswith("CynthionPlatform")
+    }
+
+    # Allow restricting the set of platforms during development/CI, e.g.
+    #   BUILD_GATEWARE_PLATFORMS="CynthionPlatformRev1D4"
+    only = os.getenv("BUILD_GATEWARE_PLATFORMS")
+    if only:
+        requested = set(only.split())
+        unknown = requested - platforms
+        if unknown:
+            raise ValueError(f"unknown platform(s): {', '.join(sorted(unknown))}")
+        platforms = requested
+
+    return platforms
+
+
+async def main() -> int:
+    assets_dir = Path(sys.argv[1])
+    max_workers = int(os.getenv("BUILD_GATEWARE_MAX_WORKERS") or 1)
+
+    platforms = collect_platforms()
+    logger.info(
+        "Building %d bitstream(s) for platforms: %s",
+        len(platforms) * len(BITSTREAMS),
+        ", ".join(sorted(platforms)),
+    )
+
+    semaphore = asyncio.Semaphore(max_workers)
+    logger.info("Building gateware with %d workers", max_workers)
+
+    results = await asyncio.gather(
+        *(
+            build_bitstream(semaphore, assets_dir, platform, bitstream)
+            for platform in sorted(platforms)
+            for bitstream in BITSTREAMS
+        ),
+        return_exceptions=True,
+    )
+
+    failures = [r for r in results if isinstance(r, BaseException)]
+    for failure in failures:
+        logger.error(failure)
+    return 1 if failures else 0
+
+
+sys.exit(asyncio.run(main()))

--- a/pkgs/development/python-modules/cynthion/default.nix
+++ b/pkgs/development/python-modules/cynthion/default.nix
@@ -2,6 +2,14 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  python,
+
+  # gateware
+  makeSetupHook,
+  nextpnr,
+  trellis,
+  which,
+  yosys,
 
   # build-system
   setuptools,
@@ -25,6 +33,20 @@
   pytestCheckHook,
   udevCheckHook,
 }:
+let
+  build-gateware-hook = makeSetupHook {
+    name = "build-gateware-hook";
+    substitutions = {
+      pythonSitePackages = python.sitePackages;
+    };
+    propagatedBuildInputs = [
+      nextpnr
+      trellis
+      which
+      yosys
+    ];
+  } ./build-gateware.sh;
+in
 buildPythonPackage rec {
   pname = "cynthion";
   version = "0.2.4";
@@ -69,9 +91,14 @@ buildPythonPackage rec {
     tqdm
   ];
 
+  nativeBuildInputs = [
+    build-gateware-hook
+  ];
   nativeCheckInputs = [
     pytestCheckHook
   ];
+
+  enableParallelBuilding = true;
 
   pythonImportsCheck = [ "cynthion" ];
 

--- a/pkgs/development/python-modules/cynthion/default.nix
+++ b/pkgs/development/python-modules/cynthion/default.nix
@@ -2,6 +2,14 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  callPackage,
+  python,
+
+  # gateware (FPGA toolchain)
+  nextpnr,
+  trellis,
+  which,
+  yosys,
 
   # build-system
   setuptools,
@@ -25,10 +33,8 @@
   pytestCheckHook,
   udevCheckHook,
 }:
-buildPythonPackage rec {
-  pname = "cynthion";
+let
   version = "0.2.5";
-  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
@@ -36,6 +42,14 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-Ju01eqBVZ7CD0pw4nIFML4LcCPXzC78dLpQru3a+5bU=";
   };
+
+  # Moondancer SoC firmware, required for `cynthion flash facedancer`.
+  moondancer = callPackage ./moondancer.nix { inherit src version; };
+in
+buildPythonPackage {
+  pname = "cynthion";
+  inherit version src;
+  pyproject = true;
 
   sourceRoot = "${src.name}/cynthion/python";
 
@@ -45,14 +59,19 @@ buildPythonPackage rec {
       --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
   '';
 
-  nativeBuildInputs = [ udevCheckHook ];
+  nativeBuildInputs = [
+    udevCheckHook
 
-  build-system = [
-    setuptools
+    # Used by the gateware build in postInstall.
+    nextpnr
+    trellis
+    which
+    yosys
   ];
 
-  pythonRelaxDeps = [ "pygreat" ];
+  build-system = [ setuptools ];
 
+  pythonRelaxDeps = [ "pygreat" ];
   pythonRemoveDeps = [ "future" ];
 
   dependencies = [
@@ -71,18 +90,34 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # Build the per-revision FPGA bitstreams in parallel (see build_gateware.py).
+  enableParallelBuilding = true;
 
   pythonImportsCheck = [ "cynthion" ];
 
-  # Make udev rules available for NixOS option services.udev.packages
-  postInstall = ''
-    install -Dm444 \
-      -t $out/lib/udev/rules.d \
-      build/lib/cynthion/assets/54-cynthion.rules
-  '';
+  postInstall =
+    let
+      assets = "$out/${python.sitePackages}/cynthion/assets";
+    in
+    ''
+      # Build a bitstream set per hardware revision into assets/, where
+      # `cynthion flash` looks for them.
+      export BUILD_GATEWARE_MAX_WORKERS="''${NIX_BUILD_CORES:-1}"
+      PYTHONPATH="$out/${python.sitePackages}''${PYTHONPATH:+:$PYTHONPATH}" \
+        python ${./build_gateware.py} "${assets}"
+
+      # Install the moondancer SoC firmware for `cynthion flash facedancer`.
+      install -Dm444 ${moondancer}/bin/moondancer.bin "${assets}/moondancer.bin"
+
+      # Make udev rules available for NixOS option services.udev.packages
+      install -Dm444 \
+        -t $out/lib/udev/rules.d \
+        build/lib/cynthion/assets/54-cynthion.rules
+    '';
+
+  passthru = { inherit moondancer; };
 
   meta = {
     description = "Python package and utilities for the Great Scott Gadgets Cynthion USB Test Instrument";

--- a/pkgs/development/python-modules/cynthion/moondancer.nix
+++ b/pkgs/development/python-modules/cynthion/moondancer.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  src,
+  version,
+  stdenv,
+  llvmPackages,
+}:
+let
+  cross = import ../../../.. {
+    system = stdenv.hostPlatform.system;
+    crossSystem = lib.systems.examples.riscv32-embedded // {
+      libc = null;
+      rust.rustcTarget = "riscv32imac-unknown-none-elf";
+    };
+  };
+
+  inherit (cross) rustPlatform;
+in
+rustPlatform.buildRustPackage {
+  pname = "moondancer";
+
+  inherit src version;
+
+  sourceRoot = "${src.name}/firmware";
+
+  cargoHash = "sha256-G/9evh3G1xNRaaEh6lgDp3hnVlB3MaCwXuhGnGJCd0Q=";
+
+  # fails to build otherwise
+  auditable = false;
+
+  nativeBuildInputs = [
+    llvmPackages.bintools
+  ];
+
+  # ldd removes required symbols without -C link-dead-code
+  RUSTFLAGS = "-C linker=lld -C linker-flavor=ld.lld -C link-arg=-Tmemory.x -C link-arg=-Tlink.x -C link-dead-code";
+
+  meta = {
+    platforms = [ "riscv32-none" ];
+  };
+}

--- a/pkgs/development/python-modules/cynthion/moondancer.nix
+++ b/pkgs/development/python-modules/cynthion/moondancer.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  src,
+  version,
+  stdenv,
+  llvmPackages,
+}:
+let
+  # Moondancer SoC firmware, cross-compiled for the bare-metal riscv32imac
+  # VexRiscv softcore inside the facedancer gateware.
+  cross = import ../../../.. {
+    localSystem = stdenv.hostPlatform.system;
+    crossSystem = lib.systems.examples.riscv32-embedded // {
+      rust.rustcTarget = "riscv32imac-unknown-none-elf";
+    };
+  };
+
+  inherit (cross) rustPlatform;
+in
+rustPlatform.buildRustPackage {
+  pname = "moondancer";
+
+  inherit version src;
+
+  sourceRoot = "${src.name}/firmware";
+
+  cargoHash = "sha256-G/9evh3G1xNRaaEh6lgDp3hnVlB3MaCwXuhGnGJCd0Q=";
+
+  # fails to build otherwise
+  auditable = false;
+
+  nativeBuildInputs = [
+    llvmPackages.bintools
+  ];
+
+  # lld strips live code without link-dead-code; memory.x (workspace root) and
+  # link.x (from riscv-rt) are the linker scripts.
+  RUSTFLAGS = "-C linker=lld -C link-arg=-Tmemory.x -C link-arg=-Tlink.x -C link-dead-code";
+
+  # cynthion flash needs a raw image, not an ELF (as upstream's
+  # `cargo objcopy -Obinary`).
+  postInstall = ''
+    llvm-objcopy -O binary \
+      $out/bin/moondancer \
+      $out/bin/moondancer.bin
+  '';
+
+  meta = {
+    description = "Moondancer SoC firmware for the Great Scott Gadgets Cynthion";
+    homepage = "https://github.com/greatscottgadgets/cynthion";
+    license = lib.licenses.bsd3;
+    platforms = [ "riscv32-none" ];
+  };
+}

--- a/pkgs/development/python-modules/luna-soc/default.nix
+++ b/pkgs/development/python-modules/luna-soc/default.nix
@@ -26,6 +26,14 @@ buildPythonPackage rec {
     substituteInPlace pyproject.toml \
       --replace-fail '"setuptools-git-versioning<2"' "" \
       --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
+
+    # Read CSR field annotations from the class, not the instance, so amaranth-soc
+    # works on Python 3.14 (PEP 649). https://github.com/greatscottgadgets/luna-soc/issues/48
+    substituteInPlace luna_soc/gateware/vendor/amaranth_soc/csr/reg.py \
+      --replace-fail 'if hasattr(self, "__annotations__"):' \
+                     'if getattr(type(self), "__annotations__", None):' \
+      --replace-fail 'filter_fields(self.__annotations__)' \
+                     'filter_fields(type(self).__annotations__)'
   '';
 
   build-system = [


### PR DESCRIPTION
It's necessary to build the FPGA bitstreams & moondancer for `cynthion flash` to work.

These changes:
* Added building and installing the FPGA bitstreams (analyzer/facedancer/selftest) for every supported hardware revision, and the `moondancer` firmware, in the appropriate location for `cynthion flash analyzer` and `cynthion flash facedancer` to pick up (4c081d6d)
* Patched `luna-soc` to fix CSR register field collection under Python 3.14, otherwise the facedancer gateware fails to build (f4c4227a)
* Added the `riscv32-none` Rust target (9a8e0dfc)

This supersedes #418303, which seems to have gone stale.

Tested on all platforms with an actual cynthion device. Both `facedancer` and `analyzer` successfully flash and work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test