### PR TITLE
jol-cli: init at 0.17

### DIFF
--- a/pkgs/by-name/jo/jol-cli/package.nix
+++ b/pkgs/by-name/jo/jol-cli/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  gitUpdater,
+  jre_headless,
+  makeWrapper,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jol-cli";
+  version = "0.17";
+
+  src = fetchurl {
+    url = "mirror://maven/org/openjdk/jol/jol-cli/${finalAttrs.version}/jol-cli-${finalAttrs.version}-full.jar";
+    hash = "sha256-6ozzG33GwYgQynrq3L56KzUvslAmG4BgzlE+ipnrzRI=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+    cp $src $out/share/${finalAttrs.pname}.jar
+    makeWrapper "${jre_headless}/bin/java" $out/bin/jol-cli \
+      --add-flags "-jar $out/share/${finalAttrs.pname}.jar"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater {
+    url = "https://github.com/openjdk/jol";
+  };
+
+  meta = {
+    description = "Java Object Layout (JOL)";
+    longDescription = ''
+      JOL (Java Object Layout) is the tiny toolbox to analyze object layout in
+      JVMs. These tools are using Unsafe, JVMTI, and Serviceability Agent (SA)
+      heavily to decode the actual object layout, footprint, and references.
+      This makes JOL much more accurate than other tools relying on heap dumps,
+      specification assumptions, etc.
+    '';
+    homepage = "https://openjdk.org/projects/code-tools/jol/";
+    license = lib.licenses.gpl2ClasspathPlus;
+    mainProgram = "jol-cli";
+    maintainers = with lib.maintainers; [ debling ];
+    platforms = lib.platforms.all;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
+})


### PR DESCRIPTION
Closes #430724

This PR adds jol-cli (Java Object Layout). I packaged following the example of existing Java CLI projects, mainly the spring-boot-cli and the jmx-prometheus-javaagent.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
