### PR TITLE
oxidized: add nixosTests

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1121,6 +1121,7 @@ in
   osquery = handleTestOn [ "x86_64-linux" ] ./osquery.nix { };
   osrm-backend = runTest ./osrm-backend.nix;
   overlayfs = runTest ./overlayfs.nix;
+  oxidized = handleTest ./oxidized.nix { };
   pacemaker = runTest ./pacemaker.nix;
   packagekit = runTest ./packagekit.nix;
   paisa = runTest ./paisa.nix;

--- a/nixos/tests/oxidized.nix
+++ b/nixos/tests/oxidized.nix
@@ -1,0 +1,104 @@
+{
+  system ? builtins.currentSystem,
+  pkgs ? import ../.. {
+    inherit system;
+    config = { };
+  },
+}:
+
+let
+  inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
+in
+makeTest {
+  name = "oxidized";
+
+  nodes.server =
+    { config, pkgs, ... }:
+    {
+      security.pam.services.sshd.allowNullPassword = true; # the default `UsePam yes` makes this necessary
+      services = {
+        sshd.enable = true;
+        openssh = {
+          settings.PermitRootLogin = "yes";
+          settings.PermitEmptyPasswords = "yes";
+        };
+        oxidized = {
+          enable = true;
+          package = pkgs.oxidized;
+          routerDB = pkgs.writeText "oxidized-router.db" ''
+            localhost:linuxgeneric:root
+          '';
+          configFile = pkgs.writeText "oxidized-config.yml" ''
+            # vi: ft=yaml
+            ---
+            extensions:
+              oxidized-web:
+                load: true
+                listen: 127.0.0.1
+                port: 8888
+                vhosts:
+                  - localhost
+                  - 127.0.0.1
+                  - oxidized
+                  - oxidized.example.com
+            interval: 3600
+            retries: 3
+            model: linuxgeneric
+            username: root
+            source:
+              default: csv
+              csv:
+                file: "/var/lib/oxidized/.config/oxidized/router.db"
+                delimiter: !ruby/regexp /:/
+                map:
+                  name: 0
+                  model: 1
+                  username: 2
+                  password: 3
+                vars_map:
+                  enable: 4
+            input:
+              default: ssh
+              utf8_encoded: true
+            output:
+              default: git
+              git:
+                single_repo:  true
+                user: oxidized
+                email: oxidized@example.com
+                repo: /var/lib/oxidized/git
+          '';
+        };
+      };
+      systemd.services.oxidized = {
+        stopIfChanged = false;
+        environment.HOME = "/var/lib/oxidized";
+        environment.APP_ENV = "production";
+        serviceConfig = {
+          StateDirectory = "oxidized";
+          MemoryDenyWriteExecute = false;
+
+          PrivateNetwork = false;
+          SystemCallFilter = "@system-service";
+        };
+
+        path = [ config.programs.ssh.package ];
+      };
+
+    };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      server.wait_for_unit("oxidized.service")
+
+      with subtest("Check if oxidized reports the correct version"):
+        server.wait_until_succeeds(("curl --silent --fail --location http://127.0.0.1:8888/ | grep '${nodes.server.services.oxidized.package.version}' >&2"))
+      with subtest("Check if oxidized can be accessed with a vhost and reports the correct version"):
+        server.wait_until_succeeds(("curl --silent --fail --resolve oxidized:8888:127.0.0.1 --location http://oxidized:8888/ | grep '${nodes.server.services.oxidized.package.version}' >&2"))
+      with subtest("Check if oxidized can connect to linuxgeneric model"):
+        server.wait_until_succeeds("journalctl -b --grep 'Oxidized::Worker -- Configuration updated for /localhost' -t oxidized")
+    '';
+}

--- a/pkgs/by-name/ox/oxidized/package.nix
+++ b/pkgs/by-name/ox/oxidized/package.nix
@@ -3,6 +3,7 @@
   ruby,
   bundlerApp,
   bundlerUpdateScript,
+  nixosTests,
 }:
 
 bundlerApp {
@@ -16,7 +17,10 @@ bundlerApp {
     "oxs"
   ];
 
-  passthru.updateScript = bundlerUpdateScript "oxidized";
+  passthru = {
+    tests = nixosTests.oxidized;
+    updateScript = bundlerUpdateScript "oxidized";
+  };
 
   meta = with lib; {
     description = "Network device configuration backup tool. It's a RANCID replacement";


### PR DESCRIPTION
Add `nixosTests.oxidized`, depends on updated oxidized in #431397.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
