### PR TITLE
maintainers: drop tuynia

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26053,11 +26053,6 @@
     githubId = 57819359;
     name = "Binh Nguyen";
   };
-  tuynia = {
-    github = "mivorasu";
-    githubId = 221005165;
-    name = "Qylia Vorlaque";
-  };
   tv = {
     email = "tv@krebsco.de";
     github = "4z3";

--- a/pkgs/applications/editors/vscode/extensions/ndonfris.fish-lsp/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ndonfris.fish-lsp/default.nix
@@ -16,6 +16,5 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=ndonfris.fish-lsp";
     homepage = "https://github.com/ndonfris/fish-lsp";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ tuynia ];
   };
 }

--- a/pkgs/applications/editors/vscode/extensions/oliver-ni.scheme-fmt/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/oliver-ni.scheme-fmt/default.nix
@@ -24,6 +24,5 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=oliver-ni.scheme-fmt";
     homepage = "https://github.com/oliver-ni/scheme-fmt";
     license = lib.licenses.cc0;
-    maintainers = with lib.maintainers; [ tuynia ];
   };
 }

--- a/pkgs/applications/editors/vscode/extensions/release-candidate.vscode-scheme-repl/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/release-candidate.vscode-scheme-repl/default.nix
@@ -24,6 +24,5 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-scheme-repl";
     homepage = "https://github.com/Release-Candidate/vscode-scheme-repl";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ tuynia ];
   };
 }

--- a/pkgs/applications/editors/vscode/extensions/tsyesika.guile-scheme-enhanced/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/tsyesika.guile-scheme-enhanced/default.nix
@@ -24,6 +24,5 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=tsyesika.guile-scheme-enhanced";
     homepage = "https://codeberg.org/tsyesika/vscode-guile-scheme-enhanced";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ tuynia ];
   };
 }

--- a/pkgs/applications/editors/vscode/extensions/ufo5260987423.magic-scheme/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ufo5260987423.magic-scheme/default.nix
@@ -26,6 +26,5 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=ufo5260987423.magic-scheme";
     homepage = "https://github.com/ufo5260987423/magic-scheme";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ tuynia ];
   };
 }


### PR DESCRIPTION
They recently deleted their account, https://github.com/mivorasu doesn't seem to exist anymore.

They also deleted their PRs with them, for example https://github.com/NixOS/nixpkgs/pull/429345 was a treewide `meta.lib` refactor, in which @emilazy and @philiptaron were involved as well. Just returns a 404 for me right now.

No need to wait for 7 days, if the account doesn't exist anymore.