### PR TITLE
flake: split into multiple files using module system

### DIFF
--- a/doc/flake-module.nix
+++ b/doc/flake-module.nix
@@ -1,0 +1,10 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  outputs.htmlDocs.nixpkgsManual = lib.flip lib.mapAttrs config.perSystem.applied.jobs (
+    _: jobSet: jobSet.manual
+  );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,251 +6,34 @@
   outputs =
     { self }:
     let
-      libVersionInfoOverlay = import ./lib/flake-version-info.nix self;
-      lib = (import ./lib).extend libVersionInfoOverlay;
+      lib = import ./lib;
 
-      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+      flake = lib.evalModules {
+        specialArgs = {
+          inherit self;
 
-      jobs = forAllSystems (
-        system:
-        import ./pkgs/top-level/release.nix {
-          nixpkgs = self;
-          inherit system;
-        }
-      );
+          mkPerSystemOption = import ./flake/per-system.nix {
+            inherit lib;
+            return = "mkPerSystemOption";
+          };
+        };
+
+        modules = [
+          ./doc/flake-module.nix
+          ./flake/checks.nix
+          ./flake/dev-shell.nix
+          ./flake/formatter.nix
+          ./flake/outputs.nix
+          ./flake/systems.nix
+          ./lib/flake-module.nix
+          ./nixos/flake-module.nix
+          ./pkgs/top-level/flake-module.nix
+          (lib.modules.importApply ./flake/per-system.nix {
+            inherit lib;
+            return = "module";
+          })
+        ];
+      };
     in
