### PR TITLE
dopamine: 3.0.0-preview.38 -> 3.0.0-preview.39

### DIFF
--- a/pkgs/by-name/do/dopamine/package.nix
+++ b/pkgs/by-name/do/dopamine/package.nix
@@ -6,11 +6,11 @@
 }:
 appimageTools.wrapType2 rec {
   pname = "dopamine";
-  version = "3.0.0-preview.38";
+  version = "3.0.0-preview.39";
 
   src = fetchurl {
     url = "https://github.com/digimezzo/dopamine/releases/download/v${version}/Dopamine-${version}.AppImage";
-    hash = "sha256-PWYymznUsJUaeC0wD5wK2bqU7y7lkY64/svB8Tw4JJQ=";
+    hash = "sha256-t4f+4ceGyEJHuJxk/8/BMWK0oGYoFXZMjk8UCHLJId8=";
   };
 
   extraInstallCommands =
@@ -32,7 +32,10 @@ appimageTools.wrapType2 rec {
     homepage = "https://github.com/digimezzo/dopamine";
     license = lib.licenses.gpl3Only;
     mainProgram = "dopamine";
-    maintainers = with lib.maintainers; [ Guanran928 ];
+    maintainers = with lib.maintainers; [
+      Guanran928
+      ern775
+    ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
-Added myself as maintainer.
-Updated from version [3.0.0-preview.38](https://github.com/digimezzo/dopamine/releases/tag/v3.0.0-preview.38) to [3.0.0-preview.39](https://github.com/digimezzo/dopamine/releases/tag/v3.0.0-preview.39). Done manually due to [r-ryantm](https://github.com/NixOS/nixpkgs/commits?author=r-ryantm) failing because of [v3.0.0-preview.39-fix-776](https://github.com/digimezzo/dopamine/releases/tag/v3.0.0-preview.39-fix-776) which has no appimage release. See https://r.ryantm.com/log/dopamine/2025-08-04.log

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
