### PR TITLE
nixos/mitmdump: init module

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -155,6 +155,30 @@
   "module-services-dump1090-fa-configuration": [
     "index.html#module-services-dump1090-fa-configuration"
   ],
+  "module-services-mitmdump": [
+    "index.html#module-services-mitmdump"
+  ],
+  "module-services-mitmdump-getting-started": [
+    "index.html#module-services-mitmdump-getting-started"
+  ],
+  "module-services-mitmdump-usage": [
+    "index.html#module-services-mitmdump-usage"
+  ],
+  "module-services-mitmdump-usage-https": [
+    "index.html#module-services-mitmdump-usage-https"
+  ],
+  "module-services-mitmdump-usage-anywhere": [
+    "index.html#module-services-mitmdump-usage-anywhere"
+  ],
+  "module-services-mitmdump-usage-logging": [
+    "index.html#module-services-mitmdump-usage-logging"
+  ],
+  "module-services-mitmdump-addons": [
+    "index.html#module-services-mitmdump-addons"
+  ],
+  "module-services-mitmdump-addons-logger": [
+    "index.html#module-services-mitmdump-addons-logger"
+  ],
   "preface": [
     "index.html#preface"
   ],

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -26,6 +26,8 @@
 
 - [dms-greeter](https://danklinux.com), a modern display manager greeter for DankMaterialShell that works with greetd and supports multiple Wayland compositors. Available as [services.displayManager.dms-greeter](#opt-services.displayManager.dms-greeter.enable).
 
+- [Mitmdump](https://docs.mitmproxy.org/stable/), a set of tools that provide an interactive, SSL/TLS-capable intercepting proxy for HTTP/1, HTTP/2, and WebSockets. Available as [services.mitmdump.instances](#opt-services.mitmdump.instances) which is used to create one or more instances of mitmdump as reverse proxy to debug network communication.
+
 - [dsearch](https://github.com/AvengeMedia/danksearch), a fast filesystem search service with fuzzy matching. Available as [programs.dsearch](#opt-programs.dsearch.enable).
 
 - [udp-over-tcp](https://github.com/mullvad/udp-over-tcp), a tunnel for proxying UDP traffic over a TCP stream. Available as `services.udp-over-tcp`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1255,6 +1255,7 @@
   ./services/networking/minidlna.nix
   ./services/networking/miniupnpd.nix
   ./services/networking/miredo.nix
+  ./services/networking/mitmdump.nix
   ./services/networking/mjpg-streamer.nix
   ./services/networking/mmsd.nix
   ./services/networking/modemmanager.nix

--- a/nixos/modules/services/networking/mitmdump.nix
+++ b/nixos/modules/services/networking/mitmdump.nix
@@ -170,6 +170,10 @@ in
         wantedBy = [ "multi-user.target" ];
       }
     ) cfg.instances;
+
+    services.mitmdump.addons = {
+      logger = ./mitmdump/addons/logger.py;
+    };
   };
 
   meta.maintainers = lib.maintainers.ibizaman;

--- a/nixos/modules/services/networking/mitmdump.nix
+++ b/nixos/modules/services/networking/mitmdump.nix
@@ -1,0 +1,176 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mapAttrs'
+    mkOption
+    nameValuePair
+    types
+    ;
+  inherit (types)
+    attrsOf
+    listOf
+    path
+    port
+    submodule
+    str
+    ;
+
+  cfg = config.services.mitmdump;
+
+  mitmdumpScript = pkgs.writers.writePython3Bin "mitmdump" {
+    libraries =
+      let
+        p = pkgs.python3Packages;
+      in
+      [
+        p.systemd
+        p.mitmproxy
+      ];
+    flakeIgnore = [ "E501" ];
+  } ./mitmdump/wrapper.py;
+in
+{
+  options.services.mitmdump = {
+    addons = mkOption {
+      type = attrsOf path;
+      default = [ ];
+      description = ''
+        Addons available to the be added to the mitmdump instance.
+
+        To enabled one, add it to the `enabledAddons` option.
+      '';
+    };
+
+    instances = mkOption {
+      default = { };
+      description = "Mitmdump instance.";
+      type = attrsOf (
+        submodule (
+          { name, ... }:
+          {
+            options = {
+              package = lib.mkPackageOption pkgs "mitmproxy" { };
+
+              serviceName = mkOption {
+                type = str;
+                description = ''
+                  Name of the mitmdump system service.
+                '';
+                default = "mitmdump-${name}.service";
+                readOnly = true;
+              };
+
+              listenHost = mkOption {
+                type = str;
+                default = "127.0.0.1";
+                description = ''
+                  Host the mitmdump instance will connect on.
+                '';
+              };
+
+              listenPort = mkOption {
+                type = port;
+                description = ''
+                  Port the mitmdump instance will listen on.
+
+                  The upstream port from the client's perspective.
+                '';
+              };
+
+              upstreamHost = mkOption {
+                type = str;
+                default = "http://127.0.0.1";
+                description = ''
+                  Host the mitmdump instance will connect to.
+
+                  If only an IP or domain is provided,
+                  mitmdump will default to connect using HTTPS.
+                  If this is not wanted, prefix the IP or domain with the 'http://' protocol.
+                '';
+              };
+
+              upstreamPort = mkOption {
+                type = port;
+                description = ''
+                  Port the mitmdump instance will connect to.
+
+                  The port the server is listening on.
+                '';
+              };
+
+              after = mkOption {
+                type = listOf str;
+                default = [ ];
+                description = ''
+                  Systemd services that must be started before this mitmdump proxy instance.
+
+                  You are guaranteed the mitmdump is listening on the `listenPort`
+                  when its systemd service has started.
+                '';
+              };
+
+              enabledAddons = mkOption {
+                type = listOf path;
+                default = [ ];
+                description = ''
+                  Addons to enable on this mitmdump instance.
+                '';
+                example = lib.literalExpression ''[ config.services.mitmdump.addons.logger ]'';
+              };
+
+              extraArgs = mkOption {
+                type = listOf str;
+                default = [ ];
+                description = ''
+                  Extra arguments to pass to the mitmdump instance.
+
+                  See upstream [manual](https://docs.mitmproxy.org/stable/concepts/options/#flow_detail) for all possible options.
+                '';
+                example = lib.literalExpression ''[ "--set" "verbose_pattern=/api" ]'';
+              };
+            };
+          }
+        )
+      );
+    };
+  };
+
+  config = {
+    systemd.services = mapAttrs' (
+      name: cfg':
+      nameValuePair "mitmdump-${name}" {
+        environment = {
+          "HOME" = "/var/lib/private/mitmdump-${name}";
+          "MITMDUMP_BIN" = "${cfg'.package}/bin/mitmdump";
+        };
+        serviceConfig = {
+          Type = "notify";
+          Restart = "on-failure";
+          StandardOutput = "journal";
+          StandardError = "journal";
+
+          DynamicUser = true;
+          WorkingDirectory = "/var/lib/mitmdump-${name}";
+          StateDirectory = "mitmdump-${name}";
+
+          ExecStart =
+            let
+              addons = lib.concatMapStringsSep " " (addon: "-s ${addon}") cfg'.enabledAddons;
+              extraArgs = lib.concatStringsSep " " cfg'.extraArgs;
+            in
+            "${lib.getExe mitmdumpScript} --listen_host ${cfg'.listenHost} --listen_port ${toString cfg'.listenPort} --upstream_host ${cfg'.upstreamHost} --upstream_port ${toString cfg'.upstreamPort} ${addons} ${extraArgs}";
+        };
+        requires = cfg'.after;
+        after = cfg'.after;
+        wantedBy = [ "multi-user.target" ];
+      }
+    ) cfg.instances;
+  };
+
+  meta.maintainers = lib.maintainers.ibizaman;
+}

--- a/nixos/modules/services/networking/mitmdump.nix
+++ b/nixos/modules/services/networking/mitmdump.nix
@@ -176,5 +176,6 @@ in
     };
   };
 