-    {
-      /**
-        `nixpkgs.lib` is a combination of the [Nixpkgs library](https://nixos.org/manual/nixpkgs/unstable/#id-1.4), and other attributes
-        that are _not_ part of the Nixpkgs library, but part of the Nixpkgs flake:
-
-        - `lib.nixosSystem` for creating a NixOS system configuration
-
-        - `lib.nixos` for other NixOS-provided functionality, such as [`runTest`](https://nixos.org/manual/nixos/unstable/#sec-call-nixos-test-outside-nixos)
-      */
-      # DON'T USE lib.extend TO ADD NEW FUNCTIONALITY.
-      # THIS WAS A MISTAKE. See the warning in lib/default.nix.
-      lib = lib.extend (
-        final: prev: {
-
-          /**
-            Other NixOS-provided functionality, such as [`runTest`](https://nixos.org/manual/nixos/unstable/#sec-call-nixos-test-outside-nixos).
-            See also `lib.nixosSystem`.
-          */
-          nixos = import ./nixos/lib { lib = final; };
-
-          /**
-            Create a NixOS system configuration.
-
-            Example:
-
-                lib.nixosSystem {
-                  modules = [ ./configuration.nix ];
-                }
-
-            Inputs:
-
-            - `modules` (list of paths or inline modules): The NixOS modules to include in the system configuration.
-
-            - `specialArgs` (attribute set): Extra arguments to pass to all modules, that are available in `imports` but can not be extended or overridden by the `modules`.
-
-            - `modulesLocation` (path): A default location for modules that aren't passed by path, used for error messages.
-
-            Legacy inputs:
-
-            - `system`: Legacy alias for `nixpkgs.hostPlatform`, but this is already set in the generated `hardware-configuration.nix`, included by `configuration.nix`.
-            - `pkgs`: Legacy alias for `nixpkgs.pkgs`; use `nixpkgs.pkgs` and `nixosModules.readOnlyPkgs` instead.
-          */
-          nixosSystem =
-            args:
-            import ./nixos/lib/eval-config.nix (
-              {
-                lib = final;
-                # Allow system to be set modularly in nixpkgs.system.
-                # We set it to null, to remove the "legacy" entrypoint's
-                # non-hermetic default.
-                system = null;
-
-                modules = args.modules ++ [
-                  # This module is injected here since it exposes the nixpkgs self-path in as
-                  # constrained of contexts as possible to avoid more things depending on it and
-                  # introducing unnecessary potential fragility to changes in flakes itself.
-                  #
-                  # See: failed attempt to make pkgs.path not copy when using flakes:
-                  # https://github.com/NixOS/nixpkgs/pull/153594#issuecomment-1023287913
-                  (
-                    {
-                      config,
-                      pkgs,
-                      lib,
-                      ...
-                    }:
-                    {
-                      config.nixpkgs.flake.source = self.outPath;
-                    }
-                  )
-                ];
-              }
-              // builtins.removeAttrs args [ "modules" ]
-            );
-        }
-      );
-
-      checks = forAllSystems (
-        system:
-        { }
-        //
-          lib.optionalAttrs
-            (
-              # Exclude x86_64-freebsd because "Failed to evaluate rustc-wrapper-1.85.0: «broken»: is marked as broken"
-              system != "x86_64-freebsd"
-            )
-            {
-              tarball = jobs.${system}.tarball;
-            }
-        //
-          lib.optionalAttrs
-            (
-              self.legacyPackages.${system}.stdenv.hostPlatform.isLinux
-              # Exclude power64 due to "libressl is not available on the requested hostPlatform" with hostPlatform being power64
-              && !self.legacyPackages.${system}.targetPlatform.isPower64
-              # Exclude armv6l-linux because "cannot bootstrap GHC on this platform ('armv6l-linux' with libc 'defaultLibc')"
-              && system != "armv6l-linux"
-              # Exclude riscv64-linux because "cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')"
-              && system != "riscv64-linux"
-            )
-            {
-              # Test that ensures that the nixosSystem function can accept a lib argument
-              # Note: prefer not to extend or modify `lib`, especially if you want to share reusable modules
-              #       alternatives include: `import` a file, or put a custom library in an option or in `_module.args.<libname>`
-              nixosSystemAcceptsLib =
-                (self.lib.nixosSystem {
-                  pkgs = self.legacyPackages.${system};
-                  lib = self.lib.extend (
-                    final: prev: {
-                      ifThisFunctionIsMissingTheTestFails = final.id;
-                    }
-                  );
-                  modules = [
-                    ./nixos/modules/profiles/minimal.nix
-                    (
-                      { lib, ... }:
-                      lib.ifThisFunctionIsMissingTheTestFails {
-                        # Define a minimal config without eval warnings
-                        nixpkgs.hostPlatform = "x86_64-linux";
-                        boot.loader.grub.enable = false;
-                        fileSystems."/".device = "nodev";
-                        # See https://search.nixos.org/options?show=system.stateVersion&query=stateversion
-                        system.stateVersion = lib.trivial.release; # DON'T do this in real configs!
-                      }
-                    )
-                  ];
-                }).config.system.build.toplevel;
-            }
-      );
-
-      htmlDocs = {
-        nixpkgsManual = builtins.mapAttrs (_: jobSet: jobSet.manual) jobs;
-        nixosManual =
-          (import ./nixos/release-small.nix {
-            nixpkgs = self;
-          }).nixos.manual;
-      };
-
-      devShells = forAllSystems (
-        system:
-        { }
-        //
-          lib.optionalAttrs
-            (
-              # Exclude armv6l-linux because "Package ‘ghc-9.6.6’ in .../pkgs/development/compilers/ghc/common-hadrian.nix:579 is not available on the requested hostPlatform"
-              system != "armv6l-linux"
-              # Exclude riscv64-linux because "Package ‘ghc-9.6.6’ in .../pkgs/development/compilers/ghc/common-hadrian.nix:579 is not available on the requested hostPlatform"
-              && system != "riscv64-linux"
-              # Exclude x86_64-freebsd because "Package ‘ghc-9.6.6’ in .../pkgs/development/compilers/ghc/common-hadrian.nix:579 is not available on the requested hostPlatform"
-              && system != "x86_64-freebsd"
-            )
-            {
-              /**
-                A shell to get tooling for Nixpkgs development. See nixpkgs/shell.nix.
-              */
-              default = import ./shell.nix { inherit system; };
-            }
-      );
-
-      formatter = lib.filterAttrs (
-        system: _:
-        # Exclude armv6l-linux because "cannot bootstrap GHC on this platform ('armv6l-linux' with libc 'defaultLibc')"
-        system != "armv6l-linux"
-        # Exclude riscv64-linux because "cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')"
-        && system != "riscv64-linux"
-        # Exclude x86_64-freebsd because "Package ‘go-1.22.12-freebsd-amd64-bootstrap’ in /nix/store/0yw40qnrar3lvc5hax5n49abl57apjbn-source/pkgs/development/compilers/go/binary.nix:50 is not available on the requested hostPlatform"
-        && system != "x86_64-freebsd"
-      ) (forAllSystems (system: (import ./ci { inherit system; }).fmt.pkg));
-
-      /**
-        A nested structure of [packages](https://nix.dev/manual/nix/latest/glossary#package-attribute-set) and other values.
-
-        The "legacy" in `legacyPackages` doesn't imply that the packages exposed
-        through this attribute are "legacy" packages. Instead, `legacyPackages`
-        is used here as a substitute attribute name for `packages`. The problem
-        with `packages` is that it makes operations like `nix flake show
-        nixpkgs` unusably slow due to the sheer number of packages the Nix CLI
-        needs to evaluate. But when the Nix CLI sees a `legacyPackages`
-        attribute it displays `omitted` instead of evaluating all packages,
-        which keeps `nix flake show` on Nixpkgs reasonably fast, though less
-        information rich.
-
-        The reason why finding the tree structure of `legacyPackages` is slow,
-        is that for each attribute in the tree, it is necessary to check whether
-        the attribute value is a package or a package set that needs further
-        evaluation. Evaluating the attribute value tends to require a significant
-        amount of computation, even considering lazy evaluation.
-      */
-      legacyPackages = forAllSystems (
-        system:
-        (import ./. {
-          inherit system;
-          overlays = import ./pkgs/top-level/impure-overlays.nix ++ [
-            (final: prev: {
-              lib = prev.lib.extend libVersionInfoOverlay;
-            })
-          ];
-        })
-      );
-
-      /**
-        Optional modules that can be imported into a NixOS configuration.
-
-        Example:
-
-            # flake.nix
-            outputs = { nixpkgs, ... }: {
-              nixosConfigurations = {
-                foo = nixpkgs.lib.nixosSystem {
-                  modules = [
-                    ./foo/configuration.nix
-                    nixpkgs.nixosModules.notDetected
-                  ];
-                };
-              };
-            };
-      */
-      nixosModules = {
-        notDetected = ./nixos/modules/installer/scan/not-detected.nix;
-
-        /**
-          Make the `nixpkgs.*` configuration read-only. Guarantees that `pkgs`
-          is the way you initialize it.
-
-          Example:
-
-              {
-                imports = [ nixpkgs.nixosModules.readOnlyPkgs ];
-                nixpkgs.pkgs = nixpkgs.legacyPackages.x86_64-linux;
-              }
-        */
-        readOnlyPkgs = ./nixos/modules/misc/nixpkgs/read-only.nix;
-      };
-    };
+    flake.config.outputs;
 }

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  mkPerSystemOption,
+  config,
+  ...
+}:
+{
+  imports = [
+    (mkPerSystemOption {
+      name = "checks";
+      type = lib.types.lazyAttrsOf lib.types.package;
+    })
+  ];
+
+  outputs = { inherit (config.perSystem.applied) checks; };
+}

