### PR TITLE
internalallthethings: init at 0-unstable-2025-08-03

### DIFF
--- a/pkgs/by-name/in/internalallthethings/mkdocs.patch
+++ b/pkgs/by-name/in/internalallthethings/mkdocs.patch
@@ -1,0 +1,17 @@
+diff --git a/mkdocs.yml b/mkdocs.yml
+index 2f7f387..7ddfcf2 100644
+--- a/mkdocs.yml
++++ b/mkdocs.yml
+@@ -53,11 +53,6 @@ markdown_extensions:
+   - pymdownx.inlinehilite
+   - pymdownx.snippets
+   - attr_list
+-  - pymdownx.emoji:
+-      emoji_index: !!python/name:material.extensions.emoji.twemoji
+-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+ 
+ plugins:
+   - search
+-  - git-revision-date-localized
+-  - social
+\ No newline at end of file

--- a/pkgs/by-name/in/internalallthethings/package.nix
+++ b/pkgs/by-name/in/internalallthethings/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  python3Packages,
+}:
+let
+  inherit (python3Packages) mkdocs mkdocs-material;
+in
+stdenvNoCC.mkDerivation {
+  pname = "internalallthethings";
+  version = "0-unstable-2025-11-27";
+
+  src = fetchFromGitHub {
+    owner = "swisskyrepo";
+    repo = "InternalAllTheThings";
+    rev = "9a97b9d16e5f9834b4ef2276b6cd1b98a0748b6e";
+    hash = "sha256-NaQeRmO1JtKYZyTAhKXovDi7pZ9Zbu7Yi4iHORCU67A=";
+  };
+
+  patches = [ ./mkdocs.patch ];
+
+  nativeBuildInputs = [
+    mkdocs
+    mkdocs-material
+  ];
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  buildPhase = ''
+    mkdocs build
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $doc/share/internalallthethings
+    cp -r site/* $doc/share/internalallthethings
+
+    mkdir -p $out/share/internalallthethings
+    rm -r mkdocs.yml site
+    cp -r * $out/share/internalallthethings
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/swisskyrepo/InternalAllTheThings";
+    description = "Active Directory and Internal Pentest Cheatsheets";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = mkdocs.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}


### PR DESCRIPTION
similar to #431002

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
