### PR TITLE
[Backport release-25.05] ledger-live-desktop: 2.111.0 -> 2.122.1

### DIFF
--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -8,11 +8,11 @@
 
 let
   pname = "ledger-live-desktop";
-  version = "2.120.1";
+  version = "2.122.1";
 
   src = fetchurl {
     url = "https://download.live.ledger.com/${pname}-${version}-linux-x86_64.AppImage";
-    hash = "sha256-zr+m0ytG5wcdI6IvCklpcQVmiaTUaQb5a90lRl1+YxQ=";
+    hash = "sha256-Cy74WFxNX5cJhkx3FmiIgCLoWFos2BXntl6mEeK6MQ8=";
   };
 
   appimageContents = appimageTools.extractType2 {

--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -8,11 +8,11 @@
 
 let
   pname = "ledger-live-desktop";
-  version = "2.111.0";
+  version = "2.113.0";
 
   src = fetchurl {
     url = "https://download.live.ledger.com/${pname}-${version}-linux-x86_64.AppImage";
-    hash = "sha256-doREuoX6Lpm9V0yPvf/Ne13v4xvSZ16WzqIVAdVBeMw=";
+    hash = "sha256-mF6YwgbqZF5ccJCABoagtEq5WpnhDNFcvij1wL+buF0=";
   };
 
   appimageContents = appimageTools.extractType2 {

--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -8,11 +8,11 @@
 
 let
   pname = "ledger-live-desktop";
-  version = "2.115.1";
+  version = "2.117.0";
 
   src = fetchurl {
     url = "https://download.live.ledger.com/${pname}-${version}-linux-x86_64.AppImage";
-    hash = "sha256-JLX1EbtrvkQPLGXlvn2pv1p1nT2mJ/yng4VumxV2z6E=";
+    hash = "sha256-YcnTJFbkbPTr9ZfiOEnN1oHjTMl9S2XsJyMxozPXxa8=";
   };
 
   appimageContents = appimageTools.extractType2 {

--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -8,11 +8,11 @@
 
 let
   pname = "ledger-live-desktop";
-  version = "2.118.1";
+  version = "2.120.1";
 
   src = fetchurl {
     url = "https://download.live.ledger.com/${pname}-${version}-linux-x86_64.AppImage";
-    hash = "sha256-FG1vlcLUjQpXfoEczvTOyqLFuCYU/72KeAdsg/SMjLQ=";
+    hash = "sha256-zr+m0ytG5wcdI6IvCklpcQVmiaTUaQb5a90lRl1+YxQ=";
   };
 
   appimageContents = appimageTools.extractType2 {

--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -8,11 +8,11 @@
 
 let
   pname = "ledger-live-desktop";
-  version = "2.117.0";
+  version = "2.118.1";
 
   src = fetchurl {
     url = "https://download.live.ledger.com/${pname}-${version}-linux-x86_64.AppImage";
-    hash = "sha256-YcnTJFbkbPTr9ZfiOEnN1oHjTMl9S2XsJyMxozPXxa8=";
+    hash = "sha256-FG1vlcLUjQpXfoEczvTOyqLFuCYU/72KeAdsg/SMjLQ=";
   };
 
   appimageContents = appimageTools.extractType2 {

--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -8,11 +8,11 @@
 
 let
   pname = "ledger-live-desktop";
-  version = "2.113.2";
+  version = "2.115.1";
 
   src = fetchurl {
     url = "https://download.live.ledger.com/${pname}-${version}-linux-x86_64.AppImage";
-    hash = "sha256-jJvIncD1vGZ2t0Rpl42AoVGKPlLGhMsoU91//rxOWnw=";
+    hash = "sha256-JLX1EbtrvkQPLGXlvn2pv1p1nT2mJ/yng4VumxV2z6E=";
   };
 
   appimageContents = appimageTools.extractType2 {

--- a/pkgs/by-name/le/ledger-live-desktop/package.nix
+++ b/pkgs/by-name/le/ledger-live-desktop/package.nix
@@ -8,11 +8,11 @@
 
 let
   pname = "ledger-live-desktop";
-  version = "2.113.0";
+  version = "2.113.2";
 
   src = fetchurl {
     url = "https://download.live.ledger.com/${pname}-${version}-linux-x86_64.AppImage";
-    hash = "sha256-mF6YwgbqZF5ccJCABoagtEq5WpnhDNFcvij1wL+buF0=";
+    hash = "sha256-jJvIncD1vGZ2t0Rpl42AoVGKPlLGhMsoU91//rxOWnw=";
   };
 
   appimageContents = appimageTools.extractType2 {


### PR DESCRIPTION
Manual backport of #408585, #412057, #415182, #418044, #420656, #425904, and #428237

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
