### PR TITLE
ci/eval/compare: don't treat renames as rebuilds

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -73,12 +73,11 @@ let
     ;
 
   # Attrs
-  # - keys: "added", "changed" and "removed"
+  # - keys: "added", "changed", "removed" and "rebuilds"
   # - values: lists of `packagePlatformPath`s
   diffAttrs = builtins.fromJSON (builtins.readFile "${combinedDir}/combined-diff.json");
 
-  rebuilds = diffAttrs.added ++ diffAttrs.changed;
-  rebuildsPackagePlatformAttrs = convertToPackagePlatformAttrs rebuilds;
+  rebuildsPackagePlatformAttrs = convertToPackagePlatformAttrs diffAttrs.rebuilds;
 
   changed-paths =
     let
@@ -90,7 +89,7 @@ let
     in
     writeText "changed-paths.json" (
       builtins.toJSON {
-        attrdiff = lib.mapAttrs (_: extractPackageNames) diffAttrs;
+        attrdiff = lib.mapAttrs (_: extractPackageNames) { inherit (diffAttrs) added changed removed; };
         inherit
           rebuildsByPlatform
           rebuildsByKernel

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -218,7 +218,8 @@ let
           reduce .[] as $item ({}; {
             added: (.added + $item.added),
             changed: (.changed + $item.changed),
-            removed: (.removed + $item.removed)
+            removed: (.removed + $item.removed),
+            rebuilds: (.rebuilds + $item.rebuilds)
           })
         ' > $out/combined-diff.json
 

--- a/ci/eval/diff.nix
+++ b/ci/eval/diff.nix
@@ -18,13 +18,20 @@ let
       added: [ <keys only in the second object> ],
       removed: [ <keys only in the first object> ],
       changed: [ <keys with different values between the two objects> ],
+      rebuilds: [ <keys in the second object with values not present at all in first object> ],
     }
   */
   diff =
+    old: new:
     let
       filterKeys = cond: attrs: lib.attrNames (lib.filterAttrs cond attrs);
+      oldOutputs = lib.pipe old [
+        (lib.mapAttrsToList (_: lib.attrValues))
+        lib.concatLists
+        (lib.flip lib.genAttrs (_: true))
+      ];
     in
-    old: new: {
+    {
       added = filterKeys (n: _: !(old ? ${n})) new;
       removed = filterKeys (n: _: !(new ? ${n})) old;
       changed = filterKeys (
@@ -35,6 +42,16 @@ let
         # Filter out attributes that are the same as the new value
         && (v != (new.${n}))
       ) old;
+      # A "rebuild" is every attrpath ...
+      rebuilds = filterKeys (
+        _: pkg:
+        # ... that has at least one output ...
+        lib.any (
+          output:
+          # ... which has not been built in "old" already.
+          !(oldOutputs ? ${output})
+        ) (lib.attrValues pkg)
+      ) new;
     };
 
   getAttrs =


### PR DESCRIPTION
When a package's attrpath is renamed it is currently treated as a rebuild, even though the outpath already exists and is already cached.

This [also happens](https://github.com/NixOS/nixpkgs/pull/405039) when adding new names for packagesets that already exist, for example when starting to eval `perlPackages` in CI, which is just the same as `perl540Packages` currently. It would also happen when `perlPackages` is switched from `perl540Packages` to `perl999Packages`. Assuming that `perl999Packages` had already been built before, this doesn't really cause any rebuilds.

## Things done

- [x] Test with removal of `perlPackages = {}` in `release.nix`, should result in no rebuilds (only works in my fork, because the comparison changes need to be on the target branch already)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
