### PR TITLE
ci/pinned: update

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -124,8 +124,6 @@ rec {
     };
     officialRelease = false;
     inherit pkgs lib-tests;
-    # 2.28 / 2.29 take 9x longer than 2.30 or Lix.
-    # TODO: Switch back to nixVersions.latest
-    nix = pkgs.lix;
+    nix = pkgs.nixVersions.latest;
   };
 }

--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -9,9 +9,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "2baf8e1658cba84a032c3a8befb1e7b06629242a",
-      "url": "https://github.com/NixOS/nixpkgs/archive/2baf8e1658cba84a032c3a8befb1e7b06629242a.tar.gz",
-      "hash": "0l48zkf2zs7r53fjq46j770vpb5avxihyfypra3fv429akqnsmm1"
+      "revision": "6a489c9482ca676ce23c0bcd7f2e1795383325fa",
+      "url": "https://github.com/NixOS/nixpkgs/archive/6a489c9482ca676ce23c0bcd7f2e1795383325fa.tar.gz",
+      "hash": "0vsvkhy3gb8yzq62vazhmpqixssmd4xinnll7w73l4vrqd611wlf"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "421b56313c65a0815a52b424777f55acf0b56ddf",
-      "url": "https://github.com/numtide/treefmt-nix/archive/421b56313c65a0815a52b424777f55acf0b56ddf.tar.gz",
-      "hash": "1l57hzz704s7izkkcl3xsg77xjfza57cl0fchs24rdpdhmry2dmp"
+      "revision": "58bd4da459f0a39e506847109a2a5cfceb837796",
+      "url": "https://github.com/numtide/treefmt-nix/archive/58bd4da459f0a39e506847109a2a5cfceb837796.tar.gz",
+      "hash": "01bg9b4xzlv6s5q1q78vib6l2csw02b3rk5bm5yj4gx2sk2hvmrq"
     }
   },
   "version": 5


### PR DESCRIPTION
This gives us [Nix 2.30 as `nixVersions.latest`](https://github.com/NixOS/nixpkgs/pull/429084), which enables it for Eval in CI automatically.

It also gives us [markdown-code-runner 0.2.0](https://github.com/NixOS/nixpkgs/pull/427516), which [allows it to run with treefmt](https://github.com/NixOS/nixpkgs/pull/427460).

From the nixpkgs-unstable channel:
https://hydra.nixos.org/eval/1817362#tabs-inputs

Changes for treefmt-nix:
https://github.com/numtide/treefmt-nix/compare/421b56313c65a0815a52b424777f55acf0b56ddf...58bd4da459f0a39e506847109a2a5cfceb837796

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
