### PR TITLE
linuxPackages.nvidiaPackages.beta: 575.51.02 -> 580.65.06

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -90,12 +90,12 @@ rec {
   });
 
   beta = selectHighestVersion latest (generic {
-    version = "575.51.02";
-    sha256_64bit = "sha256-XZ0N8ISmoAC8p28DrGHk/YN1rJsInJ2dZNL8O+Tuaa0=";
-    sha256_aarch64 = "sha256-NNeQU9sPfH1sq3d5RUq1MWT6+7mTo1SpVfzabYSVMVI=";
-    openSha256 = "sha256-NQg+QDm9Gt+5bapbUO96UFsPnz1hG1dtEwT/g/vKHkw=";
-    settingsSha256 = "sha256-6n9mVkEL39wJj5FB1HBml7TTJhNAhS/j5hqpNGFQE4w=";
-    persistencedSha256 = "sha256-dgmco+clEIY8bedxHC4wp+fH5JavTzyI1BI8BxoeJJI=";
+    version = "580.65.06";
+    sha256_64bit = "sha256-BLEIZ69YXnZc+/3POe1fS9ESN1vrqwFy6qGHxqpQJP8=";
+    sha256_aarch64 = "sha256-4CrNwNINSlQapQJr/dsbm0/GvGSuOwT/nLnIknAM+cQ=";
+    openSha256 = "sha256-BKe6LQ1ZSrHUOSoV6UCksUE0+TIa0WcCHZv4lagfIgA=";
+    settingsSha256 = "sha256-9PWmj9qG/Ms8Ol5vLQD3Dlhuw4iaFtVHNC0hSyMCU24=";
+    persistencedSha256 = "sha256-ETRfj2/kPbKYX1NzE0dGr/ulMuzbICIpceXdCRDkAxA=";
   });
 
   # Vulkan developer beta driver


### PR DESCRIPTION
- Fixed a bug that could cause Vulkan applications to hang when destroying swapchains after a lost device event.
- Fixed a bug that could allow atomic commit and other DRM operations to return success status despite having failed due to handling an interrupt: https://github.com/NVIDIA/open-gpu-kernel-modules/issues/832
- Fixed a bug that could cause GTK 4 applications to crash when using the Vulkan backend on Wayland.
- Fixed a bug that could intermittently cause llama.cpp to crash on exit when using the Vulkan backend: https://github.com/ggml-org/llama.cpp/issues/10528
- Added support for the fifo-v1 Wayland protocol on Vulkan.
- Updated GPU clock value reporting in nvidia-settings, NVML, and nvidia-smi to show clocks before thermal and idle slowdowns for better consistency with the equivalent functionality on Windows.
- Fixed compatibility with Bigscreen Beyond Head Mounted Displays.
- Fixed a bug that could result in a black screen when setting specific modes on HDMI displays.
- Fixed a bug that caused blank or frozen screens under the following conditions: nvidia-drm is loaded with the modeset=1 and fbdev=1 parameters, using a Maxwell or Pascal series GPU, and more than one display device of differing resolutions are connected.
- Fixed a bug that caused nvidia-suspend.service to fail when available system memory is low.
- Enabled RMIntrLockingMode by default. This feature can help reduce stutter especially when using virtual reality. This feature was originally introduced in the r570 series. It can be disabled by loading nvidia.ko with the `NVreg_RegistryDwords=RMIntrLockingMode=0` kernel module parameter.
- Implemented another feature that can reduce time spent in the interrupt top half for low latency display interrupts by deferring the work until later. This feature is experimental and disabled by default. This feature can be enabled by loading nvidia.ko with the `NVreg_RegistryDwords=RmEnableAggressiveVblank=1` kernel module parameter.
- Fixed a bug that could cause blank rendering on some single-buffered GLX applications when running on Xwayland.
- Fixed a bug that could cause a kernel use-after-free on pre-Turing GPUs.
- Fixed a bug that could cause OpenGL applications and compositors to stall when using NVIDIA as a PRIME Display Offload sink ("Reverse PRIME"), potentially resulting in a black screen.
- Fixed a bug that led to increasing memory usage in X11 OpenGL and Vulkan applications after suspend/resume cycles.
- Fixed a bug that could cause 32-bit x86 applications running on recent builds of glibc to crash on dlopen().

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
