### PR TITLE
nixos/doc: use consistent IEC binary units

### DIFF
--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -207,14 +207,14 @@ update /etc/fstab.
     which will be used by the boot partition.
 
     ```ShellSession
-    # parted /dev/sda -- mkpart root ext4 512MB -8GB
+    # parted /dev/sda -- mkpart root ext4 512MiB -8GiB
     ```
 
 3.  Next, add a *swap* partition. The size required will vary according
-    to needs, here a 8GB one is created.
+    to needs, here a 8GiB one is created.
 
     ```ShellSession
-    # parted /dev/sda -- mkpart swap linux-swap -8GB 100%
+    # parted /dev/sda -- mkpart swap linux-swap -8GiB 100%
     ```
 
     ::: {.note}
@@ -227,7 +227,7 @@ update /etc/fstab.
     reserved 512MiB at the start of the disk.
 
     ```ShellSession
-    # parted /dev/sda -- mkpart ESP fat32 1MB 512MB
+    # parted /dev/sda -- mkpart ESP fat32 1MiB 512MiB
     # parted /dev/sda -- set 3 esp on
     ```
     ::: {.note}
@@ -258,7 +258,7 @@ update /etc/fstab.
     end part, where the swap will live.
 
     ```ShellSession
-    # parted /dev/sda -- mkpart primary 1MB -8GB
+    # parted /dev/sda -- mkpart primary 1MiB -8GiB
     ```
 
 3.  Set the root partition's boot flag to on. This allows the disk to be booted from.
@@ -268,10 +268,10 @@ update /etc/fstab.
     ```
 
 4.  Finally, add a *swap* partition. The size required will vary
-    according to needs, here a 8GB one is created.
+    according to needs, here a 8GiB one is created.
 
     ```ShellSession
-    # parted /dev/sda -- mkpart primary linux-swap -8GB 100%
+    # parted /dev/sda -- mkpart primary linux-swap -8GiB 100%
     ```
 
     ::: {.note}
@@ -517,8 +517,8 @@ corresponding configuration Nix expression.
 ### Example partition schemes for NixOS on `/dev/sda` (MBR)
 ```ShellSession
 # parted /dev/sda -- mklabel msdos
-# parted /dev/sda -- mkpart primary 1MB -8GB
-# parted /dev/sda -- mkpart primary linux-swap -8GB 100%
+# parted /dev/sda -- mkpart primary 1MiB -8GiB
+# parted /dev/sda -- mkpart primary linux-swap -8GiB 100%
 ```
 :::
 
@@ -526,9 +526,9 @@ corresponding configuration Nix expression.
 ### Example partition schemes for NixOS on `/dev/sda` (UEFI)
 ```ShellSession
 # parted /dev/sda -- mklabel gpt
-# parted /dev/sda -- mkpart root ext4 512MB -8GB
-# parted /dev/sda -- mkpart swap linux-swap -8GB 100%
-# parted /dev/sda -- mkpart ESP fat32 1MB 512MB
+# parted /dev/sda -- mkpart root ext4 512MiB -8GiB
+# parted /dev/sda -- mkpart swap linux-swap -8GiB 100%
+# parted /dev/sda -- mkpart ESP fat32 1MiB 512MiB
 # parted /dev/sda -- set 3 esp on
 ```
 :::


### PR DESCRIPTION
The installing manual uses inconsistent units, descriptions use base-2 IEC units, but the associated parted commands use base-10 units, which will not result in a partition size matching the description.

As of parted 2.4 (2011) IEC binary units can be used.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