+  meta.doc = ./mitmdump/manual.md;
   meta.maintainers = lib.maintainers.ibizaman;
 }

--- a/nixos/modules/services/networking/mitmdump/addons/logger.py
+++ b/nixos/modules/services/networking/mitmdump/addons/logger.py
@@ -1,0 +1,48 @@
+import logging
+from collections.abc import Sequence
+from mitmproxy import ctx, http
+import re
+
+
+logger = logging.getLogger(__name__)
+
+
+class RegexLogger:
+    def __init__(self):
+        self.verbose_patterns = None
+
+    def load(self, loader):
+        loader.add_option(
+            name="verbose_pattern",
+            typespec=Sequence[str],
+            default=[],
+            help="Regex patterns for verbose logging",
+        )
+
+    def response(self, flow: http.HTTPFlow):
+        if self.verbose_patterns is None:
+            self.verbose_patterns = [re.compile(p) for p in ctx.options.verbose_pattern]
+
+        matched = any(p.search(flow.request.path) for p in self.verbose_patterns)
+        if matched:
+            logger.info(format_flow(flow))
+
+
+def format_flow(flow: http.HTTPFlow) -> str:
+    return (
+        "\n"
+        "RequestHeaders:\n"
+        f"    {format_headers(flow.request.headers.items())}\n"
+        f"RequestBody:     {flow.request.get_text()}\n"
+        f"Status:          {flow.response.data.status_code}\n"
+        "ResponseHeaders:\n"
+        f"    {format_headers(flow.response.headers.items())}\n"
+        f"ResponseBody:    {flow.response.get_text()}\n"
+    )
+
+
+def format_headers(headers) -> str:
+    return "\n    ".join(k + ": " + v for k, v in headers)
+
+
+addons = [RegexLogger()]

