### PR TITLE
steamworks: Various fixes

### DIFF
--- a/pkgs/by-name/st/steamworks/1001-Add-missing-logger-methods.patch
+++ b/pkgs/by-name/st/steamworks/1001-Add-missing-logger-methods.patch
@@ -1,0 +1,26 @@
+From 5f144d5d26ea0dd1754ed25a583ebafa01ecbb4b Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Sun, 3 Aug 2025 20:06:49 +0200
+Subject: [PATCH] src/common/logger.h: Add missing methods under NDEBUG
+
+---
+ src/common/logger.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/common/logger.h b/src/common/logger.h
+index 0901205..259f058 100644
+--- a/src/common/logger.h
++++ b/src/common/logger.h
+@@ -81,6 +81,9 @@ public:
+ 	LoggerStream& getStream(int level) { return stream; }
+ 
+ 	void debug(...) {}
++	void warn(...) {}
++
++	bool isDebugEnabled() { return false; }
+ };
+ 
+ // Bogus level numbers; I don't know if these are compatible with
+-- 
+2.50.1
+


### PR DESCRIPTION
- Change `updateScript` to `gitUpdater`, `nix-update-script` was trying to downgrade to the last tag with a release page
  (Accepting alternative solutions for this, I'm just more familiar with `gitUpdater`)
- Add `catch2` to `checkInputs`, was previously unused
- Fix `catch2` linking
- Fix non-debug compilation
- Enable tests
- Add references to upstream-submitted fixes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
