### PR TITLE
tests:  fix some tests

### DIFF
--- a/pkgs/build-support/fetchdebianpatch/tests.nix
+++ b/pkgs/build-support/fetchdebianpatch/tests.nix
@@ -5,7 +5,7 @@
     pname = "pysimplesoap";
     version = "1.16.2";
     debianRevision = "5";
-    patch = "Add-quotes-to-SOAPAction-header-in-SoapClient";
+    patch = "Add-quotes-to-SOAPAction-header-in-SoapClient.patch";
     hash = "sha256-xA8Wnrpr31H8wy3zHSNfezFNjUJt1HbSXn3qUMzeKc0=";
   };
 
@@ -13,7 +13,7 @@
     pname = "libfile-pid-perl";
     version = "1.01";
     debianRevision = "2";
-    patch = "missing-pidfile";
+    patch = "missing-pidfile.patch";
     hash = "sha256-VBsIYyCnjcZLYQ2Uq2MKPK3kF2wiMKvnq0m727DoavM=";
   };
 }

--- a/pkgs/test/auto-patchelf-hook/package.nix
+++ b/pkgs/test/auto-patchelf-hook/package.nix
@@ -100,4 +100,8 @@ stdenv.mkDerivation {
 
   doInstallCheck = true;
   inherit __structuredAttrs;
+  meta = {
+    # Downloads an x86_64-linux only binary
+    platforms = [ "x86_64-linux" ];
+  };
 }

--- a/pkgs/test/buildFHSEnv/default.nix
+++ b/pkgs/test/buildFHSEnv/default.nix
@@ -47,21 +47,28 @@ let
       };
       find_lib-in-FHS = "${find_libFHSEnv}/bin/${find_libFHSEnv.name}";
     in
-    runCommand "FHS-lib-test" { } ''
-      echo original ldd output is:
-      ${ldd} ${sharedObject}
-      lddOutput="$(${ldd-in-FHS} ${sharedObject})"
-      echo ldd output inside FHS is:
-      echo "$lddOutput"
-      if echo $lddOutput | grep -q "not found"; then
-        echo "shared object could not find all dependencies in the FHS!"
-        echo The libraries below where found in the FHS:
-        ${find_lib-in-FHS}
-        exit 1
-      else
-        echo $lddOutput > $out
-      fi
-    '';
+    runCommand "FHS-lib-test"
+      {
+        meta = {
+          # Downloads an x86_64-linux only binary
+          platforms = [ "x86_64-linux" ];
+        };
+      }
+      ''
+        echo original ldd output is:
+        ${ldd} ${sharedObject}
+        lddOutput="$(${ldd-in-FHS} ${sharedObject})"
+        echo ldd output inside FHS is:
+        echo "$lddOutput"
+        if echo $lddOutput | grep -q "not found"; then
+          echo "shared object could not find all dependencies in the FHS!"
+          echo The libraries below where found in the FHS:
+          ${find_lib-in-FHS}
+          exit 1
+        else
+          echo $lddOutput > $out
+        fi
+      '';
 
 in
 {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
