### PR TITLE
linuxPackages.nvidiaPackages.legacy_340: Add latest AUR patches

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -226,8 +226,8 @@ rec {
       aurPatches = fetchFromGitHub {
         owner = "archlinux-jerry";
         repo = "nvidia-340xx";
-        rev = "7616dfed253aa93ca7d2e05caf6f7f332c439c90";
-        hash = "sha256-1qlYc17aEbLD4W8XXn1qKryBk2ltT6cVIv5zAs0jXZo=";
+        rev = "09154c494dbaa6368bf85c24d1d07956a4bf789a";
+        hash = "sha256-O6UaPV03c0XcN5F5yIGXDb0fBfhtAIzuj/PbKeSMjmg=";
       };
       patchset = [
         "0001-kernel-5.7.patch"
@@ -245,6 +245,10 @@ rec {
         "0013-kernel-6.3.patch"
         "0014-kernel-6.5.patch"
         "0015-kernel-6.6.patch"
+        "0016-kernel-6.8.patch"
+        "0017-gcc-14.patch"
+        "0018-gcc-15.patch"
+        "0019-kernel-6.15.patch"
       ];
     in
     generic {
@@ -255,7 +259,6 @@ rec {
       persistencedSha256 = "1ax4xn3nmxg1y6immq933cqzw6cj04x93saiasdc0kjlv0pvvnkn";
       useGLVND = false;
 
-      broken = kernel.kernelAtLeast "6.7";
       patches = map (patch: "${aurPatches}/${patch}") patchset;
 
       # fixes the bug described in https://bbs.archlinux.org/viewtopic.php?pid=2083439#p2083439


### PR DESCRIPTION
The current nvidia-340xx module is broken from kernel 6.7. This change gets the latest patches from the upstream repo from AUR, which fixes the module for now. I tested the changes on my machine, and I could get the driver to run with these patches.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
