### PR TITLE
tptp: 7.2.0 -> 9.1.0

### DIFF
--- a/pkgs/by-name/tp/tptp/package.nix
+++ b/pkgs/by-name/tp/tptp/package.nix
@@ -2,28 +2,32 @@
   lib,
   stdenv,
   fetchurl,
-  yap,
+  swi-prolog,
   tcsh,
   perl,
   patchelf,
+  curl,
 }:
 
 stdenv.mkDerivation rec {
   pname = "TPTP";
-  version = "7.2.0";
+  version = "9.1.0";
 
   src = fetchurl {
     urls = [
-      "http://tptp.cs.miami.edu/TPTP/Distribution/TPTP-v${version}.tgz"
-      "http://tptp.cs.miami.edu/TPTP/Archive/TPTP-v${version}.tgz"
+      "https://tptp.org/TPTP/Distribution/TPTP-v${version}.tgz"
+      "https://tptp.org/TPTP/Archive/TPTP-v${version}.tgz"
     ];
-    sha256 = "0yq8452b6mym4yscy46pshg0z2my8xi74b5bp2qlxd5bjwcrg6rl";
+    hash = "sha256-KylCpKEdjvXTzYU2MOi0FDrr4e6je2YB366+dxy3Xmo=";
   };
 
-  nativeBuildInputs = [ patchelf ];
+  nativeBuildInputs = [
+    patchelf
+    swi-prolog
+  ];
   buildInputs = [
     tcsh
-    yap
+    swi-prolog
     perl
   ];
 
@@ -40,7 +44,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $sharedir/TPTP2X/tptp2X_install --replace /bin/mv mv
     tcsh $sharedir/TPTP2X/tptp2X_install -default
 
-    patchelf --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $sharedir/Scripts/tptp4X
+    patchelf --interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath ${lib.getLib curl}/lib $sharedir/Scripts/tptp4X
 
     mkdir -p $out/bin
     ln -s $sharedir/TPTP2X/tptp2X $out/bin
@@ -60,5 +64,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfreeRedistributable;
+    homepage = "https://tptp.org/TPTP/";
   };
 }


### PR DESCRIPTION
An update. Will self-merge eventually, and probably after not too long. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
