### PR TITLE
python3Packages.bertopic: init at 0.17.3 + pyqtree, pylabeladjust, datamapplot

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10032,6 +10032,12 @@
     githubId = 1631166;
     name = "Marcel Müller";
   };
+  hendrikheil = {
+    email = "hendrik@ciidyr.com";
+    github = "hendrikheil";
+    githubId = 19904485;
+    name = "Hendrik Heil";
+  };
   henkery = {
     email = "jim@reupload.nl";
     github = "henkery";

--- a/pkgs/development/python-modules/bertopic/default.nix
+++ b/pkgs/development/python-modules/bertopic/default.nix
@@ -1,0 +1,116 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  hdbscan,
+  lib,
+  llvmlite,
+  numpy,
+  pandas,
+  plotly,
+  pytestCheckHook,
+  scikit-learn,
+  sentence-transformers,
+  setuptools,
+  tqdm,
+  umap-learn,
+  writableTmpDirAsHomeHook,
+
+  # extras: datamap
+  datamapplot,
+  matplotlib,
+
+  # extras: fastembed
+  fastembed,
+
+  # extras: gensim
+  gensim,
+
+  # extras: spacy
+  spacy,
+
+  # extras: vision
+  accelerate,
+  pillow,
+}:
+
+buildPythonPackage rec {
+  pname = "bertopic";
+  version = "0.17.3";
+  pyproject = true;
+
+  # pypi does not ship with all test files included
+  src = fetchFromGitHub {
+    owner = "MaartenGr";
+    repo = "BERTopic";
+    tag = "v${version}";
+    hash = "sha256-wtFOe/Y0liEH23PmefRR5aYHsWmvjGZR7rKXUseFpSw=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    hdbscan
+    umap-learn
+    numpy
+    pandas
+    plotly
+    scikit-learn
+    sentence-transformers
+    tqdm
+    llvmlite
+  ];
+
+  optional-dependencies = {
+    datamap = [
+      datamapplot
+      matplotlib
+    ];
+    fastembed = [ fastembed ];
+    gensim = [ gensim ];
+    spacy = [ spacy ];
+    vision = [
+      accelerate
+      pillow
+    ];
+  };
+
+  pythonImportsCheck = [ "bertopic" ];
+
+  nativeCheckInputs = [
+    # numba caches some compiled functions in the home dir
+    # See https://github.com/numba/numba/issues/4032#issuecomment-488102702
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # network access
+    "tests/test_bertopic.py"
+    "tests/test_plotting/test_approximate.py"
+    "tests/test_plotting/test_bar.py"
+    "tests/test_plotting/test_documents.py"
+    "tests/test_plotting/test_dynamic.py"
+    "tests/test_plotting/test_heatmap.py"
+    "tests/test_plotting/test_term_rank.py"
+    "tests/test_plotting/test_topics.py"
+    "tests/test_reduction/test_merge.py"
+    "tests/test_representation/test_get.py"
+    "tests/test_representation/test_labels.py"
+    "tests/test_representation/test_representations.py"
+    "tests/test_sub_models/test_dim_reduction.py"
+    "tests/test_sub_models/test_embeddings.py"
+    "tests/test_variations/test_class.py"
+    "tests/test_variations/test_dynamic.py"
+    "tests/test_variations/test_hierarchy.py"
+    "tests/test_vectorizers/test_ctfidf.py"
+    "tests/test_vectorizers/test_online_cv.py"
+  ];
+
+  meta = {
+    changelog = "https://github.com/MaartenGr/BERTopic/releases/tag/v${version}";
+    description = "Topic modeling with state-of-the-art transformer models";
+    homepage = "https://maartengr.github.io/BERTopic/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hendrikheil ];
+  };
+}

--- a/pkgs/development/python-modules/datamapplot/default.nix
+++ b/pkgs/development/python-modules/datamapplot/default.nix
@@ -1,0 +1,98 @@
+{
+  buildPythonPackage,
+  colorcet,
+  colorspacious,
+  dask,
+  datashader,
+  fetchFromGitHub,
+  importlib-resources,
+  jinja2,
+  lib,
+  matplotlib,
+  numba,
+  numpy,
+  platformdirs,
+  pyarrow,
+  pylabeladjust,
+  rcssmin,
+  requests,
+  rjsmin,
+  scikit-image,
+  scikit-learn,
+  setuptools,
+  typing-extensions,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "datamapplot";
+  version = "0.6.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "TutteInstitute";
+    repo = "datamapplot";
+    tag = "release-${version}";
+    hash = "sha256-C3quac3gW3X/I3pPwaK2svK8qvmzMkgy/bgRqREH9VA=";
+  };
+
+  pythonRelaxDeps = [ "dask" ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    colorcet
+    colorspacious
+    dask
+    datashader
+    importlib-resources
+    jinja2
+    matplotlib
+    numba
+    numpy
+    pyarrow
+    pylabeladjust
+    requests
+    rcssmin
+    rjsmin
+    scikit-image
+    scikit-learn
+    platformdirs
+    typing-extensions
+  ]
+  ++ dask.optional-dependencies.complete;
+
+  pythonImportsCheck = [ "datamapplot" ];
+
+  nativeCheckInputs = [
+    # numba caches some compiled functions in the home dir
+    # See https://github.com/numba/numba/issues/4032#issuecomment-488102702
+    writableTmpDirAsHomeHook
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # network access
+    "test_plot_wikipedia"
+
+    # requires package to be installed (i.e. pip install -e .)
+    # to be able to execute dmp_offline_cache from console_scripts defined in setup.cfg
+    "test_import_no_clobber"
+    "test_import_clobber_partial"
+    "test_import_no_confirm"
+    "test_export_no_clobber"
+    "test_export_clobber_partial"
+    "test_export_no_confirm"
+    "test_bail_stdin_closed"
+  ];
+
+  meta = {
+    changelog = "https://github.com/TutteInstitute/datamapplot/releases/tag/release-${version}";
+    description = "Library for presentation and publication ready plots of data maps";
+    homepage = "https://github.com/TutteInstitute/datamapplot";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hendrikheil ];
+    mainProgram = "dmp_offline_cache";
+  };
+}

