### PR TITLE
fire: 1.0.1-unstable-2025-03-12 -> 1.0.2-unstable-2025-07-05

### DIFF
--- a/pkgs/by-name/fi/fire/package.nix
+++ b/pkgs/by-name/fi/fire/package.nix
@@ -1,10 +1,13 @@
 {
   stdenv,
   lib,
+  fetchurl,
   fetchFromGitHub,
+  runCommand,
   unstableGitUpdater,
   catch2_3,
   cmake,
+  fontconfig,
   pkg-config,
   libX11,
   libXrandr,
@@ -13,36 +16,102 @@
   libXcursor,
   freetype,
   alsa-lib,
+
+  # Only able to test this myself in Linux
+  withStandalone ? stdenv.hostPlatform.isLinux,
 }:
 
+let
+  # Required version, base URL and expected location specified in cmake/CPM.cmake
+  cpmDownloadVersion = "0.40.2";
+  cpmSrc = fetchurl {
+    url = "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${cpmDownloadVersion}/CPM.cmake";
+    hash = "sha256-yM3DLAOBZTjOInge1ylk3IZLKjSjENO3EEgSpcotg10=";
+  };
+  cpmSourceCache = runCommand "cpm-source-cache" { } ''
+    mkdir -p $out/cpm
+    ln -s ${cpmSrc} $out/cpm/CPM_${cpmDownloadVersion}.cmake
+  '';
+
+  pathMappings = [
+    {
+      from = "LV2";
+      to = "${placeholder "out"}/${
+        if stdenv.hostPlatform.isDarwin then "Library/Audio/Plug-Ins/LV2" else "lib/lv2"
+      }";
+    }
+    {
+      from = "VST3";
+      to = "${placeholder "out"}/${
+        if stdenv.hostPlatform.isDarwin then "Library/Audio/Plug-Ins/VST3" else "lib/vst3"
+      }";
+    }
+    # this one's a guess, don't know where ppl have agreed to put them yet
+    {
+      from = "CLAP";
+      to = "${placeholder "out"}/${
+        if stdenv.hostPlatform.isDarwin then "Library/Audio/Plug-Ins/CLAP" else "lib/clap"
+      }";
+    }
+  ]
+  ++ lib.optionals withStandalone [
+    {
+      from = "Standalone";
+      to = "${placeholder "out"}/bin";
+    }
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Audio Unit is a macOS-specific thing
+    {
+      from = "AU";
+      to = "${placeholder "out"}/Library/Audio/Plug-Ins/Components";
+    }
+  ];
+
+  x11Libs = [
+    libX11
+    libXrandr
+    libXinerama
+    libXext
+    libXcursor
+  ];
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fire";
-  version = "1.0.1-unstable-2025-03-12";
+  version = "1.0.2-unstable-2025-07-05";
 
   src = fetchFromGitHub {
     owner = "jerryuhoo";
     repo = "Fire";
-    rev = "b7ded116ce7ab78a57bb9b6b61796cb2cf3a6e8b";
+    rev = "a0553c6fcced4919871771da3add390e931e29de";
     fetchSubmodules = true;
-    hash = "sha256-d8w+b4OpU2/kQdcAimR4ihDEgVTM1V7J0hj7saDrQpY=";
+    hash = "sha256-bHqWP3EZQg42OBi44Z1RvkIB2Ou0dDxgBLcidgxaMU8=";
   };
 
-  postPatch = ''
-    # Disable automatic copying of built plugins during buildPhase, it defaults
-    # into user home and we want to have building & installing separated.
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'COPY_PLUGIN_AFTER_BUILD TRUE' 'COPY_PLUGIN_AFTER_BUILD FALSE'
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    # Remove hardcoded LTO flags: needs extra setup on Linux
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
-  ''
-  + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'include(Tests)' '# Not building tests' \
-      --replace-fail 'include(Benchmarks)' '# Not building benchmark test'
-  '';
+  postPatch =
+    let
+      formatsListing = lib.strings.concatMapStringsSep " " (entry: entry.from) pathMappings;
+    in
+    ''
+      # Allow all the formats we can handle
+      # Set LV2URI again for LV2 build
+      # Disable automatic copying of built plugins during buildPhase, it defaults
+      # into user home and we want to have building & installing separated.
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'set(FORMATS' 'set(FORMATS ${formatsListing}) #' \
+        --replace-fail 'BUNDLE_ID "''${BUNDLE_ID}"' 'BUNDLE_ID "''${BUNDLE_ID}" LV2URI "https://www.bluewingsmusic.com/Fire/"' \
+        --replace-fail 'COPY_PLUGIN_AFTER_BUILD TRUE' 'COPY_PLUGIN_AFTER_BUILD FALSE'
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      # Remove hardcoded LTO flags: needs extra setup on Linux
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'juce::juce_recommended_lto_flags' '# Not forcing LTO'
+    ''
+    + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'include(Tests)' '# Not building tests' \
+        --replace-fail 'include(Benchmarks)' '# Not building benchmark test'
+    '';
 
   strictDeps = true;
 
