### PR TITLE
pokemon-colorscripts: init at 0-unstable-2024-10-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26636,6 +26636,11 @@
     githubId = 5837359;
     name = "Adrian Pistol";
   };
+  viitorags = {
+    name = "Vitor Gabriel";
+    github = "viitorags";
+    githubId = 152658654;
+  };
   vikanezrimaya = {
     email = "vika@fireburn.ru";
     github = "vikanezrimaya";

--- a/pkgs/by-name/po/pokemon-colorscripts/package.nix
+++ b/pkgs/by-name/po/pokemon-colorscripts/package.nix
@@ -1,0 +1,44 @@
+{
+  stdenv,
+  fetchFromGitLab,
+  lib,
+  python3,
+}:
+
+stdenv.mkDerivation {
+  pname = "pokemon-colorscripts";
+  version = "0-unstable-2024-10-19";
+
+  src = fetchFromGitLab {
+    owner = "phoneybadger";
+    repo = "pokemon-colorscripts";
+    rev = "5802ff67520be2ff6117a0abc78a08501f6252ad";
+    hash = "sha256-gKVmpHKt7S2XhSxLDzbIHTjJMoiIk69Fch202FZffqU=";
+  };
+
+  buildInputs = [
+    python3
+  ];
+
+  postPatch = ''
+    patchShebangs --build ./install.sh
+    substituteInPlace install.sh --replace-fail "/usr/local" "$out"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    ./install.sh
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Scripts for Pokémon color manipulation";
+    homepage = "https://gitlab.com/phoneybadger/pokemon-colorscripts";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.viitorags ];
+    mainProgram = "pokemon-colorscripts";
+  };
+}


### PR DESCRIPTION
**This PR adds the new package `pokemon-colorscripts`.**

It's a collection of scripts that display Pokémon sprites with colors in the terminal.  
**Homepage:** https://gitlab.com/phoneybadger/pokemon-colorscripts

---

### Things done

- [x] Built on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`

- [x] Tested, as applicable:
  - [ ] NixOS test(s)
  - [ ] package tests  
    *(or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test))*
  - [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [ ] Made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package)
  - [ ] Tested compilation of all packages that depend on this change using  
    ```bash
    nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
    ```  
    *(Note: all changes have to be committed. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage))*

---

### Nixpkgs 25.11 Release Notes  
*(or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) release notes)*

- [ ] **(Package updates)** Added a release notes entry if the change is major or breaking  
- [ ] **(Module updates)** Added a release notes entry if the change is significant  
- [ ] **(Module addition)** Added a release notes entry if adding a new NixOS module

---

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
