### PR TITLE
muse-sounds-manager: 1.1.0.587 -> 2.0.4.872

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22587,6 +22587,12 @@
     githubId = 178904;
     name = "Daniel Ehlers";
   };
+  sarunint = {
+    email = "nixpkgs@sarunint.com";
+    github = "sarunint";
+    githubId = 3850197;
+    name = "Sarun Intaralawan";
+  };
   sascha8a = {
     email = "sascha@localhost.systems";
     github = "sascha8a";

--- a/pkgs/by-name/mu/muse-sounds-manager/package.nix
+++ b/pkgs/by-name/mu/muse-sounds-manager/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchurl,
   autoPatchelfHook,
-  dpkg,
   fontconfig,
   zlib,
   icu,
@@ -14,27 +13,30 @@
   libICE,
   libSM,
   openssl,
+  unzip,
+  xdg-utils,
+  makeWrapper,
 }:
 
 stdenv.mkDerivation rec {
   pname = "muse-sounds-manager";
-  version = "1.1.0.587";
+  version = "2.0.4.872";
 
   # Use web.archive.org since upstream does not provide a stable (versioned) URL.
   # To see if there are new versions on the Web Archive, visit
-  # http://web.archive.org/cdx/search/cdx?url=https://muse-cdn.com/Muse_Sounds_Manager_Beta.deb
+  # http://web.archive.org/cdx/search/cdx?url=https://muse-cdn.com/Muse_Sounds_Manager_x64.tar.gz
   # then replace the date in the URL below with date when the SHA1
-  # changes (currently A3NX3WHFZWXCHZVME2ABUL2VRENTWOD5) and replace
+  # changes (currently QLR46LKDOAPB7VSF45HEAXWVNWFJHITG) and replace
   # the version above with the version in the .deb metadata (or in the
   # settings of muse-sounds-manager).
   src = fetchurl {
-    url = "https://web.archive.org/web/20240826143936/https://muse-cdn.com/Muse_Sounds_Manager_Beta.deb";
-    hash = "sha256-wzZAIjme1cv8+jMLiKT7kUQvCb+UhsvOnLDV4hCL3hw=";
+    url = "https://web.archive.org/web/20250729165100if_/https://muse-cdn.com/Muse_Sounds_Manager_x64.tar.gz";
+    hash = "sha256-VcLBXpLDk90yd0j9NIzBOXXAciSLWP9y5X51L2/9W4A=";
   };
 
   nativeBuildInputs = [
     autoPatchelfHook
-    dpkg
+    makeWrapper
   ];
 
   buildInputs = [
@@ -55,24 +57,34 @@ stdenv.mkDerivation rec {
     openssl
   ];
 
-  unpackPhase = "dpkg -x $src .";
-
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out
-    mv usr/* opt $out/
-    substituteInPlace $out/bin/muse-sounds-manager --replace-fail /opt/ $out/opt/
+    mkdir -p $out $out/share/applications $out/share/icons
+    cp -p -R bin/ $out/
+    cp -p res/*.desktop $out/share/applications
+    cp -p -R res/icons $out/share
 
     runHook postInstall
   '';
+
+  postInstall = ''
+    ln -s ${xdg-utils}/bin/xdg-open $out/bin/open
+    wrapProgram $out/bin/muse-sounds-manager \
+      --prefix PATH : ${lib.makeBinPath [ unzip ]}
+  '';
+
+  dontStrip = true;
 
   meta = {
     description = "Manage Muse Sounds (Muse Hub) libraries for MuseScore";
     homepage = "https://musescore.org/";
     license = lib.licenses.unfree;
     mainProgram = "muse-sounds-manager";
-    maintainers = with lib.maintainers; [ orivej ];
+    maintainers = with lib.maintainers; [
+      orivej
+      sarunint
+    ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };


### PR DESCRIPTION
Muse Sounds Manager now provides a tarball for other Linux distributions to package it. This is a good opportunity for us to update to the latest version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
