### PR TITLE
sing-box: 1.11.15 -> 1.12.3, nixos/sing-box: add user and group, nixosTests.sing-box: migrate config

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -103,6 +103,9 @@
 - The non-LTS Forgejo package (`forgejo`) has been updated to 12.0.0. This release contains breaking changes, see the [release blog post](https://forgejo.org/2025-07-release-v12-0/)
   for all the details and how to ensure smooth upgrades.
 
+- `sing-box` has been updated to 1.12.3, which includes a number of breaking changes, old configurations may need updating or they will cause the tool to fail to run.
+  See the [change log](https://sing-box.sagernet.org/changelog/#1123) for details and [migration](https://sing-box.sagernet.org/migration/#1120) for how to update old configurations.
+
 - The Pocket ID module ([`services.pocket-id`][#opt-services.pocket-id.enable]) and package (`pocket-id`) has been updated to 1.0.0. Some environment variables have been changed or removed, see the [migration guide](https://pocket-id.org/docs/setup/migrate-to-v1/).
 
 - The `zigbee2mqtt` package was updated to version 2.x, which contains breaking changes. See the [discussion](https://github.com/Koenkk/zigbee2mqtt/discussions/24198) for further information.

--- a/nixos/modules/services/networking/sing-box.nix
+++ b/nixos/modules/services/networking/sing-box.nix
@@ -12,7 +12,10 @@ in
 {
 
   meta = {
-    maintainers = with lib.maintainers; [ nickcao ];
+    maintainers = with lib.maintainers; [
+      nickcao
+      prince213
+    ];
   };
 
   options = {

--- a/nixos/tests/sing-box.nix
+++ b/nixos/tests/sing-box.nix
@@ -111,7 +111,10 @@ in
   name = "sing-box";
 
   meta = {
-    maintainers = with lib.maintainers; [ nickcao ];
+    maintainers = with lib.maintainers; [
+      nickcao
+      prince213
+    ];
   };
 
   nodes = {

--- a/nixos/tests/sing-box.nix
+++ b/nixos/tests/sing-box.nix
@@ -450,6 +450,12 @@ in
                   tag = "dns:fakeip";
                   inet4_range = "198.18.0.0/16";
                 }
+                {
+                  type = "resolved";
+                  tag = "dns:resolved";
+                  service = "service:resolved";
+                  accept_default_resolvers = true;
+                }
               ];
               rules = [
                 {
@@ -488,6 +494,12 @@ in
                 }
               ];
             };
+            services = [
+              {
+                type = "resolved";
+                tag = "service:resolved";
+              }
+            ];
           };
         };
       };

--- a/nixos/tests/sing-box.nix
+++ b/nixos/tests/sing-box.nix
@@ -439,26 +439,19 @@ in
             dns = {
               final = "dns:default";
               independent_cache = true;
-              fakeip = {
-                enabled = true;
-                inet4_range = "198.18.0.0/16";
-              };
               servers = [
                 {
-                  detour = "outbound:direct";
+                  type = "udp";
                   tag = "dns:default";
-                  address = hosts."${target_host}";
+                  server = hosts."${target_host}";
                 }
                 {
+                  type = "fakeip";
                   tag = "dns:fakeip";
-                  address = "fakeip";
+                  inet4_range = "198.18.0.0/16";
                 }
               ];
               rules = [
-                {
-                  outbound = [ "any" ];
-                  server = "dns:default";
-                }
                 {
                   query_type = [
                     "A"
@@ -482,6 +475,7 @@ in
               }
             ];
             route = {
+              default_domain_resolver = "dns:default";
               default_interface = "eth1";
               final = "outbound:direct";
               rules = [

--- a/pkgs/by-name/si/sing-box/package.nix
+++ b/pkgs/by-name/si/sing-box/package.nix
@@ -10,27 +10,26 @@
 
 buildGoModule (finalAttrs: {
   pname = "sing-box";
-  version = "1.11.15";
+  version = "1.12.3";
 
   src = fetchFromGitHub {
     owner = "SagerNet";
     repo = "sing-box";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uqPV3PGk3hFpV1B8+htBG9x58RVWew0sBDUItpxyv8Q=";
+    hash = "sha256-OHhCC+tSDZRSDN9i3L6NtwgarBKHv+KGNyPhHttqo4g=";
   };
 
-  vendorHash = "sha256-qZlnY0MxB4/ttgjuAroTfqGWqGRea549EyIjSxPAlOI=";
+  vendorHash = "sha256-Y/UP2rbee4WSctelk9QddMXciucz5dNLOLDDWtEFfLU=";
 
   tags = [
     "with_quic"
     "with_dhcp"
     "with_wireguard"
-    "with_ech"
     "with_utls"
-    "with_reality_server"
     "with_acme"
     "with_clash_api"
     "with_gvisor"
+    "with_tailscale"
   ];
 
   subPackages = [
@@ -50,6 +49,9 @@ buildGoModule (finalAttrs: {
       --replace-fail "/usr/bin/sing-box" "$out/bin/sing-box" \
       --replace-fail "/bin/kill" "${coreutils}/bin/kill"
     install -Dm444 -t "$out/lib/systemd/system/" release/config/sing-box{,@}.service
+
+    install -Dm444 release/config/sing-box.rules $out/share/polkit-1/rules.d/sing-box.rules
+    install -Dm444 release/config/sing-box-split-dns.xml $out/share/dbus-1/system.d/sing-box-split-dns.conf
   '';
 
   passthru = {


### PR DESCRIPTION
Release notes: https://github.com/SagerNet/sing-box/releases/tag/v1.12.3
Changelog: https://sing-box.sagernet.org/changelog/#1123

Reference:
- https://git.sr.ht/~prince213/nix-packages/tree/main/item/pkgs/sing-box-beta/default.nix
- https://git.sr.ht/~prince213/nix-packages/tree/main/item/modules/services/networking/sing-box.nix

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
