### PR TITLE
utpm: 0-unstable-2024-12-17 -> 0.2.0

### DIFF
--- a/pkgs/by-name/ut/utpm/package.nix
+++ b/pkgs/by-name/ut/utpm/package.nix
@@ -4,19 +4,22 @@
   rustPlatform,
   openssl,
   pkg-config,
+  stdenv,
+  buildPackages,
+  installShellFiles,
 }:
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "utpm";
-  version = "0-unstable-2024-12-17";
-
-  cargoHash = "sha256-fqGxor2PgsQemnPNoZkgNUNc7yRg2eqHTLzJAVpt6+8=";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "Thumuss";
     repo = "utpm";
-    rev = "6c2cabc8e7e696ea129f55aa7732a6be63bc2319";
-    hash = "sha256-uuET0BG2kBFEEWSSZ35h6+tnqTTjEHOP50GR3IkL+CE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NlH+fPkTNqaQc2BrjerktnKS2L731K9G3z+N2xdx3kg=";
   };
+
+  cargoHash = "sha256-WR9LD5HjLgh9jirnjTc6BeNg8KjVZI+DuJRYEbN3tmE=";
 
   env.OPENSSL_NO_VENDOR = 1;
 
@@ -25,9 +28,23 @@ rustPlatform.buildRustPackage {
   ];
   nativeBuildInputs = [
     pkg-config
+    installShellFiles
   ];
 
-  doCheck = false; # no tests
+  postInstall =
+    let
+      utpm =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          placeholder "out"
+        else
+          buildPackages.utpm;
+    in
+    ''
+      installShellCompletion --cmd utpm \
+        --bash <(${utpm}/bin/utpm generate bash) \
+        --fish <(${utpm}/bin/utpm generate fish) \
+        --zsh <(${utpm}/bin/utpm generate zsh)
+    '';
 
   meta = {
     description = "Package manager for typst";
@@ -41,4 +58,4 @@ rustPlatform.buildRustPackage {
     mainProgram = "utpm";
     maintainers = with lib.maintainers; [ louis-thevenet ];
   };
-}
+})


### PR DESCRIPTION
Release: 
- https://github.com/typst-community/utpm/releases/tag/v0.2.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
