### PR TITLE
perlPackages.Tirex: 0.7.1 → 0.8.0

### DIFF
--- a/pkgs/development/perl-modules/Tirex/default.nix
+++ b/pkgs/development/perl-modules/Tirex/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPerlPackage,
   fetchFromGitHub,
-  fetchpatch,
   GD,
   IPCShareLite,
   JSON,
@@ -15,22 +14,16 @@
 
 buildPerlPackage rec {
   pname = "Tirex";
-  version = "0.7.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "openstreetmap";
     repo = "tirex";
     tag = "v${version}";
-    hash = "sha256-p2P19tifA/AvJatTzboyhtt7W1SwKJQzqpU4oDalfhU=";
+    hash = "sha256-tFDyN3slj9ipa9JPB6f+mnzMIW926vOge4ZSbmxjtiE=";
   };
 
   patches = [
-    # Support Mapnik >= v4.0.0 (`mapnik/box2d.hpp` -> `mapnik/geometry/box2d.hpp`)
-    # https://github.com/openstreetmap/tirex/pull/54
-    (fetchpatch {
-      url = "https://github.com/openstreetmap/tirex/commit/5f131231c9c12e88793afba471b150ca8af8d587.patch";
-      hash = "sha256-bnL1ZGy8ZNSZuCRbZn59qRVLg3TL0GjFYnhRKroeVO0=";
-    })
     # Support Mapnik >= v4.0.0 (no more mapnik-config)
     ./use-pkg-config.patch
   ];

--- a/pkgs/development/perl-modules/Tirex/use-pkg-config.patch
+++ b/pkgs/development/perl-modules/Tirex/use-pkg-config.patch
@@ -6,7 +6,7 @@
 -CXXFLAGS = `mapnik-config --cflags` $(CFLAGS)
 +CXXFLAGS += `pkg-config --cflags libmapnik` -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
  CXXFLAGS += -Wall -Wextra -pedantic -Wredundant-decls -Wdisabled-optimization -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wold-style-cast
--LDFLAGS= `mapnik-config --libs --ldflags --dep-libs`
+-LDFLAGS= `mapnik-config --libs --ldflags --dep-libs` -lboost_filesystem
 +LDFLAGS += `pkg-config --libs libmapnik` -lboost_filesystem
 
  backend-mapnik: renderd.o metatilehandler.o networklistener.o networkmessage.o networkrequest.o networkresponse.o debuggable.o requesthandler.o


### PR DESCRIPTION
https://github.com/openstreetmap/tirex/releases/tag/v0.8.0

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
