### PR TITLE
discourse: 3.4.4 -> 3.4.6

### DIFF
--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -733,14 +733,14 @@ in
       after = [
         "redis-discourse.service"
         "postgresql.target"
-        "discourse-postgresql.target"
+        "discourse-postgresql.service"
       ];
       bindsTo = [
         "redis-discourse.service"
       ]
       ++ lib.optionals (cfg.database.host == null) [
         "postgresql.target"
-        "discourse-postgresql.target"
+        "discourse-postgresql.service"
       ];
       path = cfg.package.runtimeDeps ++ [
         postgresqlPackage

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -422,7 +422,14 @@ in
   dex-oidc = runTest ./dex-oidc.nix;
   dhparams = runTest ./dhparams.nix;
   disable-installer-tools = runTest ./disable-installer-tools.nix;
-  discourse = runTest ./discourse.nix;
+  discourse = runTest {
+    imports = [ ./discourse.nix ];
+    _module.args.package = pkgs.discourse;
+  };
+  discourseAllPlugins = runTest {
+    imports = [ ./discourse.nix ];
+    _module.args.package = pkgs.discourseAllPlugins;
+  };
   dnscrypt-proxy2 = runTestOn [ "x86_64-linux" ] ./dnscrypt-proxy2.nix;
   dnsdist = import ./dnsdist.nix { inherit pkgs runTest; };
   doas = runTest ./doas.nix;

--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -4,9 +4,9 @@
 #  3. replying to that message via email.
 
 {
+  lib,
   package,
   pkgs,
-  lib,
   ...
 }:
 let
@@ -25,8 +25,6 @@ in
 {
   name = "discourse";
   meta.maintainers = with lib.maintainers; [ talyz ];
-
-  _module.args.package = lib.mkDefault pkgs.discourse;
 
   nodes.discourse =
     { nodes, ... }:
@@ -62,7 +60,7 @@ in
 
       services.discourse = {
         enable = true;
-        inherit admin;
+        inherit admin package;
         hostname = discourseDomain;
         sslCertificate = "${certs.${discourseDomain}.cert}";
         sslCertificateKey = "${certs.${discourseDomain}.key}";

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -8,9 +8,9 @@
   fetchFromGitHub,
   bundlerEnv,
   callPackage,
+  nixosTests,
 
   ruby_3_3,
-  replace,
   gzip,
   gnutar,
   git,
@@ -43,7 +43,7 @@
   uglify-js,
 
   plugins ? [ ],
-}@args:
+}:
 
 let
   version = "3.4.6";
@@ -433,13 +433,13 @@ let
       enabledPlugins = plugins;
       plugins = callPackage ./plugins/all-plugins.nix { inherit mkDiscoursePlugin; };
       ruby = rubyEnv.wrappedRuby;
-      tests = import ../../../../nixos/tests/discourse.nix {
-        inherit (stdenv) system;
-        inherit pkgs;
-        package = pkgs.discourse.override args;
+      tests = {
+        inherit (nixosTests)
+          discourse
+          discourseAllPlugins
+          ;
       };
     };
-
     meta = with lib; {
       homepage = "https://www.discourse.org/";
       platforms = platforms.linux;

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -46,13 +46,13 @@
 }@args:
 
 let
-  version = "3.4.4";
+  version = "3.4.6";
 
   src = fetchFromGitHub {
     owner = "discourse";
     repo = "discourse";
     rev = "v${version}";
-    sha256 = "sha256-rA42fOhSJVrNPcFSB2+On7JVeZch8t2yNo+36UK+QcA=";
+    sha256 = "sha256-HS13jNhSrPo7CHAk2zZEKSt54lBTw1PdMCIJUO0rjLc=";
   };
 
   ruby = ruby_3_3;

--- a/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
+++ b/pkgs/servers/web-apps/discourse/rubyEnv/Gemfile.lock
@@ -745,4 +745,4 @@ DEPENDENCIES
   zeitwerk
 
 BUNDLED WITH
-   2.6.6
+   2.6.9


### PR DESCRIPTION
https://meta.discourse.org/t/3-4-5-security-fixes-release/369347
https://meta.discourse.org/t/3-4-6-security-fix-release/370631

Fixes: CVE-2025-48877, CVE-2025-48062, CVE-2025-48053, CVE-2025-49845


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (`discourseAllPlugins`)
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
