### PR TITLE
nixos/freshrss: fix loading extensions' static content

### DIFF
--- a/nixos/modules/services/web-apps/freshrss.nix
+++ b/nixos/modules/services/web-apps/freshrss.nix
@@ -18,7 +18,7 @@ let
     DATA_PATH = cfg.dataDir;
   }
   // lib.optionalAttrs (cfg.extensions != [ ]) {
-    THIRDPARTY_EXTENSIONS_PATH = "${extension-env}/share/freshrss/";
+    THIRDPARTY_EXTENSIONS_PATH = "${extension-env}/share/freshrss";
   };
 in
 {

--- a/nixos/tests/freshrss/extensions.nix
+++ b/nixos/tests/freshrss/extensions.nix
@@ -8,14 +8,30 @@
         enable = true;
         baseUrl = "http://localhost";
         authType = "none";
-        extensions = [ pkgs.freshrss-extensions.youtube ];
+        extensions = [
+          pkgs.freshrss-extensions.youtube
+          pkgs.freshrss-extensions.title-wrap
+        ];
       };
     };
+  extraPythonPackages = p: [
+    p.lxml
+    p.lxml-stubs
+  ];
+  skipTypeCheck = true;
 
   testScript = ''
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_open_port(80)
-    response = machine.succeed("curl -vvv -s http://localhost:80/i/?c=extension")
+    response = machine.succeed("curl -s http://localhost:80/i/?c=extension")
     assert '<span class="ext_name disabled">YouTube Video Feed</span>' in response, "Extension not present in extensions page."
+
+    # enable Title-Wrap extension
+    from lxml import etree
+    tree = etree.HTML(response)
+    csrf = tree.xpath("/html/body/header/nav/form/input/@value")[0]
+    response = machine.succeed(f"curl --fail-with-body -s 'http://localhost:80/i/?c=extension&a=enable&e=Title-Wrap' -d '_csrf={csrf}'")
+    # verify that the Title-Wrap css is accessible.
+    machine.succeed("curl --fail-with-body -s 'http://localhost:80/ext.php?1=&f=xExtension-TitleWrap/static/title_wrap.css'")
   '';
 }


### PR DESCRIPTION
Before this change, the THIRDPARTY_EXTENSIONS_PATH would end up with a double-slash in the path, which was breaking FreshRSS's is_valid_path detection.

Fixes #427211 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
