### PR TITLE
nixos-render-docs: Improve redirects hint

### DIFF
--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/redirects.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/redirects.py
@@ -59,6 +59,8 @@ This can happen when an identifier was added, renamed, or removed.
 
     Added new content?
         $ redirects add-content ❬identifier❭ ❬path❭
+    often:
+        $ redirects add-content ❬identifier❭ index.html
 
     Moved existing content to a different output path?
         $ redirects move-content ❬identifier❭ ❬path❭
@@ -69,7 +71,11 @@ This can happen when an identifier was added, renamed, or removed.
     Removed content? Redirect to alternatives or relevant release notes.
         $ redirects remove-and-redirect ❬identifier❭ ❬target-identifier❭
 
-    NOTE: Run `nix-shell doc` or `nix-shell nixos/doc/manual` to make this command available.
+    NOTE: Run the right nix-shell to make this command available.
+        Nixpkgs:
+        $ nix-shell doc
+        NixOS:
+        $ nix-shell nixos/doc/manual
 """)
         error_messages.append("NOTE: If your build passes locally and you see this message in CI, you probably need a rebase.")
         return "\n".join(error_messages)


### PR DESCRIPTION
Make it even easier to extend the redirects JSON.

(I'm :pinching_hand: close to making it splurge out a bunch of complete add commands, but at least this leaves some room for human thought.)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
