### PR TITLE
nixos/postfix: improve migration suggestions

### DIFF
--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -1235,10 +1235,10 @@ in
       "services.postfix.lookupMX was removed. Use services.postfix.settings.main.relayhost and put the hostname in angled brackets, if you need to turn off MX and SRV lookups."
     )
     (lib.mkRemovedOptionModule [ "services" "postfix" "relayHost" ]
-      "services.postfix.relayHost was removed in favor of services.postfix.settings.main.relayhost, which now takes a list of host/port."
+      "services.postfix.relayHost was removed in favor of services.postfix.settings.main.relayhost, which now takes a list of host:port."
     )
     (lib.mkRemovedOptionModule [ "services" "postfix" "relayPort" ]
-      "services.postfix.relayPort was removed in favor of services.postfix.settings.main.relayhost, which now takes a list of host/port."
+      "services.postfix.relayPort was removed in favor of services.postfix.settings.main.relayhost, which now takes a list of host:port."
     )
     (lib.mkRemovedOptionModule [ "services" "postfix" "extraConfig" ]
       "services.postfix.extraConfig was replaced by the structured freeform service.postfix.settings.main option."

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -1238,7 +1238,7 @@ in
       "services.postfix.relayHost was removed in favor of services.postfix.settings.main.relayhost, which now takes a list of host/port."
     )
     (lib.mkRemovedOptionModule [ "services" "postfix" "relayPort" ]
-      "services.postfix.relayHost was removed in favor of services.postfix.settings.main.relayhost, which now takes a list of host/port."
+      "services.postfix.relayPort was removed in favor of services.postfix.settings.main.relayhost, which now takes a list of host/port."
     )
     (lib.mkRemovedOptionModule [ "services" "postfix" "extraConfig" ]
       "services.postfix.extraConfig was replaced by the structured freeform service.postfix.settings.main option."


### PR DESCRIPTION
Split up into two commits: the first is hopefully not contentious, but the second is maybe a matter of taste - I found the original a bit confusing since it made me think the `/` character might be a literal part of the new combined notation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
