### PR TITLE
ocamlPackages.logs: 0.8.0 → 0.9.0; refactor to buildTokpkg

### DIFF
--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -13,7 +13,6 @@
   js_of_ocaml-compiler,
   lwtSupport ? true,
   lwt,
-  result,
 }:
 let
   pname = "logs";
@@ -60,7 +59,6 @@ buildTopkgPackage rec {
   };
 
   buildInputs = [ topkg ] ++ optional_buildInputs;
-  propagatedBuildInputs = [ result ];
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -3,18 +3,17 @@
   stdenv,
   fetchurl,
   ocaml,
-  findlib,
-  ocamlbuild,
   topkg,
-  result,
-  lwt,
-  cmdliner,
-  fmt,
-  fmtSupport ? lib.versionAtLeast ocaml.version "4.08",
-  js_of_ocaml-compiler,
-  jsooSupport ? true,
-  lwtSupport ? true,
+  buildTopkgPackage,
   cmdlinerSupport ? true,
+  cmdliner,
+  fmtSupport ? lib.versionAtLeast ocaml.version "4.08",
+  fmt,
+  jsooSupport ? true,
+  js_of_ocaml-compiler,
+  lwtSupport ? true,
+  lwt,
+  result,
 }:
 let
   pname = "logs";
@@ -49,39 +48,29 @@ let
   optional_buildInputs = map (d: d.pkg) (lib.filter (d: d.enabled) optional_deps);
 in
 
-if lib.versionOlder ocaml.version "4.03" then
-  throw "logs is not available for OCaml ${ocaml.version}"
-else
+buildTopkgPackage rec {
+  inherit pname;
+  version = "0.8.0";
 
-  stdenv.mkDerivation rec {
-    name = "ocaml${ocaml.version}-${pname}-${version}";
-    version = "0.8.0";
+  minimalOCamlVersion = "4.03";
 
-    src = fetchurl {
-      url = "${webpage}/releases/${pname}-${version}.tbz";
-      hash = "sha256-mmFRQJX6QvMBIzJiO2yNYF1Ce+qQS2oNF3+OwziCNtg=";
-    };
+  src = fetchurl {
+    url = "${webpage}/releases/${pname}-${version}.tbz";
+    hash = "sha256-mmFRQJX6QvMBIzJiO2yNYF1Ce+qQS2oNF3+OwziCNtg=";
+  };
 
-    nativeBuildInputs = [
-      ocaml
-      findlib
-      ocamlbuild
-      topkg
-    ];
-    buildInputs = [ topkg ] ++ optional_buildInputs;
-    propagatedBuildInputs = [ result ];
+  buildInputs = [ topkg ] ++ optional_buildInputs;
+  propagatedBuildInputs = [ result ];
 
-    strictDeps = true;
+  strictDeps = true;
 
-    buildPhase = "${topkg.run} build ${lib.escapeShellArgs enable_flags}";
+  buildPhase = "${topkg.run} build ${lib.escapeShellArgs enable_flags}";
 
-    inherit (topkg) installPhase;
-
-    meta = with lib; {
-      description = "Logging infrastructure for OCaml";
-      homepage = webpage;
-      inherit (ocaml.meta) platforms;
-      maintainers = [ maintainers.sternenseemann ];
-      license = licenses.isc;
-    };
-  }
+  meta = with lib; {
+    description = "Logging infrastructure for OCaml";
+    homepage = webpage;
+    inherit (ocaml.meta) platforms;
+    maintainers = [ maintainers.sternenseemann ];
+    license = licenses.isc;
+  };
+}

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   ocaml,
+  version ? if lib.versionAtLeast ocaml.version "4.14" then "0.9.0" else "0.8.0",
   topkg,
   buildTopkgPackage,
   cmdlinerSupport ? true,
@@ -15,6 +16,19 @@
   lwt,
 }:
 let
+  param =
+    {
+      "0.8.0" = {
+        minimalOCamlVersion = "4.03";
+        sha512 = "c34c67b00d6a989a2660204ea70db8521736d6105f15d1ee0ec6287a662798fe5c4d47075c6e7c84f5d5372adb5af5c4c404f79db70d69140af5e0ebbea3b6a5";
+      };
+      "0.9.0" = {
+        minimalOCamlVersion = "4.14";
+        sha512 = "b75fb28e83f33461b06b5c9b60972c4a9a9a1599d637b4a0c7b1e86a87f34fe5361e817cb31f42ad7e7cbb822473b28fab9f58a02870eb189ebe88dae8e045ff";
+      };
+    }
+    .${version};
+
   pname = "logs";
   webpage = "https://erratique.ch/software/${pname}";
 
@@ -46,16 +60,13 @@ let
   ]) optional_deps;
   optional_buildInputs = map (d: d.pkg) (lib.filter (d: d.enabled) optional_deps);
 in
-
-buildTopkgPackage rec {
-  inherit pname;
-  version = "0.8.0";
-
-  minimalOCamlVersion = "4.03";
+buildTopkgPackage {
+  inherit pname version;
+  inherit (param) minimalOCamlVersion;
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    hash = "sha256-mmFRQJX6QvMBIzJiO2yNYF1Ce+qQS2oNF3+OwziCNtg=";
+    inherit (param) sha512;
   };
 
   buildInputs = [ topkg ] ++ optional_buildInputs;


### PR DESCRIPTION
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/NixOS/nixpkgs/pull/424216 like this but without changing the OCaml version checks. In fact, closes #424216. Bonus: we can mean what we say & unite with `→ RIGHTWARDS ARROW`, not `-> DASH + GREATER THAN` (for @vbgl)!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
