### PR TITLE
workflows/merge-group: init

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -61,3 +61,17 @@ This results in a key with the following semantics:
 ```
 <running-workflow>-<triggering-workflow>-<triggered-event>-<pull-request/fallback>
 ```
+
+## Required Status Checks
+
+The "Required Status Checks" branch ruleset is implemented in two top-level workflows: `pr.yml` and `merge-group.yml`.
+
+The PR workflow defines all checks that need to succeed to add a Pull Request to the Merge Queue.
+If no Merge Queue is set up for a branch, the PR workflow defines the checks required to merge into the target branch.
+
+The Merge Group workflow defines all checks that are run as part of the Merge Queue.
+Only when these pass, a Pull Request is finally merged into the target branch.
+They don't apply when no Merge Queue is set up.
+
+Both workflows work with the same `no PR failures` status check.
+This name can never be changed, because it's used in the branch ruleset for these rules.

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -1,0 +1,31 @@
+name: Merge Group
+
+on:
+  merge_group:
+
+permissions: {}
+
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+    with:
+      mergedSha: ${{ github.event.merge_group.head_sha }}
+      targetSha: ${{ github.event.merge_group.base_sha }}
+
+  # This job's only purpose is to serve as a target for the "Required Status Checks" branch ruleset.
+  # It "needs" all the jobs that should block the Merge Queue.
+  # If they pass, it is skipped — which counts as "success" for purposes of the branch ruleset.
+  # However, if any of them fail, this job will also fail — thus blocking the branch ruleset.
+  no-pr-failures:
+    # Modify this list to add or remove jobs from required status checks.
+    needs:
+      - lint
+    # WARNING:
+    # Do NOT change the name of this job, otherwise the rule will not catch it anymore.
+    # This would prevent all PRs from passing the merge queue.
+    name: no PR failures
+    if: ${{ failure() }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - run: exit 1


### PR DESCRIPTION
Introduces a basic merge queue workflow to initially only run lints. This will avoid accidentally merging changes which break nixfmt after its recent update to 1.0.0.

cc @emilazy who asked for it in https://github.com/NixOS/nixpkgs/pull/428350#issuecomment-3118007548 and https://github.com/NixOS/nixpkgs/pull/430675#issue-3287284389.

## Things done

- [ ] Support merge queues in nixpkgs-merge-bot: https://github.com/NixOS/nixpkgs-merge-bot/issues/202
- [x] Add nixpkgs branch protection ruleset to enable the queue: https://github.com/NixOS/org/pull/149
- [x] Tested in https://github.com/infinisil-test-org/nixpkgs/pull/43
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
