### PR TITLE
Fix compiler-rt builds for Android

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -85,7 +85,12 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://github.com/llvm/llvm-project/pull/99837/commits/14ae0a660a38e1feb151928a14f35ff0f4487351.patch";
     hash = "sha256-JykABCaNNhYhZQxCvKiBn54DZ5ZguksgCHnpdwWF2no=";
     relative = "compiler-rt";
-  });
+  })
+  ++ lib.optional (!haveLibc && isAndroid) [
+    # Patch to get compiler-rt-no-libc building for Android, being
+    # upstreamed: https://github.com/llvm/llvm-project/pull/152394
+    ./no-libc-android.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -42,7 +42,10 @@ let
   haveLibcxx = stdenv.cc.libcxx != null;
   isDarwinStatic = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isStatic;
   inherit (stdenv.hostPlatform) isMusl isWindows isAndroid;
-  noSanitizers = !haveLibc || bareMetal || isMusl || isDarwinStatic || isWindows;
+  # On Android there's a weird error stating SSIZE_MAX doesn't exist.
+  # https://github.com/NixOS/nixpkgs/issues/380604#issuecomment-3159316203
+  # TODO: Figure out how to build sanitizers for Android
+  noSanitizers = !haveLibc || bareMetal || isMusl || isDarwinStatic || isWindows || isAndroid;
 in
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -41,7 +41,7 @@ let
   # use clean up the `cmakeFlags` rats nest below.
   haveLibcxx = stdenv.cc.libcxx != null;
   isDarwinStatic = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isStatic;
-  inherit (stdenv.hostPlatform) isMusl isAarch64 isWindows;
+  inherit (stdenv.hostPlatform) isMusl isWindows isAndroid;
   noSanitizers = !haveLibc || bareMetal || isMusl || isDarwinStatic || isWindows;
 in
 
@@ -241,7 +241,8 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optionalString (stdenv.hostPlatform.isDarwin) ''
       ln -s "$out/lib"/*/* "$out/lib"
     ''
-    + lib.optionalString (useLLVM && stdenv.hostPlatform.isLinux) ''
+    # `!isAndroid`: CRT isn't built with compiler-rt on Android
+    + lib.optionalString (useLLVM && stdenv.hostPlatform.isLinux && !isAndroid) ''
       ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/crtbegin.o
       ln -s $out/lib/*/clang_rt.crtend-*.o $out/lib/crtend.o
       # Note the history of crt{begin,end}S in previous versions of llvm in nixpkg:

--- a/pkgs/development/compilers/llvm/common/compiler-rt/no-libc-android.patch
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/no-libc-android.patch
@@ -1,0 +1,42 @@
+diff --git a/lib/builtins/CMakeLists.txt b/lib/builtins/CMakeLists.txt
+index 3ab9240..d6f2f48 100644
+--- a/lib/builtins/CMakeLists.txt
++++ b/lib/builtins/CMakeLists.txt
+@@ -160,7 +160,6 @@ set(GENERIC_SOURCES
+   negvdi2.c
+   negvsi2.c
+   negvti2.c
+-  os_version_check.c
+   paritydi2.c
+   paritysi2.c
+   parityti2.c
+@@ -242,6 +241,7 @@ if(NOT FUCHSIA AND NOT COMPILER_RT_BAREMETAL_BUILD AND NOT COMPILER_RT_GPU_BUILD
+     emutls.c
+     enable_execute_stack.c
+     eprintf.c
++    os_version_check.c
+   )
+ endif()
+ 
+diff --git a/lib/builtins/cpu_model/aarch64.c b/lib/builtins/cpu_model/aarch64.c
+index be002dd..5af475e 100644
+--- a/lib/builtins/cpu_model/aarch64.c
++++ b/lib/builtins/cpu_model/aarch64.c
+@@ -43,7 +43,7 @@ _Bool __aarch64_have_lse_atomics
+ #elif defined(__Fuchsia__)
+ #include "aarch64/hwcap.inc"
+ #include "aarch64/lse_atomics/fuchsia.inc"
+-#elif defined(__ANDROID__)
++#elif defined(__ANDROID__) && __has_include(<sys/system_properties.h>)
+ #include "aarch64/hwcap.inc"
+ #include "aarch64/lse_atomics/android.inc"
+ #elif defined(__linux__) && __has_include(<sys/auxv.h>)
+@@ -73,7 +73,7 @@ struct {
+ #include "aarch64/fmv/freebsd.inc"
+ #elif defined(__Fuchsia__)
+ #include "aarch64/fmv/fuchsia.inc"
+-#elif defined(__ANDROID__)
++#elif defined(__ANDROID__) && __has_include(<sys/system_properties.h>)
+ #include "aarch64/fmv/mrs.inc"
+ #include "aarch64/fmv/android.inc"
+ #elif defined(__linux__) && __has_include(<sys/auxv.h>)


### PR DESCRIPTION
Fixes `compiler-rt` builds for Android.

Should not affect any non-Android builds.

Could someone test these changes with `aarch64-android-prebuilt`?

Fixes: #380604
Fixes: #269077

@NixOS/llvm

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (`pkgsCross.aarch64-android.llvmPackages.compiler-rt-{no-libc,libc}`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
