### PR TITLE
linux-manual: ensure kernel-doc.py and split-man.pl are executable for patchShebangs

### DIFF
--- a/pkgs/by-name/li/linux-manual/package.nix
+++ b/pkgs/by-name/li/linux-manual/package.nix
@@ -21,14 +21,17 @@ stdenv.mkDerivation {
   dontBuild = true;
   doInstallCheck = true;
 
-  postPatch = ''
-    # Use scripts/kernel-doc.py here, not scripts/kernel-doc because
-    # patchShebangs skips symlinks
-
-    patchShebangs --build \
-      scripts/kernel-doc.py \
-      scripts/split-man.pl
-  '';
+  postPatch =
+    let
+      scripts = lib.escapeShellArgs [
+        "scripts/kernel-doc.py"
+        "scripts/split-man.pl"
+      ];
+    in
+    ''
+      chmod +x ${scripts}
+      patchShebangs --build ${scripts}
+    '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Without the executable bit, patchShebangs silently skips the files, causing issues during build.
Grouping scripts into a list to eliminate repetition and improve maintainability, allowing easy updates and for script handling logic to be extended in the future.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
