### PR TITLE
core: init at 0-unstable-2025-08-05

### DIFF
--- a/pkgs/by-name/co/core/package.nix
+++ b/pkgs/by-name/co/core/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "core";
+  version = "0-unstable-2025-10-12";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "core-lang";
+    repo = "core";
+    rev = "bee6db08cf855dc7a9dea54246ece31b6f1f3916";
+    hash = "sha256-PRVYB2B3oq2WMdnmI1gr+J7QKaOEkF6TVvzPTA/M2Qs=";
+  };
+
+  cargoHash = "sha256-R7F1zlphIwdQ2zVmJOT3xQPNw/kkqDBufm/Wdx1SCM4=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Compiler, runtime and standard library of Core";
+    longDescription = ''
+      Core is a modern programming language that uses a minimal set of
+      orthogonal building blocks to ensure simplicity, readability,
+      modifiability and stability.
+    '';
+    homepage = "https://core-lang.dev";
+    changelog = "https://core-lang.dev/changes.html";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "core";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