--- a/flake/dev-shell.nix
+++ b/flake/dev-shell.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  mkPerSystemOption,
+  config,
+  ...
+}:
+{
+  imports = [
+    (mkPerSystemOption {
+      name = "devShells";
+      type = lib.types.lazyAttrsOf lib.types.package;
+    })
+  ];
+
+  perSystem.module =
+    { system, ... }:
+    lib.mkIf
+      (
+        # Because "Package ‘ghc-9.6.6’ in .../pkgs/development/compilers/ghc/common-hadrian.nix:579 is not available on the requested hostPlatform"
+        !lib.elem system [
+          "armv6l-linux"
+          "riscv64-linux"
+          "x86_64-freebsd"
+        ]
+      )
+      {
+        devShells.default = import ../shell.nix { inherit system; };
+      };
+
+  outputs = { inherit (config.perSystem.applied) devShells; };
+}

--- a/flake/formatter.nix
+++ b/flake/formatter.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  mkPerSystemOption,
+  ...
+}:
+{
+  imports = [
+    (mkPerSystemOption {
+      name = "formatter";
+      type = lib.types.package;
+    })
+  ];
+
+  perSystem.module =
+    { system, ... }:
+    lib.mkIf
+      (
+        !lib.elem system [
+          # Because "cannot bootstrap GHC on this platform ('armv6l-linux' with libc 'defaultLibc')"
+          "armv6l-linux"
+          # Because "cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')"
+          "riscv64-linux"
+          # Because "Package ‘go-1.22.12-freebsd-amd64-bootstrap’ in /nix/store/0yw40qnrar3lvc5hax5n49abl57apjbn-source/pkgs/development/compilers/go/binary.nix:50 is not available on the requested hostPlatform"
+          "x86_64-freebsd"
+        ]
+      )
+      {
+        formatter = (import ../ci { inherit system; }).fmt.pkg;
+      };
+
+  outputs = { inherit (config.perSystem.applied) formatter; };
+}

