### PR TITLE
nixos/console: start vconsole-setup service after local-fs.target

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -208,6 +208,9 @@ in
             "systemd-vconsole-setup.service"
           ];
 
+          # Start the vconsole setup only after local-fs.target, else it might have trouble accessing data on disk
+          systemd.services.systemd-vconsole-setup.after = [ "local-fs.target" ];
+
           systemd.services.reload-systemd-vconsole-setup = {
             description = "Reset console on configuration changes";
             wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
This fixes the instances where the service might have trouble accessing custom fonts on disk.

```
May 17 19:48:23 Ainz-NIX systemd-vconsole-setup[901]: popen: /nix/store/hragmx5p3izmwinv4441hj5706sxy4xs-gzip-1.13/bin/gzip -d -c /etc/kbd/keymaps/i386/qwerty/us.map.gz: No such file or directory
May 17 19:48:23 Ainz-NIX systemd-vconsole-setup[901]: popen: /nix/store/hragmx5p3izmwinv4441hj5706sxy4xs-gzip-1.13/bin/gzip -d -c /nix/store/bjzji701dz67bfrrwx9smqqyy1pnf2c9-kbd-2.6.4/share/keymaps/i386/qwerty/us.map.gz: No such file or directory
May 17 19:48:23 Ainz-NIX systemd-vconsole-setup[901]: loadkeys: Unable to open file: us: No such file or directory
May 17 19:48:22 Ainz-NIX systemd-vconsole-setup[832]: /nix/store/bjzji701dz67bfrrwx9smqqyy1pnf2c9-kbd-2.6.4/bin/loadkeys failed with exit status 1.
May 17 19:48:22 Ainz-NIX systemd-vconsole-setup[832]: KD_FONT_OP_GET failed while trying to get the font metadata: Invalid argument
May 17 19:48:22 Ainz-NIX systemd-vconsole-setup[832]: Fonts will not be copied to remaining consoles
May 17 19:48:22 Ainz-NIX systemd[1]: systemd-vconsole-setup.service: Main process exited, code=exited, status=1/FAILURE
May 17 19:48:22 Ainz-NIX systemd[1]: systemd-vconsole-setup.service: Failed with result 'exit-code'.
```

Fixes https://github.com/NixOS/nixpkgs/issues/312452

Suggested by @fzakaria [on Discourse](https://discourse.nixos.org/t/systemd-1-failed-to-start-virtual-console-setup/44798/6).

With this fix applied:

```
❯  journalctl -b | grep Console  
Aug 04 16:00:58 Ainz-NIX kernel: Console: colour dummy device 80x25
Aug 04 16:00:58 Ainz-NIX kernel: Console: switching to colour frame buffer device 240x67
Aug 04 16:00:58 Ainz-NIX kernel: Console: switching to colour dummy device 80x25
Aug 04 16:00:58 Ainz-NIX kernel: Console: switching to colour frame buffer device 240x67
Aug 04 16:00:58 Ainz-NIX systemd[1]: Started Dispatch Password Requests to Console Directory Watch.
Aug 04 16:00:59 Ainz-NIX systemd[1]: Starting Virtual Console Setup...
Aug 04 16:00:59 Ainz-NIX systemd[1]: Finished Virtual Console Setup.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] Tested with my configuration

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
