### PR TITLE
 vscode-extensions.msjsdiag.vscode-react-native: init at 1.13.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9630,6 +9630,11 @@
     githubId = 76840985;
     name = "GueLaKais";
   };
+  guhou = {
+    github = "guhou";
+    githubId = 6924529;
+    name = "Angus Houston";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3573,6 +3573,8 @@ let
         };
       };
 
+      msjsdiag.vscode-react-native = callPackage ./msjsdiag.vscode-react-native { };
+
       mskelton.one-dark-theme = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "one-dark-theme";

--- a/pkgs/applications/editors/vscode/extensions/msjsdiag.vscode-react-native/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/msjsdiag.vscode-react-native/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    publisher = "msjsdiag";
+    name = "vscode-react-native";
+    version = "1.13.0";
+    hash = "sha256-zryzoO9sb1+Kszwup5EhnN/YDmAPz7TOQW9I/K28Fmg=";
+  };
+
+  meta = {
+    changelog = "https://github.com/microsoft/vscode-react-native/releases";
+    description = "Development environment for React Native projects for Visual Studio Code";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=msjsdiag.vscode-react-native";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.guhou ];
+  };
+}


### PR DESCRIPTION
Add new extension for Visual Studio Code: React Native Tools
https://marketplace.visualstudio.com/items?itemName=msjsdiag.vscode-react-native

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
