### PR TITLE
ctrld: init at 1.4.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9683,6 +9683,12 @@
     githubId = 28863828;
     name = "guserav";
   };
+  GustavoWidman = {
+    name = "Gustavo Widman";
+    email = "admin@r3dlust.com";
+    github = "GustavoWidman";
+    githubId = 123963822;
+  };
   guyonvarch = {
     github = "guyonvarch";
     githubId = 6768842;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1112,6 +1112,7 @@
   ./services/networking/crab-hole.nix
   ./services/networking/create_ap.nix
   ./services/networking/croc.nix
+  ./services/networking/ctrld.nix
   ./services/networking/dae.nix
   ./services/networking/dante.nix
   ./services/networking/ddclient.nix

--- a/nixos/modules/services/networking/ctrld.nix
+++ b/nixos/modules/services/networking/ctrld.nix
@@ -1,0 +1,139 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.ctrld;
+  toml = pkgs.formats.toml { };
+  configFile =
+    if lib.isString cfg.settings then
+      cfg.settings
+    else if lib.isPath cfg.settings then
+      builtins.toString cfg.settings
+    else
+      toml.generate "ctrld.toml" cfg.settings;
+in
+{
+  options.services.ctrld = {
+    enable = lib.mkEnableOption "Enable ctrld DNS proxy";
+    package = lib.mkPackageOption pkgs "ctrld" { };
+
+    # https://github.com/Control-D-Inc/ctrld/blob/main/README.md#default-config
+    settings = lib.mkOption {
+      type =
+        with lib.types;
+        lib.types.oneOf [
+          path
+          str
+          toml.type
+        ];
+
+      default = {
+        listener."listener.0" = {
+          ip = "";
+          port = 0;
+          restricted = false;
+        };
+
+        network."network.0" = {
+          cidrs = [ "0.0.0.0/0" ];
+          name = "Network 0";
+        };
+
+        service = {
+          log_level = "info";
+          log_path = "";
+        };
+
+        upstream = {
+          "upstream.0" = {
+            bootstrap_ip = "76.76.2.11";
+            endpoint = "https://freedns.controld.com/p1";
+            name = "Control D - Anti-Malware";
+            timeout = 5000;
+            type = "doh";
+          };
+
+          "upstream.1" = {
+            bootstrap_ip = "76.76.2.11";
+            endpoint = "p2.freedns.controld.com";
+            name = "Control D - No Ads";
+            timeout = 3000;
+            type = "doq";
+          };
+        };
+      };
+
+      description = ''
+        Configuration for ctrld. Accepts path to a TOML file, see
+        <https://github.com/Control-D-Inc/ctrld/blob/main/docs/config.md>
+      '';
+    };
+
+    setNameservers = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        If true, sets the nameservers of this machine to 127.0.0.1 (our local ctrld instance)
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.nameservers = lib.mkIf cfg.setNameservers [ "127.0.0.1" ];
+
+    systemd.services.ctrld = {
+      description = "Control-D DNS Proxy";
+      after = [
+        "network.target"
+      ];
+      before = [ "nss-lookup.target" ];
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ cfg.package ];
+
+      serviceConfig = {
+        Type = "exec";
+        Restart = "always";
+        RestartSec = 5;
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ "/var/run" ];
+
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+        ];
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged @resources"
+        ];
+
+        MemoryDenyWriteExecute = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectClock = true;
+
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        PrivateDevices = true;
+        LockPersonality = true;
+
+        NoNewPrivileges = true;
+        RestrictSUIDSGID = true;
+
+        ExecStart = "${pkgs.lib.getExe cfg.package} run --config=${configFile}";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ GustavoWidman ];
+}

--- a/pkgs/by-name/ct/ctrld/package.nix
+++ b/pkgs/by-name/ct/ctrld/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "ctrld";
+  version = "1.4.5";
+
+  src = fetchFromGitHub {
+    owner = "Control-D-Inc";
+    repo = "ctrld";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZiNyB8d4x6SBG5MIGqzHzQgFbMCRunPPpGKzffwmXBM=";
+  };
+
+  vendorHash = "sha256-AVR+meUcjpExjUo7J1U6zUPY2B+9NOqBh7K/I8qrqL4=";
+  proxyVendor = true;
+  subPackages = [ "cmd/ctrld" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/Control-D-Inc/ctrld/cmd/cli.version=${finalAttrs.version}"
+    "-X github.com/Control-D-Inc/ctrld/cmd/cli.commit=${finalAttrs.src.rev}"
+  ];
+
+  meta = {
+    description = "Highly configurable, multi-protocol DNS forwarding proxy";
+    homepage = "https://github.com/Control-D-Inc/ctrld";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GustavoWidman ];
+    platforms = lib.platforms.all;
+    mainProgram = "ctrld";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Description

Adds package and configurable systemd service for the ctrld DNS proxy. This is my first time adding a package to nixpkgs, not quite sure if i'm doing everything "to the book" but i checked relevant documentations, kept code formatted using `nixfmt` and checked other PRs over here to at least try and mimic how packages are usually added.

Homepage: https://github.com/Control-D-Inc/ctrld/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