--- a/nixos/modules/services/networking/mitmdump/manual.md
+++ b/nixos/modules/services/networking/mitmdump/manual.md
@@ -1,0 +1,200 @@
+# Mitmdump {#module-services-mitmdump}
+
+[mitmproxy][] is a set of tools that provide an interactive, SSL/TLS-capable intercepting proxy for HTTP/1, HTTP/2, and WebSockets.
+[mitmdump][] is the command-line non-interactive version of mitmproxy.
+
+This module sets up one or multiple instances of mitmdump in [reverse proxy][] mode
+which allows to intercept network graphic and dump the HTTP requests and responses.
+It is particularly useful to debug interaction between two services.
+
+[mitmproxy]: https://docs.mitmproxy.org/stable
+[mitmdump]: https://plattner.me/mp-docs/#mitmdump
+[reverse proxy]: https://plattner.me/mp-docs/concepts-modes/#reverse-proxy
+
+Each `mitmdump` instance has its own systemd service which is only considered started
+when the mitmdump instance has started listening on the expected port.
+
+Also, addons can be enabled with the `enabledAddons` option.
+
+## Getting Started {#module-services-mitmdump-getting-started}
+
+Let's assume a server is listening on port 8000
+which responds a plain text response `test1`
+and its related systemd service is named `test1.service`.
+Sorry, creative naming is not my forte.
+
+Let's put an mitmdump instance in front of it, like so:
+
+```nix
+{
+  services.mitmdump.instances."test1" = {
+    listenPort = 8001;
+    upstreamPort = 8000;
+    after = [ "test1.service" ];
+    extraArgs = [
+      "--set"
+      "flow_detail=3"
+      "--set"
+      "content_view_lines_cutoff=2000"
+    ];
+  };
+}
+```
+
+This creates an `mitmdump-test1.service` systemd service.
+We can then use `journalctl -u mitmdump-test1.service` to see the output.
+
+If we make a `curl` request to it: `curl -v http://127.0.0.1:8001`,
+we will get the following output:
+
+```
+mitmdump-test1[971]: 127.0.0.1:40878: GET http://127.0.0.1:8000/ HTTP/1.1
+mitmdump-test1[971]:     Host: 127.0.0.1:8000
+mitmdump-test1[971]:     User-Agent: curl/8.14.1
+mitmdump-test1[971]:     Accept: */*
+mitmdump-test1[971]:  << HTTP/1.0 200 OK 5b
+mitmdump-test1[971]:     Server: BaseHTTP/0.6 Python/3.13.4
+mitmdump-test1[971]:     Date: Thu, 31 Jul 2025 20:55:16 GMT
+mitmdump-test1[971]:     Content-Type: text/plain
+mitmdump-test1[971]:     Content-Length: 5
+mitmdump-test1[971]:     test1
+```
+
+## Usage {#module-services-mitmdump-usage}
+
+Put mitmdump in front of a HTTP server listening on port 8000 on the same machine:
+
+```nix
+{
+  services.mitmdump.instances."my-instance" = {
+    listenPort = 8001;
+    upstreamHost = "http://127.0.0.1";
+    upstreamPort = 8000;
+    after = [ "server.service" ];
+  };
+}
+```
+
+`upstreamHost` has its default value here and can be left out.
+
+Put mitmdump in front of a HTTP server listening on port 8000 on another machine:
+
+```nix
+{
+  services.mitmdump.instances."my-instance" = {
+    listenPort = 8001;
+    upstreamHost = "http://otherhost";
+    upstreamPort = 8000;
+    after = [ "server.service" ];
+  };
+}
+```
+
+### Handle Upstream TLS {#module-services-mitmdump-usage-https}
+
+Replace `http` with `https` in `upstreamHost` if the server expects an HTTPS connection.
+
+### Accept Connections from Anywhere {#module-services-mitmdump-usage-anywhere}
+
+By default, `mitmdump` is configured to only listen for connections from localhost.
+Add `listenHost` to make `mitmdump` be more open:
+
+```nix
+{
+  services.mitmdump.instances."my-instance" = {
+    listenHost = "0.0.0.0";
+    listenPort = 8001;
+    upstreamHost = "http://otherhost";
+    upstreamPort = 8000;
+    after = [ "server.service" ];
+  };
+}
+```
+
+Of course this can expose the upstream service to the open internet,
+great care should be taken when doing that.
+
+### Extra Logging {#module-services-mitmdump-usage-logging}
+
+To print request and response bodies and headers, increase the logging with `extraArgs`:
+
+```nix
+{
+  services.mitmdump.instances."my-instance" = {
+    extraArgs = [
+      "--set"
+      "flow_detail=3"
+      "--set"
+      "content_view_lines_cutoff=2000"
+    ];
+  };
+}
+```
+
+The default `flow_details` is 1. See the [mitmdump manual][] for more explanations on the option.
+
+[manual]: (https://docs.mitmproxy.org/stable/concepts/options/#flow_detail)
+
+This will change the verbosity for all requests and responses.
+If you need more fine grained logging, configure instead the [Logger Addon][].
+
+[Logger Addon]: #module-services-mitmdump-addons-logger
+
+## Addons {#module-services-mitmdump-addons}
+
+All provided addons can be found under the `services.mitmproxy.addons` option.
+
+To enable one for an instance, add it to its `enabledAddons` option. For example:
+
+```nix
+{
+  services.mitmdump.instances."my-instance" = {
+    enabledAddons = [ config.services.mitmdump.addons.logger ];
+  };
+}
+```
+
+### Fine Grained Logger {#module-services-mitmdump-addons-logger}
+
+The Fine Grained Logger addon is found under `services.mitmproxy.addons.logger`.
+Enabling this addon will add the `mitmdump` option `verbose_pattern` which takes a regex and if it matches,
+prints the request and response headers and body.
+If it does not match, it will just print the response status.
+
+For example, with the `extraArgs`:
+
+```nix
+{
+  services.mitmdump.instances."test1".extraArgs = [
+    "--set"
+    "verbose_pattern=/verbose"
+  ];
+}
+```
+
+A `GET` request to `/notverbose` will print something similar to:
+
+```
+mitmdump[972]: 127.0.0.1:53586: GET http://127.0.0.1:8000/notverbose HTTP/1.1
+mitmdump[972]:      << HTTP/1.0 200 OK 16b
+```
+
+While a `GET` request to `/verbose` will print something similar to:
+
+```
+mitmdump[972]: [22:42:58.840]
+mitmdump[972]: RequestHeaders:
+mitmdump[972]:     Host: 127.0.0.1:8000
+mitmdump[972]:     User-Agent: curl/8.14.1
+mitmdump[972]:     Accept: */*
+mitmdump[972]: RequestBody:
+mitmdump[972]: Status:          200
+mitmdump[972]: ResponseHeaders:
+mitmdump[972]:     Server: BaseHTTP/0.6 Python/3.13.4
+mitmdump[972]:     Date: Sun, 03 Aug 2025 22:42:58 GMT
+mitmdump[972]:     Content-Type: text/plain
+mitmdump[972]:     Content-Length: 13
+mitmdump[972]: ResponseBody:    test2/verbose
+mitmdump[972]: 127.0.0.1:53602: GET http://127.0.0.1:8000/verbose HTTP/1.1
+mitmdump[972]:      << HTTP/1.0 200 OK 13b
+```

--- a/nixos/modules/services/networking/mitmdump/wrapper.py
+++ b/nixos/modules/services/networking/mitmdump/wrapper.py
@@ -1,0 +1,63 @@
+from systemd.daemon import notify
+import argparse
+import logging
+import os
+import subprocess
+import socket
+import sys
+import time
+
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+
+def wait_for_port(host, port, timeout=10):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.5):
+                return True
+        except Exception:
+            time.sleep(0.1)
+    return False
+
+
+def flatten(xss):
+    return [x for xs in xss for x in xs]
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--listen_host", default="127.0.0.1", help="Host mitmdump will listen on")
+parser.add_argument("--listen_port", required=True, help="Port mitmdump will listen on")
+parser.add_argument("--upstream_host", default="http://127.0.0.1", help="Host mitmdump will connect to for upstream. Example: http://127.0.0.1 or https://otherhost")
+parser.add_argument("--upstream_port", required=True, help="Port mitmdump will connect to for upstream")
+args, rest = parser.parse_known_args()
+
+MITMDUMP_BIN = os.environ.get("MITMDUMP_BIN")
+if MITMDUMP_BIN is None:
+    raise Exception("MITMDUMP_BIN env var must be set to the path of the mitmdump binary")
+
+logging.info(f"Waiting for upstream address '{args.upstream_host}:{args.upstream_port}' to be up.")
+wait_for_port(args.upstream_host, args.upstream_port, timeout=10)
+logging.info(f"Upstream address '{args.upstream_host}:{args.upstream_port}' is up.")
+
+proc = subprocess.Popen(
+    [
+        MITMDUMP_BIN,
+        "--listen-host", args.listen_host,
+        "-p", args.listen_port,
+        "--mode", f"reverse:{args.upstream_host}:{args.upstream_port}",
+    ] + rest,
+    stdout=sys.stdout,
+    stderr=sys.stderr,
+)
+
+logging.info(f"Waiting for mitmdump instance to start on port {args.listen_port}.")
+if wait_for_port("127.0.0.1", args.listen_port, timeout=10):
+    logging.info(f"Mitmdump is started on port {args.listen_port}.")
+    notify("READY=1")
+else:
+    proc.terminate()
+    exit(1)
+
+proc.wait()

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -960,6 +960,7 @@ in
   miriway = runTest ./miriway.nix;
   misc = runTest ./misc.nix;
   misskey = runTest ./misskey.nix;
