### PR TITLE
[25.05] cjdns: 21.4 -> 22.1

### DIFF
--- a/nixos/modules/services/networking/cjdns.nix
+++ b/nixos/modules/services/networking/cjdns.nix
@@ -49,7 +49,7 @@ let
         k: v:
         lib.optionalString (
           v.hostname != ""
-        ) "echo $(${pkgs.cjdns}/bin/publictoip6 ${v.publicKey}) ${v.hostname}"
+        ) "echo $(${pkgs.cjdns}/bin/cjdnstool util key2ip6 ${v.publicKey}) ${v.hostname}"
       ) (cfg.ETHInterface.connectTo // cfg.UDPInterface.connectTo)
     )}
   '';
@@ -268,7 +268,7 @@ in
 
         if [ -z "$CJDNS_PRIVATE_KEY" ]; then
             shopt -s lastpipe
-            ${pkg}/bin/makekeys | { read private ipv6 public; }
+            ${pkg}/bin/cjdnstool util keygen | { read private ipv6 public; }
 
             install -m 600 <(echo "CJDNS_PRIVATE_KEY=$private") /etc/cjdns.keys
             install -m 444 <(echo -e "CJDNS_IPV6=$ipv6\nCJDNS_PUBLIC_KEY=$public") /etc/cjdns.public

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -18,117 +18,115 @@ let
 
 in
 
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "cjdns";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ ehmry ];
-    };
+{ pkgs, ... }:
+{
+  name = "cjdns";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ ehmry ];
+  };
 
