### PR TITLE
uplift: init at 2.26.0

### DIFF
--- a/pkgs/by-name/up/uplift/package.nix
+++ b/pkgs/by-name/up/uplift/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "uplift";
+  version = "2.26.0";
+
+  src = fetchFromGitHub {
+    owner = "gembaadvantage";
+    repo = "uplift";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cXZAxsQWjzYgoRAEKflJFcVN0OabdPHuJonJ0KMEaXs=";
+  };
+
+  vendorHash = "sha256-mjhNgy/QGHVdujmy94NQaoyvfrVmsIKZS3uWYK1XQr0=";
+
+  ldflags = with finalAttrs.src; [
+    "-s"
+    "-w"
+    "-X=github.com/gembaadvantage/uplift/internal/version.version=${tag}"
+    "-X=github.com/gembaadvantage/uplift/internal/version.gitCommit=${tag}"
+    "-X=github.com/gembaadvantage/uplift/internal/version.gitBranch=main"
+    "-X=github.com/gembaadvantage/uplift/internal/version.buildDate=1970-01-01T00:00:00Z"
+  ];
+
+  doCheck = false; # Bad upstream tests
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Semantic versioning the easy way";
+    longDescription = ''
+      By harnessing the power of Conventional Commits, Uplift
+      simplifies the release management of your project through your
+      use of commit messages.
+
+      Built for Continuous Integration (CI), Uplift is incredibly
+      simple to use, and its modular design allows you to choose which
+      release cycle features you want to incorporate into your
+      workflow. It adheres to the Semantic Versioning specification
+      and plays nicely with other tools.
+    '';
+    homepage = "https://upliftci.dev";
+    downloadPage = "https://github.com/gembaadvantage/uplift";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "uplift";
+  };
+})


### PR DESCRIPTION
Resolves #427996

cc @rzsita for testing

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