--- a/flake/outputs.nix
+++ b/flake/outputs.nix
@@ -1,0 +1,6 @@
+{ lib, ... }:
+{
+  options.outputs = lib.mkOption {
+    type = lib.types.lazyAttrsOf lib.types.unspecified;
+  };
+}

--- a/flake/per-system.nix
+++ b/flake/per-system.nix
@@ -1,0 +1,46 @@
+{ lib, return }:
+lib.getAttr return {
+  mkPerSystemOption =
+    {
+      name,
+      type,
+    }:
+    {
+      config.perSystem.module = {
+        options.${name} = lib.mkOption {
+          type = lib.types.nullOr type;
+          default = null;
+        };
+      };
+
+      options.perSystem.applied.${name} = lib.mkOption {
+        type = lib.types.lazyAttrsOf type;
+        default = { };
+      };
+    };
+
+  module =
+    { lib, config, ... }:
+    {
+      options.perSystem.module = lib.mkOption {
+        type = lib.types.deferredModule;
+      };
+
+      config.perSystem.applied = lib.pipe config.systems [
+        (map (
+          system:
+          let
+            perSystem = lib.evalModules {
+              specialArgs = { inherit system; };
+              modules = [ config.perSystem.module ];
+            };
+          in
+          lib.pipe perSystem.config [
+            (lib.filterAttrs (name: value: (value != null)))
+            (lib.mapAttrs (name: value: { ${system} = value; }))
+          ]
+        ))
+        lib.mkMerge
+      ];
+    };
+}

--- a/flake/systems.nix
+++ b/flake/systems.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+{
+  options.systems = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+  };
+  config.systems = lib.systems.flakeExposed;
+}

