### PR TITLE
rust-addr2line: init at 0.25.0

### DIFF
--- a/pkgs/by-name/ru/rust-addr2line/package.nix
+++ b/pkgs/by-name/ru/rust-addr2line/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rust-addr2line";
+  version = "0.25.0";
+
+  src = fetchFromGitHub {
+    owner = "gimli-rs";
+    repo = "addr2line";
+    tag = version;
+    hash = "sha256-1kjFrDHfvGdU5FfSaLE+EFN83XjF0iSpydwsucjV7NQ=";
+  };
+
+  cargoBuildFlags = "--bin addr2line --features bin";
+
+  cargoHash = "sha256-IJ+hZ36QL5Awq4vI+ajTTHwbRU4paG+bnB/TZU9bCCk=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cross-platform `addr2line` clone written in Rust, using `gimli`";
+    homepage = "https://github.com/gimli-rs/addr2line";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = [ lib.maintainers.axka ];
+    mainProgram = "addr2line";
+  };
+}


### PR DESCRIPTION
https://github.com/gimli-rs/addr2line

Useful for getting [`flamegraph`, `cargo flamegraph`](https://github.com/flamegraph-rs/flamegraph) and `perf script report flamegraph` to run faster.

Name taken from here: https://repology.org/project/rust%3Aaddr2line/packages

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
