### PR TITLE
mubeng: update GitHub repository owner 

### DIFF
--- a/pkgs/by-name/mu/mubeng/package.nix
+++ b/pkgs/by-name/mu/mubeng/package.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
   version = "0.22.0";
 
   src = fetchFromGitHub {
-    owner = "kitabisa";
+    owner = "mubeng";
     repo = "mubeng";
     tag = "v${version}";
     hash = "sha256-YK3a975l/gMCaWxTB4gEQWAzzX+GRnYSvKksPmp3ZRA=";
@@ -20,13 +20,13 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X=ktbs.dev/mubeng/common.Version=${version}"
+    "-X=github.com/mubeng/mubeng/common.Version=${version}"
   ];
 
   meta = {
     description = "Proxy checker and IP rotator";
-    homepage = "https://github.com/kitabisa/mubeng";
-    changelog = "https://github.com/kitabisa/mubeng/releases/tag/v${version}";
+    homepage = "https://github.com/mubeng/mubeng";
+    changelog = "https://github.com/mubeng/mubeng/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "mubeng";

--- a/pkgs/by-name/mu/mubeng/package.nix
+++ b/pkgs/by-name/mu/mubeng/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -22,6 +23,12 @@ buildGoModule rec {
     "-w"
     "-X=github.com/mubeng/mubeng/common.Version=${version}"
   ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
 
   meta = {
     description = "Proxy checker and IP rotator";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The upstream repository owner changed in version 0.21.0.
ref: https://github.com/mubeng/mubeng/pull/262

~This caused the wrong version number to display in nixpkgs.~
Version number in nixpkgs output seems not displayed since version 0.15.0 https://github.com/mubeng/mubeng/commit/6681713175923b5e02080e10416429f26c79171d

Before

```console
> nix run github:NixOS/nixpkgs/nixos-24.05#mubeng -- --version
mubeng version 0.14.2

> nix run github:NixOS/nixpkgs/nixos-24.11#mubeng -- --version
mubeng version unknown (go-get)

> nix build --print-out-paths github:NixOS/nixpkgs/nixos-24.11#mubeng
/nix/store/w2a3jblyyilqnb24jy78wiz2rfl1wh3c-mubeng-0.18.0
```

After

```console
> ./result/bin/mubeng --version
mubeng version 0.22.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
