### PR TITLE
mkosi-full: use the correct qemu package

### DIFF
--- a/pkgs/tools/virtualization/mkosi/default.nix
+++ b/pkgs/tools/virtualization/mkosi/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
+  python3Packages,
   fetchFromGitHub,
   stdenv,
-  python,
   systemd,
   pandoc,
   kmod,
@@ -15,13 +15,6 @@
   libseccomp,
   replaceVars,
   udevCheckHook,
-
-  # Python packages
-  setuptools,
-  setuptools-scm,
-  wheel,
-  buildPythonApplication,
-  pytestCheckHook,
 
   # Optional dependencies
   withQemu ? false,
@@ -46,7 +39,7 @@ let
     withKernelInstall = true;
   };
 
-  pythonWithPefile = python.withPackages (ps: [ ps.pefile ]);
+  pythonWithPefile = python3Packages.python.withPackages (ps: [ ps.pefile ]);
 
   deps = [
     bash
@@ -63,7 +56,7 @@ let
     qemu
   ];
 in
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "mkosi";
   version = "25.3-unstable-2025-04-01";
   format = "pyproject";
@@ -106,9 +99,9 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [
     pandoc
-    setuptools
-    setuptools-scm
-    wheel
+    python3Packages.setuptools
+    python3Packages.setuptools-scm
+    python3Packages.wheel
     udevCheckHook
   ];
 
@@ -119,7 +112,7 @@ buildPythonApplication rec {
   '';
 
   checkInputs = [
-    pytestCheckHook
+    python3Packages.pytestCheckHook
   ];
 
   postInstall = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1102,7 +1102,7 @@ with pkgs;
     };
   };
 
-  mkosi = python3Packages.callPackage ../tools/virtualization/mkosi { inherit systemd; };
+  mkosi = callPackage ../tools/virtualization/mkosi { };
 
   mkosi-full = mkosi.override { withQemu = true; };
 


### PR DESCRIPTION
`python3Packages.qemu` is not the same as `qemu`

And because `python3Pacakges.callPackage` was used, the `qemu` was accidentally replaced with `python3Pacakges.callPackage`.

This PR migrates the `mkosi` package to use `callPackage` instead of `python3Pacakges.callPackage`, meaning that we have to explicitly specify when we want a package from `python3Packages`.

This fixes the wrong `qemu` usage.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
