### PR TITLE
emacsPackages.eaf-airshare: init at 0-unstable-2023-07-11

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-airshare/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/eaf-airshare/package.nix
@@ -1,0 +1,48 @@
+{
+  # Basic
+  lib,
+  melpaBuild,
+  fetchFromGitHub,
+  # Updater
+  unstableGitUpdater,
+}:
+
+melpaBuild {
+
+  pname = "eaf-airshare";
+  version = "0-unstable-2023-07-11";
+
+  src = fetchFromGitHub {
+    owner = "emacs-eaf";
+    repo = "eaf-airshare";
+    rev = "71b4507ad5724babcf34da941a53c5a94bf7666a";
+    hash = "sha256-jpODlbg/luuCuDOayBqhVCF3vXww2FolYLniykeZr6E=";
+  };
+
+  files = ''
+    ("*.el"
+     "*.py")
+  '';
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+    eafPythonDeps =
+      ps:
+      with ps;
+      [
+        qrcode
+      ]
+      ++ ps.qrcode.optional-dependencies.pil;
+    eafOtherDeps = [ ];
+  };
+
+  meta = {
+    description = "Share text by qr-code in Emacs";
+    homepage = "https://github.com/emacs-eaf/eaf-airshare";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      thattemperature
+    ];
+  };
+
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
