### PR TITLE
python3Packages.librosa: disable failing tests on aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/librosa/default.nix
+++ b/pkgs/development/python-modules/librosa/default.nix
@@ -107,6 +107,16 @@ buildPythonPackage rec {
     "test_axis_bound_warning"
     "test_auto_aspect"
   ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # AssertionError (numerical comparison fails)
+    "test_beat_track_multi"
+    "test_beat_track_multi_bpm_vector"
+    "test_melspectrogram_multi"
+    "test_melspectrogram_multi_time"
+    "test_nnls_matrix"
+    "test_nnls_multiblock"
+    "test_onset_detect"
+  ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # Flaky (numerical comparison fails)
     "test_istft_multi"


### PR DESCRIPTION
## Things done

```
=========================== short test summary info ============================
FAILED tests/test_multichannel.py::test_melspectrogram_multi[test1_44100.wav] - assert not True
FAILED tests/test_multichannel.py::test_melspectrogram_multi_time[test1_44100.wav] - assert False
FAILED tests/test_multichannel.py::test_onset_detect[test1_44100.wav] - assert not True
FAILED tests/test_multichannel.py::test_beat_track_multi[test1_44100.wav-False] - assert False
FAILED tests/test_multichannel.py::test_beat_track_multi[test1_44100.wav-True] - assert False
FAILED tests/test_multichannel.py::test_beat_track_multi_bpm_scalar[test1_44100.wav] - assert False
FAILED tests/test_multichannel.py::test_beat_track_multi_bpm_vector[test1_44100.wav] - assert False
FAILED tests/test_util.py::test_nnls_matrix[3-float32-float32] - AssertionError: assert np.float32(3.0867014) <= 0.0002
FAILED tests/test_util.py::test_nnls_matrix[3-float64-float32] - AssertionError: assert np.float64(3.086701525235159) <= 0.0002
FAILED tests/test_util.py::test_nnls_matrix[30-float32-float32] - AssertionError: assert np.float32(5.4100404) <= 0.0002
FAILED tests/test_util.py::test_nnls_matrix[30-float64-float32] - AssertionError: assert np.float64(5.410040325025114) <= 0.0002
FAILED tests/test_util.py::test_nnls_multiblock[16-float32-float32] - AssertionError: assert np.float32(67.70106) <= 0.0002
FAILED tests/test_util.py::test_nnls_multiblock[16-float64-float32] - AssertionError: assert np.float64(67.70106009912884) <= 0.0002
FAILED tests/test_util.py::test_nnls_multiblock[64-float32-float32] - AssertionError: assert np.float32(69.8225) <= 0.0002
FAILED tests/test_util.py::test_nnls_multiblock[64-float64-float32] - AssertionError: assert np.float64(69.8225069622934) <= 0.0002
FAILED tests/test_util.py::test_nnls_multiblock[256-float32-float32] - AssertionError: assert np.float32(71.914955) <= 0.0002
FAILED tests/test_util.py::test_nnls_multiblock[256-float64-float32] - AssertionError: assert np.float64(71.91494950113204) <= 0.0002
= 17 failed, 13952 passed, 3 skipped, 59 deselected, 513 xfailed, 1 warning in 224.98s (0:03:44) =
```

cc @GuillaumeDesforges

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