-    nodes = {
-      # Alice finds peers over over ETHInterface.
-      alice =
-        { ... }:
-        {
-          imports = [ basicConfig ];
+  nodes = {
+    # Alice finds peers over over ETHInterface.
+    alice =
+      { ... }:
+      {
+        imports = [ basicConfig ];
 
-          services.cjdns.ETHInterface.bind = "eth1";
+        services.cjdns.ETHInterface.bind = "eth1";
 
-          services.httpd.enable = true;
-          services.httpd.adminAddr = "foo@example.org";
-          networking.firewall.allowedTCPPorts = [ 80 ];
-        };
+        services.httpd.enable = true;
+        services.httpd.adminAddr = "foo@example.org";
+        networking.firewall.allowedTCPPorts = [ 80 ];
+      };
 
-      # Bob explicitly connects to Carol over UDPInterface.
-      bob =
-        { ... }:
+    # Bob explicitly connects to Carol over UDPInterface.
+    bob =
+      { ... }:
 
-        {
-          imports = [ basicConfig ];
+      {
+        imports = [ basicConfig ];
 
-          networking.interfaces.eth1.ipv4.addresses = [
-            {
-              address = "192.168.0.2";
-              prefixLength = 24;
-            }
-          ];
+        networking.interfaces.eth1.ipv4.addresses = [
+          {
+            address = "192.168.0.2";
+            prefixLength = 24;
+          }
+        ];
 
-          services.cjdns = {
-            UDPInterface = {
-              bind = "0.0.0.0:1024";
-              connectTo."192.168.0.1:1024" = {
-                password = carolPassword;
-                publicKey = carolPubKey;
-              };
+        services.cjdns = {
+          UDPInterface = {
+            bind = "0.0.0.0:1024";
+            connectTo."192.168.0.1:1024" = {
+              password = carolPassword;
+              publicKey = carolPubKey;
             };
           };
         };
+      };
 
-      # Carol listens on ETHInterface and UDPInterface,
-      # but knows neither Alice or Bob.
-      carol =
-        { ... }:
-        {
-          imports = [ basicConfig ];
+    # Carol listens on ETHInterface and UDPInterface,
+    # but knows neither Alice or Bob.
+    carol =
+      { ... }:
+      {
+        imports = [ basicConfig ];
 
-          environment.etc."cjdns.keys".text = ''
-            CJDNS_PRIVATE_KEY=${carolKey}
-            CJDNS_ADMIN_PASSWORD=FOOBAR
-          '';
+        environment.etc."cjdns.keys".text = ''
+          CJDNS_PRIVATE_KEY=${carolKey}
+          CJDNS_ADMIN_PASSWORD=FOOBAR
+        '';
 
-          networking.interfaces.eth1.ipv4.addresses = [
-            {
-              address = "192.168.0.1";
-              prefixLength = 24;
-            }
-          ];
+        networking.interfaces.eth1.ipv4.addresses = [
+          {
+            address = "192.168.0.1";
+            prefixLength = 24;
+          }
+        ];
 
-          services.cjdns = {
-            authorizedPasswords = [ carolPassword ];
-            ETHInterface.bind = "eth1";
-            UDPInterface.bind = "192.168.0.1:1024";
-          };
-          networking.firewall.allowedUDPPorts = [ 1024 ];
+        services.cjdns = {
+          authorizedPasswords = [ carolPassword ];
+          ETHInterface.bind = "eth1";
+          UDPInterface.bind = "192.168.0.1:1024";
         };
+        networking.firewall.allowedUDPPorts = [ 1024 ];
+      };
 
-    };
+  };
 
-    testScript = ''
-      import re
+  testScript = ''
+    import re
 
-      start_all()
+    start_all()
 
-      alice.wait_for_unit("cjdns.service")
-      bob.wait_for_unit("cjdns.service")
-      carol.wait_for_unit("cjdns.service")
-
-
-      def cjdns_ip(machine):
-          res = machine.succeed("ip -o -6 addr show dev tun0")
-          ip = re.split("\s+|/", res)[3]
-          machine.log("has ip {}".format(ip))
-          return ip
+    alice.wait_for_unit("cjdns.service")
+    bob.wait_for_unit("cjdns.service")
+    carol.wait_for_unit("cjdns.service")
 
 
-      alice_ip6 = cjdns_ip(alice)
-      bob_ip6 = cjdns_ip(bob)
-      carol_ip6 = cjdns_ip(carol)
+    def cjdns_ip(machine):
+        res = machine.succeed("ip -o -6 addr show dev tun0")
+        ip = re.split("\s+|/", res)[3]
+        machine.log("has ip {}".format(ip))
+        return ip
 
-      # ping a few times each to let the routing table establish itself
 
-      alice.succeed("ping -c 4 {}".format(carol_ip6))
-      bob.succeed("ping -c 4 {}".format(carol_ip6))
+    alice_ip6 = cjdns_ip(alice)
+    bob_ip6 = cjdns_ip(bob)
+    carol_ip6 = cjdns_ip(carol)
 
-      carol.succeed("ping -c 4 {}".format(alice_ip6))
-      carol.succeed("ping -c 4 {}".format(bob_ip6))
+    # ping a few times each to let the routing table establish itself
 
-      alice.succeed("ping -c 4 {}".format(bob_ip6))
-      bob.succeed("ping -c 4 {}".format(alice_ip6))
+    alice.succeed("ping -c 4 {}".format(carol_ip6))
+    bob.succeed("ping -c 4 {}".format(carol_ip6))
 
-      alice.wait_for_unit("httpd.service")
+    carol.succeed("ping -c 4 {}".format(alice_ip6))
+    carol.succeed("ping -c 4 {}".format(bob_ip6))
 
-      bob.succeed("curl --fail -g http://[{}]".format(alice_ip6))
-    '';
-  }
-)
+    alice.succeed("ping -c 4 {}".format(bob_ip6))
+    bob.succeed("ping -c 4 {}".format(alice_ip6))
+
+    alice.wait_for_unit("httpd.service")
+
+    bob.succeed("curl --fail -g http://[{}]".format(alice_ip6))
+  '';
+}

--- a/nixos/tests/cjdns.nix
+++ b/nixos/tests/cjdns.nix
@@ -105,7 +105,7 @@ in
 
     def cjdns_ip(machine):
         res = machine.succeed("ip -o -6 addr show dev tun0")
-        ip = re.split("\s+|/", res)[3]
+        ip = re.split("\\s+|/", res)[3]
         machine.log("has ip {}".format(ip))
         return ip
 
@@ -116,14 +116,14 @@ in
 
     # ping a few times each to let the routing table establish itself
 
-    alice.succeed("ping -c 4 {}".format(carol_ip6))
-    bob.succeed("ping -c 4 {}".format(carol_ip6))
+    alice.wait_until_succeeds("ping -c 4 {}".format(carol_ip6))
+    bob.wait_until_succeeds("ping -c 4 {}".format(carol_ip6))
 
-    carol.succeed("ping -c 4 {}".format(alice_ip6))
-    carol.succeed("ping -c 4 {}".format(bob_ip6))
+    carol.wait_until_succeeds("ping -c 4 {}".format(alice_ip6))
+    carol.wait_until_succeeds("ping -c 4 {}".format(bob_ip6))
 
-    alice.succeed("ping -c 4 {}".format(bob_ip6))
-    bob.succeed("ping -c 4 {}".format(alice_ip6))
+    alice.wait_until_succeeds("ping -c 4 {}".format(bob_ip6))
+    bob.wait_until_succeeds("ping -c 4 {}".format(alice_ip6))
 
     alice.wait_for_unit("httpd.service")
 

--- a/pkgs/by-name/cj/cjdns-tools/package.nix
+++ b/pkgs/by-name/cj/cjdns-tools/package.nix
@@ -37,12 +37,12 @@ stdenv.mkDerivation {
     cp -r node_modules $out/node_modules
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cjdelisle/cjdns";
     description = "Tools for cjdns managment";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
     maintainers = [ ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "cjdns-tools";
   };
 }

--- a/pkgs/by-name/cj/cjdns-tools/package.nix
+++ b/pkgs/by-name/cj/cjdns-tools/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
     description = "Tools for cjdns managment";
     license = licenses.gpl3Plus;
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     mainProgram = "cjdns-tools";
   };
 }

