### PR TITLE
dte: init at 1.11.1

### DIFF
--- a/pkgs/by-name/dt/dte/package.nix
+++ b/pkgs/by-name/dt/dte/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  nix-update-script,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dte";
+  version = "1.11.1";
+
+  src = fetchFromGitLab {
+    owner = "craigbarnes";
+    repo = "dte";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PG9yfRzJKXVKAg8ubIvX2Rj4nLO3dki7shP+zAa7nxo=";
+  };
+
+  installFlags = [ "DESTDIR=${placeholder "out"}" ];
+
+  postInstall = ''
+    mv $out/usr/local/* $out
+    rm -rf $out/usr
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "dte -V";
+    };
+  };
+
+  meta = {
+    description = "Small, configurable terminal text editor";
+    homepage = "https://gitlab.com/craigbarnes/dte";
+    changelog = "https://gitlab.com/craigbarnes/dte/-/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "dte";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
