### PR TITLE
nixos/resolved: add dns option

### DIFF
--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -13,9 +13,7 @@ let
 
   resolvedConf = ''
     [Resolve]
-    ${optionalString (
-      config.networking.nameservers != [ ]
-    ) "DNS=${concatStringsSep " " config.networking.nameservers}"}
+    ${optionalString (cfg.dns != [ ]) "DNS=${concatStringsSep " " cfg.dns}"}
     ${optionalString (cfg.fallbackDns != null) "FallbackDNS=${concatStringsSep " " cfg.fallbackDns}"}
     ${optionalString (cfg.domains != [ ]) "Domains=${concatStringsSep " " cfg.domains}"}
     LLMNR=${cfg.llmnr}
@@ -36,6 +34,19 @@ in
         Whether to enable the systemd DNS resolver daemon, `systemd-resolved`.
 
         Search for `services.resolved` to see all options.
+      '';
+    };
+
+    services.resolved.dns = mkOption {
+      default = config.networking.nameservers;
+      defaultText = literalExpression "config.networking.nameservers";
+      example = [
+        "8.8.8.8"
+        "2001:4860:4860::8844"
+      ];
+      type = types.listOf types.str;
+      description = ''
+        A space-separated list of IPv4 and IPv6 addresses to use as system DNS servers.
       '';
     };
 


### PR DESCRIPTION
Not using networking.nameservers directly. This makes chaining DNS resolvers much easier.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
