### PR TITLE
Revert ".devcontainer: nixfmt-rfc-style -> nixfmt"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,8 @@
     "ghcr.io/devcontainers/features/nix:1": {
       // fails in the devcontainer sandbox, enable sandbox via config instead
       "multiUser": false,
+      // TODO: nixfmt-rfc-style → nixfmt (once it's in a stable release)
+      // https://github.com/NixOS/nixpkgs/issues/425583
       "packages": "nixpkgs.nixd,nixpkgs.nixfmt-rfc-style",
       "useAttributePath": true,
       "extraNixConfig": "experimental-features = nix-command flakes,sandbox = true"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "ghcr.io/devcontainers/features/nix:1": {
       // fails in the devcontainer sandbox, enable sandbox via config instead
       "multiUser": false,
-      "packages": "nixpkgs.nixd,nixpkgs.nixfmt",
+      "packages": "nixpkgs.nixd,nixpkgs.nixfmt-rfc-style",
       "useAttributePath": true,
       "extraNixConfig": "experimental-features = nix-command flakes,sandbox = true"
     }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#430330

As per https://github.com/NixOS/nixpkgs/issues/425583 and https://github.com/NixOS/nixpkgs/pull/430330#issuecomment-3156334137, I believe this was bumped prematurely.

Unless the devcontainer is using the in-tree copy of nixpkgs, the CI-pinned revision, or some other known-to-be up-to-date revision... If we can guarantee the devcontainer always uses an up-to-date nixpkgs, then this can be closed.

If the devcontainer is using nixpkgs from (e.g.) the NIX_PATH, then we don't know whether `pkgs.nixfmt` is the rfc-style formatter or the classic version. That's because NIX_PATH may contain an old revision or a stable release.