--- a/pkgs/development/python-modules/pylabeladjust/default.nix
+++ b/pkgs/development/python-modules/pylabeladjust/default.nix
@@ -1,0 +1,37 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  matplotlib,
+  pandas,
+  poetry-core,
+  pyqtree,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "pylabeladjust";
+  version = "0.1.13";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-I8H5+AlsXH3p+nlnjOcpyjcwuI2XmZf6JOmcA3pI9Zs=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pyqtree
+    tqdm
+    pandas
+    matplotlib
+  ];
+
+  meta = {
+    description = "Gephi's Label-Adjust algorithm ported to python";
+    homepage = "https://github.com/MNoichl/pylabeladjust";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ hendrikheil ];
+  };
+}

--- a/pkgs/development/python-modules/pyqtree/default.nix
+++ b/pkgs/development/python-modules/pyqtree/default.nix
@@ -1,0 +1,31 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  setuptools,
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "pyqtree";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "Pyqtree";
+    inherit version;
+    hash = "sha256-TzbVFg3fFw1yRenHECpFIRuFADOD3VUrbNEJ5QzDr4E=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "pyqtree" ];
+
+  meta = {
+    changelog = "https://github.com/karimbahgat/Pyqtree/blob/v${version}/CHANGELOG.md";
+    description = "Pure Python quad tree spatial index for GIS or rendering usage";
+    homepage = "https://github.com/karimbahgat/Pyqtree";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hendrikheil ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13666,6 +13666,8 @@ self: super: with self; {
 
   pyqtgraph = callPackage ../development/python-modules/pyqtgraph { };
 
+  pyqtree = callPackage ../development/python-modules/pyqtree { };
+
   pyqtwebengine = callPackage ../development/python-modules/pyqtwebengine { };
 
   pyquaternion = callPackage ../development/python-modules/pyquaternion { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13088,6 +13088,8 @@ self: super: with self; {
 
   pykwb = callPackage ../development/python-modules/pykwb { };
 
+  pylabeladjust = callPackage ../development/python-modules/pylabeladjust { };
+
   pylacrosse = callPackage ../development/python-modules/pylacrosse { };
 
   pylacus = callPackage ../development/python-modules/pylacus { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1811,6 +1811,8 @@ self: super: with self; {
 
   berkeleydb = callPackage ../development/python-modules/berkeleydb { };
 
+  bertopic = callPackage ../development/python-modules/bertopic { };
+
   bespon = callPackage ../development/python-modules/bespon { };
 
   betacode = callPackage ../development/python-modules/betacode { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3331,6 +3331,8 @@ self: super: with self; {
 
   datalad-next = callPackage ../development/python-modules/datalad-next { };
 
+  datamapplot = callPackage ../development/python-modules/datamapplot { };
+
   datamodel-code-generator = callPackage ../development/python-modules/datamodel-code-generator { };
 
   datamodeldict = callPackage ../development/python-modules/datamodeldict { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR primarily aims to init [bertopic](https://github.com/MaartenGr/BERTopic) at 0.17.3. Bertopic itself as an optional dependency on datamapplot, which itself had two unpackaged python packages, both of which I added in this PR as well.

BERTopic is a topic modeling technique that leverages transformers and c-TF-IDF to create dense clusters allowing for easily interpretable topics whilst keeping important words in the topic descriptions.

There are two sets of optional dependency extras that I did not opt to add, as the dependencies are rather large and probably deserves their own PRs. Both dependencies being for for embedding backends, [flair](https://github.com/flairNLP/flair) and use, which depends on tensorflow_hub and tensorflow_text.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `fbe8125a3fcc8d80330f795b96a3957548ed52a6`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 16 packages built:</summary>
  <ul>
    <li>python312Packages.bertopic</li>
    <li>python312Packages.bertopic.dist</li>
    <li>python312Packages.datamapplot</li>
    <li>python312Packages.datamapplot.dist</li>
    <li>python312Packages.pylabeladjust</li>
    <li>python312Packages.pylabeladjust.dist</li>
    <li>python312Packages.pyqtree</li>
    <li>python312Packages.pyqtree.dist</li>
    <li>python313Packages.bertopic</li>
    <li>python313Packages.bertopic.dist</li>
    <li>python313Packages.datamapplot</li>
    <li>python313Packages.datamapplot.dist</li>
    <li>python313Packages.pylabeladjust</li>
    <li>python313Packages.pylabeladjust.dist</li>
    <li>python313Packages.pyqtree</li>
    <li>python313Packages.pyqtree.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
