### PR TITLE
ycmd: unstable-2023-11-06 -> unstable-2025-06-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22286,6 +22286,13 @@
     githubId = 766350;
     name = "Richard Zetterberg";
   };
+  S0AndS0 = {
+    name = "S0AndS0";
+    email = "S0AndS0@digital-mercenaries.com";
+    github = "S0AndS0";
+    githubId = 4116150;
+    matrix = "@s0ands0:matrix.org";
+  };
   s0me1newithhand7s = {
     name = "hand7s";
     email = "s0me1newithhand7s@gmail.com";

--- a/pkgs/by-name/yc/ycmd/package.nix
+++ b/pkgs/by-name/yc/ycmd/package.nix
@@ -21,15 +21,14 @@
 
 stdenv.mkDerivation {
   pname = "ycmd";
-  version = "0-unstable-2023-11-06";
-  disabled = !python3.isPy3k;
+  version = "0-unstable-2025-06-16";
 
   # required for third_party directory creation
   src = fetchFromGitHub {
     owner = "ycm-core";
     repo = "ycmd";
-    rev = "0607eed2bc211f88f82657b7781f4fe66579855b";
-    hash = "sha256-SzEcMQ4lX7NL2/g9tuhA6CaZ8pX/DGs7Fla/gr+RcOU=";
+    rev = "9160b4eee67ea61c8501bad36d061bcec5340021";
+    hash = "sha256-MSzYX1vXuhd4TNxUfHWaRu7O0r89az1XjZBIZ6B3gBk=";
     fetchSubmodules = true;
   };
 
@@ -46,6 +45,7 @@ stdenv.mkDerivation {
       boost
       libllvm.all
       libclang.all
+      legacy-cgi
     ]
     ++ [
       jedi
@@ -84,6 +84,9 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     ln -s $out/lib/ycmd/ycmd/__main__.py $out/bin/ycmd
 
+    ## Work-around CMake/Nix naming of `.so` output
+    ln -s $out/lib/ycmd/ycm_core.cpython-[[:digit:]-][^[:space:]]*-gnu${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/ycmd/ycm_core.so
+
     # Copy everything: the structure of third_party has been known to change.
     # When linking our own libraries below, do so with '-f'
     # to clobber anything we may have copied here.
@@ -120,6 +123,15 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Code-completion and comprehension server";
+    longDescription = ''
+      Note if YouCompleteMe Vim plugin complains with;
+
+      > ImportError: Python version mismatch: module was compiled for Python 3.13, but the interpreter version is incompatible: 3.10.18
+
+      ...  then set something similar to following in `programs.vim.extraConfig`;
+
+          let g:ycm_server_python_interpreter = "${python3.interpreter}"
+    '';
     mainProgram = "ycmd";
     homepage = "https://github.com/ycm-core/ycmd";
     license = licenses.gpl3;

--- a/pkgs/by-name/yc/ycmd/package.nix
+++ b/pkgs/by-name/yc/ycmd/package.nix
@@ -127,6 +127,7 @@ stdenv.mkDerivation {
       rasendubi
       lnl7
       mel
+      S0AndS0
     ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
It was discovered, while struggling with the YouCompleteMe plugin/package [Issue](https://github.com/NixOS/nixpkgs/issues/429485), that sometime within the past two years the Python team made good on threats to remove `cgi` from the standard library.

This set of changes adds `legacy-cgi` to the `buildInputs` because the `ycmd` package needs `cgi` and, because I was already doing stuff, I updated the `rev`, `sha256`, and `version` attributes too ;-)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
