### PR TITLE
nixos/{consul-template,vault-agent}: drop `template` sub-option

### DIFF
--- a/nixos/modules/services/security/vault-agent.nix
+++ b/nixos/modules/services/security/vault-agent.nix
@@ -58,23 +58,6 @@ let
                           Path to use for the pid file.
                         '';
                       };
-
-                      template = lib.mkOption {
-                        default = null;
-                        type = with types; nullOr (listOf (attrsOf anything));
-                        description =
-                          let
-                            upstreamDocs =
-                              if flavour == "vault-agent" then
-                                "https://developer.hashicorp.com/vault/docs/agent/template"
-                              else
-                                "https://github.com/hashicorp/consul-template/blob/main/docs/configuration.md#templates";
-                          in
-                          ''
-                            Template section of ${flavour}.
-                            Refer to <${upstreamDocs}> for supported values.
-                          '';
-                      };
                     };
                   };
 


### PR DESCRIPTION
An HCL config can be represented as JSON in different ways and we forced users to use a list of attrsets for `cfg.settings.template` prior to this change.

Similarly, a user may opt to use `vault-agent` exclusively as auth-proxy without any templates, which would result in `null` ending up in the resulting JSON configuration and prevent `vault-agent` from starting.

A lot of NixOS modules opt to recursively filter out any `null` values when hitting this, either by defining a function in `apply =` in `cfg.settings` or in the `format.generate` call, but that comes with its own set of downsides.

While I personally can't think of a use-case involving `consul-template` without templates, it does manage to start without one just fine and `consul-template` is equally affected by our opinionated JSON representation forced onto the user.

As such, we decided in favor of removing the option entirely in the discussion leading up to this.

This is one of the 3 suggested implementations from issue #420208. You can see the other 2 there too, if you are curious.

tl;dr: Non-breaking bug fix to allow using `vault-agent` without templates and no longer forcing our opinionated JSON representation onto the user.

cc @vypxl

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test