### PR TITLE
tmux-sessionizer: 0.4.5 -> 0.5.0

### DIFF
--- a/pkgs/by-name/tm/tmux-sessionizer/package.nix
+++ b/pkgs/by-name/tm/tmux-sessionizer/package.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   stdenv,
   rustPlatform,
-  openssl,
   pkg-config,
   testers,
   tmux-sessionizer,
@@ -12,7 +11,7 @@
 let
 
   name = "tmux-sessionizer";
-  version = "0.4.5";
+  version = "0.5.0";
 
 in
 rustPlatform.buildRustPackage {
@@ -23,24 +22,20 @@ rustPlatform.buildRustPackage {
     owner = "jrmoulton";
     repo = name;
     rev = "v${version}";
-    hash = "sha256-uoSm9oWZSiqwsg7dVVMay9COL5MEK3a5Pd+D66RzzPM=";
+    hash = "sha256-6eMKwp5639DIyhM6OD+db7jr4uF34JSt0Xg+lpyIPSI=";
   };
 
-  cargoHash = "sha256-fd0IEORqnqxKN9zisXTT0G8CwRNVsGd3HZmCVY5DKsM=";
+  cargoHash = "sha256-gIsqHbCmfYs1c3LPNbE4zLVjzU3GJ4MeHMt0DC5sS3c=";
 
   passthru.tests.version = testers.testVersion {
     package = tmux-sessionizer;
     version = version;
   };
 
-  # Needed to get openssl-sys to use pkg-config.
-  OPENSSL_NO_VENDOR = 1;
-
   nativeBuildInputs = [
     pkg-config
     installShellFiles
   ];
-  buildInputs = [ openssl ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd tms \

--- a/pkgs/by-name/tm/tmux-sessionizer/package.nix
+++ b/pkgs/by-name/tm/tmux-sessionizer/package.nix
@@ -1,12 +1,12 @@
 {
-  lib,
   fetchFromGitHub,
-  stdenv,
-  rustPlatform,
+  installShellFiles,
+  lib,
   pkg-config,
+  rustPlatform,
+  stdenv,
   testers,
   tmux-sessionizer,
-  installShellFiles,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tmux-sessionizer";

--- a/pkgs/by-name/tm/tmux-sessionizer/package.nix
+++ b/pkgs/by-name/tm/tmux-sessionizer/package.nix
@@ -8,20 +8,14 @@
   tmux-sessionizer,
   installShellFiles,
 }:
-let
-
-  name = "tmux-sessionizer";
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tmux-sessionizer";
   version = "0.5.0";
-
-in
-rustPlatform.buildRustPackage {
-  pname = name;
-  inherit version;
 
   src = fetchFromGitHub {
     owner = "jrmoulton";
-    repo = name;
-    rev = "v${version}";
+    repo = "tmux-sessionizer";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-6eMKwp5639DIyhM6OD+db7jr4uF34JSt0Xg+lpyIPSI=";
   };
 
@@ -29,7 +23,7 @@ rustPlatform.buildRustPackage {
 
   passthru.tests.version = testers.testVersion {
     package = tmux-sessionizer;
-    version = version;
+    version = finalAttrs.version;
   };
 
   nativeBuildInputs = [
@@ -54,4 +48,4 @@ rustPlatform.buildRustPackage {
     ];
     mainProgram = "tms";
   };
-}
+})

--- a/pkgs/by-name/tm/tmux-sessionizer/package.nix
+++ b/pkgs/by-name/tm/tmux-sessionizer/package.nix
@@ -5,8 +5,7 @@
   pkg-config,
   rustPlatform,
   stdenv,
-  testers,
-  tmux-sessionizer,
+  versionCheckHook,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tmux-sessionizer";
@@ -21,10 +20,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-gIsqHbCmfYs1c3LPNbE4zLVjzU3GJ4MeHMt0DC5sS3c=";
 
-  passthru.tests.version = testers.testVersion {
-    package = tmux-sessionizer;
-    version = finalAttrs.version;
-  };
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
- Bump version to 0.5.0 (supersedes #430057).
- Remove `openssl` buildInput (see https://github.com/NixOS/nixpkgs/pull/430057#issuecomment-3143742738).
- Use `finalAttrs` pattern.
- Use `versionCheckHook`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
