### PR TITLE
julec: 0.1.5 -> 0.1.6

### DIFF
--- a/pkgs/by-name/ju/julec/package.nix
+++ b/pkgs/by-name/ju/julec/package.nix
@@ -21,23 +21,23 @@ let
 in
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "julec";
-  version = "0.1.5";
+  version = "0.1.6";
 
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "jule";
     tag = "jule${finalAttrs.version}";
     name = "jule-${finalAttrs.version}";
-    hash = "sha256-gFlca9XdRNv2CI3jfMiWejcmGGzabP0VGs4vlvFs72o=";
+    hash = "sha256-y4v8FdQkB5Si3SYkchFG9fAU4ZhabAMcPkDcLEWW+6k=";
   };
 
   irSrc = fetchFromGitHub {
     owner = "julelang";
     repo = "julec-ir";
     # revision determined by the upstream commit hash in julec-ir/README.md
-    rev = "4a3bf4fc84b53aa607855df6635d95d3e310f7ad";
+    rev = "aebbd12c0f89f6a04f856f3e23d5ea39741c3e0f";
     name = "jule-ir-${finalAttrs.version}";
-    hash = "sha256-Wl5AYRGYcQpj/R9nynxNC5r1HK1EmImwkLokdZfp9sE=";
+    hash = "sha256-7eDOYMmCEfW+0zZpESY1+ql3hWZZ/Q75lKT0nBQPktE=";
   };
 
   dontConfigure = true;
@@ -65,6 +65,10 @@ clangStdenv.mkDerivation (finalAttrs: {
       -Wno-everything \
       -fwrapv \
       -ffloat-store \
+      -fno-fast-math \
+      -fno-rounding-math \
+      -ffp-contract=fast \
+      -fexcess-precision=standard \
       -DNDEBUG \
       -fomit-frame-pointer \
       -fno-strict-aliasing \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
