### PR TITLE
homepage-dashboard: 1.3.2 -> 1.4.6

### DIFF
--- a/nixos/modules/services/misc/homepage-dashboard.nix
+++ b/nixos/modules/services/misc/homepage-dashboard.nix
@@ -191,6 +191,16 @@ in
         default = { };
       };
 
+      proxmox = lib.mkOption {
+        inherit (settingsFormat) type;
+        description = ''
+          Homepage proxmox configuration.
+
+          See <https://gethomepage.dev/configs/proxmox/>.
+        '';
+        default = { };
+      };
+
       settings = lib.mkOption {
         inherit (settingsFormat) type;
         description = ''
@@ -215,6 +225,7 @@ in
       "homepage-dashboard/services.yaml".source = settingsFormat.generate "services.yaml" cfg.services;
       "homepage-dashboard/settings.yaml".source = settingsFormat.generate "settings.yaml" cfg.settings;
       "homepage-dashboard/widgets.yaml".source = settingsFormat.generate "widgets.yaml" cfg.widgets;
+      "homepage-dashboard/proxmox.yaml".source = settingsFormat.generate "proxmox.yaml" cfg.proxmox;
     };
 
     systemd.services.homepage-dashboard = {

--- a/nixos/tests/homepage-dashboard.nix
+++ b/nixos/tests/homepage-dashboard.nix
@@ -7,6 +7,20 @@
     services.homepage-dashboard = {
       enable = true;
       settings.title = "test title rodUsEagid"; # something random/unique
+      bookmarks = [
+        {
+          Developer = [
+            {
+              nixpkgs = [
+                {
+                  abbr = "NX";
+                  href = "https://github.com/nixos/nixpkgs";
+                }
+              ];
+            }
+          ];
+        }
+      ];
     };
   };
 
@@ -19,8 +33,12 @@
     # Ensure /etc/homepage-dashboard is created.
     machine.succeed("test -d /etc/homepage-dashboard")
 
-    # Ensure that we see the custom title *only in the managed config*
-    page = machine.succeed("curl --fail http://localhost:8082/")
+    # Ensure that we see the custom title reflected in the manifest
+    page = machine.succeed("curl --fail http://localhost:8082/site.webmanifest?v=4")
     assert "test title rodUsEagid" in page, "Custom title not found"
+
+    # Ensure that we see the custom bookmarks on the page
+    page = machine.succeed("curl --fail http://127.0.0.1:8082/api/bookmarks")
+    assert "nixpkgs" in page, "Custom bookmarks not found"
   '';
 }

--- a/pkgs/by-name/ho/homepage-dashboard/package.nix
+++ b/pkgs/by-name/ho/homepage-dashboard/package.nix
@@ -28,13 +28,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "homepage-dashboard";
-  version = "1.4.3";
+  version = "1.4.6";
 
   src = fetchFromGitHub {
     owner = "gethomepage";
     repo = "homepage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ib2sErgz1FPnHxmUE8LD/tD1smNcOc0/Ljncl+E9YdM=";
+    hash = "sha256-ug7cT/HMiOQF6CX6EEFlvgttXFZdRctSTqPAAkun2KU=";
   };
 
   # This patch ensures that the cache implementation respects the env

--- a/pkgs/by-name/ho/homepage-dashboard/package.nix
+++ b/pkgs/by-name/ho/homepage-dashboard/package.nix
@@ -28,13 +28,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "homepage-dashboard";
-  version = "1.3.2";
+  version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "gethomepage";
     repo = "homepage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-45Z2XS+ij6J6WSCb9/oDQa2eC9wKu+D7ncYwcB6K5gQ=";
+    hash = "sha256-ib2sErgz1FPnHxmUE8LD/tD1smNcOc0/Ljncl+E9YdM=";
   };
 
   # This patch ensures that the cache implementation respects the env
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
       patches
       ;
     fetcherVersion = 1;
