### PR TITLE
Revert "haskell.compiler.ghc981: build stage 2 compiler for “native c…

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -132,10 +132,12 @@
     -- no way to set this via the command line
     finalStage :: Stage
     finalStage = ${
-      # Always build the stage 2 compiler if possible.
-      # TODO(@sternensemann): unify condition with make-built GHCs
-      if stdenv.hostPlatform.canExecute stdenv.targetPlatform then
-        "Stage2" # native compiler or “native” cross e.g. pkgsStatic
+      # N. B. hadrian ignores this setting if it doesn't agree it's possible,
+      # i.e. when its cross-compiling setting is true. So while we could, in theory,
+      # build Stage2 if hostPlatform.canExecute targetPlatform, hadrian won't play
+      # ball (with make, Stage2 was built if hostPlatform.system == targetPlatform.system).
+      if stdenv.hostPlatform == stdenv.targetPlatform then
+        "Stage2" # native compiler
       else
         "Stage1" # cross compiler
     }


### PR DESCRIPTION
…ross”"

This reverts commit 1dc7345389a2baced186589cab9824cec3dc0281.

Reason for revert: The change doesn't work as in intended, i.e. hadrian refuses to build a Stage2 compiler as requested in the “native cross” case. Thus the canExecute condition only served to confuse

cc @TeofilC 

I noticed this after running:

```ShellSession
> nix-build -A haskell.packages.native-bignum.ghc9102.ghc
/nix/store/lmfqwpkrsvdprqsqc4wl89m20rqs0fs5-ghc-native-bignum-9.10.2
> ./result/bin/ghc --info | grep Stage      # native, we expect Stage2
 ,("Stage","2")
> nix-build -A pkgsStatic.haskell.packages.native-bignum.ghc9102.ghc
/nix/store/49hznsgmj4dc9dmx4g19qjja7w985v46-x86_64-unknown-linux-musl-ghc-native-bignum-9.10.2
> ./result/bin/x86_64-unknown-linux-musl-ghc --info | grep Stage # “native cross”, we would like Stage2 also
 ,("Stage","1")
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
