### PR TITLE
rustPlatform.cargoDocHook: init

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-doc-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-doc-hook.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash disable=SC2154,SC2164
+
+cargoDocBuildHook() {
+  echo "Executing cargoDocBuildHook"
+
+  if [[ -v buildAndTestSubdir ]]; then
+    local targetDir
+    targetDir="$(pwd)/target"
+    pushd "$buildAndTestSubdir"
+  fi
+
+  @setEnv@ cargo doc \
+    -j "$NIX_BUILD_CORES" \
+    --target "@rustcTarget@" \
+    --profile "$cargoBuildType" \
+    --offline \
+    --no-deps \
+    ${targetDir+--target-dir "$targetDir"} \
+    ${cargoBuildNoDefaultFeatures+--no-default-features} \
+    ${cargoBuildFeatures+--features="$(concatStringsSep "," cargoBuildFeatures)"} \
+    "${cargoDocFlags[@]}"
+
+  if [[ -v buildAndTestSubdir ]]; then
+    popd
+  fi
+
+  echo "Finished cargoDocBuildHook"
+}
+
+cargoDocInstallHook() {
+  echo "Executing cargoDocInstallHook"
+
+  # If no explicit outputRustdoc is specified, try devdoc and then out.
+  if [[ ! -v outputRustdoc ]]; then
+    for var in devdoc out; do
+      if [[ -v "$var" ]]; then
+        local outputRustdoc="$var"
+        break
+      fi
+    done
+  fi
+
+  mkdir -p "${!outputRustdoc}/share"
+
+  # Not installing into /share/doc as multiple-outputs.sh hook would move it
+  # to doc output.
+  cp -R -p -d "target/@targetSubdirectory@/doc" "${!outputRustdoc}/share/rustdoc"
+
+  echo "Finished cargoDocInstallHook"
+}
+
+postBuildHooks+=(cargoDocBuildHook)
+postInstallHooks+=(cargoDocInstallHook)

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -134,4 +134,16 @@
       inherit clang;
     };
   } ./rust-bindgen-hook.sh;
+
+  cargoDocHook = makeSetupHook {
+    name = "cargo-doc-hook.sh";
+    substitutions = {
+      inherit (stdenv.targetPlatform.rust) rustcTarget;
+      inherit (rust.envVars) setEnv;
+      targetSubdirectory = target;
+    };
+    passthru.tests = {
+      test = tests.rust-hooks.cargoDocHook;
+    };
+  } ./cargo-doc-hook.sh;
 }

--- a/pkgs/build-support/rust/hooks/test/default.nix
+++ b/pkgs/build-support/rust/hooks/test/default.nix
@@ -101,4 +101,29 @@
     cargoCheckType = "release";
     doCheck = true;
   };
+
+  cargoDocHook = stdenv.mkDerivation {
+    name = "test-cargoDocHook";
+    src = ./example-rust-project;
+    outputs = [
+      "out"
+      "devdoc"
+    ];
+    cargoBuildType = "release";
+    nativeBuildInputs = [
+      rustPlatform.cargoDocHook
+      cargo
+    ];
+    buildPhase = ''
+      runHook postBuild
+    '';
+    installPhase = ''
+      mkdir -p "$out"
+      runHook postInstall
+    '';
+    doInstallCheck = true;
+    installCheckPhase = ''
+      test -d "$devdoc/share/rustdoc/hello"
+    '';
+  };
 }

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -71,6 +71,7 @@
         cargoSetupHook
         maturinBuildHook
         bindgenHook
+        cargoDocHook
         ;
     };
 })


### PR DESCRIPTION
Provide a hook to produce rustdoc documentation through `cargo doc`.

The documentation will be installed to `/share/rustdoc` of the output specified by `outputRustdoc`, defaulting to `devdoc` and falling back to `out`.

`/share/doc` is probably not a suitable destination as it is moved to the `doc` output by the `multiple-outputs.sh` hook for packages with multiple outputs and rustdoc documentation is in general only useful to developers.

I opted for in‐line construction of the cargo command line using parameter expansion to keep the code concise, but if preferred I could also modify it to use a flags array.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
