### PR TITLE
surge: migrate to by-name

### DIFF
--- a/pkgs/by-name/su/surge/package.nix
+++ b/pkgs/by-name/su/surge/package.nix
@@ -5,7 +5,7 @@
   fetchpatch,
   fetchFromGitHub,
   cmake,
-  git,
+  gitMinimal,
   pkg-config,
   python3,
   cairo,
@@ -20,13 +20,13 @@
   rsync,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "surge";
   version = "1.9.0";
 
   src = fetchurl {
-    url = "https://github.com/surge-synthesizer/releases/releases/download/${version}/SurgeSrc_${version}.tgz";
-    sha256 = "00af4lfcipl0rn0dn4gfipx7nbk8ym1mrmji8v0ar98frsrpxg4k";
+    url = "https://github.com/surge-synthesizer/releases/releases/download/${finalAttrs.version}/SurgeSrc_${finalAttrs.version}.tgz";
+    hash = "sha256-k7x+s84OpazARlHWXEP1aC57+o3uEduAzYDeyBwlTgE=";
   };
 
   extraContent = fetchFromGitHub {
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     # or: https://github.com/surge-synthesizer/surge/blob/main/cmake/stage-extra-content.cmake
     # SURGE_EXTRA_CONTENT_HASH
     rev = "afc591cc06d9adc3dc8dc515a55c66873fa10296";
-    sha256 = "1wqv86l70nwlrb10n47rib80f47a96j9qqg8w5dv46ys1sq2nz7z";
+    hash = "sha256-/3wrsA7aG7Jb4ehhnKRJ6hAH0Ir5EAvCypRbcKhBG/M=";
   };
 
   patches = [
@@ -45,14 +45,14 @@ stdenv.mkDerivation rec {
     # Patch: https://github.com/surge-synthesizer/surge/pull/4845
     (fetchpatch {
       url = "https://github.com/surge-synthesizer/surge/commit/7a552038bab4b000d188ae425aa97963dc91db17.patch";
-      sha256 = "sha256-5Flf0uJqEK6e+sadB+vr6phdvvdZYXcFFfm4ywhAeW0=";
+      hash = "sha256-5Flf0uJqEK6e+sadB+vr6phdvvdZYXcFFfm4ywhAeW0=";
       name = "glibc_build_fix.patch";
     })
   ];
 
   nativeBuildInputs = [
     cmake
-    git
+    gitMinimal
     pkg-config
     python3
   ];
@@ -92,17 +92,17 @@ stdenv.mkDerivation rec {
     build/surge-headless
   '';
 
-  meta = with lib; {
+  meta = {
     description = ''
       LV2 & VST3 synthesizer plug-in (previously released as Vember Audio
       Surge)
     '';
     homepage = "https://surge-synthesizer.github.io";
-    license = licenses.gpl3;
+    license = lib.licenses.gpl3;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       magnetophon
       orivej
     ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13562,10 +13562,6 @@ with pkgs;
     pythonBindings = true;
   };
 
-  surge = callPackage ../applications/audio/surge {
-    git = gitMinimal;
-  };
-
   supersonic-wayland = supersonic.override {
     waylandSupport = true;
   };


### PR DESCRIPTION
migrate surge to by-name
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
