### PR TITLE
ocamlPackages.jsont: flags to turn off optional dependencies

### DIFF
--- a/pkgs/development/ocaml-modules/jsont/default.nix
+++ b/pkgs/development/ocaml-modules/jsont/default.nix
@@ -1,9 +1,13 @@
 {
   lib,
   fetchzip,
+  topkg,
   buildTopkgPackage,
+  withBrr ? true,
   brr,
+  withBytesrw ? true,
   bytesrw,
+  withCmdliner ? true,
   cmdliner,
 }:
 
@@ -18,17 +22,22 @@ buildTopkgPackage rec {
     hash = "sha256-dXHl+bLuIrlrQ5Np37+uVuETFBb3j8XeDVEK9izoQFk=";
   };
 
-  # docs say these dependendencies are optional, but buildTopkgPackage doesn’t
-  # handle missing dependencies
+  buildInputs = lib.optional withCmdliner cmdliner;
 
-  buildInputs = [
-    cmdliner
-  ];
+  propagatedBuildInputs = lib.optional withBrr brr ++ lib.optional withBytesrw bytesrw;
 
-  propagatedBuildInputs = [
-    brr
-    bytesrw
-  ];
+  buildPhase = "${topkg.run} build ${
+    lib.escapeShellArgs [
+      "--with-brr"
+      (lib.boolToString withBrr)
+
+      "--with-bytesrw"
+      (lib.boolToString withBytesrw)
+
+      "--with-cmdliner"
+      (lib.boolToString withCmdliner)
+    ]
+  }";
 
   meta = {
     description = "Declarative JSON data manipulation";


### PR DESCRIPTION
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

learned from #430848 … tho somewhat awaiting whether one should prefer `with*` to `*Support` for flags in OCaml land.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
