### PR TITLE
openssh{,_hpn,_gssapi}: use PAM_RHOST patch from fedora

### DIFF
--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -59,6 +59,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     # See discussion in https://github.com/NixOS/nixpkgs/pull/16966
     ./dont_create_privsep_path.patch
+    # Don't set PAM_RHOST to "UNKNOWN" when used with vsock and systemd-ssh-generator, as it causes a massive slowdown in login
+    # Upstream PR: https://github.com/openssh/openssh-portable/pull/388
+    # See this commit for why this is needed: https://src.fedoraproject.org/rpms/openssh/c/8fb8f02a0d20c36145d00309f91356e4552ebcd3
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/openssh/raw/f6e9920c49b0edd039dc9b0e3de1b39a6650387e/f/0047-openssh-9.6p1-pam-rhost.patch";
+      hash = "sha256-AXyETs5Qylvz3C/hZX7M+mnf/1PcxE3RxQxrBnubgVI=";
+    })
   ]
   ++ extraPatches;
 


### PR DESCRIPTION
See upstream PR: https://github.com/openssh/openssh-portable/pull/388
This patch avoids a massive slowdown when logging into VMs with systemd-ssh-generator.

Not sure if we actually want to ship this, just creating this PR to open up the discussion.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
