### PR TITLE
icestorm: 2020.12.04 -> 0-unstable-2025-06-03

### DIFF
--- a/pkgs/by-name/ic/icestorm/package.nix
+++ b/pkgs/by-name/ic/icestorm/package.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation rec {
   pname = "icestorm";
-  version = "2020.12.04";
+  version = "0-unstable-2025-06-03";
 
   passthru = rec {
     pythonPkg = if (false && usePyPy) then pypy3 else python3;
@@ -30,8 +30,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "icestorm";
-    rev = "7afc64b480212c9ac2ce7cb1622731a69a7d212c";
-    sha256 = "0vxhqs2fampglg3xlfwb35229iv96kvlwp1gyxrdrmlpznhkqdrk";
+    rev = "f31c39cc2eadd0ab7f29f34becba1348ae9f8721";
+    hash = "sha256-SLSxqgVsYMUxv8YjY1iRLnVFiIAhk/GKmZr4Ido0A3o=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -39,27 +39,24 @@ stdenv.mkDerivation rec {
     passthru.pythonPkg
     libftdi1
   ];
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [
+    "PREFIX=$(out)"
+    "PYTHON3=${passthru.pythonInterp}"
+  ];
 
   enableParallelBuilding = true;
 
-  # fix icebox_vlog chipdb path. icestorm issue:
-  #   https://github.com/cliffordwolf/icestorm/issues/125
-  #
-  # also, fix up the path to the chosen Python interpreter. for pypy-compatible
+  # fix up the path to the chosen Python interpreter. for pypy-compatible
   # platforms, it offers significant performance improvements.
   patchPhase = ''
-    substituteInPlace ./icebox/icebox_vlog.py \
-      --replace /usr/local/share "$out/share"
-
-    for x in icefuzz/Makefile icebox/Makefile icetime/Makefile; do
-      substituteInPlace "$x" --replace python3 "${passthru.pythonInterp}"
-    done
-
-    for x in $(find . -type f -iname '*.py'); do
+    for x in $(find . -type f -iname '*.py' -executable); do
       substituteInPlace "$x" \
-        --replace '/usr/bin/env python3' '${passthru.pythonInterp}'
+        --replace-fail '/usr/bin/env python3' '${passthru.pythonInterp}'
     done
+
+    # We use GNU sed on Darwin, while icebox/Makefile assumed BSD sed (which
+    # requires a (potentially empty) argument for the -i flag).
+    substituteInPlace icebox/Makefile --replace-fail "sed -i '''" "sed -i"
   '';
 
   meta = {

--- a/pkgs/by-name/ic/icestorm/tests.nix
+++ b/pkgs/by-name/ic/icestorm/tests.nix
@@ -1,0 +1,29 @@
+# Run the examples from $src/examples/ as simple integration tests. They require
+# yosys and nextpnr (which itself depends on this package), so they cannot be
+# ran during the check phase.
+{
+  runCommand,
+  icestorm,
+  nextpnr,
+  yosys,
+
+  pname,
+  src,
+}:
+
+runCommand "${pname}-test-examples"
+  {
+    nativeBuildInputs = [
+      icestorm
+      nextpnr
+      yosys
+    ];
+  }
+  ''
+    cp -r ${src}/examples .
+    chmod -R +w examples
+    for example in examples/*; do
+      make -C $example
+    done
+    touch $out
+  ''


### PR DESCRIPTION
- Updated `icestorm` package.
- Removed no longer needed patches.
- Added simple integration test that runs all the [examples from upstream](https://github.com/YosysHQ/icestorm/tree/master/examples).

Project Icestorm does not have any releases. However, given the almost 5 years since the last update, this bump should be considered breaking and not backported.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
