### PR TITLE
ubootVisionFive2: Remove overrideAttrs from opensbi

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -845,25 +845,15 @@ in
     # sf probe; sf update $loadaddr 0 80000
   };
 
-  ubootVisionFive2 =
-    let
-      opensbi_vf2 = opensbi.overrideAttrs (attrs: {
-        makeFlags = attrs.makeFlags ++ [
-          # Matches u-boot documentation: https://docs.u-boot.org/en/latest/board/starfive/visionfive2.html
-          "FW_TEXT_START=0x40000000"
-          "FW_OPTIONS=0"
-        ];
-      });
-    in
-    buildUBoot {
-      defconfig = "starfive_visionfive2_defconfig";
-      extraMeta.platforms = [ "riscv64-linux" ];
-      OPENSBI = "${opensbi_vf2}/share/opensbi/lp64/generic/firmware/fw_dynamic.bin";
-      filesToInstall = [
-        "spl/u-boot-spl.bin.normal.out"
-        "u-boot.itb"
-      ];
-    };
+  ubootVisionFive2 = buildUBoot {
+    defconfig = "starfive_visionfive2_defconfig";
+    extraMeta.platforms = [ "riscv64-linux" ];
+    OPENSBI = "${opensbi}/share/opensbi/lp64/generic/firmware/fw_dynamic.bin";
+    filesToInstall = [
+      "spl/u-boot-spl.bin.normal.out"
+      "u-boot.itb"
+    ];
+  };
 
   ubootWandboard = buildUBoot {
     defconfig = "wandboard_defconfig";


### PR DESCRIPTION
FW_OPTIONS=0 overrides the dynamically set options for no reason, and
FW_TEXT_START is not useful now that OpenSBI has dropped support for
non-PIE-capable toolchains [1].
    
[1]: https://github.com/riscv-software-src/opensbi/commit/76d7e9b8ee72c226cd8424d5483827bcf4c792fa

Tested on VisionFive 2 from SD boot. (Yes it only works with some microSD cards. Yes I have one of the working ones.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux (cross to riscv64)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
