### PR TITLE
nixos/repart-verity-store: fix cross

### DIFF
--- a/nixos/modules/image/repart-verity-store.nix
+++ b/nixos/modules/image/repart-verity-store.nix
@@ -140,8 +140,8 @@ in
           pkgs.runCommand ukiFile
             {
               nativeBuildInputs = [
-                pkgs.jq
-                pkgs.systemdUkify
+                pkgs.buildPackages.jq
+                pkgs.buildPackages.systemdUkify
               ];
             }
             ''
@@ -177,9 +177,9 @@ in
               };
 
               nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [
-                pkgs.systemdUkify
+                pkgs.buildPackages.systemdUkify
                 verityHashCheck
-                pkgs.jq
+                pkgs.buildPackages.jq
               ];
 
               preBuild = ''


### PR DESCRIPTION
fixes:
```
> 'repart.d' -> '/build/amended-repart.d'
> Running phase: updateAutotoolsGnuConfigScriptsPhase
> Running phase: updateAutotoolsGnuConfigScriptsPhase
> Running phase: buildPhase
> /nix/store/sx57q0qkg6kl5bjr008l5020if5dc63g-stdenv-linux/setup: line 272: /nix/store/sb86653snbd3w56sk3ajyl6cj928sfjm-systemd-aarch64-unknown-linux-gnu-257.6/bin/ukify: cannot execute binary file: Exec format error
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
