### PR TITLE
electron-fiddle: 0.36.5-unstable-2025-07-17 -> 0.37.2

### DIFF
--- a/pkgs/by-name/el/electron-fiddle/dont-use-initial-releases-json.patch
+++ b/pkgs/by-name/el/electron-fiddle/dont-use-initial-releases-json.patch
@@ -1,0 +1,32 @@
+diff --git a/src/main/versions.ts b/src/main/versions.ts
+index 501ba1a..0c11ff7 100644
+--- a/src/main/versions.ts
++++ b/src/main/versions.ts
+@@ -5,7 +5,6 @@ import { IpcMainInvokeEvent, app } from 'electron';
+ import fs from 'fs-extra';
+ 
+ import { ipcMainManager } from './ipc';
+-import releases from '../../static/releases.json';
+ import { InstallState, Version } from '../interfaces';
+ import { IpcEvents } from '../ipc-events';
+ 
+@@ -72,7 +71,6 @@ export async function fetchVersions(): Promise<Version[]> {
+ 
+ export async function setupVersions() {
+   knownVersions = await ElectronVersions.create({
+-    initialVersions: releases,
+     paths: {
+       versionsCache: path.join(app.getPath('userData'), 'releases.json'),
+     },
+diff --git a/tools/fetch-releases.ts b/tools/fetch-releases.ts
+index 744b814..94fd971 100644
+--- a/tools/fetch-releases.ts
++++ b/tools/fetch-releases.ts
+@@ -6,6 +6,7 @@ import { ElectronVersions } from '@electron/fiddle-core';
+ const file = path.join(__dirname, '..', 'static', 'releases.json');
+ 
+ export async function populateReleases() {
++  return;
+   const elves = await ElectronVersions.create({ ignoreCache: true });
+   const releases = elves.versions.map(({ version }) =>
+     elves.getReleaseInfo(version),


### PR DESCRIPTION
Removed the old `releasesJson` usage, since the new fiddle-core update seems to have started trying to fetch it again during build-time.

Instead I just patched out the build-time fetching completely and let it do its thing during runtime.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
