### PR TITLE
sourcegit: 2025.25 -> 2025.29

### DIFF
--- a/pkgs/by-name/so/sourcegit/fix-darwin-git-path.patch
+++ b/pkgs/by-name/so/sourcegit/fix-darwin-git-path.patch
@@ -1,8 +1,8 @@
 diff --git a/src/Native/Linux.cs b/src/Native/Linux.cs
-index a24f1b6..4102274 100644
+index f6eb4eb..1840db7 100644
 --- a/src/Native/Linux.cs
 +++ b/src/Native/Linux.cs
-@@ -97,7 +97,7 @@ namespace SourceGit.Native
+@@ -119,7 +119,7 @@ namespace SourceGit.Native
              }
          }
  
@@ -10,21 +10,26 @@ index a24f1b6..4102274 100644
 +        public static string FindExecutable(string filename)
          {
              var pathVariable = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-             var pathes = pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+             var paths = pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
 diff --git a/src/Native/MacOS.cs b/src/Native/MacOS.cs
-index 5721fe8..bc2a57d 100644
+index a021a16..6b3dff0 100644
 --- a/src/Native/MacOS.cs
 +++ b/src/Native/MacOS.cs
-@@ -25,13 +25,7 @@ namespace SourceGit.Native
+@@ -46,18 +46,7 @@ namespace SourceGit.Native
  
          public string FindGitExecutable()
          {
 -            var gitPathVariants = new List<string>() {
--                 "/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git", "/opt/homebrew/opt/git/bin/git"
+-                "/usr/bin/git",
+-                "/usr/local/bin/git",
+-                "/opt/homebrew/bin/git",
+-                "/opt/homebrew/opt/git/bin/git"
 -            };
+-
 -            foreach (var path in gitPathVariants)
 -                if (File.Exists(path))
 -                    return path;
+-
 -            return string.Empty;
 +            return Linux.FindExecutable("git");
          }

--- a/pkgs/by-name/so/sourcegit/package.nix
+++ b/pkgs/by-name/so/sourcegit/package.nix
@@ -21,13 +21,13 @@
 
 buildDotnetModule (finalAttrs: {
   pname = "sourcegit";
-  version = "2025.25";
+  version = "2025.29";
 
   src = fetchFromGitHub {
     owner = "sourcegit-scm";
     repo = "sourcegit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WPwvOfbCOCQBOvJU2HuGU9/Rh00MCmhZEaKn9Nr1Q0I=";
+    hash = "sha256-ptHiC5BaX0EP2uInGE7/FV61wsCU2V+FE1VHxJKN+70=";
   };
 
   patches = [ ./fix-darwin-git-path.patch ];


### PR DESCRIPTION
https://github.com/sourcegit-scm/sourcegit/releases

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
