### PR TITLE
updating hyprshade to 4.0.0

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprshade/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprshade/default.nix
@@ -11,14 +11,13 @@
 
 buildPythonPackage rec {
   pname = "hyprshade";
-  version = "3.2.1";
+  version = "4.0.0";
   format = "pyproject";
-
   src = fetchFromGitHub {
     owner = "loqusion";
     repo = "hyprshade";
     tag = version;
-    hash = "sha256-MlbNE9n//Qb6OJc3DMkOpnPtoodfV8JlG/I5rOfWMtQ=";
+    hash = "sha256-11waygndqycnbhan0ks3f4dqgi6lx81cw1x82afs6f6000ia2win=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/hyprwm/hyprshade/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprshade/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "loqusion";
     repo = "hyprshade";
     tag = version;
-    hash = "sha256-11waygndqycnbhan0ks3f4dqgi6lx81cw1x82afs6f6000ia2win=";
+    hash = "sha256-NnKhIgDAOKOdEqgHzgLq1MSHG3FDT2AVXJZ53Ozzioc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ https://github.com/loqusion/hyprshade/compare/3.2.1...4.0.0 ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updates `hyprshade` to version `4.0.0`. This release updates the shaders to use GLES version 3.0.

Changelog: https://github.com/loqusion/hyprshade/compare/3.2.1...4.0.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
