### PR TITLE
rsync: fix tests in Darwin sandbox

### DIFF
--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-KSS8s6Hti1UfwQH3QLnw/gogKxFQJ2R89phQ1l/YjFI=";
   };
 
+  patches = [
+    # See: <https://github.com/RsyncProject/rsync/pull/790>
+    ./fix-tests-in-darwin-sandbox.patch
+  ];
+
   nativeBuildInputs = [
     updateAutotoolsGnuConfigScriptsHook
     perl
@@ -74,6 +79,8 @@ stdenv.mkDerivation rec {
   passthru.tests = { inherit (nixosTests) rsyncd; };
 
   doCheck = true;
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Fast incremental file transfer utility";

--- a/pkgs/applications/networking/sync/rsync/fix-tests-in-darwin-sandbox.patch
+++ b/pkgs/applications/networking/sync/rsync/fix-tests-in-darwin-sandbox.patch
@@ -1,0 +1,56 @@
+From 9b104ed9859f17b6ed4c4ad01806c75a0c197dd7 Mon Sep 17 00:00:00 2001
+From: Emily <hello@emily.moe>
+Date: Tue, 5 Aug 2025 15:55:24 +0100
+Subject: [PATCH] Allow `ls(1)` to fail in test setup
+
+This can happen when the tests are unable to `stat(2)` some files in
+`/etc`, `/bin`, or `/`, due to Unix permissions or other sandboxing. We
+still guard against serious errors, which use exit code 2.
+---
+ testsuite/longdir.test | 4 ++--
+ testsuite/rsync.fns    | 8 ++++----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/testsuite/longdir.test b/testsuite/longdir.test
+index 8d66bb5f..26747292 100644
+--- a/testsuite/longdir.test
++++ b/testsuite/longdir.test
+@@ -16,9 +16,9 @@ makepath "$longdir" || test_skipped "unable to create long directory"
+ touch "$longdir/1" || test_skipped "unable to create files in long directory"
+ date > "$longdir/1"
+ if [ -r /etc ]; then
+-    ls -la /etc >"$longdir/2"
++    ls -la /etc >"$longdir/2" || [ $? -eq 1 ]
+ else
+-    ls -la / >"$longdir/2"
++    ls -la / >"$longdir/2" || [ $? -eq 1 ]
+ fi
+ checkit "$RSYNC --delete -avH '$fromdir/' '$todir'" "$fromdir/" "$todir"
+ 
+diff --git a/testsuite/rsync.fns b/testsuite/rsync.fns
+index 2ab97b69..f7da363f 100644
+--- a/testsuite/rsync.fns
++++ b/testsuite/rsync.fns
+@@ -195,15 +195,15 @@ hands_setup() {
+     echo some data > "$fromdir/dir/subdir/foobar.baz"
+     mkdir "$fromdir/dir/subdir/subsubdir"
+     if [ -r /etc ]; then
+-	ls -ltr /etc > "$fromdir/dir/subdir/subsubdir/etc-ltr-list"
++	ls -ltr /etc > "$fromdir/dir/subdir/subsubdir/etc-ltr-list" || [ $? -eq 1 ]
+     else
+-	ls -ltr / > "$fromdir/dir/subdir/subsubdir/etc-ltr-list"
++	ls -ltr / > "$fromdir/dir/subdir/subsubdir/etc-ltr-list" || [ $? -eq 1 ]
+     fi
+     mkdir "$fromdir/dir/subdir/subsubdir2"
+     if [ -r /bin ]; then
+-	ls -lt /bin > "$fromdir/dir/subdir/subsubdir2/bin-lt-list"
++	ls -lt /bin > "$fromdir/dir/subdir/subsubdir2/bin-lt-list" || [ $? -eq 1 ]
+     else
+-	ls -lt / > "$fromdir/dir/subdir/subsubdir2/bin-lt-list"
++	ls -lt / > "$fromdir/dir/subdir/subsubdir2/bin-lt-list" || [ $? -eq 1 ]
+     fi
+ 
+ #      echo testing head:
+-- 
+2.50.1
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
