### PR TITLE
honeyfetch: init at 1.5.0

### DIFF
--- a/pkgs/by-name/ho/honeyfetch/package.nix
+++ b/pkgs/by-name/ho/honeyfetch/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  libdrm,
+  fetchFromGitLab,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "honeyfetch";
+  version = "1.5.0";
+
+  src = fetchFromGitLab {
+    owner = "ahoneybun";
+    repo = "honeyfetch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lFp7L3tcqZ1jAL7V7tfUJDPKO2WCvMekUx+p12fNlcM=";
+  };
+
+  cargoHash = "sha256-u+OF4ali7GoHktY8jihgqUQ+4kFuKQNbiaRUdOJrQfA=";
+
+  buildInputs = [ libdrm ];
+
+  meta = {
+    description = "Classy neofetch but in Rust";
+    homepage = "https://gitlab.com/ahoneybun/honeyfetch";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ ahoneybun ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
A fetch application (for system information) in Rust and I am the maintainer/developer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
