### PR TITLE
nixos/tuned: enable upower with tuned-ppd

### DIFF
--- a/nixos/modules/services/hardware/tuned.nix
+++ b/nixos/modules/services/hardware/tuned.nix
@@ -172,6 +172,11 @@ in
         assertion = cfg.settings.dynamic_tuning -> cfg.settings.daemon;
         message = "`services.tuned.settings.dynamic_tuning` requires `services.tuned.settings.daemon` to be `true`.";
       }
+
+      {
+        assertion = cfg.ppdSupport -> config.services.upower.enable;
+        message = "`services.tuned.ppdSupport` requires `services.upower` to be enabled.";
+      }
     ]
     # Declare service conflicts, also sourced from `tuned.service`
     ++
@@ -218,6 +223,11 @@ in
       # Many DEs (like GNOME and KDE Plasma) enable PPD by default
       # Let's try to make it easier to transition by only enabling this module
       power-profiles-daemon.enable = false;
+
+      # NOTE: Required by `tuned-ppd` for handling power supply changes
+      # (i.e., `services.tuned.ppdSettings.main.battery_detection`)
+      # https://github.com/NixOS/nixpkgs/issues/431105
+      upower.enable = lib.mkIf cfg.ppdSupport true;
     };
 
     systemd = {


### PR DESCRIPTION
Fixes: #431105


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
