### PR TITLE
hail: init at 0.2.2

### DIFF
--- a/pkgs/by-name/ha/hail/package.nix
+++ b/pkgs/by-name/ha/hail/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  pkg-config,
+  fontconfig,
+  freetype,
+  libxkbcommon,
+  wayland,
+  SDL2,
+  SDL2_image,
+  SDL2_gfx,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hail";
+  version = "0.2.2";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "periwinkle";
+    repo = "hail";
+    tag = finalAttrs.version;
+    hash = "sha256-LJodAS24x/dBNyrUxT9F0FHnu4s+Cb+CCtoe7nPM66w=";
+  };
+
+  cargoHash = "sha256-kEPnfRY2McSVNBuBC9VSKK5p8JIUeZh/LeFZQa1Hn5U=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    fontconfig
+    freetype
+    libxkbcommon
+    wayland
+    SDL2
+    SDL2_image
+    SDL2_gfx
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minimal speedrun timer";
+    homepage = "https://codeberg.org/periwinkle/hail";
+    changelog = "https://codeberg.org/periwinkle/hail/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "hail";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
