### PR TITLE
warp-terminal: 0.2025.07.23.08.12.stable_02 -> 0.2025.07.30.08.12.stable_02

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-JAqWQ3dfk4B+CNV5knj4HCnpVu3Q5STnyriqaeLPQD0=",
-    "version": "0.2025.07.23.08.12.stable_02"
+    "hash": "sha256-3j6Kqlo/nsc+gjSrW5Afuamnh0qb9TnG+sFN4E5pnxc=",
+    "version": "0.2025.07.30.08.12.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-C9p95LRS/ma5FEIq6ZQqda+dQhgbVT8dhDJIDpCilWI=",
-    "version": "0.2025.07.23.08.12.stable_02"
+    "hash": "sha256-GbkTghYchdUdYdvPNAqPv+PD7UJ2sgVc7+AAA+5bHGI=",
+    "version": "0.2025.07.30.08.12.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-KGmkuL/4I+oN99ubjtGMrEt6Ijlak9yv39LksPAo8/U=",
-    "version": "0.2025.07.23.08.12.stable_02"
+    "hash": "sha256-xIf12oEOHQE1+Sz3L/nrqli2tlP0+wWFA9dA+HHNrr0=",
+    "version": "0.2025.07.30.08.12.stable_02"
   }
 }


### PR DESCRIPTION
Changelog: https://docs.warp.dev/getting-started/changelog#id-2025.07.30-v0.2025.07.30.08.12

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
