### PR TITLE
winetricks: apply patch to make WINE_BIN and WINESERVER_BIN overridable

### DIFF
--- a/pkgs/applications/emulators/wine/winetricks.nix
+++ b/pkgs/applications/emulators/wine/winetricks.nix
@@ -13,6 +13,7 @@
   gnused,
   gnugrep,
   bash,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -20,6 +21,15 @@ stdenv.mkDerivation rec {
   version = src.version;
 
   src = (callPackage ./sources.nix { }).winetricks;
+
+  patches = [
+    (fetchpatch {
+      # make WINE_BIN and WINESERVER_BIN overridable
+      # see https://github.com/NixOS/nixpkgs/issues/338367
+      url = "https://github.com/Winetricks/winetricks/commit/1d441b422d9a9cc8b0a53fa203557957ca1adc44.patch";
+      hash = "sha256-AYXV2qLHlxuyHC5VqUjDu4qi1TcAl2pMSAi8TEp8db4=";
+    })
+  ];
 
   buildInputs = [
     perl
@@ -48,6 +58,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     sed -i \
       -e '2i PATH="${pathAdd}:$PATH"' \
+      -e '2i : "''${WINESERVER_BIN:=/run/current-system/sw/bin/wineserver}"' \
+      -e '2i : "''${WINE_BIN:=/run/current-system/sw/bin/.wine}"' \
       "$out/bin/winetricks"
   '';
 


### PR DESCRIPTION
fix https://github.com/NixOS/nixpkgs/issues/338367

- use upstream patch to make WINE_BIN and WINESERVER_BIN overridable
- default to respective pathes in `/run/current-system/bin`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
