### PR TITLE
python3Packages.pybind11: catch -> catch2

### DIFF
--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -10,7 +10,7 @@
   boost,
   eigen,
   python,
-  catch,
+  catch2,
   numpy,
   pytestCheckHook,
   libxcrypt,
@@ -59,6 +59,7 @@ buildPythonPackage rec {
 
   cmakeFlags = [
     "-DBoost_INCLUDE_DIR=${lib.getDev boost}/include"
+    "-DCATCH_INCLUDE_DIR=${lib.getDev catch2}/include/catch2"
     "-DEIGEN3_INCLUDE_DIR=${lib.getDev eigen}/include/eigen3"
   ]
   ++ lib.optionals (python.isPy3k && !stdenv.cc.isClang) [ "-DPYBIND11_CXX_STANDARD=-std=c++17" ];
@@ -76,7 +77,7 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
-    catch
+    catch2
     numpy
     pytestCheckHook
   ];
@@ -98,6 +99,10 @@ buildPythonPackage rec {
     # https://github.com/pybind/pybind11/issues/4243
     "test_cross_module_exception_translator"
   ];
+
+  postInstallCheck = ''
+    make cpptest
+  '';
 
   hardeningDisable = lib.optional stdenv.hostPlatform.isMusl "fortify";
 

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -100,7 +100,7 @@ buildPythonPackage rec {
     "test_cross_module_exception_translator"
   ];
 
-  postInstallCheck = ''
+  postCheck = ''
     make cpptest
   '';
 


### PR DESCRIPTION
Fix for CMake v4.

Upstream use [catch2](https://github.com/pybind/pybind11/blob/master/tests/pure_cpp/CMakeLists.txt). When we provide catch, [logs](https://hydra.nixos.org/build/302959038/nixlog/1) say:
```
-- Catch not detected. Interpreter tests will be skipped.
Install Catch headers manually or use `cmake -DDOWNLOAD_CATCH=ON` to fetch them automatically.
```

With this, we correctly get:
```
-- Building interpreter tests using Catch v2.13.10
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
