### PR TITLE
[Backport release-25.05] cudaPackages.{nsight_compute,nsight_systems}: fixups from 430797

### DIFF
--- a/pkgs/development/cuda-modules/_cuda/fixups/nsight_compute.nix
+++ b/pkgs/development/cuda-modules/_cuda/fixups/nsight_compute.nix
@@ -27,8 +27,7 @@ let
   inherit (qt) wrapQtAppsHook qtwebview;
   archDir =
     {
-      aarch64-linux =
-        "linux-" + (if flags.isJetsonBuild then "v4l_l4t" else "linux-desktop") + "-t210-a64";
+      aarch64-linux = "linux-" + (if flags.isJetsonBuild then "v4l_l4t" else "desktop") + "-t210-a64";
       x86_64-linux = "linux-desktop-glibc_2_11_3-x64";
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -44,7 +43,7 @@ in
       (qt6.qtwebengine or qt6.full)
       rdma-core
     ]
-    ++ lib.optionals (cudaMajorMinorVersion == "12.0" && flags.isJetsonBuild) [
+    ++ lib.optionals (cudaMajorMinorVersion == "12.0" && stdenv.hostPlatform.isAarch64) [
       libjpeg8
     ]
     ++ lib.optionals (cudaAtLeast "12.1" && cudaOlder "12.4") [

--- a/pkgs/development/cuda-modules/_cuda/fixups/nsight_compute.nix
+++ b/pkgs/development/cuda-modules/_cuda/fixups/nsight_compute.nix
@@ -4,8 +4,10 @@
   cudaOlder,
   e2fsprogs,
   elfutils,
+  flags,
   gst_all_1,
   lib,
+  libjpeg8,
   qt5 ? null,
   qt6 ? null,
   rdma-core,
@@ -25,7 +27,8 @@ let
   inherit (qt) wrapQtAppsHook qtwebview;
   archDir =
     {
-      aarch64-linux = "linux-desktop-t210-a64";
+      aarch64-linux =
+        "linux-" + (if flags.isJetsonBuild then "v4l_l4t" else "linux-desktop") + "-t210-a64";
       x86_64-linux = "linux-desktop-glibc_2_11_3-x64";
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -40,6 +43,9 @@ in
       qtwebview
       (qt6.qtwebengine or qt6.full)
       rdma-core
+    ]
+    ++ lib.optionals (cudaMajorMinorVersion == "12.0" && flags.isJetsonBuild) [
+      libjpeg8
     ]
     ++ lib.optionals (cudaAtLeast "12.1" && cudaOlder "12.4") [
       gst_all_1.gstreamer
@@ -63,13 +69,24 @@ in
 
     rm -rf host/${archDir}/Mesa/
   '';
-  postInstall = prevAttrs.postInstall or "" + ''
-    moveToOutput 'ncu' "''${!outputBin}/bin"
-    moveToOutput 'ncu-ui' "''${!outputBin}/bin"
-    moveToOutput 'host/${archDir}' "''${!outputBin}/bin"
-    moveToOutput 'target/${archDir}' "''${!outputBin}/bin"
-    wrapQtApp "''${!outputBin}/bin/host/${archDir}/ncu-ui.bin"
-  '';
+  postInstall =
+    prevAttrs.postInstall or ""
+    + ''
+      moveToOutput 'ncu' "''${!outputBin}/bin"
+      moveToOutput 'ncu-ui' "''${!outputBin}/bin"
+      moveToOutput 'host/${archDir}' "''${!outputBin}/bin"
+      moveToOutput 'target/${archDir}' "''${!outputBin}/bin"
+      wrapQtApp "''${!outputBin}/bin/host/${archDir}/ncu-ui.bin"
+    ''
+    # NOTE(@connorbaker): No idea what this platform is or how to patchelf for it.
+    + lib.optionalString (flags.isJetsonBuild && cudaAtLeast "11.8" && cudaOlder "12.9") ''
+      nixLog "Removing QNX 700 target directory for Jetson builds"
+      rm -rfv "''${!outputBin}/target/qnx-700-t210-a64"
+    ''
+    + lib.optionalString (flags.isJetsonBuild && cudaAtLeast "12.8") ''
+      nixLog "Removing QNX 800 target directory for Jetson builds"
+      rm -rfv "''${!outputBin}/target/qnx-800-tegra-a64"
+    '';
   # lib needs libtiff.so.5, but nixpkgs provides libtiff.so.6
   preFixup = prevAttrs.preFixup or "" + ''
     patchelf --replace-needed libtiff.so.5 libtiff.so "''${!outputBin}/bin/host/${archDir}/Plugins/imageformats/libqtiff.so"
@@ -81,4 +98,9 @@ in
     "Qt 5 missing (<2022.2.0)" = !(versionOlder version "2022.2.0" -> qt5 != null);
     "Qt 6 missing (>=2022.2.0)" = !(versionAtLeast version "2022.2.0" -> qt6 != null);
   };
+  # NOTE(@connorbaker): It might be a problem that when nsight_compute contains hosts and targets of different
+  # architectures, that we patchelf just the binaries matching the builder's platform; autoPatchelfHook prints
+  # messages like
+  #   skipping [$out]/host/linux-desktop-glibc_2_11_3-x64/libQt6Core.so.6 because its architecture (x64) differs from
+  #   target (AArch64)
 }

--- a/pkgs/development/cuda-modules/_cuda/fixups/nsight_compute.nix
+++ b/pkgs/development/cuda-modules/_cuda/fixups/nsight_compute.nix
@@ -1,9 +1,16 @@
 {
+  cudaAtLeast,
+  cudaMajorMinorVersion,
+  cudaOlder,
+  e2fsprogs,
+  elfutils,
+  gst_all_1,
   lib,
   qt5 ? null,
   qt6 ? null,
   rdma-core,
   stdenv,
+  ucx,
 }:
 prevAttrs:
 let
@@ -24,15 +31,36 @@ let
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 in
 {
+  outputs = [ "out" ]; # NOTE(@connorbaker): Force a single output so relative lookups work.
   nativeBuildInputs = prevAttrs.nativeBuildInputs or [ ] ++ [ wrapQtAppsHook ];
-  buildInputs = prevAttrs.buildInputs or [ ] ++ [
-    qtwayland
-    qtwebview
-    (qt.qtwebengine or qt.full)
-    rdma-core
-  ];
+  buildInputs =
+    prevAttrs.buildInputs or [ ]
+    ++ [
+      qtwayland
+      qtwebview
+      (qt6.qtwebengine or qt6.full)
+      rdma-core
+    ]
+    ++ lib.optionals (cudaAtLeast "12.1" && cudaOlder "12.4") [
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+    ]
+    ++ lib.optionals (cudaAtLeast "12.0" && cudaOlder "12.7") [
+      e2fsprogs
+      ucx
+    ]
+    ++ lib.optionals (cudaMajorMinorVersion == "12.9") [
+      elfutils
+    ];
   dontWrapQtApps = true;
   preInstall = prevAttrs.preInstall or "" + ''
+    if [[ -d nsight-compute ]]; then
+      nixLog "Lifting components of Nsight Compute to the top level"
+      mv -v nsight-compute/*/* .
+      nixLog "Removing empty directories"
+      rmdir -pv nsight-compute/*
+    fi
+
     rm -rf host/${archDir}/Mesa/
   '';
   postInstall = prevAttrs.postInstall or "" + ''
@@ -42,8 +70,8 @@ in
     moveToOutput 'target/${archDir}' "''${!outputBin}/bin"
     wrapQtApp "''${!outputBin}/bin/host/${archDir}/ncu-ui.bin"
   '';
+  # lib needs libtiff.so.5, but nixpkgs provides libtiff.so.6
   preFixup = prevAttrs.preFixup or "" + ''
-    # lib needs libtiff.so.5, but nixpkgs provides libtiff.so.6
     patchelf --replace-needed libtiff.so.5 libtiff.so "''${!outputBin}/bin/host/${archDir}/Plugins/imageformats/libqtiff.so"
   '';
   autoPatchelfIgnoreMissingDeps = prevAttrs.autoPatchelfIgnoreMissingDeps or [ ] ++ [

--- a/pkgs/development/cuda-modules/_cuda/fixups/nsight_systems.nix
+++ b/pkgs/development/cuda-modules/_cuda/fixups/nsight_systems.nix
@@ -1,6 +1,7 @@
 {
   boost178,
   cuda_cudart,
+  cudaAtLeast,
   cudaOlder,
   e2fsprogs,
   gst_all_1,
@@ -27,6 +28,7 @@ let
     else
       lib.getLib qt.qtwayland;
   qtWaylandPlugins = "${qtwayland}/${qt.qtbase.qtPluginPrefix}";
+  # NOTE(@connorbaker): nsight_systems doesn't support Jetson, so no need for case splitting on aarch64-linux.
   hostDir =
     {
       aarch64-linux = "host-linux-armv8";
@@ -39,76 +41,102 @@ let
       x86_64-linux = "target-linux-x64";
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
-  versionString = with lib.versions; "${majorMinor version}.${patch version}";
 in
 {
+  outputs = [ "out" ]; # NOTE(@connorbaker): Force a single output so relative lookups work.
+
   # An ad hoc replacement for
   # https://github.com/ConnorBaker/cuda-redist-find-features/issues/11
   env = prevAttrs.env or { } // {
     rmPatterns =
       prevAttrs.env.rmPatterns or ""
       + toString [
-        "nsight-systems/${versionString}/${hostDir}/lib{arrow,jpeg}*"
-        "nsight-systems/${versionString}/${hostDir}/lib{ssl,ssh,crypto}*"
-        "nsight-systems/${versionString}/${hostDir}/libboost*"
-        "nsight-systems/${versionString}/${hostDir}/libexec"
-        "nsight-systems/${versionString}/${hostDir}/libstdc*"
-        "nsight-systems/${versionString}/${hostDir}/python/bin/python"
-        "nsight-systems/${versionString}/${hostDir}/Mesa"
+        "${hostDir}/lib{arrow,jpeg}*"
+        "${hostDir}/lib{ssl,ssh,crypto}*"
+        "${hostDir}/libboost*"
+        "${hostDir}/libexec"
+        "${hostDir}/libstdc*"
+        "${hostDir}/python/bin/python"
+        "${hostDir}/Mesa"
       ];
   };
+
+  # NOTE(@connorbaker): nsight-exporter and nsight-sys are deprecated scripts wrapping nsys, it's fine to remove them.
+  prePatch = prevAttrs.prePatch or "" + ''
+    if [[ -d bin ]]; then
+      nixLog "Removing bin wrapper scripts"
+      for knownWrapper in bin/{nsys{,-ui},nsight-{exporter,sys}}; do
+        [[ -e $knownWrapper ]] && rm -v "$knownWrapper"
+      done
+      unset -v knownWrapper
+
+      nixLog "Removing empty bin directory"
+      rmdir -v bin
+    fi
+
+    if [[ -d nsight-systems ]]; then
+      nixLog "Lifting components of Nsight System to the top level"
+      mv -v nsight-systems/*/* .
+      nixLog "Removing empty nsight-systems directory"
+      rmdir -pv nsight-systems/*
+    fi
+  '';
+
   postPatch = prevAttrs.postPatch or "" + ''
     for path in $rmPatterns; do
       rm -r "$path"
     done
     patchShebangs nsight-systems
   '';
-  nativeBuildInputs = prevAttrs.nativeBuildInputs or [ ] ++ [ qt.wrapQtAppsHook ];
+
+  nativeBuildInputs = prevAttrs.nativeBuildInputs or [ ] ++ [ qt6.wrapQtAppsHook ];
+
   dontWrapQtApps = true;
-  buildInputs = prevAttrs.buildInputs or [ ] ++ [
-    (qt.qtdeclarative or qt.full)
-    (qt.qtsvg or qt.full)
-    (qt.qtimageformats or qt.full)
-    (qt.qtpositioning or qt.full)
-    (qt.qtscxml or qt.full)
-    (qt.qttools or qt.full)
-    (qt.qtwebengine or qt.full)
-    (qt.qtwayland or qt.full)
-    boost178
-    cuda_cudart.stubs
-    e2fsprogs
-    gst_all_1.gst-plugins-base
-    gst_all_1.gstreamer
-    nss
-    numactl
-    pulseaudio
-    qt.qtbase
-    qtWaylandPlugins
-    rdma-core
-    ucx
-    wayland
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXrandr
-    xorg.libXtst
-  ];
 
-  postInstall =
-    prevAttrs.postInstall or ""
-    # 1. Move dependencies of nsys, nsys-ui binaries to bin output
-    # 2. Fix paths in wrapper scripts
-    + ''
-      moveToOutput 'nsight-systems/${versionString}/${hostDir}' "''${!outputBin}"
-      moveToOutput 'nsight-systems/${versionString}/${targetDir}' "''${!outputBin}"
-      moveToOutput 'nsight-systems/${versionString}/bin' "''${!outputBin}"
-      substituteInPlace $bin/bin/nsys $bin/bin/nsys-ui \
-        --replace-fail 'nsight-systems-#VERSION_RSPLIT#' nsight-systems/${versionString}
-      wrapQtApp "$bin/nsight-systems/${versionString}/${hostDir}/nsys-ui.bin"
-    '';
+  buildInputs =
+    prevAttrs.buildInputs or [ ]
+    ++ [
+      (qt6.qtdeclarative or qt6.full)
+      (qt6.qtsvg or qt6.full)
+      (qt6.qtimageformats or qt6.full)
+      (qt6.qtpositioning or qt6.full)
+      (qt6.qtscxml or qt6.full)
+      (qt6.qttools or qt6.full)
+      (qt6.qtwebengine or qt6.full)
+      (qt6.qtwayland or qt6.full)
+      boost178
+      cuda_cudart.stubs
+      e2fsprogs
+      gst_all_1.gst-plugins-base
+      gst_all_1.gstreamer
+      nss
+      numactl
+      pulseaudio
+      qt6.qtbase
+      qtWaylandPlugins
+      rdma-core
+      ucx
+      wayland
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXrandr
+      xorg.libXtst
+    ]
+    # NOTE(@connorbaker): Seems to be required only for aarch64-linux.
+    ++ lib.optionals (stdenv.hostPlatform.isAarch64 && cudaAtLeast "11.8") [
+      gst_all_1.gst-plugins-bad
+    ];
 
+  postInstall = prevAttrs.postInstall or "" + ''
+    moveToOutput '${hostDir}' "''${!outputBin}"
+    moveToOutput '${targetDir}' "''${!outputBin}"
+    moveToOutput 'bin' "''${!outputBin}"
+    wrapQtApp "''${!outputBin}/${hostDir}/nsys-ui.bin"
+  '';
+
+  # lib needs libtiff.so.5, but nixpkgs provides libtiff.so.6
   preFixup = prevAttrs.preFixup or "" + ''
-    # lib needs libtiff.so.5, but nixpkgs provides libtiff.so.6
-    patchelf --replace-needed libtiff.so.5 libtiff.so $bin/nsight-systems/${versionString}/${hostDir}/Plugins/imageformats/libqtiff.so
+    patchelf --replace-needed libtiff.so.5 libtiff.so "''${!outputBin}/${hostDir}/Plugins/imageformats/libqtiff.so"
   '';
 
   autoPatchelfIgnoreMissingDeps = prevAttrs.autoPatchelfIgnoreMissingDeps or [ ] ++ [

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -173,7 +173,11 @@ let
       (
         final: _:
         {
-          cuda_compat = runCommand "cuda_compat" { meta.platforms = [ ]; } "false"; # Prevent missing attribute errors
+          # Prevent missing attribute errors
+          # NOTE(@connorbaker): CUDA 12.3 does not have a cuda_compat package; indeed, none of the release supports
+          # Jetson devices. To avoid errors in the case that cuda_compat is not defined, we have a dummy package which
+          # is always defined, but does nothing, will not build successfully, and has no platforms.
+          cuda_compat = runCommand "cuda_compat" { meta.platforms = [ ]; } "false";
         }
         // lib.packagesFromDirectoryRecursive {
           inherit (final) callPackage;

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -27,6 +27,7 @@
   lib,
   pkgs,
   stdenv,
+  runCommand,
 }:
 let
   inherit (lib)
@@ -171,7 +172,10 @@ let
     [
       (
         final: _:
-        lib.packagesFromDirectoryRecursive {
+        {
+          cuda_compat = runCommand "cuda_compat" { meta.platforms = [ ]; } "false"; # Prevent missing attribute errors
+        }
+        // lib.packagesFromDirectoryRecursive {
           inherit (final) callPackage;
           directory = ../development/cuda-modules/packages;
         }


### PR DESCRIPTION
Backports fixups largely from #430797.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