--- a/lib/flake-module.nix
+++ b/lib/flake-module.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  config,
+  self,
+  ...
+}:
+{
+  options.lib.overlays = lib.mkOption {
+    description = ''
+      The `lib` flake output is the [Nixpkgs library](https://nixos.org/manual/nixpkgs/unstable/#id-1.4)
+      extended with some additional attributes. Those are defined in other flake modules, such as the NixOS one.
+
+      DON'T USE `lib.extend` TO ADD NEW FUNCTIONALITY.
+      THIS WAS A MISTAKE. See the warning in `./default.nix`.
+    '';
+    type = lib.types.listOf (lib.types.functionTo lib.types.unspecified);
+  };
+
+  config = {
+    lib.overlays = [ (import ./flake-version-info.nix self) ];
+
+    outputs.lib = lib.foldl (cur: overlay: cur.extend overlay) lib config.lib.overlays;
+  };
+}

--- a/nixos/flake-module.nix
+++ b/nixos/flake-module.nix
@@ -1,0 +1,149 @@
+{
+  config,
+  lib,
+  self,
+  ...
+}:
+{
+  perSystem.module =
+    psArgs@{ system, ... }:
+    {
+      # Test that ensures that the nixosSystem function can accept a lib argument
+      # Note: prefer not to extend or modify `lib`, especially if you want to share reusable modules
+      #       alternatives include: `import` a file, or put a custom library in an option or in `_module.args.<libname>`
+      checks =
+        lib.mkIf
+          (
+            psArgs.config.legacyPackages.stdenv.hostPlatform.isLinux
+            # Exclude power64 due to "libressl is not available on the requested hostPlatform" with hostPlatform being power64
+            && !psArgs.config.legacyPackages.targetPlatform.isPower64
+            # Exclude armv6l-linux because "cannot bootstrap GHC on this platform ('armv6l-linux' with libc 'defaultLibc')"
+            && system != "armv6l-linux"
+            # Exclude riscv64-linux because "cannot bootstrap GHC on this platform ('riscv64-linux' with libc 'defaultLibc')"
+            && system != "riscv64-linux"
+          )
+          {
+            nixosSystemAcceptsLib =
+              (config.outputs.lib.nixosSystem {
+                pkgs = psArgs.config.legacyPackages;
+                lib = config.outputs.lib.extend (
+                  final: prev: {
+                    ifThisFunctionIsMissingTheTestFails = final.id;
+                  }
+                );
+                modules = [
+                  ./modules/profiles/minimal.nix
+                  (
+                    { lib, ... }:
+                    lib.ifThisFunctionIsMissingTheTestFails {
+                      # Define a minimal config without eval warnings
+                      nixpkgs.hostPlatform = "x86_64-linux";
+                      boot.loader.grub.enable = false;
+                      fileSystems."/".device = "nodev";
+                      # See https://search.nixos.org/options?show=system.stateVersion&query=stateversion
+                      system.stateVersion = lib.trivial.release; # DON'T do this in real configs!
+                    }
+                  )
+                ];
+              }).config.system.build.toplevel;
+          };
+    };
+
+  outputs = {
+    htmlDocs.nixosManual =
+      (import ./release-small.nix {
+        nixpkgs = self;
+      }).nixos.manual;
+
+    /**
+      Optional modules that can be imported into a NixOS configuration.
+
+      Example:
+
+          # flake.nix
+          outputs = { nixpkgs, ... }: {
+            nixosConfigurations = {
+              foo = nixpkgs.lib.nixosSystem {
+                modules = [
+                  ./foo/configuration.nix
+                  nixpkgs.nixosModules.notDetected
+                ];
+              };
+            };
+          };
+    */
+    nixosModules = {
+      notDetected = ./modules/installer/scan/not-detected.nix;
+
+      /**
+        Make the `nixpkgs.*` configuration read-only. Guarantees that `pkgs`
+        is the way you initialize it.
+
+        Example:
+
+            {
+              imports = [ nixpkgs.nixosModules.readOnlyPkgs ];
+              nixpkgs.pkgs = nixpkgs.legacyPackages.x86_64-linux;
+            }
+      */
+      readOnlyPkgs = ./modules/misc/nixpkgs/read-only.nix;
+    };
+  };
+
+  lib.overlays = [
+    (final: prev: {
+      /**
+        Other NixOS-provided functionality, such as [`runTest`](https://nixos.org/manual/nixos/unstable/#sec-call-nixos-test-outside-nixos).
+        See also `lib.nixosSystem`.
+      */
+      nixos = import ./lib { lib = final; };
+
+      /**
+        Create a NixOS system configuration.
+
+        Example:
+
+            lib.nixosSystem {
+              modules = [ ./configuration.nix ];
+            }
+
+        Inputs:
+
+        - `modules` (list of paths or inline modules): The NixOS modules to include in the system configuration.
+
+        - `specialArgs` (attribute set): Extra arguments to pass to all modules, that are available in `imports` but can not be extended or overridden by the `modules`.
+
+        - `modulesLocation` (path): A default location for modules that aren't passed by path, used for error messages.
+
+        Legacy inputs:
+
+        - `system`: Legacy alias for `nixpkgs.hostPlatform`, but this is already set in the generated `hardware-configuration.nix`, included by `configuration.nix`.
+        - `pkgs`: Legacy alias for `nixpkgs.pkgs`; use `nixpkgs.pkgs` and `nixosModules.readOnlyPkgs` instead.
+      */
+      nixosSystem =
+        args:
+        import ./lib/eval-config.nix (
+          {
+            lib = final;
+            # Allow system to be set modularly in nixpkgs.system.
+            # We set it to null, to remove the "legacy" entrypoint's
+            # non-hermetic default.
+            system = null;
+
+            modules = args.modules ++ [
+              # This module is injected here since it exposes the nixpkgs self-path in as
+              # constrained of contexts as possible to avoid more things depending on it and
+              # introducing unnecessary potential fragility to changes in flakes itself.
+              #
+              # See: failed attempt to make pkgs.path not copy when using flakes:
+              # https://github.com/NixOS/nixpkgs/pull/153594#issuecomment-1023287913
+              {
+                config.nixpkgs.flake.source = self.outPath;
+              }
+            ];
+          }
+          // builtins.removeAttrs args [ "modules" ]
+        );
+    })
+  ];
+}

--- a/pkgs/top-level/flake-module.nix
+++ b/pkgs/top-level/flake-module.nix
@@ -1,0 +1,66 @@
+{
+  config,
+  lib,
+  mkPerSystemOption,
+  self,
+  ...
+}:
+{
+  imports = [
+    (mkPerSystemOption {
+      name = "legacyPackages";
+      type = lib.types.unspecified;
+    })
+    (mkPerSystemOption {
+      name = "jobs";
+      type = lib.types.lazyAttrsOf lib.types.unspecified;
+    })
+  ];
+
+  /**
+    A nested structure of [packages](https://nix.dev/manual/nix/latest/glossary#package-attribute-set) and other values.
+
+    The "legacy" in `legacyPackages` doesn't imply that the packages exposed
+    through this attribute are "legacy" packages. Instead, `legacyPackages`
+    is used here as a substitute attribute name for `packages`. The problem
+    with `packages` is that it makes operations like `nix flake show
+    nixpkgs` unusably slow due to the sheer number of packages the Nix CLI
+    needs to evaluate. But when the Nix CLI sees a `legacyPackages`
+    attribute it displays `omitted` instead of evaluating all packages,
+    which keeps `nix flake show` on Nixpkgs reasonably fast, though less
+    information rich.
+
+    The reason why finding the tree structure of `legacyPackages` is slow,
+    is that for each attribute in the tree, it is necessary to check whether
+    the attribute value is a package or a package set that needs further
+    evaluation. Evaluating the attribute value tends to require a significant
+    amount of computation, even considering lazy evaluation.
+  */
+  perSystem.module =
+    psArgs@{ system, ... }:
+    {
+      legacyPackages = (
+        import ../.. {
+          inherit system;
+          overlays = import ./impure-overlays.nix ++ [
+            (final: prev: {
+              lib = prev.lib.extend (import ../../lib/flake-version-info.nix self);
+            })
+          ];
+        }
+      );
+
+      jobs = import ./release.nix {
+        nixpkgs = self;
+        inherit system;
+      };
+
+      checks =
+        lib.mkIf
+          # Exclude x86_64-freebsd because "Failed to evaluate rustc-wrapper-1.85.0: «broken»: is marked as broken"
+          (system != "x86_64-freebsd")
+          { tarball = psArgs.config.jobs.tarball; };
+    };
+
+  outputs = { inherit (config.perSystem.applied) legacyPackages; };
+}


### PR DESCRIPTION
For a while I have wanted to do this thing, and recently did, in my own infra repo,
where NixOS configurations are defined by providing a value to a flake-parts option
`configurations.nixos.<name>.module`. Here that is:
https://github.com/mightyiam/infra/commit/edff6bfd1079241732e616d4281b449ec789dc90

I kind of have this vision of this flake-parts option being provided by Nixpkgs.
I suppose it would be a precendent and should be discussed and that's not what this PR is about.
But, when considering that, I noticed that our `flake.nix` seems to be a mixture of multiple concerns.

So, I took what I have learned from flake-parts and tried to apply here.
The goal was to split `flake.nix` into multiple files. Ideally, each file is in a directory where it belongs.
The means: the Nixpkgs module system. An added bonus, arguably: some type checking.

Compared with flake-parts, this implementation is simple. Especially the `perSystem` feature.
And our usage is private, so I tried to avoid over-engineering anything, considering it can be changed as needed.

I have a slight improvement in mind, but overall I figured it's time to ask for some opinions.
I might add some more thoughts via line comments after submitting.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
