### PR TITLE
breitbandmessung: fix darwin build

### DIFF
--- a/pkgs/by-name/br/breitbandmessung/package.nix
+++ b/pkgs/by-name/br/breitbandmessung/package.nix
@@ -64,6 +64,9 @@ let
 
         sourceRoot = "Breitbandmessung.app";
 
+        dontFixup = true;
+        dontStrip = true;
+
         installPhase = ''
           runHook preInstall
           mkdir -p $out/Applications/Breitbandmessung.app

--- a/pkgs/by-name/br/breitbandmessung/package.nix
+++ b/pkgs/by-name/br/breitbandmessung/package.nix
@@ -62,6 +62,8 @@ let
 
         nativeBuildInputs = [ undmg ];
 
+        sourceRoot = "Breitbandmessung.app";
+
         installPhase = ''
           runHook preInstall
           mkdir -p $out/Applications/Breitbandmessung.app


### PR DESCRIPTION
Fix: `unpacker produced multiple directories`

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
