### PR TITLE
llvmPackages.llvm: propagate `libxml2`

### DIFF
--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -328,7 +328,6 @@ stdenv.mkDerivation (
     ];
 
     buildInputs = [
-      libxml2
       libffi
     ]
     ++ optional enablePFM libpfm; # exegesis
@@ -337,7 +336,10 @@ stdenv.mkDerivation (
       (lib.optional (
         lib.versionAtLeast release_version "14" || stdenv.buildPlatform == stdenv.hostPlatform
       ) ncurses)
-      ++ [ zlib ];
+      ++ [
+        zlib
+        libxml2
+      ];
 
     postPatch =
       optionalString stdenv.hostPlatform.isDarwin (
@@ -627,10 +629,6 @@ stdenv.mkDerivation (
         (lib.cmakeBool "LLVM_ENABLE_PIC" false)
         (lib.cmakeBool "CMAKE_SKIP_INSTALL_RPATH" true)
         (lib.cmakeBool "LLVM_BUILD_STATIC" true)
-        # libxml2 needs to be disabled because the LLVM build system ignores its .la
-        # file and doesn't link zlib as well.
-        # https://github.com/ClangBuiltLinux/tc-build/issues/150#issuecomment-845418812
-        (lib.cmakeBool "LLVM_ENABLE_LIBXML2" false)
       ]
       ++ optionals enableManpages [
         (lib.cmakeBool "LLVM_BUILD_DOCS" true)


### PR DESCRIPTION
It seems something changed about LLVM’s CMake dependency handling in 21, and at least the bootstrap `ld64` now passes `-lxml2` during the build.

Hopefully this also means static is also fixed, so I’ve optimistically dropped that without testing.

---

It would be good if someone could test `pkgsStatic.llvm_21`. It also probably needs conditionalizing, although I wouldn’t be surprised if the comment was already outdated…

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
