### PR TITLE
lightdm-slick-greeter: 2.2.1 -> 2.2.2

### DIFF
--- a/pkgs/by-name/li/lightdm-slick-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-slick-greeter/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lightdm-slick-greeter";
-  version = "2.2.1";
+  version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "slick-greeter";
     rev = version;
-    hash = "sha256-AErY8Gy1AkYY/vpXoSE8zhyJd/nboMw+9BO3j6N7CNc=";
+    hash = "sha256-32H2Q/JdT5v0xrdsZfSJobJ4Dxx63LPgbiB9OKIyc1U=";
   };
 
   nativeBuildInputs = [
@@ -68,10 +68,6 @@ stdenv.mkDerivation rec {
     # We prefer stable path here.
     substituteInPlace data/x.dm.slick-greeter.gschema.xml \
       --replace-fail "/usr/share/onboard" "/run/current-system/sw/share/onboard"
-
-    # This image is really just a fallback.
-    substituteInPlace src/user-prompt-box.vala \
-      --replace-fail "/usr/share/cinnamon/faces/" "/run/current-system/sw/share/cinnamon/faces/"
 
     patchShebangs files/usr/bin/*
   '';


### PR DESCRIPTION
https://github.com/linuxmint/slick-greeter/compare/2.2.1...2.2.2



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