--- a/pkgs/by-name/cj/cjdns/package.nix
+++ b/pkgs/by-name/cj/cjdns/package.nix
@@ -31,7 +31,6 @@ rustPlatform.buildRustPackage rec {
     })
   ];
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-LJEKjhyAsK6b7mKObX8tNJdKt53iagMD/YLzoY5GVPw=";
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cj/cjdns/package.nix
+++ b/pkgs/by-name/cj/cjdns/package.nix
@@ -2,11 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   rustPlatform,
   nodejs,
   which,
-  python3,
-  libuv,
   util-linux,
   nixosTests,
   libsodium,
@@ -16,26 +15,34 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cjdns";
-  version = "21.4";
+  version = "22.1";
 
   src = fetchFromGitHub {
     owner = "cjdelisle";
     repo = "cjdns";
-    rev = "cjdns-v${version}";
-    sha256 = "sha256-vI3uHZwmbFqxGasKqgCl0PLEEO8RNEhwkn5ZA8K7bxU=";
+    tag = "cjdns-v${version}";
+    hash = "sha256-0imQrkcvIA+2Eq/zlC65USMR7T3OUKwQxrB1KtVexyU=";
   };
 
   patches = [
     (replaceVars ./system-libsodium.patch {
       libsodium_include_dir = "${libsodium.dev}/include";
     })
+    # Remove mkpasswd since it is failing the build
+    (fetchpatch {
+      url = "https://github.com/cjdelisle/cjdns/commit/6391dba3f5fdab45df4b4b6b71dbe9620286ce32.patch";
+      hash = "sha256-XVA4tdTVMLrV6zuGoBCkOgQq6NXh0x7u8HgmaxFeoRI=";
+    })
+    (fetchpatch {
+      url = "https://github.com/cjdelisle/cjdns/commit/436d9a9784bae85734992c2561c778fbd2f5ac32.patch";
+      hash = "sha256-THcYNGVbMx/xf3/5UIxEhz3OlODE0qiYgDBOlHunhj8=";
+    })
   ];
 
-  cargoHash = "sha256-LJEKjhyAsK6b7mKObX8tNJdKt53iagMD/YLzoY5GVPw=";
+  cargoHash = "sha256-f96y6ZW0HxC+73ts5re8GIo2aigQgK3gXyF7fMrcJ0o=";
 
   nativeBuildInputs = [
     which
-    python3
     nodejs
     pkg-config
   ]
@@ -43,10 +50,7 @@ rustPlatform.buildRustPackage rec {
     # for flock
     lib.optional stdenv.hostPlatform.isLinux util-linux;
 
-  buildInputs = [
-    libuv
-    libsodium
-  ];
+  buildInputs = [ libsodium ];
 
   env.SODIUM_USE_PKG_CONFIG = 1;
   env.NIX_CFLAGS_COMPILE = toString (
@@ -61,10 +65,22 @@ rustPlatform.buildRustPackage rec {
     ]
   );
 
+  cargoTestFlags = [
+    # don't run doctests since they fail with "cannot find type `Ctx` in this scope"
+    "--lib"
+    "--bins"
+    "--tests"
+  ];
+
+  checkFlags = [
+    # Tests don't seem to work - "called `Result::unwrap()` on an `Err` value: DecryptErr: NO_SESSION"
+    "--skip=crypto::crypto_auth::tests::test_wireguard_iface_encrypt_decrypt"
+    "--skip=crypto::crypto_auth::tests::test_wireguard_iface_encrypt_decrypt_with_auth"
+  ];
+
   passthru.tests.basic = nixosTests.cjdns;
 
   meta = with lib; {
-    broken = true; # outdated, incompatible with supported python versions
     homepage = "https://github.com/cjdelisle/cjdns";
     description = "Encrypted networking for regular people";
     license = licenses.gpl3Plus;

--- a/pkgs/by-name/cj/cjdns/package.nix
+++ b/pkgs/by-name/cj/cjdns/package.nix
@@ -80,11 +80,11 @@ rustPlatform.buildRustPackage rec {
 
   passthru.tests.basic = nixosTests.cjdns;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/cjdelisle/cjdns";
     description = "Encrypted networking for regular people";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ ehmry ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ehmry ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/cj/cjdns/package.nix
+++ b/pkgs/by-name/cj/cjdns/package.nix
@@ -85,6 +85,6 @@ rustPlatform.buildRustPackage rec {
     description = "Encrypted networking for regular people";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ ehmry ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 }


### PR DESCRIPTION
- backport of https://github.com/NixOS/nixpkgs/pull/426168

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
