### PR TITLE
lib.attrsets{attrNamesRecursive, attrValuesRecursive}: init

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -2070,6 +2070,80 @@ rec {
     in
     (x // y) // mask;
 
+  /**
+    Recursively get the attribute names of an AttrSet.
+
+    # Inputs
+
+    `attrs`
+
+    : The AttrSet
+
+    # Type
+
+    ```
+    attrNamesRecursive :: AttrSet -> [ [ String ] ]
+    ```
+
+    # Examples
+    :::{.example}
+
+    ## `lib.attrsets.attrNamesRecursive` usage example
+
+    ```nix
+    attrNamesRecursive { a = { b = 1; c = 2; }; d = 3; e.f = "g"; h = {}; }
+    => [ [ "a" "b" ] [ "a" "c" ] [ "d" ] [ "e" "f" ] ]
+    ```
+
+    :::
+  */
+  attrNamesRecursive =
+    attrs:
+    if lib.isAttrs attrs then
+      lib.foldlAttrs (
+        acc: name: value:
+        acc ++ lib.map (path: [ name ] ++ path) (attrNamesRecursive value)
+      ) [ ] attrs
+    else
+      [ [ ] ];
+
+  /**
+    Recursively get the attribute values of an AttrSet.
+
+    # Inputs
+
+    `attrs`
+
+    : The AttrSet
+
+    # Type
+
+    ```
+    attrValuesRecursive :: AttrSet -> [ Any ]
+    ```
+
+    # Examples
+    :::{.example}
+
+    ## `lib.attrsets.attrValuesRecursive` usage example
+
+    ```nix
+    attrValuesRecursive { a = { b = 1; c = 2; }; d = 3; e.f = "g"; h = {}; }
+    => [ 1 2 3 "g" ]
+    ```
+
+    :::
+  */
+  attrValuesRecursive =
+    attrs:
+    if lib.isAttrs attrs then
+      lib.foldlAttrs (
+        acc: name: value:
+        acc ++ attrValuesRecursive value
+      ) [ ] attrs
+    else
+      [ attrs ];
+
   # DEPRECATED
   zipWithNames = warn "lib.zipWithNames is a deprecated alias of lib.zipAttrsWithNames." zipAttrsWithNames;
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2230,6 +2230,51 @@ runTests {
     someFunc = a: a + 1;
   });
 
+  testAttrNamesRecursive = {
+    expr = lib.attrsets.attrNamesRecursive {
+      a = {
+        b = 1;
+        c = 2;
+      };
+      d = 3;
+      e.f = "g";
+      h = { };
+    };
+    expected = [
+      [
+        "a"
+        "b"
+      ]
+      [
+        "a"
+        "c"
+      ]
+      [ "d" ]
+      [
+        "e"
+        "f"
+      ]
+    ];
+  };
+
+  testAttrValuesRecursive = {
+    expr = lib.attrsets.attrValuesRecursive {
+      a = {
+        b = 1;
+        c = 2;
+      };
+      d = 3;
+      e.f = "g";
+      h = { };
+    };
+    expected = [
+      1
+      2
+      3
+      "g"
+    ];
+  };
+
   # FIXED-POINTS
 
   testFix = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Motivation

These functions can't be easily replicated by chaining a couple builtins and are _somewhat_ difficult to implement cleanly. Their names are also intuitive (at least IMHO) so it shouldn't be hard to find them if someone was looking for a function like this, and it should also be pretty easy to remember. As such, I believe these meet the threshold for inclusion.

Both of these have been used in my own personal projects, particularly `attrValuesRecursive`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