+  mitmdump = runTest ./mitmdump.nix;
   mitmproxy = runTest ./mitmproxy.nix;
   mjolnir = runTest ./matrix/mjolnir.nix;
   mobilizon = runTest ./mobilizon.nix;

--- a/nixos/tests/mitmdump.nix
+++ b/nixos/tests/mitmdump.nix
@@ -1,0 +1,142 @@
+{ pkgs, lib, ... }:
+let
+  serve =
+    port: text:
+    lib.getExe (
+      pkgs.writers.writePython3Bin "serve"
+        {
+          libraries = [ pkgs.python3Packages.systemd ];
+        }
+        (
+          let
+            content = pkgs.writeText "content" text;
+          in
+          ''
+            from http.server import BaseHTTPRequestHandler, HTTPServer
+            from systemd.daemon import notify
+
+            with open("${content}", "rb") as f:
+                content = f.read()
+
+
+            class HardcodedHandler(BaseHTTPRequestHandler):
+                def do_GET(self):
+                    reponse = content + self.path.encode('utf-8')
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/plain")
+                    self.send_header("Content-Length", str(len(reponse)))
+                    self.end_headers()
+                    print("answering to GET request")
+                    self.wfile.write(reponse)
+
+                def log_message(self, format, *args):
+                    pass  # optional: suppress logging
+
+
+            if __name__ == "__main__":
+                notify('STATUS=Starting up...')
+                server_address = ('127.0.0.1', ${toString port})
+                httpd = HTTPServer(server_address, HardcodedHandler)
+                print("Serving hardcoded page on http://127.0.0.1:${toString port}")
+                notify('READY=1')
+                httpd.serve_forever()
+          ''
+        )
+    );
+in
+{
+  name = "mitmdump-default";
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      systemd.services.test1 = {
+        serviceConfig.ExecStart = serve 8000 "test1";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "notify";
+          StandardOutput = "journal";
+          StandardError = "journal";
+        };
+      };
+
+      systemd.services.test2 = {
+        serviceConfig.ExecStart = serve 8002 "test2";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "notify";
+          StandardOutput = "journal";
+          StandardError = "journal";
+        };
+      };
+
+      services.mitmdump.instances."test1" = {
+        listenPort = 8001;
+        upstreamPort = 8000;
+        after = [ "test1.service" ];
+      };
+
+      services.mitmdump.instances."test2" = {
+        listenPort = 8003;
+        upstreamPort = 8002;
+        after = [ "test2.service" ];
+        enabledAddons = [ config.services.mitmdump.addons.logger ];
+        extraArgs = [
+          "--set"
+          "verbose_pattern=/verbose"
+        ];
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      machine.wait_for_unit("test1.service")
+      machine.wait_for_unit("test2.service")
+      machine.wait_for_unit("mitmdump-test1.service")
+      machine.wait_for_unit("mitmdump-test2.service")
+
+      resp = machine.succeed("curl http://127.0.0.1:8000")
+      print(resp)
+      if resp != "test1/":
+          raise Exception("wanted 'test1'")
+
+      resp = machine.succeed("curl -v http://127.0.0.1:8001")
+      print(resp)
+      if resp != "test1/":
+          raise Exception("wanted 'test1'")
+
+      resp = machine.succeed("curl http://127.0.0.1:8002")
+      print(resp)
+      if resp != "test2/":
+          raise Exception("wanted 'test2'")
+
+      resp = machine.succeed("curl http://127.0.0.1:8003/notverbose")
+      print(resp)
+      if resp != "test2/notverbose":
+          raise Exception("wanted 'test2/notverbose'")
+
+      resp = machine.succeed("curl http://127.0.0.1:8003/verbose")
+      print(resp)
+      if resp != "test2/verbose":
+          raise Exception("wanted 'test2/verbose'")
+
+      dump = machine.succeed("journalctl -b -u mitmdump-test1.service")
+      print(dump)
+      if "HTTP/1.0 200 OK" not in dump:
+          raise Exception("expected to see HTTP/1.0 200 OK")
+      if "test1" not in dump:
+          raise Exception("expected to see test1")
+
+      dump = machine.succeed("journalctl -b -u mitmdump-test2.service")
+      print(dump)
+      if "HTTP/1.0 200 OK" not in dump:
+          raise Exception("expected to see HTTP/1.0 200 OK")
+      if "test2/notverbose" in dump:
+          raise Exception("expected not to see test2/notverbose")
+      if "test2/verbose" not in dump:
+          raise Exception("expected to see test2/verbose")
+    '';
+}


### PR DESCRIPTION
Adds network introspection capabilities to NixOS. This module can create one or more instances of mitmdump that act as a reverse proxy. It is placed between a client and a server and logs every requests and responses.

It also includes a fine-grained logging addon which can log only those requests whose path match a user-given regex. This is particularly useful to filter down noisy logs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
