### PR TITLE
hashcat: patch helper scripts

### DIFF
--- a/pkgs/by-name/ha/hashcat/0001-python-shebangs.patch
+++ b/pkgs/by-name/ha/hashcat/0001-python-shebangs.patch
@@ -1,0 +1,42 @@
+diff --git a/tools/bitlocker2hashcat.py b/tools/bitlocker2hashcat.py
+index f7501a37b..a72fb8c78 100755
+--- a/tools/bitlocker2hashcat.py
++++ b/tools/bitlocker2hashcat.py
+@@ -1,3 +1,5 @@
++#!/usr/bin/env python3
++
+ # Construct a hash for use with hashcat mode 22100
+ # Usage: python3 bitlocker2hashcat.py <bitlocker_image> -o <bitlocker_partition_offset>
+ # Hashcat supports modes $bitlocker$0$ and $bitlocker$1$ and therefore this script will output hashes that relate to a VMK protected by a user password only.
+diff --git a/tools/keybag2hashcat.py b/tools/keybag2hashcat.py
+index 83da25c5e..6a30384ac 100755
+--- a/tools/keybag2hashcat.py
++++ b/tools/keybag2hashcat.py
+@@ -1,3 +1,5 @@
++#!/usr/bin/env python3
++
+ import argparse
+ import logging
+ import sys
+diff --git a/tools/shiro1-to-hashcat.py b/tools/shiro1-to-hashcat.py
+old mode 100755
+new mode 100644
+index 9619530ef..86ee8e502
+--- a/tools/shiro1-to-hashcat.py
++++ b/tools/shiro1-to-hashcat.py
+@@ -1,3 +1,5 @@
++#!/usr/bin/env python3
++
+ import os
+ import re
+ import glob
+diff --git a/tools/veeamvbk2hashcat.py b/tools/veeamvbk2hashcat.py
+index e8d6ac05c..5f6d1977a 100755
+--- a/tools/veeamvbk2hashcat.py
++++ b/tools/veeamvbk2hashcat.py
+@@ -1,3 +1,5 @@
++#!/usr/bin/env python3
++
+ import argparse
+ import binascii
+ 

--- a/pkgs/by-name/ha/hashcat/package.nix
+++ b/pkgs/by-name/ha/hashcat/package.nix
@@ -10,6 +10,8 @@
   minizip,
   opencl-headers,
   ocl-icd,
+  perl,
+  python3,
   xxHash,
   zlib,
   libiconv,
@@ -23,6 +25,10 @@ stdenv.mkDerivation rec {
     url = "https://hashcat.net/files/hashcat-${version}.tar.gz";
     sha256 = "sha256-hCtx0NNLAgAFiCR6rp/smg/BMnfyzTpqSSWw8Jszv3U=";
   };
+
+  patches = [
+    ./0001-python-shebangs.patch
+  ];
 
   postPatch = ''
      # MACOSX_DEPLOYMENT_TARGET is defined by the enviroment
@@ -44,6 +50,17 @@ stdenv.mkDerivation rec {
   buildInputs = [
     minizip
     opencl-headers
+    perl
+    (python3.withPackages (
+      ps: with ps; [
+        # leveldb # Required for bitwarden2hashcat.py, broken since python 3.12 https://github.com/NixOS/nixpkgs/pull/342756
+        protobuf
+        pyasn1
+        pycryptodome
+        python-snappy
+        simplejson
+      ]
+    ))
     xxHash
     zlib
   ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

In https://github.com/NixOS/nixpkgs/pull/430494, I missed the addition of `$out/bin/*.pl` and `$out/bin/*.py`.
The Python helper scripts have different(and sometimes missing) shebangs, and have been patched to all use `/usr/bin/env python3`.

This PR wraps these programs to include the correct Perl/Python environments.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `90f9d304dab1cf674a0a2d7370c0b0ff4528f7e0`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>hashcat</li>
    <li>wifite2</li>
    <li>wifite2.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
