### PR TITLE
cargo-doc2readme: init at 0.6.1

### DIFF
--- a/pkgs/by-name/ca/cargo-doc2readme/package.nix
+++ b/pkgs/by-name/ca/cargo-doc2readme/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cargo-doc2readme";
+  version = "0.6.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "msrd0";
+    repo = "cargo-doc2readme";
+    tag = finalAttrs.version;
+    hash = "sha256-9LIsidrs/uyc0e8AdyAfBVLXNUXQlphhM/pbblzAtZo=";
+  };
+
+  cargoHash = "sha256-dhieV4hEuHEGY2GQBE8aJ+9DQFfNng4QZYp4zwP+r1U=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Create a readme file containing the rustdoc comments from your code";
+    longDescription = ''
+      `cargo doc2readme` is a cargo subcommand to create a readme file
+      to display on Codeberg, GitHub or crates.io, containing the
+      rustdoc comments from your code.
+    '';
+    homepage = "https://codeberg.org/msrd0/cargo-doc2readme";
+    changelog = "https://codeberg.org/msrd0/cargo-doc2readme/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "cargo-doc2readme";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
