### PR TITLE
ckb: init at 0.202.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11958,6 +11958,11 @@
     githubId = 3908945;
     name = "Juho Törmä";
   };
+  jjy = {
+    github = "jjyr";
+    githubId = 1695400;
+    name = "Jinyang Jiang";
+  };
   jk = {
     email = "hello+nixpkgs@j-k.io";
     matrix = "@j-k:matrix.org";

--- a/pkgs/by-name/ck/ckb/package.nix
+++ b/pkgs/by-name/ck/ckb/package.nix
@@ -1,0 +1,56 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  ckb,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ckb";
+  version = "0.202.0";
+
+  src = fetchFromGitHub {
+    owner = "nervosnetwork";
+    repo = "ckb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LE+w5RHkDk+1Zu2RZgPyHbHJ92C1oAxGEcVc3Qo2lQc=";
+  };
+
+  cargoHash = "sha256-R7XV//e6n6afbad7HgwlcNwQRdO0xFZ0UGy1SU294Fs=";
+
+  buildFeatures = lib.optionals (stdenv.hostPlatform.isDarwin) [ "portable" ];
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  env.OPENSSL_NO_VENDOR = true;
+  __darwinAllowLocalNetworking = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "The Nervos CKB is a public permissionless blockchain, and the layer 1 of Nervos network.";
+    homepage = "https://www.nervos.org/";
+    downloadPage = "https://github.com/nervosnetwork/ckb";
+    changelog = "https://github.com/nervosnetwork/ckb/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jjy
+    ];
+    mainProgram = "ckb";
+  };
+})


### PR DESCRIPTION
Adds new package for https://github.com/nervosnetwork/ckb. a public blockchain.

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
