### PR TITLE
abbaye-des-morts: fix darwin build, refactor

### DIFF
--- a/pkgs/by-name/ab/abbaye-des-morts/package.nix
+++ b/pkgs/by-name/ab/abbaye-des-morts/package.nix
@@ -7,14 +7,14 @@
   SDL2_mixer,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "abbaye-des-morts";
   version = "2.0.5";
 
   src = fetchFromGitHub {
     owner = "nevat";
     repo = "abbayedesmorts-gpl";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-muJt1cml0nYdgl0v8cudpUXcdSntc49e6zICTCwzkks=";
   };
 
@@ -46,4 +46,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ marius851000 ];
   };
-}
+})

--- a/pkgs/by-name/ab/abbaye-des-morts/package.nix
+++ b/pkgs/by-name/ab/abbaye-des-morts/package.nix
@@ -27,11 +27,15 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "DESTDIR="
-  ];
+  ]
+  ++ lib.optional stdenv.isDarwin "PLATFORM=mac";
 
-  preBuild = lib.optionalString stdenv.cc.isClang ''
+  # Even with PLATFORM=mac, the Makefile specifies some GCC-specific CFLAGS that
+  # are not supported by modern Clang on macOS
+  postPatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace Makefile \
-      --replace -fpredictive-commoning ""
+      --replace-fail "-funswitch-loops" "" \
+      --replace-fail "-fgcse-after-reload" ""
   '';
 
   meta = {

--- a/pkgs/by-name/ab/abbaye-des-morts/package.nix
+++ b/pkgs/by-name/ab/abbaye-des-morts/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   makeFlags = [
-    "PREFIX=$(out)"
+    "PREFIX=${placeholder "out"}"
     "DESTDIR="
   ];
 

--- a/pkgs/by-name/ab/abbaye-des-morts/package.nix
+++ b/pkgs/by-name/ab/abbaye-des-morts/package.nix
@@ -34,11 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace -fpredictive-commoning ""
   '';
 
-  preInstall = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/applications
-  '';
-
   meta = {
     homepage = "https://locomalito.com/abbaye_des_morts.php";
     description = "Retro arcade video game";


### PR DESCRIPTION
## Things done


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
