### PR TITLE
haskell.packages.ghc{94,96,98}.ghc-lib-parser: fix eval

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -59,6 +59,9 @@ self: super: {
   # Becomes a core package in GHC >= 9.10
   os-string = doDistribute self.os-string_2_0_7;
 
+  # Becomes a core package in GHC >= 9.10, no release compatible with GHC < 9.10 is available
+  ghc-internal = null;
+
   # only broken for >= 9.6
   calligraphy = doDistribute (unmarkBroken super.calligraphy);
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -196,6 +196,9 @@ in
 
   # A given major version of ghc-exactprint only supports one version of GHC.
   ghc-exactprint = addBuildDepend self.extra super.ghc-exactprint_1_7_1_0;
+
+  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_10_2_20250515;
+  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_10_0_0;
 }
 # super.ghc is required to break infinite recursion as Nix is strict in the attrNames
 //

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -67,6 +67,9 @@ in
   # Becomes a core package in GHC >= 9.10
   os-string = doDistribute self.os-string_2_0_7;
 
+  # Becomes a core package in GHC >= 9.10, no release compatible with GHC < 9.10 is available
+  ghc-internal = null;
+
   # Needs base-orphans for GHC < 9.8 / base < 4.19
   some = addBuildDepend self.base-orphans super.some;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -100,14 +100,6 @@ in
   #   A factor of 100 is insufficient, 200 seems seems to work.
   hip = appendConfigureFlag "--ghc-options=-fsimpl-tick-factor=200" super.hip;
 
-  # 2025-04-21: "flavor" for GHC 9.8.5 is missing a fix introduced for 9.8.4. See:
-  # https://github.com/digital-asset/ghc-lib/pull/571#discussion_r2052684630
-  ghc-lib-parser = warnAfterVersion "9.8.5.20250214" (
-    overrideCabal {
-      postPatch = ''
-        substituteInPlace compiler/cbits/genSym.c \
-          --replace-fail "HsWord64 u = atomic_inc64" "HsWord64 u = atomic_inc"
-      '';
-    } super.ghc-lib-parser
-  );
+  ghc-lib-parser = doDistribute self.ghc-lib-parser_9_10_2_20250515;
+  ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_10_0_0;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -67,6 +67,9 @@ in
   # Becomes a core package in GHC >= 9.10
   os-string = doDistribute self.os-string_2_0_7;
 
+  # Becomes a core package in GHC >= 9.10, no release compatible with GHC < 9.10 is available
+  ghc-internal = null;
+
   #
   # Version upgrades
   #

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -70,10 +70,10 @@ extra-packages:
   - ghc-lib == 9.10.*                   # 2024-12-30: preserve for GHC 9.10/ghc-tags 1.9
   - ghc-lib-parser == 9.2.*             # 2022-02-17: preserve for GHC 8.10, 9.0
   - ghc-lib-parser == 9.6.*             # 2024-05-19: preserve for GHC 9.2, 9.4
-  - ghc-lib-parser == 9.10.*            # 2024-12-26: preserve for GHC 9.10
+  - ghc-lib-parser == 9.10.*            # 2024-12-26: preserve for GHC 9.6, 9.8, 9.10
   - ghc-lib-parser-ex == 9.2.*          # 2022-07-13: preserve for GHC 8.10, 9.0
   - ghc-lib-parser-ex == 9.6.*          # 2024-05-19: preserve for GHC 9.2, 9.4
-  - ghc-lib-parser-ex == 9.10.*         # 2024-12-26: preserve for 9.10 HLS
+  - ghc-lib-parser-ex == 9.10.*         # 2024-12-26: preserve for GHC 9.6, 9.8, 9.10
   - ghc-source-gen < 0.4.6.0            # 2024-12-31: support GHC < 9.0
   - ghc-tags == 1.5.*                   # 2023-02-18: preserve for ghc-lib == 9.2.*
   - ghc-tags == 1.7.*                   # 2023-02-18: preserve for ghc-lib == 9.6.*


### PR DESCRIPTION
Currently, Eval is broken on haskell-updates. This fixes it, but I'm not sure whether it's the right approach.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
