### PR TITLE
python3Packages.vllm: mark as broken

### DIFF
--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -476,5 +476,8 @@ buildPythonPackage rec {
       # find_isa
       "x86_64-darwin"
     ];
+    # ValueError: 'aimv2' is already used by a Transformers config, pick another name.
+    # Version bump ongoing in https://github.com/NixOS/nixpkgs/pull/429117
+    broken = true;
   };
 }


### PR DESCRIPTION
## Things done

<details>

```
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: vllm
INFO 08-05 12:47:31 [__init__.py:244] Automatically detected platform cpu.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <lambda>
  File "/nix/store/2i76abyx06asxr2k3rgsp8zx647qj38h-python3-3.12.11/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/nix/store/pcaf8q2fnzpypjvzzil7kbk2i0q5mi0v-python3.12-vllm-0.9.1/lib/python3.12/site-packages/vllm/__init__.py", line 13, in <module>
    from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
  File "/nix/store/pcaf8q2fnzpypjvzzil7kbk2i0q5mi0v-python3.12-vllm-0.9.1/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 22, in <module>
    from vllm.config import (BlockSize, CacheConfig, CacheDType, CompilationConfig,
  File "/nix/store/pcaf8q2fnzpypjvzzil7kbk2i0q5mi0v-python3.12-vllm-0.9.1/lib/python3.12/site-packages/vllm/config.py", line 43, in <module>
    from vllm.transformers_utils.config import (
  File "/nix/store/pcaf8q2fnzpypjvzzil7kbk2i0q5mi0v-python3.12-vllm-0.9.1/lib/python3.12/site-packages/vllm/transformers_utils/config.py", line 33, in <module>
    from vllm.transformers_utils.configs import (ChatGLMConfig, Cohere2Config,
  File "/nix/store/pcaf8q2fnzpypjvzzil7kbk2i0q5mi0v-python3.12-vllm-0.9.1/lib/python3.12/site-packages/vllm/transformers_utils/configs/__init__.py", line 28, in <module>
    from vllm.transformers_utils.configs.ovis import OvisConfig
  File "/nix/store/pcaf8q2fnzpypjvzzil7kbk2i0q5mi0v-python3.12-vllm-0.9.1/lib/python3.12/site-packages/vllm/transformers_utils/configs/ovis.py", line 76, in <module>
    AutoConfig.register("aimv2", AIMv2Config)
  File "/nix/store/snp0n1bjnybvbp7hizyry563xk6dbc2h-python3.12-transformers-4.54.1/lib/python3.12/site-packages/transformers/models/auto/configuration_auto.py", line 1306, in register
    CONFIG_MAPPING.register(model_type, config, exist_ok=exist_ok)
  File "/nix/store/snp0n1bjnybvbp7hizyry563xk6dbc2h-python3.12-transformers-4.54.1/lib/python3.12/site-packages/transformers/models/auto/configuration_auto.py", line 993, in register
    raise ValueError(f"'{key}' is already used by a Transformers config, pick another name.")
ValueError: 'aimv2' is already used by a Transformers config, pick another name.
```

</details>

Version bump: https://github.com/NixOS/nixpkgs/pull/429117

cc @happysalada @CertainLach @NickCao

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
