### PR TITLE
python3Packages.fido2: skip device tests

### DIFF
--- a/pkgs/development/python-modules/fido2/default.nix
+++ b/pkgs/development/python-modules/fido2/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "-v"
     "--no-device"
   ];

--- a/pkgs/development/python-modules/fido2/default.nix
+++ b/pkgs/development/python-modules/fido2/default.nix
@@ -5,7 +5,6 @@
   fetchPypi,
   poetry-core,
   pyscard,
-  pythonOlder,
   pytestCheckHook,
 }:
 
@@ -13,8 +12,6 @@ buildPythonPackage rec {
   pname = "fido2";
   version = "2.0.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
@@ -33,7 +30,10 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  unittestFlagsArray = [ "-v" ];
+  pytestFlagsArray = [
+    "-v"
+    "--no-device"
+  ];
 
   pythonImportsCheck = [ "fido2" ];
 


### PR DESCRIPTION
By default, unit tests include hardware authenticator device tests. They hang nixpkgs builds for a long time waiting for a touch of the authenticator device. Skip such tests to avoid waiting.

Device tests look like this:

```
python3.13-fido2> Running phase: pytestCheckPhase
python3.13-fido2> Executing pytestCheckPhase
python3.13-fido2> pytest flags: -m pytest
python3.13-fido2> ============================= test session starts ==============================
python3.13-fido2> platform linux -- Python 3.13.5, pytest-8.3.5, pluggy-1.6.0
python3.13-fido2> rootdir: /build/fido2-2.0.0
python3.13-fido2> configfile: pyproject.toml
python3.13-fido2> testpaths: tests
python3.13-fido2> collected 164 items
python3.13-fido2>
python3.13-fido2> tests/device/test_bioenroll.py
python3.13-fido2> ⚠️  Tests will now run against a connected FIDO authenticator. ⚠️
python3.13-fido2>
python3.13-fido2> You may be prompted to interact with the authenticator throughout these tests.
python3.13-fido2>
python3.13-fido2>           ☠️  WARNING! THESE TESTS ARE DESTRUCTIVE! ☠️
python3.13-fido2> ANY CREDENTIALS ON THIS AUTHENTICATOR WILL BE PERMANENTLY DELETED!
python3.13-fido2>
python3.13-fido2> 👉 Touch the Authenticator
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (on a branch based on master with fido2 cherry-picks from python-updates)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
