### PR TITLE
python3Packages.cnvkit: fix build error and failing tests

### DIFF
--- a/pkgs/development/python-modules/pomegranate/default.nix
+++ b/pkgs/development/python-modules/pomegranate/default.nix
@@ -3,20 +3,15 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-
-  # build-system
+  fetchpatch,
+  pytestCheckHook,
   setuptools,
-
-  # dependencies
   apricot-select,
   networkx,
   numpy,
   scikit-learn,
   scipy,
   torch,
-
-  # tests
-  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -27,33 +22,9 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     repo = "pomegranate";
     owner = "jmschrei";
-    # tag = "v${version}";
-    # No tag for 1.1.2
-    rev = "e9162731f4f109b7b17ecffde768734cacdb839b";
-    hash = "sha256-vVoAoZ+mph11ZfINT+yxRyk9rXv6FBDgxBz56P2K95Y=";
+    tag = "v${version}";
+    hash = "sha256-p2Gn0FXnsAHvRUeAqx4M1KH0+XvDl3fmUZZ7MiMvPSs=";
   };
-
-  # _pickle.UnpicklingError: Weights only load failed.
-  # https://pytorch.org/docs/stable/generated/torch.load.html
-  postPatch = ''
-    substituteInPlace \
-      tests/distributions/test_bernoulli.py \
-      tests/distributions/test_categorical.py \
-      tests/distributions/test_exponential.py \
-      tests/distributions/test_gamma.py \
-      tests/distributions/test_independent_component.py \
-      tests/distributions/test_normal_diagonal.py \
-      tests/distributions/test_normal_full.py \
-      tests/distributions/test_poisson.py \
-      tests/distributions/test_student_t.py \
-      tests/distributions/test_uniform.py \
-      tests/test_bayes_classifier.py \
-      tests/test_gmm.py \
-      tests/test_kmeans.py \
-      --replace-fail \
-        'torch.load(".pytest.torch")' \
-        'torch.load(".pytest.torch", weights_only=False)'
-  '';
 
   build-system = [ setuptools ];
 
@@ -72,11 +43,20 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTestPaths = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+  patches = [
+    # Fix tests for pytorch 2.6
+    (fetchpatch {
+      name = "python-2.6.patch";
+      url = "https://github.com/jmschrei/pomegranate/pull/1142/commits/9ff5d5e2c959b44e569937e777b26184d1752a7b.patch";
+      hash = "sha256-BXsVhkuL27QqK/n6Fa9oJCzrzNcL3EF6FblBeKXXSts=";
+    })
+  ];
+
+  pytestFlagsArray = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # AssertionError: Arrays are not almost equal to 6 decimals
-    "=tests/distributions/test_normal_full.py::test_fit"
-    "=tests/distributions/test_normal_full.py::test_from_summaries"
-    "=tests/distributions/test_normal_full.py::test_serialization"
+    "--deselect=tests/distributions/test_normal_full.py::test_fit"
+    "--deselect=tests/distributions/test_normal_full.py::test_from_summaries"
+    "--deselect=tests/distributions/test_normal_full.py::test_serialization"
   ];
 
   disabledTests = [


### PR DESCRIPTION
Fix to both pomegranate and cnvkit to pass all tests. Tested on the [sarek pipeline](https://github.com/nf-core/sarek) from nf-core.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
