### PR TITLE
setuptools-git-versioning: fix package version

### DIFF
--- a/pkgs/by-name/jo/joycond-cemuhook/package.nix
+++ b/pkgs/by-name/jo/joycond-cemuhook/package.nix
@@ -6,8 +6,8 @@
 
 python3Packages.buildPythonApplication {
   pname = "joycond-cemuhook";
-  pyproject = true;
   version = "0-unstable-2023-08-09";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joaorb64";
@@ -16,13 +16,17 @@ python3Packages.buildPythonApplication {
     hash = "sha256-K24CEmYWhgkvVX4geg2bylH8TSvHIpsWjsPwY5BpquI=";
   };
 
-  nativeBuildInputs = with python3Packages; [
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'setuptools-git-versioning<2' 'setuptools-git-versioning'
+  '';
+
+  build-system = with python3Packages; [
     setuptools
     setuptools-git-versioning
-    setuptools-git
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     dbus-python
     evdev
     pyudev

--- a/pkgs/development/python-modules/setuptools-git-versioning/default.nix
+++ b/pkgs/development/python-modules/setuptools-git-versioning/default.nix
@@ -17,7 +17,7 @@
 buildPythonPackage rec {
   pname = "setuptools-git-versioning";
   version = "2.1.0";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dolfinus";
@@ -25,6 +25,14 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-Slf6tq83LajdTnr98SuCiFIdm/6auzftnARLAOBgyng=";
   };
+
+  postPatch = ''
+    # Because the .git dir is missing, it falls back to using version 0.0.1
+    # Instead we use the version specified in the derivation
+    substituteInPlace setup.py --replace-fail \
+      'version=version_from_git(root=here, dev_template="{tag}.post{ccount}")' \
+      "version='${version}'"
+  '';
 
   build-system = [
     setuptools


### PR DESCRIPTION
Removed the line that specifies the `pyproject` format since the project does have a `pyproject.toml` but still uses the legacy `setup.py`.
This causes the package built with a dummy 0.0.1 reported version that causes problem if the package is a dependency with locked version.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
