### PR TITLE
payloadsallthethings: 3.0 -> 4.2 (2025.1), render using mkdocs

### DIFF
--- a/pkgs/by-name/pa/payloadsallthethings/mkdocs.patch
+++ b/pkgs/by-name/pa/payloadsallthethings/mkdocs.patch
@@ -1,0 +1,21 @@
+diff --git a/mkdocs.yml b/mkdocs.yml
+index 1c4cd92..9af93f0 100644
+--- a/mkdocs.yml
++++ b/mkdocs.yml
+@@ -59,14 +59,9 @@ markdown_extensions:
+       anchor_linenums: true
+   - pymdownx.tasklist:
+       custom_checkbox: true
+-  - pymdownx.emoji:
+-      emoji_index: !!python/name:material.extensions.emoji.twemoji
+-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+   # - mdx_truly_sane_lists:
+   #     nested_indent: 2
+   #     truly_sane: True
+- 
++
+ plugins:
+   - search
+-  - git-revision-date-localized
+-  - social
+\ No newline at end of file


### PR DESCRIPTION
Hey @shard77.  I was thinking: Maybe we should render the files directly into HTML using MkDocs.
That way, they can be served directly by a web server, or accessed locally using something like `python2.7 -m SimpleHttpServer`, `python3 -m http.server`, `php -S localhost:8080`, or any other local webserver.

Also I updated to the latest version (4.2 aka. 2025.1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
