### PR TITLE
kanji-stroke-order-font: 4.004 -> 4.005

### DIFF
--- a/pkgs/by-name/ka/kanji-stroke-order-font/package.nix
+++ b/pkgs/by-name/ka/kanji-stroke-order-font/package.nix
@@ -6,17 +6,15 @@
 
 let
   font = "kanji-stroke-order";
-  version = "4.004";
 in
 stdenv.mkDerivation {
   pname = "${font}-font";
-  inherit version;
+  version = "4.005";
 
   src = fetchzip {
     # https://github.com/NixOS/nixpkgs/issues/60157
-    url = "https://drive.google.com/uc?export=download&id=1snpD-IQmT6fGGQjEePHdDzE2aiwuKrz4#${font}.zip";
-    hash = "sha256-wQpurDS6APnpNMbMHofwW/UKeBF8FXeiCVx4wAOeRoE=";
-    stripRoot = false;
+    url = "https://drive.google.com/uc?export=download&id=1DKZEYA3PJ8ulLnjYDP5bxzJ3SWi59ghr#${font}.zip";
+    hash = "sha256-6mw72eoRIGzG2IoVnPo1G0i2Z2Ot8Q/WjaJ8tNDQbMk=";
   };
 
   installPhase = ''
@@ -29,15 +27,15 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Font containing stroke order diagrams for over 6500 kanji, 180 kana and other characters";
-    homepage = "https://www.nihilist.org.uk/";
+    homepage = "https://www.kanji.uk/";
 
-    license = [ licenses.bsd3 ];
-    maintainers = with maintainers; [
+    license = [ lib.licenses.bsd3 ];
+    maintainers = with lib.maintainers; [
       ptrhlm
       stephen-huan
     ];
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Use the Google Drive link from the [homepage](https://www.kanji.uk/). For additional discussion about this, see https://github.com/NixOS/nixpkgs/pull/308702#discussion_r1588968580.

<details>
<summary>full changelog from README</summary>

```text
2025/07/27  4.005 Corrections and improvements reported by users.
                  Make files unzip into a directory.
                  U+2031 ‱ Fixed width of glyph.
                  U+2166 Ⅶ Fixed a near-invisible path glitch.
                  U+216B Ⅻ Fixed a near-invisible path glitch.
                  U+26A0 ⚠ Fixed a near-invisible path glitch.
                  U+26E4 ⛤ Added pentagram symbol.
                  U+26E7 ⛧ Added inverted pentagram symbol.
                  U+26E9 ⛩ Added Shintō shrine symbol.
                  U+51A4 冤 Clarified strokes 3 and 4. Note that this
                           JIS-approved variant of this
                           kanji strictly belongs at 冤 U+2F818. However, I
                           believe that typical users of this font are better
                           served with the JIS-approved version of this kanji
                           in this slot. Furthermore, this font does not
                           extend beyond U+FFFF. See also  U+F785 for the
                           JIS-deprecated variant of this kanji.
                  U+53F1 叱 Changed to the JIS-approved variant with stroke 4
                           starting on the left side. Note that, strictly,
                           this JIS-approved variant of this kanji belongs at
                           𠮟 U+20B9F. However, I believe that typical users
                           of this font are better served with the
                           JIS-approved version of this kanji in this slot.
                           Furthermore, this font does not extend beyond
                           U+FFFF. See  U+F783 for the JIS-deprecated variant
                           of this kanji.
                  U+55DA 嗚 Unmerged some stroke numbers from strokes.
                  U+58F0 声 Clarified numbering of stroke 6.
                  U+5FC3 心 Fixed appearance of stroke 1 so that it no longer
                           curves outwards.
                  U+6372 捲 Fixed a near-invisible path glitch.
                  U+6414 搔 Fixed a near-invisible path glitch.
                  U+68CA 棊 Fixed a near-invisible path glitch.
                  U+6C10 氐 Fixed start point of stroke 1. Made another attempt
                           to improve appearance.
                  U+72D0 狐 Fixed a near-invisible path glitch.
                  U+7483 璃 Made the 13th and 14th strokes obviously separate.
                  U+7565 略 Fixed a near-invisible path glitch.
                  U+7950 祐 Fixed a near-invisible path glitch.
                  U+7DBA 綺 Fixed a near-invisible path glitch.
                  U+8877 衷 Reverted to the JIS-approved 9-stroke variant.
                           This is a controversial kanji. See  U+F784
                           for the JIS-deprecated 10-stroke variant.
                  U+89E6 触 Fixed a near-invisible path glitch.
                  U+9077 遷 Fixed a near-invisible path glitch.
                  U+90F7 郷 Fixed a near-invisible path glitch.
                  U+936E 鍮 Fixed a near-invisible path glitch.
                  U+95BB 閻 Fixed a near-invisible path glitch.
                  U+95DC 關 Fixed a near-invisible path glitch.
                  U+98C3 飃 Fixed a near-invisible path glitch.
                  U+F783  Moved the JIS-deprecated variant of 叱 U+53F1 with
                           stroke 4 starting on the right side from 叱 U+53F1
                           to this slot in the Private Use Area. See also
                           叱 U+53F1.
                  U+F784  Added the JIS-deprecated 10-stroke variant of
                         衷 U+8877 to this slot in the Private Use Area. See
                         衷 U+8877 for the JIS-approved 9-stroke variant.
                  U+F785  Added the JIS-deprecated variant of 冤 U+51A4 to
                           this slot in the Private Use Area. See 冤 U+51A4
                           for the JIS-approved variant.
                  U+FA4F 祐 Fixed a near-invisible path glitch.
                  U+FAFF 﫿 Deleted the JIS-approved variant of U+53F1 叱 with
                           the fourth stroke starting on the left side from
                           this slot because U+FAFF is not in the Private Use
                           Area. Instead the JIS-approved variant of this
                           kanji appears at U+53F1 叱 and the JIS-deprecated
                           version of this kanji appears in the Private Use
                           Area at U+F783 . See also 叱 U+53F1 and  U+F783.
                  U+FB05 ﬅ Fixed Latin Small Ligature Long S T to depict a
                           long s instead of an f.
                  U+FF6B ｫ Improved appearance.
                  U+FF6D ｭ Improved appearance.
                  U+FF71 ｱ Improved appearance.
                  U+FF74 ｴ Improved appearance.
                  U+FF76 ｶ Improved appearance.
                  U+FF77 ｷ Improved appearance.
                  U+FF7A ｺ Improved appearance.
                  U+FF7B ｻ Improved appearance.
                  U+FF7C ｼ Improved appearance.
                  U+FF7D ｽ Improved appearance.
                  U+FF7E ｾ Improved appearance.
                  U+FF7F ｿ Improved appearance.
                  U+FF80 ﾀ Fixed half-width Katakana ta to be ta and not wo.
                  U+FF83 ﾃ Improved appearance.
                  U+FF85 ﾅ Improved appearance.
                  U+FF86 ﾆ Improved appearance.
                  U+FF8C ﾌ Improved appearance.
                  U+FF8D ﾍ Improved appearance.
                  U+FF8E ﾎ Improved appearance.
                  U+FF94 ﾔ Improved appearance.
                  U+FF95 ﾕ Improved appearance.
                  U+FF96 ﾖ Improved appearance.
                  U+FF99 ﾙ Improved appearance.
                  U+FF9C ﾜ Improved appearance.
```

</details>

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `adf7675c8a6572b42d729ef6e9fb82cb808b7135`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>kanji-stroke-order-font</li>
  </ul>
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
