### PR TITLE
actual-server: 25.7.1 -> 25.8.0

### DIFF
--- a/pkgs/by-name/ac/actual-server/package.nix
+++ b/pkgs/by-name/ac/actual-server/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  jq,
   makeWrapper,
   nodejs_22,
   python3,
@@ -10,13 +11,13 @@
 }:
 let
   yarn-berry = yarn-berry_4;
-  version = "25.7.1";
+  version = "25.8.0";
   src = fetchFromGitHub {
     name = "actualbudget-actual-source";
     owner = "actualbudget";
     repo = "actual";
     tag = "v${version}";
-    hash = "sha256-BXF9VL2HTNOOsX+l6G+5CHRi+ycGJTizky8cypijR7M=";
+    hash = "sha256-9Ov9AR+WEKtjiX+C2lvjxerc295DWSRHpTb4Lu1stoo=";
   };
   translations = fetchFromGitHub {
     name = "actualbudget-translations-source";
@@ -24,8 +25,8 @@ let
     repo = "translations";
     # Note to updaters: this repo is not tagged, so just update this to the Git
     # tip at the time the update is performed.
-    rev = "319e1b8f099b77c2ff939c8728182a0a3afdec49";
-    hash = "sha256-63Uc/2HTYOm2hQEr7grhNTLWtage6oyl4J/a6fGonVI=";
+    rev = "c1c2f298013ca3223e6cd6a4a4720bca5e8b8274";
+    hash = "sha256-3dtdymdKfEzUIzButA3L88GrehO4EjCrd/gq0Y5bcuE=";
   };
 
 in
@@ -60,6 +61,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Allow `remove-untranslated-languages` to do its job.
     chmod -R u+w ./packages/desktop-client/locale
+
+    # Disable the postinstall script for `protoc-gen-js` because it tries to
+    # use network in buildPhase. It's just used as a dev tool and the generated
+    # protobuf code is committed in the repository.
+    cat <<< $(${lib.getExe jq} '.dependenciesMeta."protoc-gen-js".built = false' ./package.json) > ./package.json
   '';
 
   buildPhase = ''
@@ -76,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
   missingHashes = ./missing-hashes.json;
   offlineCache = yarn-berry.fetchYarnBerryDeps {
     inherit (finalAttrs) src missingHashes;
-    hash = "sha256-SPLosaI2r8PshhqG+dbJktVmjcaDX1GmIXBO0bF+mY4=";
+    hash = "sha256-kbQjtZivn9ni6PLk04kAJTzhhGgubhnxgHqMnGwEXZk=";
   };
 
   pname = "actual-server";


### PR DESCRIPTION
Update actual-server to the latest version.

Changelog: https://actualbudget.org/docs/releases/#2580

Adds a patch to disable the `postinstall` script for the included version of `protoc-gen-js` as it fails within the Nix sandbox. Tested with a quick build & run and it seems to run fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
