### PR TITLE
lkl: fix hijack and zpoline when building in parallel

### DIFF
--- a/pkgs/by-name/lk/lkl/fix-hijack-and-zpoline-parallel-builds.patch
+++ b/pkgs/by-name/lk/lkl/fix-hijack-and-zpoline-parallel-builds.patch
@@ -1,0 +1,48 @@
+From 4ee5d9b78ca1425b4473ede98602b656f28027e8 Mon Sep 17 00:00:00 2001
+From: David Disseldorp <ddiss@suse.de>
+Date: Fri, 4 Jul 2025 15:51:14 +1000
+Subject: [PATCH] lkl: fix hijack and zpoline parallel builds
+
+This is a follow up change for commit 3c97822a40cb1 ("lkl: add tests
+build barrier") tracked via https://github.com/lkl/linux/issues/558.
+The hijack and zpoline libraries also share object files, so need a
+barrier to avoid parallel build failures.
+
+Signed-off-by: David Disseldorp <ddiss@suse.de>
+---
+ tools/lkl/Makefile | 7 ++++---
+ tools/lkl/Targets  | 2 ++
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/tools/lkl/Makefile b/tools/lkl/Makefile
+index 9ca22b7605e3ad..dfe7f6aef5fe02 100644
+--- a/tools/lkl/Makefile
++++ b/tools/lkl/Makefile
+@@ -176,10 +176,11 @@ headers_install: $(TARGETS)
+ 	      include/lkl_config.h $(DESTDIR)$(INCDIR) ; \
+ 	    cp -r $(OUTPUT)include/lkl $(DESTDIR)$(INCDIR)
+ 
+-libraries_install: $(libs-y:%=$(OUTPUT)%$(SOSUF)) $(OUTPUT)liblkl.a
+-	$(call QUIET_INSTALL, libraries) \
++libraries_install: $(call expand-targets,$(libs-y),$(SOSUF)) $(OUTPUT)liblkl.a
++	# filter out special .WAIT targets from install
++	$(if $(filter .%,$^),,$(call QUIET_INSTALL, libraries) \
+ 	    install -d $(DESTDIR)$(LIBDIR) ; \
+-	    install -m 644 $^ $(DESTDIR)$(LIBDIR)
++	    install -m 644 $^ $(DESTDIR)$(LIBDIR))
+ 
+ programs_install: $(call expand-targets,$(progs-y),$(EXESUF))
+ 	$(call QUIET_INSTALL, programs) \
+diff --git a/tools/lkl/Targets b/tools/lkl/Targets
+index 3d30bd8be3c840..089a832ee23627 100644
+--- a/tools/lkl/Targets
++++ b/tools/lkl/Targets
+@@ -2,6 +2,8 @@ libs-y += lib/liblkl
+ 
+ ifneq ($(LKL_HOST_CONFIG_BSD),y)
+ libs-$(LKL_HOST_CONFIG_POSIX) += lib/hijack/liblkl-hijack
++# hijack and zpoline targets share object files, breaking parallel builds
++libs-$(LKL_HOST_CONFIG_POSIX) += .WAIT
+ libs-$(LKL_HOST_CONFIG_POSIX) += lib/hijack/liblkl-zpoline
+ endif
+ LDFLAGS_lib/hijack/liblkl-hijack-y += -shared -nodefaultlibs

--- a/pkgs/by-name/lk/lkl/package.nix
+++ b/pkgs/by-name/lk/lkl/package.nix
@@ -43,6 +43,14 @@ stdenv.mkDerivation {
     libarchive
   ];
 
+  patches = [
+    # Fix corruption in hijack and zpoline libraries when building in parallel,
+    # because both hijack and zpoline share object files, which may result in
+    # missing symbols.
+    # https://github.com/lkl/linux/pull/612/commits/4ee5d9b78ca1425b4473ede98602b656f28027e8
+    ./fix-hijack-and-zpoline-parallel-builds.patch
+  ];
+
   postPatch = ''
     # Fix a /usr/bin/env reference in here that breaks sandboxed builds
     patchShebangs arch/lkl/scripts


### PR DESCRIPTION
Fix hijack and zpoline when building in parallel because they both share object files, which may result in symbols missing from the resulting build outputs.

E.g. `liblkl-hijack.so` is used by `nftables-check` and would fail because of missing symbols caused by this:

~~~
/nix/store/x6mqw6qfcmya8jvhrmk938zirvqb6hhr-nftables-1.1.3/bin/nft: symbol lookup error: /nix/store/fgzk4jdjhmz86d8vmgdjg6l42gbmfa1m-lkl-2025-03-20-lib/lib/liblkl-hijack.so: undefined symbol: dual_fds
~~~

Note: The patch is vendored, because upstream has not merged this PR yet due to Makefile compatibility concerns with older distros.

cc @RaitoBezarius 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test