### PR TITLE
virt-v2v: 2.6.0 -> 2.8.1

### DIFF
--- a/pkgs/by-name/vi/virt-v2v/package.nix
+++ b/pkgs/by-name/vi/virt-v2v/package.nix
@@ -24,6 +24,7 @@
   withWindowsGuestSupport ? true,
   pkgsCross, # for rsrvany
   virtio-win,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -93,6 +94,12 @@ stdenv.mkDerivation (finalAttrs: {
   PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR = "${placeholder "out"}/share/bash-completion/completions";
 
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+
+  passthru.updateScript = gitUpdater {
+    url = "https://github.com/libguestfs/guestfs-tools";
+    rev-prefix = "v";
+    odd-unstable = true;
+  };
 
   meta = {
     homepage = "https://github.com/libguestfs/virt-v2v";

--- a/pkgs/by-name/vi/virt-v2v/package.nix
+++ b/pkgs/by-name/vi/virt-v2v/package.nix
@@ -16,7 +16,7 @@
   libosinfo,
   pcre2,
   libxml2,
-  jansson,
+  json_c,
   glib,
   libguestfs-with-appliance,
   cdrkit,
@@ -28,17 +28,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "virt-v2v";
-  version = "2.6.0";
+  version = "2.8.1";
 
   src = fetchurl {
     url = "https://download.libguestfs.org/virt-v2v/${lib.versions.majorMinor finalAttrs.version}-stable/virt-v2v-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-W7t/n1QO9UebyH85abtnSY5i7kH/6h8JIAlFQoD1vkU=";
+    sha256 = "sha256-RJPwtI6GHN+W+Pw8jdEAgQMbR42aGqTYW2rPtAYBPYM=";
   };
 
   postPatch = ''
-    substituteInPlace common/mlv2v/uefi.ml \
-        --replace-fail '/usr/share/OVMF/OVMF_CODE.fd' "${OVMF.firmware}" \
-        --replace-fail '/usr/share/OVMF/OVMF_VARS.fd' "${OVMF.variables}"
+    # TODO: allow guest != host CPU ISA
+    substituteInPlace output/output_qemu.ml \
+        --replace-fail '/usr/share/OVMF' ""${OVMF.fd}/FV/" \
+        --replace-fail '/usr/share/AAVMF' ""${OVMF.fd}/FV/"
 
     patchShebangs .
   '';
@@ -61,10 +62,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]);
 
   buildInputs = [
+    json_c
     libosinfo
     pcre2
     libxml2
-    jansson
     glib
   ]
   ++ (with ocamlPackages; [


### PR DESCRIPTION
## Description of changes

(https://github.com/libguestfs/virt-v2v/compare/refs/tags/v2.6.0...refs/tags/v2.8.1)

fixed build by updating 2.6.0 -> 2.8.1 (Resolves #430199)
add updateScript

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
