### PR TITLE
baresip: 3.10.1 -> 3.24.0

### DIFF
--- a/pkgs/by-name/ba/baresip/fix-modules-path.patch
+++ b/pkgs/by-name/ba/baresip/fix-modules-path.patch
@@ -1,0 +1,29 @@
+commit 46479c52695cc5f8c01370fd2594468666c45c8e
+Author: rnhmjoj <rnhmjoj@inventati.org>
+Date:   Sun Aug 3 00:18:47 2025 +0200
+
+    Fix the modules path at build time
+    
+    The location of the modules is determined by reading the `module_path`
+    setting, which is set to "$out/lib/baresip/modules" when the
+    configuration file is generated during the first run. If the package is
+    updated and the store path changes, baresip breaks completely, forcing
+    the user to manually fix the configuration.
+    
+    This patch fixes the location of the modules at build time, ignoring the
+    `module_path` setting, to avoid this issue.
+
+diff --git a/src/module.c b/src/module.c
+index 9f2135c6..b62d0bdd 100644
+--- a/src/module.c
++++ b/src/module.c
+@@ -141,8 +141,7 @@ int module_init(const struct conf *conf)
+ 	if (!conf)
+ 		return EINVAL;
+ 
+-	if (conf_get(conf, "module_path", &path))
+-		pl_set_str(&path, ".");
++	pl_set_str(&path, MOD_PATH);
+ 
+ 	err = conf_apply(conf, "module", module_handler, &path);
+ 	if (err)

--- a/pkgs/by-name/ba/baresip/package.nix
+++ b/pkgs/by-name/ba/baresip/package.nix
@@ -186,6 +186,7 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       raskin
       ehmry
+      rnhmjoj
     ];
     mainProgram = "baresip";
     license = lib.licenses.bsd3;

--- a/pkgs/by-name/ba/baresip/package.nix
+++ b/pkgs/by-name/ba/baresip/package.nix
@@ -30,13 +30,13 @@
   dbusSupport ? true,
 }:
 stdenv.mkDerivation rec {
-  version = "3.10.1";
+  version = "3.24.0";
   pname = "baresip";
   src = fetchFromGitHub {
     owner = "baresip";
     repo = "baresip";
     rev = "v${version}";
-    hash = "sha256-0huZP1hopHaN5R1Hki6YutpvoASfIHzHMl/Y4czHHMo=";
+    hash = "sha256-32XyMblHF+ST+TpIbdyPFdRtWnIugYMr4lYZnfeFm/c=";
   };
   prePatch = ''
     substituteInPlace cmake/FindGTK3.cmake --replace-fail GTK3_CFLAGS_OTHER ""
@@ -102,72 +102,75 @@ stdenv.mkDerivation rec {
     -D__need_timeval -D__need_timespec -D__need_time_t
   '';
 
-  doInstallCheck = true;
   # CMake feature detection is prone to breakage between upgrades:
   # spot-check that the optional modules we care about were compiled
-  postInstallCheck = lib.concatMapStringsSep "\n" (m: "test -x $out/lib/baresip/modules/${m}.so") [
-    "account"
-    "alsa"
-    "aubridge"
-    "auconv"
-    "aufile"
-    "auresamp"
-    "ausine"
-    "avcodec"
-    "avfilter"
-    "avformat"
-    "cons"
-    "contact"
-    "ctrl_dbus"
-    "ctrl_tcp"
-    "debug_cmd"
-    "dtls_srtp"
-    "ebuacip"
-    "echo"
-    "evdev"
-    "fakevideo"
-    "g711"
-    "g722"
-    "g726"
-    "gst"
-    "gtk"
-    "httpd"
-    "httpreq"
-    "ice"
-    "l16"
-    "menu"
-    "mixausrc"
-    "mixminus"
-    "multicast"
-    "mwi"
-    "natpmp"
-    "netroam"
-    "pcp"
-    "pipewire"
-    "plc"
-    "portaudio"
-    "presence"
-    "rtcpsummary"
-    "sdl"
-    "selfview"
-    "serreg"
-    "snapshot"
-    "sndfile"
-    "srtp"
-    "stdio"
-    "stun"
-    "swscale"
-    "syslog"
-    "turn"
-    "uuid"
-    "v4l2"
-    "vidbridge"
-    "vidinfo"
-    "vp8"
-    "vp9"
-    "vumeter"
-    "x11"
-  ];
+  installCheckPhase = ''
+    runHook preInstallCheck
+    ${lib.concatMapStringsSep "\n" (m: "test -x $out/lib/baresip/modules/${m}.so") [
+      "account"
+      "alsa"
+      "aubridge"
+      "auconv"
+      "aufile"
+      "auresamp"
+      "ausine"
+      "avcodec"
+      "avfilter"
+      "avformat"
+      "cons"
+      "contact"
+      "ctrl_dbus"
+      "ctrl_tcp"
+      "debug_cmd"
+      "dtls_srtp"
+      "ebuacip"
+      "echo"
+      "evdev"
+      "fakevideo"
+      "g711"
+      "g722"
+      "g726"
+      "gst"
+      "gtk"
+      "httpd"
+      "httpreq"
+      "ice"
+      "l16"
+      "menu"
+      "mixausrc"
+      "mixminus"
+      "multicast"
+      "mwi"
+      "natpmp"
+      "netroam"
+      "pcp"
+      "pipewire"
+      "plc"
+      "portaudio"
+      "presence"
+      "rtcpsummary"
+      "sdl"
+      "selfview"
+      "serreg"
+      "snapshot"
+      "sndfile"
+      "srtp"
+      "stdio"
+      "stun"
+      "swscale"
+      "syslog"
+      "turn"
+      "uuid"
+      "v4l2"
+      "vidbridge"
+      "vidinfo"
+      "vp8"
+      "vp9"
+      "vumeter"
+      "x11"
+    ]}
+    runHook postInstallCheck
+  '';
 
   meta = {
     description = "Modular SIP User-Agent with audio and video support";

--- a/pkgs/by-name/ba/baresip/package.nix
+++ b/pkgs/by-name/ba/baresip/package.nix
@@ -29,21 +29,29 @@
   zlib,
   dbusSupport ? true,
 }:
+
 stdenv.mkDerivation rec {
   version = "3.24.0";
   pname = "baresip";
+
   src = fetchFromGitHub {
     owner = "baresip";
     repo = "baresip";
     rev = "v${version}";
     hash = "sha256-32XyMblHF+ST+TpIbdyPFdRtWnIugYMr4lYZnfeFm/c=";
   };
+
+  patches = [
+    ./fix-modules-path.patch
+  ];
+
   prePatch = ''
     substituteInPlace cmake/FindGTK3.cmake --replace-fail GTK3_CFLAGS_OTHER ""
   ''
   + lib.optionalString (!dbusSupport) ''
     substituteInPlace cmake/modules.cmake --replace-fail 'list(APPEND MODULES ctrl_dbus)' ""
   '';
+
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/by-name/li/libre/package.nix
+++ b/pkgs/by-name/li/libre/package.nix
@@ -8,13 +8,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.10.0";
+  version = "3.24.0";
   pname = "libre";
   src = fetchFromGitHub {
     owner = "baresip";
     repo = "re";
     rev = "v${version}";
-    sha256 = "sha256-OWVDuKlF7YLipDURC46s14WOLWWagUqWg20sH0kSIA4=";
+    sha256 = "sha256-wcntgFKpVxDlRMF8a7s9UxeXihguiGxTL/PGv9ImB80=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Update and fix issues #173505, #320010

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


cc: @ehmry @7c6f434c