### PR TITLE
Simplify definitions of libcs

### DIFF
--- a/pkgs/by-name/av/avrlibc/package.nix
+++ b/pkgs/by-name/av/avrlibc/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  stdenv,
+  stdenvNoLibc,
   fetchurl,
   automake,
   autoconf,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "avr-libc";
   version = "2.2.1";
 

--- a/pkgs/by-name/mu/musl/package.nix
+++ b/pkgs/by-name/mu/musl/package.nix
@@ -1,11 +1,17 @@
 {
   stdenv,
+  stdenvNoLibc,
   lib,
   fetchurl,
   linuxHeaders ? null,
   useBSDCompatHeaders ? true,
 }:
 let
+  stdenv' = if stdenv.hostPlatform != stdenv.buildPlatform then stdenvNoLibc else stdenv;
+in
+let
+  stdenv = stdenv';
+
   cdefs_h = fetchurl {
     name = "sys-cdefs.h";
     url = "https://git.alpinelinux.org/aports/plain/main/libc-dev/sys-cdefs.h?id=7ca0ed62d4c0d713d9c7dd5b9a077fba78bce578";

--- a/pkgs/by-name/wa/wasilibc/package.nix
+++ b/pkgs/by-name/wa/wasilibc/package.nix
@@ -1,7 +1,6 @@
 {
-  stdenv,
+  stdenvNoLibc,
   buildPackages,
-  fetchFromGitHub,
   lib,
   firefox-unwrapped,
   firefox-esr-unwrapped,
@@ -11,7 +10,7 @@ let
   pname = "wasilibc";
   version = "22-unstable-2024-10-16";
 in
-stdenv.mkDerivation {
+stdenvNoLibc.mkDerivation {
   inherit pname version;
 
   src = buildPackages.fetchFromGitHub {

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoLibc,
   fetchurl,
   buildPackages,
   lib,
@@ -11,7 +11,7 @@
   nanoizeNewlib ? false,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "newlib";
   version = "4.5.0.20241231";
 
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     # "normal" view to the outside world: the binaries in $out will
     # execute on `stdenv.hostPlatform`.  We then fool newlib's build
     # process into doing the right thing.
-    "--host=${stdenv.targetPlatform.config}"
+    "--host=${stdenvNoLibc.targetPlatform.config}"
 
   ]
   ++ (
@@ -134,8 +134,8 @@ stdenv.mkDerivation (finalAttrs: {
     + ''[ "$(find $out -type f | wc -l)" -gt 0 ] || (echo '$out is empty' 1>&2 && exit 1)'';
 
   passthru = {
-    incdir = "/${stdenv.targetPlatform.config}/include";
-    libdir = "/${stdenv.targetPlatform.config}/lib";
+    incdir = "/${stdenvNoLibc.targetPlatform.config}/include";
+    libdir = "/${stdenvNoLibc.targetPlatform.config}/lib";
   };
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6646,10 +6646,6 @@ with pkgs;
 
   h3 = h3_3;
 
-  avrlibc = callPackage ../development/misc/avr/libc {
-    stdenv = stdenvNoLibc;
-  };
-
   sourceFromHead = callPackage ../build-support/source-from-head-fun.nix { };
 
   jruby = callPackage ../development/interpreters/jruby { };
@@ -8005,12 +8001,6 @@ with pkgs;
     withGd = true;
   };
 
-  musl = callPackage ../by-name/mu/musl/package.nix (
-    lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
-      stdenv = stdenvNoLibc;
-    }
-  );
-
   # These are used when building compiler-rt / libgcc, prior to building libc.
   preLibcHeaders =
     let
@@ -8081,10 +8071,6 @@ with pkgs;
         # For win32 or posix set this to null
         package = windows.mcfgthreads;
       };
-
-  wasilibc = callPackage ../development/libraries/wasilibc {
-    stdenv = stdenvNoLibc;
-  };
 
   # Only supported on Linux and only on glibc
   glibcLocales =
@@ -16287,12 +16273,9 @@ with pkgs;
 
   xp-pen-deco-01-v2-driver = libsForQt5.xp-pen-deco-01-v2-driver;
 
-  newlib = callPackage ../development/misc/newlib {
-    stdenv = stdenvNoLibc;
-  };
+  newlib = callPackage ../development/misc/newlib { };
 
   newlib-nano = callPackage ../development/misc/newlib {
-    stdenv = stdenvNoLibc;
     nanoizeNewlib = true;
   };
 


### PR DESCRIPTION
- Used `stdenvNoLibc` directly in the package files instead of overriding `stdenv` to it in `all-packages.nix`
- Moved applicable libcs to `pkgs/by-name` (note: not newlib because it's also accessible via `newlib-nano`)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Maintainer ping:

avrlibc: @mguentner @emilytrau
musl: @thoughtpolice @dtzWill
wasilibc: @matthewbauer @rvolosatovs
newlib: none?
stdenv: @NixOS/stdenv

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