-    hash = "sha256-aPkXHKG3vDsfYqYx9q9+2wZhuFqmPcXdoBqOfAvW9oA=";
+    hash = "sha256-IYmAl4eHR0jVpQJfxQRlOBTIbrrjS+dnJpUsl8ee6y4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ho/homepage-dashboard/prerender_cache_path.patch
+++ b/pkgs/by-name/ho/homepage-dashboard/prerender_cache_path.patch
@@ -1,8 +1,8 @@
-diff --git a/package.json b/package.json
-index bb093c43..deeb4b8b 100644
---- a/package.json
-+++ b/package.json
-@@ -66,6 +66,9 @@
+diff --git c/package.json i/package.json
+index 536d73bf..565de99e 100644
+--- c/package.json
++++ i/package.json
+@@ -73,6 +73,9 @@
    "pnpm": {
      "onlyBuiltDependencies": [
        "sharp"
@@ -13,14 +13,14 @@ index bb093c43..deeb4b8b 100644
 +    }
    }
  }
-diff --git a/patches/next.patch b/patches/next.patch
+diff --git c/patches/next.patch i/patches/next.patch
 new file mode 100644
-index 00000000..dd1d8b7c
+index 00000000..52266e70
 --- /dev/null
-+++ b/patches/next.patch
++++ i/patches/next.patch
 @@ -0,0 +1,13 @@
 +diff --git a/dist/server/lib/incremental-cache/file-system-cache.js b/dist/server/lib/incremental-cache/file-system-cache.js
