### PR TITLE
Contributor documentation for Modular Services

### DIFF
--- a/doc/contributing/reviewing-contributions.chapter.md
+++ b/doc/contributing/reviewing-contributions.chapter.md
@@ -16,7 +16,7 @@ This section has been moved to [nixos/README.md](https://github.com/NixOS/nixpkg
 
 ## New modules {#reviewing-contributions-new-modules}
 
-This section has been moved to [nixos/README.md](https://github.com/NixOS/nixpkgs/blob/master/nixos/README.md).
+This section has been moved to [nixos/README.md](https://github.com/NixOS/nixpkgs/blob/master/nixos/README.md#new-modules).
 
 ## Individual maintainer list {#reviewing-contributions-individual-maintainer-list}
 

--- a/nixos/README-modular-services.md
+++ b/nixos/README-modular-services.md
@@ -1,0 +1,97 @@
+
+# Writing and Reviewing Modular Services
+
+## Status
+
+Modular Services are, as of writing, a new feature with support in NixOS.
+It is in development, and be considerate of the fact that the intermediate outcome of RFC 163 is that we should try a module-based approach to portable services; it is not yet a widely agreed upon solution.
+
+## Relation to NixOS Modules
+
+- A modular service is not a replacement for a NixOS module, but may be in the future.
+- Using a modular service to implement a NixOS module is an expected use case, but exposes the NixOS module to a degree of uncertainty that is not acceptable for widely used modules yet.
+
+## Maintainership
+
+If you contribute a modular service, you must mark yourself as maintainer of the modular service.
+The maintainership of a modular service does not need to be the same as the maintainership of a NixOS module.
+If you are not a maintainer of the NixOS module, you should offer to join the NixOS module's `meta.maintainers` team, so that you are included in reviews and discussions, most of which also affect the modular service.
+The NixOS module maintainers have no obligation towards the modular service, except perhaps to notify you if they notice that the modular service breaks.
+
+## Minimum Standard
+
+Modular services **MUST** be accompanied by a **NixOS VM test** that exercises the modular service.
+
+Modular services **MUST** have a `meta.maintainers` module attribute that lists the maintainers of the modular service.
+
+## Reviewing Modular Services
+
+When reviewing a modular service, you should check the following. Details and rationale are provided below.
+
+```markdown
+- [ ] Has a NixOS VM test
+- [ ] Has a `meta.maintainers` attribute
+- [ ] Systemd-specific definitions are behind `optionalAttrs (options ? systemd)` to promote portability.
+- [ ] `_class = "service"`
+- [ ] Modular services provided through `passthru.services` must override the default of the package option using `finalAttrs.finalPackage`
+- [ ] Is the modular services infrastructure sufficient for this service? If one or more features are not covered, comment in https://github.com/NixOS/nixpkgs/issues/428084
+```
+
+## Details
+
+### NixOS VM test
+
+See the initial [Modular Services PR](https://github.com/NixOS/nixpkgs/pull/372170) for an [example](https://github.com/NixOS/nixpkgs/pull/372170/files#diff-e7fe16489cf3cd08ecc22b2c7896039d407a329b75691c046c95447423b3153f) of a NixOS VM test.
+TBD: describe best practices here.
+
+### `_class = "service"`
+
+A [`_class`](https://nixos.org/manual/nixpkgs/unstable/#module-system-lib-evalModules-param-class) declaration ensures a clear error when the module is accidentally imported into a configuration that isn't a modular service, such as a NixOS configuration.
+
+Provide it as the first attribute in the module:
+
+```nix
+{ lib, config, ... }:
+{
+  _class = "service";
+
+  options = {
+    # ...
+  };
+  config = {
+    # ...
+  };
+}
+```
+
+### Overriding the package default
+
+When a modular service is provided through `passthru.services`, it must override the default of the package option using [`finalAttrs.finalPackage`](https://nixos.org/manual/nixpkgs/unstable/#mkderivation-recursive-attributes).
+If this is not possible, or if the module is not represented by a single package, consider exposing the modular service directly by file path only.
+
+Otherwise, since some packages are *defined* by an override, the modular service would launch a wrong package, if it builds at all.
+
+Example:
+
+`package.nix`
+```nix
+{
+  stdenv,
+  nixosTests,
+# ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "example";
+  # ...
+
+  passthru = {
+    services = {
+      default = {
+        imports = [ ./service.nix ];
+        example.package = finalAttrs.finalPackage;
+        # ...
+      };
+    };
+  };
+})
+```

--- a/nixos/README.md
+++ b/nixos/README.md
@@ -116,3 +116,5 @@ Sample template for a new module review is provided below.
 
 ##### Comments
 ```
+
+See also [./README-modular-services.md](./README-modular-services.md).

--- a/nixos/doc/manual/development/modular-services.md
+++ b/nixos/doc/manual/development/modular-services.md
@@ -83,6 +83,10 @@ Moving their logic into separate Nix files may still be beneficial for the effic
 
 <!-- TODO example of a single-instance service -->
 
+## Writing and Reviewing a Modular Service {#modular-service-review}
+
+Refer to the contributor documentation in [`nixos/README-modular-services.md`](https://github.com/NixOS/nixpkgs/blob/master/nixos/README-modular-services.md).
+
 ## Portable Service Options {#modular-service-options-portable}
 
 ```{=include=} options

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -26,6 +26,9 @@
   "modular-service-portability": [
     "index.html#modular-service-portability"
   ],
+  "modular-service-review": [
+    "index.html#modular-service-review"
+  ],
   "modular-services": [
     "index.html#modular-services"
   ],


### PR DESCRIPTION
1. Anyone should be able to review this new kind of module
2. Modular Services is a new feature for an unmerged RFC: manage expectations and avoid imposing any undue load on maintainers; try to help them instead


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
