### PR TITLE
wpaperd: add man pages and shell completions

### DIFF
--- a/pkgs/by-name/wp/wpaperd/package.nix
+++ b/pkgs/by-name/wp/wpaperd/package.nix
@@ -7,6 +7,8 @@
   wayland,
   libGL,
   dav1d,
+  installShellFiles,
+  scdoc,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -24,6 +26,8 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
+    installShellFiles
+    scdoc
   ];
   buildInputs = [
     wayland
@@ -35,6 +39,20 @@ rustPlatform.buildRustPackage rec {
   buildFeatures = [
     "avif"
   ];
+
+  postBuild = ''
+    scdoc < man/wpaperd-output.5.scd > man/wpaperd-output.5
+  '';
+
+  postInstall =
+    let
+      targetDir = "target/*/$cargoBuildType";
+    in
+    ''
+      installShellCompletion ${targetDir}/completions/*.{bash,fish}
+      installShellCompletion --zsh ${targetDir}/completions/_*
+      installManPage ${targetDir}/man/*.1 man/*.5
+    '';
 
   meta = with lib; {
     description = "Minimal wallpaper daemon for Wayland";


### PR DESCRIPTION
Added man pages and shell completions to derivation output.

Fixes #430409

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
