### PR TITLE
tpm2-tss: use finalAttrs for overriding doInstallCheck

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -29,14 +29,14 @@ let
   procps_pkg = if stdenv.hostPlatform.isLinux then procpsWithoutSystemd else procps;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tpm2-tss";
   version = "4.1.3";
 
   src = fetchFromGitHub {
     owner = "tpm2-software";
-    repo = pname;
-    rev = version;
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
     hash = "sha256-BP28utEUI9g1VNv3lCXuiKrDtEImFQxxZfIjLiE3Wr8=";
   };
 
@@ -67,9 +67,9 @@ stdenv.mkDerivation rec {
   # when unit and/or integration testing is enabled
   # cmocka doesn't build with pkgsStatic, and we don't need it anyway
   # when tests are not run
-  ++ lib.optional doInstallCheck cmocka;
+  ++ lib.optional finalAttrs.doInstallCheck cmocka;
 
-  nativeInstallCheckInputs = lib.optionals doInstallCheck [
+  nativeInstallCheckInputs = lib.optionals finalAttrs.doInstallCheck [
     cmocka
     which
     openssl
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
     substituteInPlace ./test/unit/tctildr-dl.c \
       --replace-fail '@PREFIX@' $out/lib/
     substituteInPlace ./bootstrap \
-      --replace-fail 'git describe --tags --always --dirty' 'echo "${version}"'
+      --replace-fail 'git describe --tags --always --dirty' 'echo "${finalAttrs.version}"'
     for src in src/tss2-tcti/tcti-libtpms.c test/unit/tcti-libtpms.c; do
       substituteInPlace "$src" \
         --replace-fail '"libtpms.so"' '"${libtpms.out}/lib/libtpms.so"' \
@@ -125,7 +125,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags =
-    lib.optionals doInstallCheck [
+    lib.optionals finalAttrs.doInstallCheck [
       "--enable-unit"
       "--enable-integration"
     ]
@@ -163,4 +163,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [ baloo ];
   };
-}
+})


### PR DESCRIPTION
Use mkDerivation finalAttrs to make doInstallCheck overridable.

When overriding to `doInstallCheck=false` the configure phase failed with:
```
> configure: error: Missing required program 'ss': ensure it is installed and on PATH.
```

This check is only triggered with `--enable-integration`, which was apparently still set because `doInstallCheck` is set explicitly within the recursive attribute set -> not overridden?. Not sure why it would add the configure flag but not the `nativeInstallCheckInputs` though.

This PR uses finalAttrs instead to cleanly override `doInstallCheck`.

 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
