### PR TITLE
strongswan: added EAP-PEAP

### DIFF
--- a/nixos/modules/services/networking/strongswan.nix
+++ b/nixos/modules/services/networking/strongswan.nix
@@ -175,6 +175,8 @@ in
       # here we should use the default strongswan ipsec.secrets and
       # append to it (default one is empty so not a pb for now)
       environment.etc."ipsec.secrets".text = ipsecSecrets cfg.secrets;
+       # some environments like NetworkManager will be looking in /etc/strongswan.conf regardless of what the environment variable is
+      environment.etc."strongswan.conf".source = config.systemd.services.strongswan.environment.STRONGSWAN_CONF;
 
       systemd.services.strongswan = {
         description = "strongSwan IPSec Service";

--- a/nixos/modules/services/networking/strongswan.nix
+++ b/nixos/modules/services/networking/strongswan.nix
@@ -175,8 +175,9 @@ in
       # here we should use the default strongswan ipsec.secrets and
       # append to it (default one is empty so not a pb for now)
       environment.etc."ipsec.secrets".text = ipsecSecrets cfg.secrets;
-       # some environments like NetworkManager will be looking in /etc/strongswan.conf regardless of what the environment variable is
-      environment.etc."strongswan.conf".source = config.systemd.services.strongswan.environment.STRONGSWAN_CONF;
+      # some environments like NetworkManager will be looking in /etc/strongswan.conf regardless of what the environment variable is
+      environment.etc."strongswan.conf".source =
+        config.systemd.services.strongswan.environment.STRONGSWAN_CONF;
 
       systemd.services.strongswan = {
         description = "strongSwan IPSec Service";

--- a/pkgs/by-name/st/strongswan/package.nix
+++ b/pkgs/by-name/st/strongswan/package.nix
@@ -125,6 +125,7 @@ stdenv.mkDerivation rec {
     "--enable-eap-aka-3gpp2"
     "--enable-eap-mschapv2"
     "--enable-eap-radius"
+    "--enable-eap-peap"
     "--enable-xauth-eap"
     "--enable-ext-auth"
     "--enable-acert"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently, the Strongswan build in Nixpkgs does not support EAP-PEAP. As far as I know, this is a relatively common protocol used for VPNs. When I was testing this with NetworkManager, I also ran into issue #375352, so I added a tentative fix for that in order to get things working.

When I was attempting to setup the EAP-PEAP VPN, it took many hours for me to realize that it was an issue with the build and not a matter of an improper configuration leading to the eap-peap plugin not being enabled. So, hopefully this will fix future problems

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ As far as I know] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
