### PR TITLE
python3Packages.python-dali: init at 0.11

### DIFF
--- a/pkgs/development/python-modules/python-dali/default.nix
+++ b/pkgs/development/python-modules/python-dali/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  buildPythonPackage,
+  setuptools,
+  pyusb,
+  pymodbus,
+  pyserial-asyncio,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage rec {
+  pname = "python-dali";
+  version = "0.11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sde1000";
+    repo = "python-dali";
+    tag = "v${version}";
+    hash = "sha256-F/D0wyMVCUaL2SCdPKvnGS22tSgDnvUh6rs2ToKON2c=";
+  };
+
+  patches = [
+    # pymodbus 3.x support
+    (fetchpatch {
+      url = "https://github.com/sde1000/python-dali/commit/fe85b8fd9a746d16a03de8fd8c643ef4254d1ccd.patch";
+      hash = "sha256-bcfr948g7M6m3AQVArcYw9a22jA5eMim+J58iKci55s=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  optional-dependencies = {
+    driver-unipi = [
+      pyusb
+      pymodbus
+    ];
+    driver-serial = [ pyserial-asyncio ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ]
+  ++ lib.flatten (lib.attrValues optional-dependencies);
+
+  pythonImportsCheck = [ "dali" ];
+
+  meta = {
+    description = "IEC 62386 (DALI) lighting control library";
+    homepage = "https://github.com/sde1000/python-dali";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14481,6 +14481,8 @@ self: super: with self; {
 
   python-daemon = callPackage ../development/python-modules/python-daemon { };
 
+  python-dali = callPackage ../development/python-modules/python-dali { };
+
   python-datemath = callPackage ../development/python-modules/python-datemath { };
 
   python-dateutil = callPackage ../development/python-modules/python-dateutil { };


### PR DESCRIPTION
https://github.com/sde1000/python-dali - IEC 62386 (DALI) lighting control library

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