-+index c5bbdefd8aa2e97df91df00d1686d63fe54c8c0d..4dcdd8760e5ed135f7509c289abb33b5005ed470 100644
++index 0b6b2b30f29fbe60eec331c83f81b712c61f18b7..36572d52414927b2b092182c19940ec23cfec313 100644
 +--- a/dist/server/lib/incremental-cache/file-system-cache.js
 ++++ b/dist/server/lib/incremental-cache/file-system-cache.js
 +@@ -24,7 +24,7 @@ class FileSystemCache {
@@ -30,19 +30,19 @@ index 00000000..dd1d8b7c
 +-        this.serverDistDir = ctx.serverDistDir;
 ++        this.serverDistDir = require("path").join((process.env.NIXPKGS_HOMEPAGE_CACHE_DIR || "/var/cache/homepage-dashboard"), "homepage");
 +         this.revalidatedTags = ctx.revalidatedTags;
-+         this.debug = !!process.env.NEXT_PRIVATE_DEBUG_CACHE;
 +         if (ctx.maxMemoryCacheSize) {
-diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index e3387dea..05918fa6 100644
---- a/pnpm-lock.yaml
-+++ b/pnpm-lock.yaml
++             if (!FileSystemCache.memoryCache) {
+diff --git c/pnpm-lock.yaml i/pnpm-lock.yaml
+index c7887131..55604102 100644
+--- c/pnpm-lock.yaml
++++ i/pnpm-lock.yaml
 @@ -4,6 +4,11 @@ settings:
    autoInstallPeers: true
    excludeLinksFromLockfile: false
  
 +patchedDependencies:
 +  next:
-+    hash: 9673472f3289a59e3cf64a56303c75752c2556c0d74d2a648eca3576b2695cab
++    hash: ec4324097eadbe8364e1a29668eeea85c2b267b7028a2be86a59a926fbd46666
 +    path: patches/next.patch
 +
  importers:
@@ -51,61 +51,39 @@ index e3387dea..05918fa6 100644
 @@ -52,10 +57,10 @@ importers:
          version: 1.2.2
        next:
-         specifier: ^15.3.1
--        version: 15.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-+        version: 15.3.1(patch_hash=9673472f3289a59e3cf64a56303c75752c2556c0d74d2a648eca3576b2695cab)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+         specifier: ^15.4.5
+-        version: 15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
++        version: 15.4.5(patch_hash=ec4324097eadbe8364e1a29668eeea85c2b267b7028a2be86a59a926fbd46666)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
        next-i18next:
          specifier: ^12.1.0
--        version: 12.1.0(next@15.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-+        version: 12.1.0(next@15.3.1(patch_hash=9673472f3289a59e3cf64a56303c75752c2556c0d74d2a648eca3576b2695cab)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+-        version: 12.1.0(next@15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
++        version: 12.1.0(next@15.4.5(patch_hash=ec4324097eadbe8364e1a29668eeea85c2b267b7028a2be86a59a926fbd46666)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
        ping:
          specifier: ^0.4.4
          version: 0.4.4
-@@ -98,10 +103,6 @@ importers:
-       xml-js:
-         specifier: ^1.6.11
-         version: 1.6.11
--    optionalDependencies:
--      osx-temperature-sensor:
--        specifier: ^1.0.8
--        version: 1.0.8
-     devDependencies:
-       '@tailwindcss/forms':
-         specifier: ^0.5.10
-@@ -151,6 +152,10 @@ importers:
-       typescript:
-         specifier: ^5.7.3
-         version: 5.7.3
-+    optionalDependencies:
-+      osx-temperature-sensor:
-+        specifier: ^1.0.8
-+        version: 1.0.8
- 
- packages:
- 
-@@ -4901,7 +4906,7 @@ snapshots:
+@@ -5060,7 +5065,7 @@ snapshots:
  
    natural-compare@1.4.0: {}
  
--  next-i18next@12.1.0(next@15.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-+  next-i18next@12.1.0(next@15.3.1(patch_hash=9673472f3289a59e3cf64a56303c75752c2556c0d74d2a648eca3576b2695cab)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+-  next-i18next@12.1.0(next@15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
++  next-i18next@12.1.0(next@15.4.5(patch_hash=ec4324097eadbe8364e1a29668eeea85c2b267b7028a2be86a59a926fbd46666)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
      dependencies:
        '@babel/runtime': 7.26.9
        '@types/hoist-non-react-statics': 3.3.6
-@@ -4909,14 +4914,14 @@ snapshots:
+@@ -5068,14 +5073,14 @@ snapshots:
        hoist-non-react-statics: 3.3.2
        i18next: 21.10.0
        i18next-fs-backend: 1.2.0
--      next: 15.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-+      next: 15.3.1(patch_hash=9673472f3289a59e3cf64a56303c75752c2556c0d74d2a648eca3576b2695cab)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+-      next: 15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
++      next: 15.4.5(patch_hash=ec4324097eadbe8364e1a29668eeea85c2b267b7028a2be86a59a926fbd46666)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
        react: 18.3.1
        react-i18next: 11.18.6(i18next@21.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
      transitivePeerDependencies:
        - react-dom
        - react-native
  
--  next@15.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-+  next@15.3.1(patch_hash=9673472f3289a59e3cf64a56303c75752c2556c0d74d2a648eca3576b2695cab)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+-  next@15.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
++  next@15.4.5(patch_hash=ec4324097eadbe8364e1a29668eeea85c2b267b7028a2be86a59a926fbd46666)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
      dependencies:
-       '@next/env': 15.3.1
-       '@swc/counter': 0.1.3
+       '@next/env': 15.4.5
+       '@swc/helpers': 0.5.15

--- a/pkgs/by-name/ho/homepage-dashboard/update.sh
+++ b/pkgs/by-name/ho/homepage-dashboard/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=./. -i bash -p curl jq git pnpm_10 sd
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq git nodejs pnpm sd
 # shellcheck shell=bash
 set -euo pipefail
 nixpkgs="$(pwd)"


### PR DESCRIPTION
## Things done

Bumps to the latest [upstream 1.4.3 release](https://github.com/gethomepage/homepage/releases/tag/v1.4.3) using the maintainer script, which needed a quick fix along the way!

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
