### PR TITLE
haskellPackages.gitrev-typed: unbreak for ghc 9.10, 9.12

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -101,4 +101,10 @@ in
   fsnotify = dontCheck super.fsnotify; # https://github.com/haskell-fswatch/hfsnotify/issues/115
   hinotify = pkgs.haskell.lib.dontCheck super.hinotify; # https://github.com/kolmodin/hinotify/issues/38
   monad-dijkstra = dontCheck super.monad-dijkstra; # needs hlint 3.10
+
+  #
+  # Unbreaking
+  #
+  # 2025-08-04: Requires filepath >= 1.5.0.1 <=> GHC >= 9.10
+  gitrev-typed = unmarkBroken super.gitrev-typed;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -132,6 +132,12 @@ with haskellLib;
     dontCheck super.interpolate;
 
   #
+  # Unbreaking
+  #
+  # 2025-08-04: Requires filepath >= 1.5.0.1 <=> GHC >= 9.10
+  gitrev-typed = unmarkBroken super.gitrev-typed;
+
+  #
   # Multiple issues
   #
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Unbreaks the `gitrev-typed` package for ghc 9.10 and 9.12. The [hydra failure](https://hydra.nixos.org/build/299137966) is due to requiring `filepath >=1.5` (i.e. ghc 9.10+), whereas the job was run when ghc 9.8 was the default, hence filepath was too low.

```
Configuring gitrev-typed-0.1...
CallStack (from HasCallStack):
  withMetadata, called at libraries/Cabal/Cabal/src/Distribution/Simple/Utils.hs:368:14 in Cabal-3.10.3.0-31b8:Distribution.Simple.Utils
Error: Setup: Encountered missing or private dependencies:
filepath >=1.5.0.1 && <1.6
```

`nix build .#haskell.packages.ghc9102.gitrev-typed` works after this.

Alternatively -- since ghc 9.10 (therefore filepath >= 1.5) is going to be the default in the next update -- presumably all that needs to happen is for the hydra job to be run again. I'm unsure of the normal process for retrying a failed package, hence opening this PR.

Thanks!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
