### PR TITLE
k3s: fix prefetching of traefik charts in update script

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/update-script.sh
+++ b/pkgs/applications/networking/cluster/k3s/update-script.sh
@@ -61,17 +61,19 @@ fi
 cd "${NIXPKGS_K3S_PATH}/${MAJOR_VERSION}_${MINOR_VERSION}"
 
 CHARTS_URL=https://k3s.io/k3s-charts/assets
+TRAEFIK_CRD_CHART_SHA256=$(nix-hash --type sha256 --base32 --flat <(curl -o - "${CHARTS_URL}/traefik-crd/${CHART_FILES[0]}"))
+TRAEFIK_CHART_SHA256=$(nix-hash --type sha256 --base32 --flat <(curl -o - "${CHARTS_URL}/traefik/${CHART_FILES[1]}"))
 # Get metadata for both files
 rm -f chart-versions.nix.update
 cat > chart-versions.nix.update <<EOF
 {
   traefik-crd = {
     url = "${CHARTS_URL}/traefik-crd/${CHART_FILES[0]}";
-    sha256 = "$(nix-prefetch-url --quiet "${CHARTS_URL}/traefik-crd/${CHART_FILES[0]}")";
+    sha256 = "$TRAEFIK_CRD_CHART_SHA256";
   };
   traefik = {
     url = "${CHARTS_URL}/traefik/${CHART_FILES[1]}";
-    sha256 = "$(nix-prefetch-url --quiet "${CHARTS_URL}/traefik/${CHART_FILES[1]}")";
+    sha256 = "$TRAEFIK_CHART_SHA256";
   };
 }
 EOF


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Lately `nix-prefetch-url` provides a hash different to what `pkgs.fetchurl` expects. This leads to automated update PRs failing with a hash mismatch (e.g. see https://github.com/NixOS/nixpkgs/pull/422171). I don't know why the hashes are different suddenly, but in fact both commands yield different store paths

```
ls -l /nix/store/qn6c3g3azp96gs845gda9wa7m5v6cwcj-traefik-crd-27.0.201+up27.0.2.tgz /nix/store/vqc4p9zy52q2gjyiv5cv16xj3zw2z8zd-traefik-crd-27.0.201+up27.0.2.tgz
-r--r--r-- 2 root root 269824  1. Jan 1970  /nix/store/qn6c3g3azp96gs845gda9wa7m5v6cwcj-traefik-crd-27.0.201+up27.0.2.tgz
-r--r--r-- 2 root root  30954  1. Jan 1970  /nix/store/vqc4p9zy52q2gjyiv5cv16xj3zw2z8zd-traefik-crd-27.0.201+up27.0.2.tgz
```

When extracted, both produce the same result but it's obvious that the two compressed files are different. For now I suggest to work around the issue by using `nix-hash` to get the hashes.

@NixOS/k3s 

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
