### PR TITLE
carla: 2.5.9 -> 2.5.10

### DIFF
--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -28,23 +28,14 @@ assert withQt -> wrapQtAppsHook != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "carla";
-  version = "2.5.9";
+  version = "2.5.10";
 
   src = fetchFromGitHub {
     owner = "falkTX";
     repo = "carla";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-FM/6TtNhDml1V9C5VisjLcZ3CzXsuwCZrsoz4yP3kI8=";
+    hash = "sha256-21QaFCIjGjRTcJtf2nwC5RcVJF8JgcFPIbS8apvf9tw=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      # https://github.com/falkTX/Carla/pull/1933
-      name = "prefer-pyliblo3-over-pyliblo.patch";
-      url = "https://github.com/falkTX/Carla/commit/a81a2a545d2529233a6e0faa776fbd2d851442fb.patch?full_index=1";
-      hash = "sha256-CHK3Aq/W9PdfMGsJunLN/WAxOmWJHc0jr/3TdEaIcMM=";
-    })
-  ];
 
   nativeBuildInputs = [
     python3Packages.wrapPython


### PR DESCRIPTION
Removed the pyliblo3 patch, as it was integrated upstream

Release notes: https://github.com/falkTX/Carla/releases/tag/v2.5.10


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `fd2190fbc3ed34db0aaf234d79d4bb8b82ff60ed`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>carla</li>
    <li>lmms</li>
    <li>zrythm</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
