### PR TITLE
k3s: add all meta-test

### DIFF
--- a/nixos/tests/k3s/default.nix
+++ b/nixos/tests/k3s/default.nix
@@ -7,28 +7,56 @@ let
   allK3s = lib.filterAttrs (
     n: _: lib.strings.hasPrefix "k3s_" n && (builtins.tryEval pkgs.${n}).success
   ) pkgs;
+
+  tests =
+    (selfTests: {
+      all = lib.mapAttrs (
+        _: k3s:
+        let
+          k3sKeyVersion = "k3s_" + (lib.versions.major k3s.version) + "_" + (lib.versions.minor k3s.version);
+        in
+        pkgs.buildEnv {
+          name = "k3s-${k3s.version}-tests-all";
+          paths =
+            let
+              selfTestsExceptAll = builtins.removeAttrs selfTests [ "all" ];
+              getAttrsKeysAsList =
+                attrs: builtins.map (item: selfTests.${item}.${k3sKeyVersion}) (builtins.attrNames attrs);
+            in
+            getAttrsKeysAsList selfTestsExceptAll;
+        }
+      ) allK3s;
+
+      airgap-images = lib.mapAttrs (
+        _: k3s: import ./airgap-images.nix { inherit system pkgs k3s; }
+      ) allK3s;
+
+      auto-deploy = lib.mapAttrs (_: k3s: import ./auto-deploy.nix { inherit system pkgs k3s; }) allK3s;
+
+      auto-deploy-charts = lib.mapAttrs (
+        _: k3s: import ./auto-deploy-charts.nix { inherit system pkgs k3s; }
+      ) allK3s;
+
+      containerd-config = lib.mapAttrs (
+        _: k3s: import ./containerd-config.nix { inherit system pkgs k3s; }
+      ) allK3s;
+
+      etcd = lib.mapAttrs (
+        _: k3s:
+        import ./etcd.nix {
+          inherit system pkgs k3s;
+          inherit (pkgs) etcd;
+        }
+      ) allK3s;
+
+      kubelet-config = lib.mapAttrs (
+        _: k3s: import ./kubelet-config.nix { inherit system pkgs k3s; }
+      ) allK3s;
+
+      multi-node = lib.mapAttrs (_: k3s: import ./multi-node.nix { inherit system pkgs k3s; }) allK3s;
+
+      single-node = lib.mapAttrs (_: k3s: import ./single-node.nix { inherit system pkgs k3s; }) allK3s;
+    })
+      tests;
 in
-{
-  airgap-images = lib.mapAttrs (
-    _: k3s: import ./airgap-images.nix { inherit system pkgs k3s; }
-  ) allK3s;
-  auto-deploy = lib.mapAttrs (_: k3s: import ./auto-deploy.nix { inherit system pkgs k3s; }) allK3s;
-  auto-deploy-charts = lib.mapAttrs (
-    _: k3s: import ./auto-deploy-charts.nix { inherit system pkgs k3s; }
-  ) allK3s;
-  containerd-config = lib.mapAttrs (
-    _: k3s: import ./containerd-config.nix { inherit system pkgs k3s; }
-  ) allK3s;
-  etcd = lib.mapAttrs (
-    _: k3s:
-    import ./etcd.nix {
-      inherit system pkgs k3s;
-      inherit (pkgs) etcd;
-    }
-  ) allK3s;
-  kubelet-config = lib.mapAttrs (
-    _: k3s: import ./kubelet-config.nix { inherit system pkgs k3s; }
-  ) allK3s;
-  multi-node = lib.mapAttrs (_: k3s: import ./multi-node.nix { inherit system pkgs k3s; }) allK3s;
-  single-node = lib.mapAttrs (_: k3s: import ./single-node.nix { inherit system pkgs k3s; }) allK3s;
-}
+tests


### PR DESCRIPTION
k3s: add all meta-test

Goal is to allow to trigger build of all 8+ tests in a single build. In the past I've overlooked running some test and since there are multiple versions of K3s the odds of getting this wrong is high (8*4=24), this comes handy.

To tests builds:

  > nix build .#k3s.passthru.tests.all
  > nix build .#k3s_1_33.passthru.tests.all
  > nix build .#k3s_1_32.passthru.tests.all
  > nix build .#k3s_1_31.passthru.tests.all
  > nix build .#k3s_1_30.passthru.tests.all

- Can test breaking some test on purpose and seeing if it catches the breakage. (It worked for me.)

Since nixfmt is already messing with formatting of all tests. I've added an extra line to each test entry to make reading it easier.

CC @NixOS/k3s