@@ -51,74 +120,55 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    libX11
-    libXrandr
-    libXinerama
-    libXext
-    libXcursor
-    freetype
-    alsa-lib
-  ];
+  buildInputs = [
+    catch2_3
+    fontconfig
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux (
+    x11Libs
+    ++ [
+      freetype
+      alsa-lib
+    ]
+  );
 
   cmakeFlags = [
-    (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
-    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_CATCH2" "${catch2_3.src}")
+    (lib.cmakeFeature "CPM_SOURCE_CACHE" "${cpmSourceCache}")
+    (lib.cmakeBool "CPM_LOCAL_PACKAGES_ONLY" true)
+    (lib.cmakeFeature "Catch2_SOURCE_DIR" "${catch2_3.src}")
   ];
 
-  installPhase =
-    let
-      pathMappings = [
-        {
-          from = "LV2";
-          to = "${placeholder "out"}/${
-            if stdenv.hostPlatform.isDarwin then "Library/Audio/Plug-Ins/LV2" else "lib/lv2"
-          }";
-        }
-        {
-          from = "VST3";
-          to = "${placeholder "out"}/${
-            if stdenv.hostPlatform.isDarwin then "Library/Audio/Plug-Ins/VST3" else "lib/vst3"
-          }";
-        }
-        # this one's a guess, don't know where ppl have agreed to put them yet
-        {
-          from = "CLAP";
-          to = "${placeholder "out"}/${
-            if stdenv.hostPlatform.isDarwin then "Library/Audio/Plug-Ins/CLAP" else "lib/clap"
-          }";
-        }
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        {
-          from = "AU";
-          to = "${placeholder "out"}/Library/Audio/Plug-Ins/Components";
-        }
-      ];
-    in
-    ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-    ''
-    + lib.strings.concatMapStringsSep "\n" (entry: ''
-      mkdir -p ${entry.to}
-      # Exact path of the build artefact depends on used CMAKE_BUILD_TYPE
-      cp -r Fire_artefacts/*/${entry.from}/* ${entry.to}/
-    '') pathMappings
-    + ''
+  ''
+  + lib.strings.concatMapStringsSep "\n" (entry: ''
+    mkdir -p ${entry.to}
+    # Exact path of the build artefact depends on used CMAKE_BUILD_TYPE
+    cp -r -t ${entry.to} Fire_artefacts/${finalAttrs.cmakeBuildType or "Release"}/${entry.from}/*
+  '') pathMappings
+  + ''
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Standalone dlopen's X11 libraries
+  postFixup = lib.strings.optionalString (withStandalone && stdenv.hostPlatform.isLinux) ''
+    patchelf --add-rpath ${lib.makeLibraryPath x11Libs} $out/bin/Fire
+  '';
 
   passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
 
   meta = {
     description = "Multi-band distortion plugin by Wings";
-    homepage = "https://github.com/jerryuhoo/Fire";
+    homepage = "https://www.bluewingsmusic.com/Fire";
     license = lib.licenses.agpl3Only; # Not clarified if Only or Plus
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ OPNA2608 ];
+  }
+  // lib.optionalAttrs withStandalone {
+    mainProgram = "Fire";
   };
 })


### PR DESCRIPTION
I added a standalone build, cus I'm too lazy to test a plugin in another application all the time.

<img width="1008" height="534" alt="image" src="https://github.com/user-attachments/assets/4136b91d-4bda-416c-bb31-1a87b9ca402a" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
