### PR TITLE
stdenv.mkDerivation: support mainProgram as a top‐level attribute

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -402,7 +402,7 @@ rec {
     licstr: default: lowercaseLicenses.${lib.toLower licstr} or default;
 
   /**
-    Get the path to the main program of a package based on meta.mainProgram
+    Get the path to the main program of a package based on `mainProgram`.
 
     # Inputs
 
@@ -432,12 +432,12 @@ rec {
   getExe =
     x:
     getExe' x (
-      x.meta.mainProgram or (
+      x.mainProgram or x.meta.mainProgram or (
         # This could be turned into an error when 23.05 is at end of life
         lib.warn
           "getExe: Package ${
             lib.strings.escapeNixIdentifier x.meta.name or x.pname or x.name
-          } does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo \"bar\"."
+          } does not have the mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo \"bar\"."
           lib.getName
           x
       )

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -4086,6 +4086,16 @@ runTests {
       type = "derivation";
       out = "somelonghash";
       bin = "somelonghash";
+      mainProgram = "mainProgram";
+    };
+    expected = "somelonghash/bin/mainProgram";
+  };
+
+  testGetExeOutputMeta = {
+    expr = getExe {
+      type = "derivation";
+      out = "somelonghash";
+      bin = "somelonghash";
       meta.mainProgram = "mainProgram";
     };
     expected = "somelonghash/bin/mainProgram";

--- a/pkgs/by-name/he/hello/package.nix
+++ b/pkgs/by-name/he/hello/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Give hello some install checks for testing purpose.
   postInstallCheck = ''
-    stat "''${!outputBin}/bin/${finalAttrs.meta.mainProgram}"
+    stat "''${!outputBin}/bin/${finalAttrs.mainProgram}"
   '';
 
   passthru.tests = {
@@ -42,6 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   passthru.tests.run = callPackage ./test.nix { hello = finalAttrs.finalPackage; };
+
+  mainProgram = "hello";
 
   meta = {
     description = "Program that produces a familiar, friendly greeting";
@@ -53,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ stv0g ];
-    mainProgram = "hello";
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ve/versionCheckHook/hook.sh
+++ b/pkgs/by-name/ve/versionCheckHook/hook.sh
@@ -40,19 +40,19 @@ versionCheckHook(){
     local cmdProgram cmdArg echoPrefix
     if [[ ! -z "${versionCheckProgram-}" ]]; then
         cmdProgram="$versionCheckProgram"
-    elif [[ ! -z "${NIX_MAIN_PROGRAM-}" ]]; then
-        cmdProgram="${!outputBin}/bin/${NIX_MAIN_PROGRAM}"
+    elif [[ ! -z "${mainProgram-}" ]]; then
+        cmdProgram="${!outputBin}/bin/${mainProgram}"
     elif [[ ! -z "${pname-}" ]]; then
-        echo "versionCheckHook: Package \`${pname}\` does not have the \`meta.mainProgram\` attribute." \
+        echo "versionCheckHook: Package \`${pname}\` does not have the \`mainProgram\` attribute." \
             "We'll assume that the main program has the same name for now, but this behavior is deprecated," \
             "because it leads to surprising errors when the assumption does not hold." \
-            "If the package has a main program, please set \`meta.mainProgram\` in its definition to make this warning go away." \
+            "If the package has a main program, please set \`mainProgram\` in its definition to make this warning go away." \
             "Should the binary that outputs the intended version differ from \`meta.mainProgram\`, consider setting \`versionCheckProgram\` instead." >&2
         cmdProgram="${!outputBin}/bin/${pname}"
     else
-        echo "versionCheckHook: \$NIX_MAIN_PROGRAM, \$versionCheckProgram and \$pname are all empty, so" \
+        echo "versionCheckHook: \$mainProgram, \$versionCheckProgram and \$pname are all empty, so" \
             "we don't know how to run the versionCheckPhase." \
-            "To fix this, set one of \`meta.mainProgram\` or \`versionCheckProgram\`." >&2
+            "To fix this, set one of \`mainProgram\` or \`versionCheckProgram\`." >&2
         exit 2
     fi
 

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -605,6 +605,14 @@ let
       ]
       ++ optional (hasOutput "man") "man";
     }
+    // optionalAttrs (attrs ? mainProgram) {
+      # This is used within derivations, but is also useful metadata
+      # for external consumers.
+      #
+      # TODO: Phase out setting this in `meta` (but still keep
+      # inheriting it here).
+      inherit (attrs) mainProgram;
+    }
     // (filterAttrs (_: v: v != null) {
       # CI scripts look at these to determine pings. Note that we should filter nulls out of this,
       # or nix-env complains: https://github.com/NixOS/nix/blob/2.18.8/src/nix-env/nix-env.cc#L963

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -747,9 +747,6 @@ let
       );
 
     let
-      mainProgram = meta.mainProgram or null;
-      env' = env // lib.optionalAttrs (mainProgram != null) { NIX_MAIN_PROGRAM = mainProgram; };
-
       derivationArg = makeDerivationArgument (
         removeAttrs attrs ([
           "meta"
@@ -776,11 +773,11 @@ let
 
       checkedEnv =
         let
-          overlappingNames = attrNames (builtins.intersectAttrs env' derivationArg);
+          overlappingNames = attrNames (builtins.intersectAttrs env derivationArg);
           prettyPrint = lib.generators.toPretty { };
           makeError =
             name:
-            "  - ${name}: in `env`: ${prettyPrint env'.${name}}; in derivation arguments: ${
+            "  - ${name}: in `env`: ${prettyPrint env.${name}}; in derivation arguments: ${
                 prettyPrint derivationArg.${name}
               }";
           errors = lib.concatMapStringsSep "\n" makeError overlappingNames;
@@ -794,7 +791,7 @@ let
           assert assertMsg (isString v || isBool v || isInt v || isDerivation v)
             "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";
           v
-        ) env';
+        ) env;
 
       # Fixed-output derivations may not reference other paths, which means that
       # for a fixed-output derivation, the corresponding inputDerivation should


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/412768#issuecomment-3148779355 for context. Totally untested, needs docs, could be a bikeshed magnet, would need eventual follow‐up with a tree‐wide and staged warnings/errors, etc., but putting it out there. This would also currently break `versionCheckHook`’s default for any non‐migrated package, so we’d have to decide whether we want to pull it in as a full attribute for compatibility for now, or else couple reducing use of the `pname` default to lifting `mainProgram` out. Also if this eventually gets merged and I see people bikeshedding about moving it in unrelated PRs rather than automating it I’ll lose it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
