### PR TITLE
python3Packages.duckduckgo-search: rename to python3Packages.duckduckgo-search_8

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -68,6 +68,10 @@
 
 - [private-gpt](https://github.com/zylon-ai/private-gpt) service has been removed by lack of maintenance upstream.
 
+- `duckduckgo-search` has been updated to v9+ and therefore has be renamed to `ddgs`.
+  If you'd like to keep using v8, the package has been renamed `duckduckgo-search_8`.
+  See [release note for v9.0.0](https://github.com/deedy5/ddgs/releases/tag/v9.0.0)
+
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/development/python-modules/duckduckgo-search_8/default.nix
+++ b/pkgs/development/python-modules/duckduckgo-search_8/default.nix
@@ -9,7 +9,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "duckduckgo-search";
+  pname = "duckduckgo-search_8";
   version = "8.1.1";
   pyproject = true;
 

--- a/pkgs/development/python-modules/smolagents/default.nix
+++ b/pkgs/development/python-modules/smolagents/default.nix
@@ -33,7 +33,7 @@
   # openai
   openai,
   # toolkit
-  duckduckgo-search,
+  duckduckgo-search_8,
   markdownify,
   # torch
   numpy,
@@ -108,7 +108,7 @@ buildPythonPackage rec {
     #   opentelemetry-sdk
     # ];
     toolkit = [
-      duckduckgo-search
+      duckduckgo-search_8
       markdownify
     ];
     torch = [

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -229,6 +229,7 @@ mapAliases ({
   doctest-ignore-unicode = throw "doctest-ignore-unicode has been removed since it has been unmaintained for 11 years"; # added 2024-05-20
   dogpile_cache = dogpile-cache; # added 2021-10-28
   dogpile-core = throw "dogpile-core is no longer maintained, use dogpile-cache instead"; # added 2021-11-20
+  duckduckgo-search = throw "duckduckgo-search was rename to ddgs, use ddgs or duckduckgo-search_8 instead"; # added 2025-08-04
   dugong = throw "dugong is unmaintained since 2022 and has therefore been removed"; # added 2024-12-12
   eebrightbox = throw "eebrightbox is unmaintained upstream and has therefore been removed"; # added 2022-02-03
   EasyProcess = easyprocess; # added 2023-02-19

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4388,7 +4388,7 @@ self: super: with self; {
 
   duckdb-engine = callPackage ../development/python-modules/duckdb-engine { };
 
-  duckduckgo-search = callPackage ../development/python-modules/duckduckgo-search { };
+  duckduckgo-search_8 = callPackage ../development/python-modules/duckduckgo-search_8 { };
 
   duct-py = callPackage ../development/python-modules/duct-py { };
 


### PR DESCRIPTION
`duckduckgo-search` is the previous name of `ddgs`. Because of breaking changes, we need to keep those two versions coexisting. To signify this, I'd like to propose to rename the package to `duckduckgo-search_8`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
