### PR TITLE
opam: 2.3.0 -> 2.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/opam-core/default.nix
+++ b/pkgs/development/ocaml-modules/opam-core/default.nix
@@ -4,6 +4,7 @@
   opam,
   jsonm,
   ocamlgraph,
+  patch,
   re,
   sha,
   swhid_core,
@@ -20,6 +21,7 @@ buildDunePackage {
     ocamlgraph
     uutf
     re
+    patch
     sha
     swhid_core
   ];

--- a/pkgs/development/ocaml-modules/patch/default.nix
+++ b/pkgs/development/ocaml-modules/patch/default.nix
@@ -9,7 +9,7 @@
 
 buildDunePackage rec {
   pname = "patch";
-  version = "2.0.0";
+  version = "3.0.0";
 
   minimalOCamlVersion = "4.03";
 
@@ -17,7 +17,7 @@ buildDunePackage rec {
     owner = "hannesm";
     repo = "patch";
     tag = "v${version}";
-    hash = "sha256-xqcUZaKlbyXF2//MbCom7/pGA2ej6KHYI3rizXwoqTY=";
+    hash = "sha256-WIleUxfGp8cvQHYAyRRI6S/MSP4u0BbEyAqlRxCb/To=";
   };
 
   checkInputs = [

--- a/pkgs/development/ocaml-modules/raylib/default.nix
+++ b/pkgs/development/ocaml-modules/raylib/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchurl,
+  fetchpatch,
   buildDunePackage,
   dune-configurator,
   ctypes,
@@ -22,6 +23,18 @@ buildDunePackage rec {
     url = "https://github.com/tjammer/raylib-ocaml/releases/download/${version}/raylib-${version}.tbz";
     hash = "sha256-/SeKgQOrhsAgMNk6ODAZlopL0mL0lVfCTx1ugmV1P/s=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-build-with-patch-3.0.0.patch";
+      url = "https://github.com/tjammer/raylib-ocaml/commit/40e6fef44e3c39d4526806c4b830da77c4fe4bb8.patch";
+      excludes = [
+        "dune-project"
+        "raygui.opam"
+      ];
+      hash = "sha256-MEZkkBgjL2iT6Av/s0tJCrW7+oyp9QD6sUbXEusCAWI=";
+    })
+  ];
 
   buildInputs = [
     dune-configurator

--- a/pkgs/development/ocaml-modules/raylib/raygui.nix
+++ b/pkgs/development/ocaml-modules/raylib/raygui.nix
@@ -13,6 +13,8 @@ buildDunePackage rec {
     hash = "sha256-PQcVTAQKeTPkOOHk5w3O3Tz0n7jLvkIo3Urvrk66eMs=";
   };
 
+  inherit (raylib) patches;
+
   propagatedBuildInputs = [
     raylib
   ];

--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -15,11 +15,11 @@ assert lib.versionAtLeast ocaml.version "4.08.0";
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opam";
-  version = "2.3.0";
+  version = "2.4.1";
 
   src = fetchurl {
     url = "https://github.com/ocaml/opam/releases/download/${finalAttrs.version}/opam-full-${finalAttrs.version}.tar.gz";
-    hash = "sha256-UGunaGXcMVtn35qonnq9XBqJen8KkteyaUl0/cUys0Y=";
+    hash = "sha256-xNBTApeTxxTk5zQLEVdCjA+QeDWF+xfzUVgkemQEZ9k=";
   };
 
   strictDeps = true;
@@ -37,12 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [ bubblewrap ];
 
   patches = [ ./opam-shebangs.patch ];
-
-  preConfigure = ''
-    # Fix opam sandboxing on nixos. Remove after opam >= 2.4.0 is released
-    substituteInPlace src/state/shellscripts/bwrap.sh \
-      --replace-fail 'for dir in /*; do' 'for dir in /{*,run/current-system/sw}; do'
-  '';
 
   configureFlags = [
     "--with-vendored-deps"

--- a/pkgs/development/tools/ocaml/opam/opam-shebangs.patch
+++ b/pkgs/development/tools/ocaml/opam/opam-shebangs.patch
@@ -1,8 +1,8 @@
 diff --git a/src/client/opamInitDefaults.ml b/src/client/opamInitDefaults.ml
-index eca13a7c..1fd66f43 100644
+index 5e6456023c..861b499402 100644
 --- a/src/client/opamInitDefaults.ml
 +++ b/src/client/opamInitDefaults.ml
-@@ -42,16 +42,20 @@ let eval_variables = [
+@@ -38,6 +38,9 @@
  let os_filter os =
    FOp (FIdent ([], OpamVariable.of_string "os", None), `Eq, FString os)
  
@@ -12,22 +12,17 @@ index eca13a7c..1fd66f43 100644
  let linux_filter = os_filter "linux"
  let macos_filter = os_filter "macos"
  let openbsd_filter = os_filter "openbsd"
- let freebsd_filter = os_filter "freebsd"
- let netbsd_filter = os_filter "netbsd"
- let dragonflybsd_filter = os_filter "dragonfly"
- let not_open_free_bsd_filter =
-   FNot (FOr (openbsd_filter,  freebsd_filter))
- let win32_filter = os_filter "win32"
+@@ -51,6 +54,7 @@
  let not_win32_filter =
    FOp (FIdent ([], OpamVariable.of_string "os", None), `Neq, FString "win32")
  let sandbox_filter = FOr (linux_filter, macos_filter)
 +let nixos_filter = os_distribution_filter "nixos"
  
- let gpatch_filter =
-   FOr (FOr (openbsd_filter, netbsd_filter),
-        FOr (freebsd_filter, dragonflybsd_filter))
- let patch_filter = FNot gpatch_filter
-@@ -79,4 +81,9 @@ let wrappers ~sandboxing () =
+ let gtar_filter = openbsd_filter
+ let tar_filter = FNot gtar_filter
+@@ -69,6 +73,11 @@
+ 
+ let wrappers ~sandboxing () =
    let w = OpamFile.Wrappers.empty in
 +  let w = { w with
 +            OpamFile.Wrappers.
@@ -37,7 +32,7 @@ index eca13a7c..1fd66f43 100644
    if sandboxing then
      List.fold_left OpamFile.Wrappers.(fun w -> function
          | `build wrap_build -> { w with wrap_build }
-@@ -113,6 +122,7 @@ let required_tools ~sandboxing () =
+@@ -147,6 +156,7 @@
  let init_scripts () = [
    ("sandbox.sh", OpamScript.bwrap), Some bwrap_filter;
    ("sandbox.sh", OpamScript.sandbox_exec), Some macos_filter;
@@ -46,17 +41,17 @@ index eca13a7c..1fd66f43 100644
  
  module I = OpamFile.InitConfig
 diff --git a/src/state/opamScript.mli b/src/state/opamScript.mli
-index 03449970..83de0b53 100644
+index 8bfe74d0e3..84f6b688fb 100644
 --- a/src/state/opamScript.mli
 +++ b/src/state/opamScript.mli
-@@ -20,3 +20,4 @@ val env_hook : string
+@@ -20,3 +20,4 @@
  val env_hook_zsh : string
  val env_hook_csh : string
  val env_hook_fish : string
 +val patch_shebangs : string
 diff --git a/src/state/shellscripts/patch_shebangs.sh b/src/state/shellscripts/patch_shebangs.sh
-new file mode 100755
-index 00000000..3ea84e2d
+new file mode 100644
+index 0000000000..e74a559702
 --- /dev/null
 +++ b/src/state/shellscripts/patch_shebangs.sh
 @@ -0,0 +1,73 @@


### PR DESCRIPTION
https://github.com/ocaml/opam/releases/tag/2.4.0
https://github.com/ocaml/opam/releases/tag/2.4.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
