### PR TITLE
workflows/eval: disable swap

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -32,12 +32,11 @@ jobs:
     outputs:
       targetRunId: ${{ steps.targetRunId.outputs.targetRunId }}
     steps:
-      - name: Enable swap
+      # We'd rather fail than run slow eval on swap.
+      # Failing allows us to adjust the chunkSize to remain fast.
+      - name: Disable swap
         run: |
-          sudo fallocate -l 10G /swap
-          sudo chmod 600 /swap
-          sudo mkswap /swap
-          sudo swapon /swap
+          sudo swapoff -a
 
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -56,7 +55,7 @@ jobs:
         run: |
           nix-build untrusted/ci -A eval.singleSystem \
             --argstr evalSystem "$MATRIX_SYSTEM" \
-            --arg chunkSize 10000 \
+            --arg chunkSize 8000 \
             --out-link merged
           # If it uses too much memory, slightly decrease chunkSize
 


### PR DESCRIPTION
[Recent performance tests](https://github.com/NixOS/nixpkgs/pull/427724#issuecomment-3114392727) show that (a) swapping heavily slows down the Eval job, while (b) lowering the chunkSize does not have an effect on run-time. It does on memory usage, though - thus we can get rid of swapping entirely by reducing chunkSize respectively.

Looking closer at the results in #427724 shows that with a chunkSize of 10k some Lix versions already started swapping. To enable https://github.com/NixOS/nixpkgs/pull/428076#issuecomment-3151464867, I selected a chunkSize that works for all Nix/Lix versions.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
