### PR TITLE
botan3: 3.8.1 -> 3.9.0; python3Packages.botan3: init at 3.9.0

### DIFF
--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -12,6 +12,7 @@
   esdm,
   tpm2-tss,
   static ? stdenv.hostPlatform.isStatic, # generates static libraries *only*
+  windows,
 
   # build ESDM RNG plugin
   withEsdm ? false,
@@ -73,11 +74,14 @@ let
       ++ lib.optionals (stdenv.hostPlatform.isLinux && withTpm2) [
         tpm2-tss
       ]
-      ++ lib.optionals (lib.versionAtLeast version "3.6.0") [
+      ++ lib.optionals (lib.versionAtLeast version "3.6.0" && !stdenv.hostPlatform.isMinGW) [
         jitterentropy
       ]
-      ++ lib.optionals (lib.versionAtLeast version "3.7.0" && withEsdm) [
+      ++ lib.optionals (lib.versionAtLeast version "3.7.0" && withEsdm && !stdenv.hostPlatform.isMinGW) [
         esdm
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.isMinGW) [
+        windows.pthreads
       ];
 
       buildTargets = [
@@ -105,10 +109,10 @@ let
       ++ lib.optionals (stdenv.hostPlatform.isLinux && withTpm2) [
         "--with-tpm2"
       ]
-      ++ lib.optionals (lib.versionAtLeast version "3.6.0") [
+      ++ lib.optionals (lib.versionAtLeast version "3.6.0" && !stdenv.hostPlatform.isMinGW) [
         "--enable-modules=jitter_rng"
       ]
-      ++ lib.optionals (lib.versionAtLeast version "3.7.0" && withEsdm) [
+      ++ lib.optionals (lib.versionAtLeast version "3.7.0" && withEsdm && !stdenv.hostPlatform.isMinGW) [
         "--enable-modules=esdm_rng"
       ]
       ++ lib.optionals (lib.versionAtLeast version "3.8.0" && policy != null) [
@@ -117,6 +121,9 @@ let
       ++ lib.optionals (lib.versionAtLeast version "3.8.0" && policy == "bsi") [
         "--enable-module=ffi"
         "--enable-module=shake"
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.isMinGW) [
+        "--os=mingw"
       ];
 
       configurePhase = ''
@@ -151,15 +158,15 @@ let
           thillux
           nikstur
         ];
-        platforms = platforms.unix;
+        platforms = platforms.unix ++ lib.optionals (lib.versionAtLeast version "3.0") platforms.windows;
         license = licenses.bsd2;
       };
     });
 in
 {
   botan3 = common {
-    version = "3.8.1";
-    hash = "sha256-sDloHUuGGi9YU3Rti6gG9VPiOGntctie2/o8Pb+hfmg=";
+    version = "3.9.0";
+    hash = "sha256-jD8oS1jd1C6OQ+n6hqcSnYfqfD93aoDT2mPsIHIrCIM=";
   };
 
   botan2 = common {

--- a/pkgs/development/python-modules/botan3/default.nix
+++ b/pkgs/development/python-modules/botan3/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+
+  # dependencies
+  botan3,
+
+  # build dependencies
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "botan3";
+
+  inherit (botan3) src version;
+
+  pyproject = true;
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  # not necessary for build, but makes it easier to discover for
+  # SBOM tooling
+  buildInputs = [ botan3 ];
+
+  # not necessary for build, but makes it easier to discover for
+  # SBOM tooling
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  sourceRoot = "Botan-${version}/src/python";
+
+  postPatch = ''
+    # remove again, when https://github.com/randombit/botan/pull/5040 got
+    # merged
+    cp ${./pyproject.toml} pyproject.toml
+  ''
+  + (
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        botanLibPath=$(find ${lib.getLib botan3}/lib -name 'libbotan-3.dylib' -print -quit)
+        substituteInPlace botan3.py --replace-fail 'libbotan-3.dylib' "$botanLibPath"
+      ''
+    else if stdenv.hostPlatform.isMinGW then
+      ''
+        botanLibPath=$(find ${lib.getLib botan3}/lib -name 'libbotan-3.dll' -print -quit)
+        substituteInPlace botan3.py --replace-fail 'libbotan-3.dll' "$botanLibPath"
+      ''
+    # Linux/other Unix-like system
+    else
+      ''
+        botanLibPath=$(find ${lib.getLib botan3}/lib -name 'libbotan-3.so' -print -quit)
+        substituteInPlace botan3.py --replace-fail 'libbotan-3.so' "$botanLibPath"
+      ''
+  );
+
+  pythonImportsCheck = [ "botan3" ];
+
+  meta = {
+    description = "Python Bindings for botan3 cryptography library";
+    homepage = "https://github.com/randombit/botan";
+    changelog = "https://github.com/randombit/botan/blob/${version}/news.rst";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ thillux ];
+  };
+}

--- a/pkgs/development/python-modules/botan3/pyproject.toml
+++ b/pkgs/development/python-modules/botan3/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "botan3"
+description = "Python bindings for Botan C++ cryptography library"
+license = "BSD-2-Clause"
+dynamic = [ "version" ]
+authors = [
+    {name = "Jack Lloyd", email = "jack@randombit.net"},
+    {name = "Botan contributors" }
+]
+maintainers = [ {name = "Jack Lloyd", email = "jack@randombit.net"} ]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Topic :: Security :: Cryptography",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy"
+]
+# adapt from time to time with the latest still supported version
+requires-python = ">=3.9"
+
+[project.urls]
+Homepage = "https://botan.randombit.net/"
+Issues = "https://github.com/randombit/botan/issues"
+
+[build-system]
+requires = [ "setuptools>=61", "setuptools-scm>=8" ]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["botan3"]
+
+# read version information from git
+[tool.setuptools_scm]
+root = "../.."

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2054,6 +2054,8 @@ self: super: with self; {
 
   bot-safe-agents = callPackage ../development/python-modules/bot-safe-agents { };
 
+  botan3 = callPackage ../development/python-modules/botan3 { inherit (pkgs) botan3; };
+
   boto3 = callPackage ../development/python-modules/boto3 { };
 
   boto3-stubs = callPackage ../development/python-modules/boto3-stubs { };


### PR DESCRIPTION
Release notes: https://botan.randombit.net/news.html#version-3-9-0-2025-08-05

Notable changes:
- Support for RFC3779
- Speedups for various algorithms with vector instructions (SHA-1, ECC, ...)
- better cmake support

nixpkgs related:
- added python package for botan3
- fix cross compilation to Windows with MingGW

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
