### PR TITLE
pinentry_mac: fix the build with `sandbox = true`

### DIFF
--- a/pkgs/tools/security/pinentry/fix-with-xcbuild-plistbuddy.patch
+++ b/pkgs/tools/security/pinentry/fix-with-xcbuild-plistbuddy.patch
@@ -1,0 +1,21 @@
+diff --git a/macosx/copyInfoPlist.sh b/macosx/copyInfoPlist.sh
+index f366665153..dfd9511e79 100755
+--- a/macosx/copyInfoPlist.sh
++++ b/macosx/copyInfoPlist.sh
+@@ -20,9 +20,10 @@
+ cp "$1" "$dest" || exit 1
+ 
+ 
+-/usr/libexec/PlistBuddy \
+-	-c "Set CommitHash '${COMMIT_HASH:--}'" \
+-	-c "Set BuildNumber '${BUILD_NUMBER:-0}'" \
+-	-c "Set CFBundleVersion '${BUILD_VERSION:-0n}'" \
+-	-c "Set CFBundleShortVersionString '$VERSION'" \
+-	"$dest" || exit 1
++PlistBuddy "$dest" <<EOF || exit 1
++    Set CommitHash "${COMMIT_HASH:--}"
++    Set BuildNumber "${BUILD_NUMBER:-0}"
++    Set CFBundleVersion "${BUILD_VERSION:-0n}"
++    Set CFBundleShortVersionString "$VERSION"
++    Save
++EOF

--- a/pkgs/tools/security/pinentry/mac.nix
+++ b/pkgs/tools/security/pinentry/mac.nix
@@ -7,6 +7,7 @@
   libgpg-error,
   makeBinaryWrapper,
   texinfo,
+  xcbuild,
   common-updater-scripts,
   writers,
 }:
@@ -27,6 +28,9 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./gettext-0.25.patch
+
+    # Fix the build with xcbuild’s inferior `PlistBuddy(8)`.
+    ./fix-with-xcbuild-plistbuddy.patch
   ];
 
   # use pregenerated nib files because generating them requires XCode
@@ -38,16 +42,14 @@ stdenv.mkDerivation rec {
     cp '${lib.getDev libassuan}/share/aclocal/libassuan.m4' m4/libassuan.m4
   '';
 
-  # Unfortunately, PlistBuddy from xcbuild is not compatible enough pinentry-mac’s build process.
-  sandboxProfile = ''
-    (allow process-exec (literal "/usr/libexec/PlistBuddy"))
-  '';
-
   strictDeps = true;
   nativeBuildInputs = [
     autoreconfHook
     makeBinaryWrapper
     texinfo
+
+    # for `PlistBuddy(8)`
+    xcbuild
   ];
 
   configureFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
