### PR TITLE
python3Packages.pynitrokey: 0.9.3 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/pynitrokey/default.nix
+++ b/pkgs/development/python-modules/pynitrokey/default.nix
@@ -4,33 +4,27 @@
   fetchPypi,
   installShellFiles,
   libnitrokey,
-  flit-core,
-  certifi,
+  poetry-core,
   cffi,
   click,
   cryptography,
-  ecdsa,
   fido2,
+  hidapi,
   intelhex,
   nkdfu,
-  python-dateutil,
   pyusb,
   requests,
   tqdm,
   tlv8,
-  typing-extensions,
-  click-aliases,
   semver,
   nethsm,
-  importlib-metadata,
   nitrokey,
   pyscard,
-  asn1crypto,
 }:
 
 let
   pname = "pynitrokey";
-  version = "0.9.3";
+  version = "0.10.0";
   mainProgram = "nitropy";
 in
 
@@ -40,48 +34,41 @@ buildPythonPackage {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-nZBgKJfRIte/KyHqdBLe6spudJW7livyA9OvdZ4/q4o=";
+    hash = "sha256-Kr6VtBADLvXUva7csbsHujGzBfRG1atJLF7qbIWmToM=";
   };
 
   nativeBuildInputs = [ installShellFiles ];
 
-  build-system = [ flit-core ];
+  build-system = [ poetry-core ];
 
   dependencies = [
-    certifi
     cffi
     click
     cryptography
-    ecdsa
     fido2
+    hidapi
     intelhex
     nkdfu
-    python-dateutil
+    nitrokey
     pyusb
     requests
     tqdm
     tlv8
-    typing-extensions
-    click-aliases
     semver
     nethsm
-    importlib-metadata
-    nitrokey
-    pyscard
-    asn1crypto
   ];
 
-  pythonRelaxDeps = true;
+  optional-dependencies = {
+    pcsc = [
+      pyscard
+    ];
+  };
 
-  # pythonRelaxDepsHook runs in postBuild so cannot be used
-  pypaBuildFlags = [ "--skip-dependency-check" ];
+  pythonRelaxDeps = true;
 
   # libnitrokey is not propagated to users of the pynitrokey Python package.
   # It is only usable from the wrapped bin/nitropy
   makeWrapperArgs = [ "--set LIBNK_PATH ${lib.makeLibraryPath [ libnitrokey ]}" ];
-
-  # no tests
-  doCheck = false;
 
   pythonImportsCheck = [ "pynitrokey" ];
 


### PR DESCRIPTION
https://github.com/Nitrokey/pynitrokey/releases/tag/v0.10.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (built on master with some additional cherry-picks from python-updates, not built on python-updates directly)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
