### PR TITLE
windsurf: 1.11.2 -> 1.11.3

### DIFF
--- a/pkgs/by-name/wi/windsurf/info.json
+++ b/pkgs/by-name/wi/windsurf/info.json
@@ -1,20 +1,20 @@
 {
   "aarch64-darwin": {
-    "version": "1.11.2",
+    "version": "1.11.3",
     "vscodeVersion": "1.99.3",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/a2714d538be16de1c91a0bc6fa1f52acdb0a07d2/Windsurf-darwin-arm64-1.11.2.zip",
-    "sha256": "d0deea25454cef4fda962436980dcf9a7d374e30e681933e1b036258179e8cd1"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/stable/b623f33d83cdc5b0d5eaf6ebc9e4d8193a0b5f50/Windsurf-darwin-arm64-1.11.3.zip",
+    "sha256": "83df03ffe0ef8e03301355f101192e81734841e8c658b2bc2fb238e7a83679d4"
   },
   "x86_64-darwin": {
-    "version": "1.11.2",
+    "version": "1.11.3",
     "vscodeVersion": "1.99.3",
-    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/a2714d538be16de1c91a0bc6fa1f52acdb0a07d2/Windsurf-darwin-x64-1.11.2.zip",
-    "sha256": "e874198d263dbbfcc46283151d50a20187460d7c42c1988b6165016b17a33351"
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/stable/b623f33d83cdc5b0d5eaf6ebc9e4d8193a0b5f50/Windsurf-darwin-x64-1.11.3.zip",
+    "sha256": "e5bda964d69f52bf49d92bd0f2e0a824c2c45dc708f2dcfd93b9797d5fecb80c"
   },
   "x86_64-linux": {
-    "version": "1.11.2",
+    "version": "1.11.3",
     "vscodeVersion": "1.99.3",
-    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/a2714d538be16de1c91a0bc6fa1f52acdb0a07d2/Windsurf-linux-x64-1.11.2.tar.gz",
-    "sha256": "b0b5439245ca9c05ac4a600da2835757641820005c219c971a294acb91f3f114"
+    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/stable/b623f33d83cdc5b0d5eaf6ebc9e4d8193a0b5f50/Windsurf-linux-x64-1.11.3.tar.gz",
+    "sha256": "d4f5848f152c5c185c9aa7c89a34700455d41d7388592fa90e05c0329f1943bd"
   }
 }


### PR DESCRIPTION
https://windsurf.com/changelog#1.11.3

VS code version has not changed (still 1.99.3)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
