### PR TITLE
home-assistant: 2025.7.4 -> 2025.8.0

### DIFF
--- a/pkgs/development/python-modules/aioairzone-cloud/default.nix
+++ b/pkgs/development/python-modules/aioairzone-cloud/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "aioairzone-cloud";
-  version = "0.6.16";
+  version = "0.7.1";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "Noltari";
     repo = "aioairzone-cloud";
     tag = version;
-    hash = "sha256-EPj6tql05ZUImMAeeUTyNms1NdwJgtdCJmJ+O8HXP3I=";
+    hash = "sha256-BolgPHN7lc98kYWf1qDNvf1z5WNoDtAIvbY8+sgwB+E=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/aioamazondevices/default.nix
+++ b/pkgs/development/python-modules/aioamazondevices/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "aioamazondevices";
-  version = "3.6.0";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "chemelli74";
     repo = "aioamazondevices";
     tag = "v${version}";
-    hash = "sha256-CVwpu0TW6ah7Stx2GhQgw9EkmHJ6rRB7DN416EatUMo=";
+    hash = "sha256-Ch3IP7fMEDYYRFDk3eoZWjhjnkQY0qcAFJdmkoW4o/0=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/aioautomower/default.nix
+++ b/pkgs/development/python-modules/aioautomower/default.nix
@@ -8,11 +8,13 @@
   ical,
   mashumaro,
   poetry-core,
+  poetry-dynamic-versioning,
   pyjwt,
   pytest-asyncio,
   pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
+  python-dateutil,
   syrupy,
   time-machine,
   tzlocal,
@@ -20,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "aioautomower";
-  version = "2025.6.0";
+  version = "2.1.2";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -28,8 +30,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Thomas55555";
     repo = "aioautomower";
-    tag = version;
-    hash = "sha256-6V3utjqCLQmO2iuWdn6kE8oz9XcJ/sCfeSMWmxL/2NE=";
+    tag = "v${version}";
+    hash = "sha256-NQCkJLVOqqKodSclx941HCEEBLS6gJuNS1uZysuXf8A=";
   };
 
   postPatch = ''
@@ -38,13 +40,17 @@ buildPythonPackage rec {
       --replace-fail 'version = "0.0.0"' 'version = "${version}"'
   '';
 
-  build-system = [ poetry-core ];
+  build-system = [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
 
   dependencies = [
     aiohttp
     ical
     mashumaro
     pyjwt
+    python-dateutil
     tzlocal
   ];
 
@@ -68,6 +74,9 @@ buildPythonPackage rec {
     # Timezone mismatches
     "test_full_planner_event"
     "test_sinlge_planner_event"
+    "test_set_datetime"
+    "test_message_event"
+    "test_async_get_messages"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/aiodiscover/default.nix
+++ b/pkgs/development/python-modules/aiodiscover/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "aiodiscover";
-  version = "2.7.0";
+  version = "2.7.1";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "bdraco";
     repo = "aiodiscover";
     tag = "v${version}";
-    hash = "sha256-zJOsf4oZbZgaiaaPM0HfR0GNwxvGoR6fgkJB5ZFY0O8=";
+    hash = "sha256-q0HXANSfoDPlGdokfiQcsMHkt9ZmD604JRL/SDQx2hw=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/aioesphomeapi/default.nix
+++ b/pkgs/development/python-modules/aioesphomeapi/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "aioesphomeapi";
-  version = "33.1.1";
+  version = "37.2.5";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     owner = "esphome";
     repo = "aioesphomeapi";
     tag = "v${version}";
-    hash = "sha256-vXBTumh1oB1vTVlX4VJvIUTnkYLG9j/8cNuHFQ2PklY=";
+    hash = "sha256-+l/tEdraTkNt70sjcGpS/e1uEyudEsJdlqgoHPhMNg0=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/aioshelly/default.nix
+++ b/pkgs/development/python-modules/aioshelly/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "aioshelly";
-  version = "13.7.2";
+  version = "13.8.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "aioshelly";
     tag = version;
-    hash = "sha256-8OOg6+oKaeLk2kUJ44ynxuNx1ZGtAydLhgAhM2N9Hn0=";
+    hash = "sha256-SzEoLOjHlXVEB8V1Qc2IcA46YVIQ3w+FGADB5EaIb4k=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/amcrest/default.nix
+++ b/pkgs/development/python-modules/amcrest/default.nix
@@ -16,22 +16,22 @@
 
 buildPythonPackage rec {
   pname = "amcrest";
-  version = "1.9.8";
+  version = "1.9.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tchellomello";
     repo = "python-amcrest";
     tag = version;
-    hash = "sha256-v0jWEZo06vltEq//suGrvJ/AeeDxUG5CCFhbf03q34w=";
+    hash = "sha256-UPxs/sL8ZpUf29fpQFnLY4tV7qSQIxm0UVSl6Pm1dAY=";
   };
 
   patches = [
     (fetchpatch2 {
-      # https://github.com/tchellomello/python-amcrest/pull/235
-      name = "replace-distutils.patch";
-      url = "https://github.com/tchellomello/python-amcrest/commit/ec56049c0f5b49bc4c5bcf0acb7fea89ec1c1df4.patch";
-      hash = "sha256-ym+Bn795y+JqhNMk4NPnOVr3DwO9DkUV0d9LEaz3CMo=";
+      # https://github.com/tchellomello/python-amcrest/pull/240
+      name = "distutils-str2bool.patch";
+      url = "https://github.com/tchellomello/python-amcrest/commit/9cced67d643da6c33d92e85dde22e01b44fb0936.patch";
+      hash = "sha256-i9UeYo43Eiwz06KfWyVQUPTLCJLmMjjNcjA7ZQcPIqQ=";
     })
   ];
 

--- a/pkgs/development/python-modules/arcam-fmj/default.nix
+++ b/pkgs/development/python-modules/arcam-fmj/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "arcam-fmj";
-  version = "1.8.1";
+  version = "1.8.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "elupus";
     repo = "arcam_fmj";
     tag = version;
-    hash = "sha256-sNV2k3cbQe60Jpq1J2T6TQAz+NEyLXvS97//vXJ17TM=";
+    hash = "sha256-iks3ENcv7OtU30kZyG6Z7bG/WrYQQLbfXP55IkltmaE=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/axis/default.nix
+++ b/pkgs/development/python-modules/axis/default.nix
@@ -3,6 +3,7 @@
   async-timeout,
   attrs,
   buildPythonPackage,
+  faust-cchardet,
   fetchFromGitHub,
   httpx,
   orjson,
@@ -15,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "axis";
-  version = "64";
+  version = "65";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -24,13 +25,13 @@ buildPythonPackage rec {
     owner = "Kane610";
     repo = "axis";
     tag = "v${version}";
-    hash = "sha256-6g4Dqk+oGlEcqlNuMiwep+NCVFmwRZjKgEZC1OzmKw0=";
+    hash = "sha256-65njqnnahpYhx5CShjWOuNlkckQbt8tMjKf8OUCrmbw=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools==75.6.0" "setuptools" \
-      --replace-fail "wheel==0.45.1" "wheel"
+      --replace-fail "setuptools==80.9.0" "setuptools" \
+      --replace-fail "wheel==0.46.1" "wheel"
   '';
 
   build-system = [ setuptools ];
@@ -38,6 +39,7 @@ buildPythonPackage rec {
   dependencies = [
     async-timeout
     attrs
+    faust-cchardet
     httpx
     orjson
     packaging

--- a/pkgs/development/python-modules/bellows/default.nix
+++ b/pkgs/development/python-modules/bellows/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "bellows";
-  version = "0.45.2";
+  version = "0.45.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "bellows";
     tag = version;
-    hash = "sha256-HVa1QFw9hLTgHu5up+llvM6q5+HCWNwKnJem3GSxcPg=";
+    hash = "sha256-7CU3o7SrBDxgf4Bd7SBkZlfwwdeo1Rr+UyapX3ORyfU=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/bleak-esphome/default.nix
+++ b/pkgs/development/python-modules/bleak-esphome/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "bleak-esphome";
-  version = "2.16.0";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bluetooth-devices";
     repo = "bleak-esphome";
     tag = "v${version}";
-    hash = "sha256-1NqalsFUXTcVX0UVV4BMStX+EAcu0/3vEKpkq+z+KDE=";
+    hash = "sha256-L2/DtT1vEkP67oktLNix+/+eoVbJoMfUvW6232gSMCM=";
   };
 
   postPatch = ''
@@ -54,6 +54,13 @@ buildPythonPackage rec {
     pytest-codspeed
     pytest-cov-stub
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # bleak_client.services.get_characteristic returns None
+    "test_client_get_services_and_read_write"
+    "test_bleak_client_get_services_and_read_write"
+    "test_bleak_client_cached_get_services_and_read_write"
   ];
 
   pythonImportsCheck = [ "bleak_esphome" ];

--- a/pkgs/development/python-modules/bleak-retry-connector/default.nix
+++ b/pkgs/development/python-modules/bleak-retry-connector/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "bleak-retry-connector";
-  version = "3.9.0";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Bluetooth-Devices";
     repo = "bleak-retry-connector";
     tag = "v${version}";
-    hash = "sha256-weZ44YhbCoDRByzta/tkl1maEuxewS+53jxFRDHK6so=";
+    hash = "sha256-zF1wGDpcUK/88A+2JHuu2bU1tYmJIvSfdZX/IZEmauQ=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/bleak/default.nix
+++ b/pkgs/development/python-modules/bleak/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "bleak";
-  version = "0.22.3";
+  version = "1.0.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "hbldh";
     repo = "bleak";
     tag = "v${version}";
-    hash = "sha256-kPeKQcJETZE6+btQsmCgb37yRI2Klg0lZ1ZIrm8ODow=";
+    hash = "sha256-JHTyTHMMZDD75baQK3nf4R+8eW0Tt62CMTXb8eRKp94=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/bless/default.nix
+++ b/pkgs/development/python-modules/bless/default.nix
@@ -47,6 +47,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "bless" ];
 
   meta = with lib; {
+    broken = true; # not compatible with bleak>=1.0 and no maintenance since 2024-03
     description = "Library for creating a BLE Generic Attribute Profile (GATT) server";
     homepage = "https://github.com/kevincar/bless";
     changelog = "https://github.com/kevincar/bless/releases/tag/v${version}";

--- a/pkgs/development/python-modules/bluetooth-adapters/default.nix
+++ b/pkgs/development/python-modules/bluetooth-adapters/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "bluetooth-adapters";
-  version = "0.21.4";
+  version = "2.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "Bluetooth-Devices";
     repo = "bluetooth-adapters";
     tag = "v${version}";
-    hash = "sha256-JUh4v9YeqMeecJh/eTpmLMwNsxbc/oqZY2CrEJUO418=";
+    hash = "sha256-0WZ6M/e5HLG1jS635Ir9eSGUW/2+YdU0tfszt+gM/qo=";
   };
 
   outputs = [

--- a/pkgs/development/python-modules/dbus-fast/default.nix
+++ b/pkgs/development/python-modules/dbus-fast/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "dbus-fast";
-  version = "2.44.1";
+  version = "2.44.3";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "Bluetooth-Devices";
     repo = "dbus-fast";
     tag = "v${version}";
-    hash = "sha256-r9F/3H/Bagi9QJHZDEsa80dglVE9vS1f9Cqt7CZWn8Y=";
+    hash = "sha256-ZpTQjAmrLoenDWzd/0NpD7fqTd6Dv1J0Ks0db4twwYk=";
   };
 
   # The project can build both an optimized cython version and an unoptimized

--- a/pkgs/development/python-modules/gcal-sync/default.nix
+++ b/pkgs/development/python-modules/gcal-sync/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "gcal-sync";
-  version = "7.2.0";
+  version = "8.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "allenporter";
     repo = "gcal_sync";
     tag = version;
-    hash = "sha256-cdQwjjZNQlIj6oN4kJ53B576pKkLeYiXjGWqMB/EReU=";
+    hash = "sha256-+L34vKV7xCD+Jj47WrQufzLZddPhhKWaSMo1UQKeHRY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/habluetooth/default.nix
+++ b/pkgs/development/python-modules/habluetooth/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "habluetooth";
-  version = "3.49.0";
+  version = "4.0.2";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "Bluetooth-Devices";
     repo = "habluetooth";
     tag = "v${version}";
-    hash = "sha256-+jv6345Qfay66hl4KBy93B3AMg4lwN/DtjohuFvh9+M=";
+    hash = "sha256-82eV76oY/exkHbhZt3OaifOoKxN2D6npstvfBDVgszw=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/hahomematic/default.nix
+++ b/pkgs/development/python-modules/hahomematic/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "hahomematic";
-  version = "2025.6.0";
+  version = "2025.8.3";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "SukramJ";
     repo = "hahomematic";
     tag = version;
-    hash = "sha256-1gZ0TWBFDe+RN5Rb3dUEZyEsy1kyR8Qhlpj9eJRuh60=";
+    hash = "sha256-BztVWvDUDXTgC1uha7grD4hcWJqKcua4UVgy3KivWSI=";
   };
 
   __darwinAllowLocalNetworking = true;
@@ -51,6 +51,11 @@ buildPythonPackage rec {
     pytest-aiohttp
     pytest-socket
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # AssertionError: assert 548 == 555
+    "test_central_full"
   ];
 
   pythonImportsCheck = [ "hahomematic" ];

--- a/pkgs/development/python-modules/halohome/default.nix
+++ b/pkgs/development/python-modules/halohome/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
     csrmesh
   ];
 
+  pythonRelaxDeps = [ "bleak" ];
+
   # Project has no tests
   doCheck = false;
 

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -8,12 +8,15 @@
   ciso8601,
   cryptography,
   fetchFromGitHub,
+  freezegun,
   pycognito,
   pyjwt,
   pytest-aiohttp,
+  pytest-socket,
   pytest-timeout,
   pytestCheckHook,
   pythonOlder,
+  sentence-stream,
   setuptools,
   snitun,
   syrupy,
@@ -23,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.106.0";
+  version = "0.111.1";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -32,7 +35,7 @@ buildPythonPackage rec {
     owner = "nabucasa";
     repo = "hass-nabucasa";
     tag = version;
-    hash = "sha256-GrdtZGAaDZWVsKatiWxp9uSNSLjnzM0Cw+26IHm1KN0=";
+    hash = "sha256-WmsLn/pHI3KJSmX5U20eNUEs0Q1upuwkkzcHIYPNYjY=";
   };
 
   build-system = [ setuptools ];
@@ -51,12 +54,15 @@ buildPythonPackage rec {
     cryptography
     pycognito
     pyjwt
+    sentence-stream
     snitun
     webrtc-models
   ];
 
   nativeCheckInputs = [
+    freezegun
     pytest-aiohttp
+    pytest-socket
     pytest-timeout
     pytestCheckHook
     syrupy

--- a/pkgs/development/python-modules/holidays/default.nix
+++ b/pkgs/development/python-modules/holidays/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "holidays";
-  version = "0.75";
+  version = "0.78";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "vacanza";
     repo = "python-holidays";
     tag = "v${version}";
-    hash = "sha256-xlDCIQb1XeMi+uNIkqMgm1t+fDSuQlqgOx57LnAuyVo=";
+    hash = "sha256-THZg1125rN5HLoiw7xMiKwSNcKzXZgXL8DkbnCMiJ/c=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/home-assistant-bluetooth/default.nix
+++ b/pkgs/development/python-modules/home-assistant-bluetooth/default.nix
@@ -48,6 +48,8 @@ buildPythonPackage rec {
 
   dependencies = [ habluetooth ];
 
+  doCheck = false; # broken with habluetooth>=4.0
+
   nativeCheckInputs = [
     bleak
     pytest-cov-stub

--- a/pkgs/development/python-modules/huum/default.nix
+++ b/pkgs/development/python-modules/huum/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "huum";
-  version = "0.7.12";
+  version = "0.8.1";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "frwickst";
     repo = "pyhuum";
     tag = version;
-    hash = "sha256-IyPsRtVaxsI9Y0BpzKCSsc2oAqdGQI92UqxaRGpGmak=";
+    hash = "sha256-8wldXJAdo1PK4bKX0rKJjNwwTS5FSgr9RcwiyVhESb8=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/ical/default.nix
+++ b/pkgs/development/python-modules/ical/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "ical";
-  version = "10.0.4";
+  version = "11.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "allenporter";
     repo = "ical";
     tag = version;
-    hash = "sha256-T58A2oBDD97C5Jz5WlbAJYOnoJzP+jAryKb5Oim4TuU=";
+    hash = "sha256-jn4xPwnJ/RQNTItYv4QY54UejayI0MmDhKZtg2lkpr8=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/idasen-ha/default.nix
+++ b/pkgs/development/python-modules/idasen-ha/default.nix
@@ -1,6 +1,7 @@
 {
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   idasen,
   lib,
   pytest-asyncio,
@@ -19,6 +20,14 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-Z4MfJGL2uDqY1ddoV2fB+Ty/dKFhCUY8qBfP/i/naJs=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "bleak-1.0.0-compat.patch";
+      url = "https://github.com/abmantis/idasen-ha/commit/57e5ba4affb99b17ffc95a33a0aec60c7518be2b.patch";
+      hash = "sha256-Jc6e9uYrifXZ91aNhoxqyquq1WMzHWrVKPBXYhosbRM=";
+    })
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/imgw-pib/default.nix
+++ b/pkgs/development/python-modules/imgw-pib/default.nix
@@ -1,10 +1,12 @@
 {
+  aiofiles,
   aiohttp,
   aioresponses,
   buildPythonPackage,
   fetchFromGitHub,
   freezegun,
   lib,
+  orjson,
   pytest-asyncio,
   pytestCheckHook,
   setuptools,
@@ -13,19 +15,23 @@
 
 buildPythonPackage rec {
   pname = "imgw-pib";
-  version = "1.1.0";
+  version = "1.5.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = "imgw-pib";
     tag = version;
-    hash = "sha256-6vN1f0qHDJZh80IvWhnpGr2Qg/2/jCaCSxOvlVGc3B8=";
+    hash = "sha256-7x6tqgyFkFLil8R20/v05wrsnoq+mLlsyKVvGDmwmpo=";
   };
 
   build-system = [ setuptools ];
 
-  dependencies = [ aiohttp ];
+  dependencies = [
+    aiofiles
+    aiohttp
+    orjson
+  ];
 
   pythonImportsCheck = [ "imgw_pib" ];
 

--- a/pkgs/development/python-modules/israel-rail-api/default.nix
+++ b/pkgs/development/python-modules/israel-rail-api/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "israel-rail-api";
-  version = "0.1.2";
+  version = "0.1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sh0oki";
     repo = "israel-rail-api";
     tag = "v${version}";
-    hash = "sha256-OiWK3gi7dQ7SF4fvusKtSFzdhrsvePlscX0EYQ/hlYk=";
+    hash = "sha256-viIETVCW3YSwJOsFxkYoi0Ko9vXQEP9d+fjQAlb142c=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/lcn-frontend/default.nix
+++ b/pkgs/development/python-modules/lcn-frontend/default.nix
@@ -7,20 +7,14 @@
 
 buildPythonPackage rec {
   pname = "lcn-frontend";
-  version = "0.2.5";
+  version = "0.2.6";
   pyproject = true;
 
   src = fetchPypi {
     pname = "lcn_frontend";
     inherit version;
-    hash = "sha256-WPjK/CzEpi9S1raEotR10n7eM06jg5ihAUKCLt8KDig=";
+    hash = "sha256-7PdUI1G8jmemjS5/rA+88YR6iugt8/9ojtuU26nFa1s=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools~=68.0" setuptools \
-      --replace-fail "wheel~=0.40.0" wheel
-  '';
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/letpot/default.nix
+++ b/pkgs/development/python-modules/letpot/default.nix
@@ -5,19 +5,20 @@
   fetchFromGitHub,
   lib,
   poetry-core,
+  pytest-asyncio,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "letpot";
-  version = "0.4.0";
+  version = "0.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jpelgrom";
     repo = "python-letpot";
     tag = "v${version}";
-    hash = "sha256-ScguCgShoZ+qSfw558kqodpcpyPGy9HU6c2qAVOQb+c=";
+    hash = "sha256-CUTZvzLC7YGiKXOJSj6gdPOznHQIQ+Bu2YW7LyLB0Sg=";
   };
 
   build-system = [ poetry-core ];
@@ -30,6 +31,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "letpot" ];
 
   nativeCheckInputs = [
+    pytest-asyncio
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/mashumaro/default.nix
+++ b/pkgs/development/python-modules/mashumaro/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "mashumaro";
-  version = "3.15";
+  version = "3.16";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "Fatal1ty";
     repo = "mashumaro";
     tag = "v${version}";
-    hash = "sha256-Zv2FijxYOLGflJ3bc3udkM3SXgHHzHIeCGHlfybyLGE=";
+    hash = "sha256-SAdhBNQx5zWsXFwWxEAozprb2c7eJRdxZQwZMgBj/iA=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/midea-local/default.nix
+++ b/pkgs/development/python-modules/midea-local/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "midea-local";
-  version = "6.3.0";
+  version = "6.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "midea-lan";
     repo = "midea-local";
     tag = "v${version}";
-    hash = "sha256-J044JyRrpig2RmX39tvxBbjFExFouK3++0mvaPN+8To=";
+    hash = "sha256-jeQ5PXkKxVz041VJ58lJVpqIoj1Y054VADFtnutddg4=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/opower/default.nix
+++ b/pkgs/development/python-modules/opower/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "opower";
-  version = "0.12.4";
+  version = "0.15.1";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "tronikos";
     repo = "opower";
     tag = "v${version}";
-    hash = "sha256-wUkPXfiXwKWVIQcPw2dsXJ5VMn1hf1rBFzDINnCVtEM=";
+    hash = "sha256-FB9m1aFEqbqLYfg5cMhZMLvp9ENsudQqf5dXKnGtZkA=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/plugwise/default.nix
+++ b/pkgs/development/python-modules/plugwise/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  aiofiles,
   aiohttp,
   buildPythonPackage,
   defusedxml,
@@ -17,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "plugwise";
-  version = "1.7.6";
+  version = "1.7.8";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -26,7 +27,7 @@ buildPythonPackage rec {
     owner = "plugwise";
     repo = "python-plugwise";
     tag = "v${version}";
-    hash = "sha256-x3UiEO2dduMHpDkMZAdpUBNR9VStM7qInEXxZeHqeTM=";
+    hash = "sha256-hGXjwEOvcSIvfw3xeIUVF59bSXjVXL7CMUncHqeVZ1Y=";
   };
 
   postPatch = ''
@@ -37,6 +38,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
+    aiofiles
     aiohttp
     defusedxml
     munch

--- a/pkgs/development/python-modules/pyblu/default.nix
+++ b/pkgs/development/python-modules/pyblu/default.nix
@@ -3,28 +3,28 @@
   aioresponses,
   buildPythonPackage,
   fetchFromGitHub,
+  hatchling,
   lib,
   lxml,
-  poetry-core,
   pytest-asyncio,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pyblu";
-  version = "2.0.1";
+  version = "2.0.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "LouisChrist";
     repo = "pyblu";
     tag = "v${version}";
-    hash = "sha256-4dWRz7KPLgjN57U/jsm6VCqzkzfMY5yuHL0ZSBeALyI=";
+    hash = "sha256-nzTqakEMl9gywIQpC9OR0xiqZzawU5RxOx3NQT+CiFc=";
   };
 
   pythonRelaxDeps = [ "aiohttp" ];
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/pykulersky/default.nix
+++ b/pkgs/development/python-modules/pykulersky/default.nix
@@ -7,24 +7,24 @@
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
-  pythonOlder,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pykulersky";
-  version = "0.5.8";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.6";
+  version = "0.6.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "emlove";
     repo = "pykulersky";
     rev = version;
-    hash = "sha256-BaGcsHlQpuEnUn8OgSUsJi2q89vFl7vpkinviKnUZJk=";
+    hash = "sha256-YHGEDAsbQN3sYu7mdVUbb3xX7FMnR0xAhXkvf7Ok7qs=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     bleak
     click
   ];

--- a/pkgs/development/python-modules/pymicrobot/default.nix
+++ b/pkgs/development/python-modules/pymicrobot/default.nix
@@ -10,15 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pymicrobot";
-  version = "0.0.22";
+  version = "0.0.23";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
   src = fetchPypi {
-    pname = "PyMicroBot";
-    inherit version;
-    hash = "sha256-8Nkkgznt4JzImJSAbdaX6znhvmgqwOIBjAXVhaMorLk=";
+    inherit pname version;
+    hash = "sha256-fRCXCT3DR42HhYom23hVcWBXFngLPn7UZmyKrjb+MNY=";
   };
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/pymitsubishi/default.nix
+++ b/pkgs/development/python-modules/pymitsubishi/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pymitsubishi";
-  version = "0.1.7";
+  version = "0.1.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymitsubishi";
     repo = "pymitsubishi";
     tag = "v${version}";
-    hash = "sha256-tEmhllXvUwiJG1q7MyBrHPVVxzcZYgzTHzD8jnqfXvA=";
+    hash = "sha256-hawPxP8WqpHUikmbcSFIjSeSTNyWu1zYtgT/TCPbOro=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pysmi/default.nix
+++ b/pkgs/development/python-modules/pysmi/default.nix
@@ -2,9 +2,9 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  flit-core,
   jinja2,
   ply,
-  poetry-core,
   pysmi,
   pysnmp,
   pytestCheckHook,
@@ -13,7 +13,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.5.10";
+  version = "1.6.2";
   pname = "pysmi";
   pyproject = true;
 
@@ -23,10 +23,10 @@ buildPythonPackage rec {
     owner = "lextudio";
     repo = "pysmi";
     tag = "v${version}";
-    hash = "sha256-fJwMkOzI5IrDEyH6wV/zD79k6rzuuqDvfZkuHC44TGY=";
+    hash = "sha256-GyG3J6qntEIszXrm1t623+x1cYbhJLbTEQl6N2h2LA0=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ flit-core ];
 
   dependencies = [
     ply

--- a/pkgs/development/python-modules/pysnmp/default.nix
+++ b/pkgs/development/python-modules/pysnmp/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build-system
-  poetry-core,
+  flit-core,
 
   # dependencies
   pyasn1,
@@ -19,17 +19,17 @@
 
 buildPythonPackage rec {
   pname = "pysnmp";
-  version = "7.1.16";
+  version = "7.1.21";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lextudio";
     repo = "pysnmp";
     tag = "v${version}";
-    hash = "sha256-HGIbxvq4twyZavtjkf2Uu9SEFIXzPCT34lAJEeprwXU=";
+    hash = "sha256-IbVs/fjNRDhp4a78ZbgqUOxyrlZjEwsKSlQV3+mmCjo=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ flit-core ];
 
   dependencies = [
     pyasn1
@@ -71,6 +71,7 @@ buildPythonPackage rec {
     "test_syntax_integer"
     "test_syntax_unsigned"
     "test_add_asn1_mib_source"
+    "test_syntax_fixed_length_octet_string"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/pysnooz/bleak-compat.patch
+++ b/pkgs/development/python-modules/pysnooz/bleak-compat.patch
@@ -1,0 +1,39 @@
+diff --git a/tests/test_api.py b/tests/test_api.py
+index 3289252..30388b2 100644
+--- a/tests/test_api.py
++++ b/tests/test_api.py
+@@ -25,7 +25,7 @@ DBUS_ERROR_UNKNOWN = BleakDBusError("org.bluez.Error.SomethingNotHandled", [])
+ @pytest.fixture()
+ def mock_client() -> MockSnoozClient:
+     return MockSnoozClient(
+-        BLEDevice("Snooz-ABCD", "00:00:00:00:12:34", [], 0), SnoozDeviceModel.ORIGINAL
++        BLEDevice("Snooz-ABCD", "00:00:00:00:12:34", []), SnoozDeviceModel.ORIGINAL
+     )
+ 
+ 
+diff --git a/tests/test_device.py b/tests/test_device.py
+index f24a7c6..38240e4 100644
+--- a/tests/test_device.py
++++ b/tests/test_device.py
+@@ -127,7 +127,7 @@ def snooz(
+     model_name = (
+         MODEL_NAME_BREEZ if model == SnoozDeviceModel.BREEZ else MODEL_NAME_SNOOZ
+     )
+-    device = BLEDevice("AA:BB:CC:DD:EE:FF", f"{model_name}-EEFF", [], 0)
++    device = BLEDevice("AA:BB:CC:DD:EE:FF", f"{model_name}-EEFF", [])
+     password = "AABBCCDDEEFF"
+     adv_data = SnoozAdvertisementData(
+         model,
+diff --git a/tests/test_testing.py b/tests/test_testing.py
+index d8ce6f2..7a1002d 100644
+--- a/tests/test_testing.py
++++ b/tests/test_testing.py
+@@ -22,7 +22,7 @@ from pysnooz.testing import MockSnoozClient, MockSnoozDevice
+ 
+ from . import SUPPORTED_MODELS
+ 
+-TEST_BLE_DEVICE = BLEDevice("00:00:00:00:AB:CD", "Snooz-ABCD", [], 0)
++TEST_BLE_DEVICE = BLEDevice("00:00:00:00:AB:CD", "Snooz-ABCD", [])
+ 
+ 
+ @pytest.mark.asyncio

--- a/pkgs/development/python-modules/pysnooz/default.nix
+++ b/pkgs/development/python-modules/pysnooz/default.nix
@@ -20,7 +20,7 @@
 buildPythonPackage rec {
   pname = "pysnooz";
   version = "0.10.0";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.9";
 
@@ -31,15 +31,20 @@ buildPythonPackage rec {
     hash = "sha256-jOXmaJprU35sdNRrBBx/YUyiDyyaE1qodWksXkTSEe0=";
   };
 
+  patches = [
+    # https://github.com/AustinBrunkhorst/pysnooz/pull/20
+    ./bleak-compat.patch
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'transitions = "^0.8.11"' 'transitions = ">=0.8.11"' \
-      --replace 'Events = "^0.4"' 'Events = ">=0.4"'
+      --replace-fail 'transitions = "^0.8.11"' 'transitions = ">=0.8.11"' \
+      --replace-fail 'Events = "^0.4"' 'Events = ">=0.4"'
   '';
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     bleak
     bleak-retry-connector
     bluetooth-sensor-state-data

--- a/pkgs/development/python-modules/pytouchlinesl/default.nix
+++ b/pkgs/development/python-modules/pytouchlinesl/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pytouchlinesl";
-  version = "0.3.0";
+  version = "0.4.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";

--- a/pkgs/development/python-modules/pyzerproc/bleak-compat.patch
+++ b/pkgs/development/python-modules/pyzerproc/bleak-compat.patch
@@ -1,0 +1,76 @@
+diff --git a/pyzerproc/discovery.py b/pyzerproc/discovery.py
+index e383996..1810bbe 100644
+--- a/pyzerproc/discovery.py
++++ b/pyzerproc/discovery.py
+@@ -4,6 +4,9 @@ import logging
+ from .light import Light
+ from .exceptions import ZerprocException
+ 
++from bleak import BLEDevice, BleakScanner, AdvertisementData
++from bleak.exc import BleakError
++
+ _LOGGER = logging.getLogger(__name__)
+ 
+ EXPECTED_SERVICES = [
+@@ -13,27 +16,25 @@ EXPECTED_SERVICES = [
+ ]
+ 
+ 
+-def is_valid_device(device):
++def is_valid_device(device: BLEDevice, advertisement_data: AdvertisementData):
+     """Returns true if the given device is a Zerproc light."""
+     for service in EXPECTED_SERVICES:
+-        if service not in device.metadata['uuids']:
++        if service not in advertisement_data.service_uuids:
+             return False
+     return True
+ 
+ 
+ async def discover(timeout=10):
+     """Returns nearby discovered lights."""
+-    import bleak
+-
+     _LOGGER.info("Starting scan for local devices")
+ 
+     lights = []
+     try:
+-        devices = await bleak.BleakScanner.discover(timeout=timeout)
+-    except bleak.exc.BleakError as ex:
++        devices = await BleakScanner.discover(timeout=timeout, return_adv=True)
++    except BleakError as ex:
+         raise ZerprocException() from ex
+-    for device in devices:
+-        if is_valid_device(device):
++    for device, advertisement_data in devices:
++        if is_valid_device(device, advertisement_data):
+             lights.append(Light(device.address, device.name))
+ 
+     _LOGGER.info("Scan complete")
+diff --git a/tests/test_discovery.py b/tests/test_discovery.py
+index 7a1442d..6b271b8 100644
+--- a/tests/test_discovery.py
++++ b/tests/test_discovery.py
+@@ -16,7 +16,6 @@ async def test_discover_devices(scanner, client_class):
+                 'AA:BB:CC:11:22:33',
+                 'LEDBlue-CC112233',
+                 {},
+-                0,
+                 uuids=[
+                     "0000ffe0-0000-1000-8000-00805f9b34fb",
+                     "0000ffe5-0000-1000-8000-00805f9b34fb",
+@@ -27,7 +26,6 @@ async def test_discover_devices(scanner, client_class):
+                 'AA:BB:CC:44:55:66',
+                 'LEDBlue-CC445566',
+                 {},
+-                0,
+                 uuids=[
+                     "0000ffe0-0000-1000-8000-00805f9b34fb",
+                     "0000ffe5-0000-1000-8000-00805f9b34fb",
+@@ -38,7 +36,6 @@ async def test_discover_devices(scanner, client_class):
+                 'DD:EE:FF:11:22:33',
+                 'Other',
+                 {},
+-                0,
+                 uuids=[
+                     "0000fe9f-0000-1000-8000-00805f9b34fb",
+                 ],

--- a/pkgs/development/python-modules/pyzerproc/default.nix
+++ b/pkgs/development/python-modules/pyzerproc/default.nix
@@ -4,20 +4,13 @@
   click,
   buildPythonPackage,
   fetchFromGitHub,
-  pytest-asyncio,
-  pytest-mock,
-  pythonAtLeast,
-  pytest-cov-stub,
-  pytestCheckHook,
-  pythonOlder,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pyzerproc";
   version = "0.4.12";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.9";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "emlove";
@@ -26,22 +19,16 @@ buildPythonPackage rec {
     hash = "sha256-vS0sk/KjDhWispZvCuGlmVLLfeFymHqxwNzNqNRhg6k=";
   };
 
-  propagatedBuildInputs = [
+  patches = [ ./bleak-compat.patch ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
     bleak
     click
   ];
 
-  nativeCheckInputs = [
-    pytest-asyncio
-    pytest-mock
-    pytest-cov-stub
-    pytestCheckHook
-  ];
-
-  disabledTestPaths = lib.optionals (pythonAtLeast "3.11") [
-    # unittest.mock.InvalidSpecError: Cannot spec a Mock object.
-    "tests/test_light.py"
-  ];
+  doCheck = false; # tries to access dbus, which leads to FileNotFoundError
 
   pythonImportsCheck = [ "pyzerproc" ];
 

--- a/pkgs/development/python-modules/sentence-stream/default.nix
+++ b/pkgs/development/python-modules/sentence-stream/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  regex,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "sentence-stream";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "OHF-Voice";
+    repo = "sentence-stream";
+    tag = "v${version}";
+    hash = "sha256-2jEEytDa8LIkwoYV5MXuA9mpEFrZYymtdxj0vgMAiWo=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    regex
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "sentence_stream"
+  ];
+
+  meta = {
+    description = "A small sentence splitter for text streams";
+    homepage = "https://github.com/OHF-Voice/sentence-stream";
+    changelog = "https://github.com/OHF-Voice/sentence-stream/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+}

--- a/pkgs/development/python-modules/smpclient/bleak-compat.patch
+++ b/pkgs/development/python-modules/smpclient/bleak-compat.patch
@@ -1,0 +1,18 @@
+diff --git a/tests/test_smp_ble_transport.py b/tests/test_smp_ble_transport.py
+index 95a7ade..f469438 100644
+--- a/tests/test_smp_ble_transport.py
++++ b/tests/test_smp_ble_transport.py
+@@ -73,11 +73,11 @@ def test_SMP_gatt_consts() -> None:
+ 
+ @patch(
+     "smpclient.transport.ble.BleakScanner.find_device_by_address",
+-    return_value=BLEDevice("address", "name", None, -60),
++    return_value=BLEDevice("address", "name", None),
+ )
+ @patch(
+     "smpclient.transport.ble.BleakScanner.find_device_by_name",
+-    return_value=BLEDevice("address", "name", None, -60),
++    return_value=BLEDevice("address", "name", None),
+ )
+ @patch("smpclient.transport.ble.BleakClient", new=MockBleakClient)
+ @pytest.mark.asyncio

--- a/pkgs/development/python-modules/smpclient/default.nix
+++ b/pkgs/development/python-modules/smpclient/default.nix
@@ -25,7 +25,10 @@ buildPythonPackage rec {
     hash = "sha256-NQRVEvi/B+KdhPIzw8pm22uXpYPkoaatkCNFnEcibzo=";
   };
 
-  pythonRelaxDeps = [ "smp" ];
+  pythonRelaxDeps = [
+    "bleak"
+    "smp"
+  ];
 
   build-system = [
     poetry-core
@@ -44,6 +47,8 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ];
+
+  patches = [ ./bleak-compat.patch ];
 
   pythonImportsCheck = [ "smpclient" ];
 

--- a/pkgs/development/python-modules/tesla-fleet-api/default.nix
+++ b/pkgs/development/python-modules/tesla-fleet-api/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "tesla-fleet-api";
-  version = "1.2.2";
+  version = "1.2.3";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "Teslemetry";
     repo = "python-tesla-fleet-api";
     tag = "v${version}";
-    hash = "sha256-FWOAjNjzpImDWSFxbVVdBFuM1gUJUYyLN694B24kD9U=";
+    hash = "sha256-mNqntKsZeUZOhfquyaA+6IC29XnCf/a5FIm0cFzHg/M=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/tinytuya/default.nix
+++ b/pkgs/development/python-modules/tinytuya/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "tinytuya";
-  version = "1.17.1";
+  version = "1.17.2";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "jasonacox";
     repo = "tinytuya";
     tag = "v${version}";
-    hash = "sha256-ivtd61r68kUP/OOIkdTjVI5FiD7QsYe6eSr2WiVF7OI=";
+    hash = "sha256-x6ZfpT3ucby95uthHX4KLLZNLWxyh6+ERDd5jb7p09g=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/weatherflow4py/default.nix
+++ b/pkgs/development/python-modules/weatherflow4py/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "weatherflow4py";
-  version = "1.3.1";
+  version = "1.4.1";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "jeeftor";
     repo = "weatherflow4py";
     tag = "v${version}";
-    hash = "sha256-X5zMxX8PthiqaEIM0/fElGIjeeCey0ossVDKevy1Mnw=";
+    hash = "sha256-nHpLdzO49HhX5+gtYrgche4whs7Onzp4HeRNFwLHcVI=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/whirlpool-sixth-sense/default.nix
+++ b/pkgs/development/python-modules/whirlpool-sixth-sense/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "whirlpool-sixth-sense";
-  version = "0.20.0";
+  version = "0.21.1";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "abmantis";
     repo = "whirlpool-sixth-sense";
     tag = version;
-    hash = "sha256-Sl8Y1sVZolk8KLS3bKGQNFXTVntcPusrf2A0zdixq8A=";
+    hash = "sha256-uhqDm6BOUX6Ov4580EmBOD4si9BsMvnsvEmA/DbKE7M=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/wyoming/default.nix
+++ b/pkgs/development/python-modules/wyoming/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "wyoming";
-  version = "1.7.1";
+  version = "1.7.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "wyoming";
     tag = version;
-    hash = "sha256-jP2RLKjm79tb4lPbTp1zcDnRV0phn7I2qjxYpC6hqTM=";
+    hash = "sha256-tLwMysBxNPk5ztkwuuOhChhGgY+uEE9uA4S5ZVlVtY0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/yalexs-ble/default.nix
+++ b/pkgs/development/python-modules/yalexs-ble/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "yalexs-ble";
-  version = "3.0.0";
+  version = "3.1.2";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "bdraco";
     repo = "yalexs-ble";
     tag = "v${version}";
-    hash = "sha256-sHAdeL3mUUsKqRkv9suA3mfbwJvMADpMqt1Qu5lITnQ=";
+    hash = "sha256-0eFW2KZPpoxEF2FnuYzcR7GuD3jGBjOZlArzYbKcnUI=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/yoto-api/default.nix
+++ b/pkgs/development/python-modules/yoto-api/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "yoto-api";
-  version = "1.26.1";
+  version = "1.26.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cdnninja";
     repo = "yoto_api";
     tag = "v${version}";
-    hash = "sha256-Erq6whZX8pfQSoszyCMrnRj24nZN3QD52SRs+G24O7k=";
+    hash = "sha256-QlcZZjyMPIPGG5zHTFM9E2Y8sa/etbvMmxRp15NzKEo=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -7,12 +7,13 @@
   pytestCheckHook,
   pythonOlder,
   setuptools,
+  time-machine,
   zigpy,
 }:
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.139";
+  version = "0.0.142";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -21,7 +22,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha-device-handlers";
     tag = version;
-    hash = "sha256-16gv2t1hudIULybmAXK+sMl9MsFATHMGQeZWhmVhrkk=";
+    hash = "sha256-D1FIkyVSa4j6p4PHkjCAU08zpZjjXPGWoL5lKlWUHuU=";
   };
 
   postPatch = ''
@@ -40,6 +41,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
+    time-machine
   ];
 
   disabledTests = [
@@ -47,6 +49,9 @@ buildPythonPackage rec {
     "test_mfg_cluster_events"
     "test_co2_sensor"
     "test_smart_air_sensor"
+    # AssertionError: expected call not found
+    "test_moes"
+    "test_tuya_mcu_set_time"
   ];
 
   pythonImportsCheck = [ "zhaquirks" ];

--- a/pkgs/development/python-modules/zha/default.nix
+++ b/pkgs/development/python-modules/zha/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "zha";
-  version = "0.0.62";
+  version = "0.0.66";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha";
     tag = version;
-    hash = "sha256-UM2cxiLXWYuidtmIIpA8CrFZqOpWDUc+A0nY4cRYuus=";
+    hash = "sha256-74rJ2bdscbGkaLuHMQr8sNxL1wNN72UrlpH4zIkSprY=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zigpy-deconz/default.nix
+++ b/pkgs/development/python-modules/zigpy-deconz/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "zigpy-deconz";
-  version = "0.25.0";
+  version = "0.25.1";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zigpy-deconz";
     tag = version;
-    hash = "sha256-aZRLfvAnJ1yO+d3LUx2ouqWPuwsIk51v+TSUkFfBbQA=";
+    hash = "sha256-Vw6unTB4PkjlrsXmsry1OC/NMAcd/sCbJ/A/eHgu3JU=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -25,14 +25,14 @@
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.80.1";
+  version = "0.82.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy";
     tag = version;
-    hash = "sha256-OHwX2bwM6XYPGs2n7X5OQ3lW1lsD0RaaPNSFXOX+C/Q=";
+    hash = "sha256-j1gB5+UCseakfkqgA7hmm7qCchIN/BIAAZTdy7mKztM=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zwave-js-server-python/default.nix
+++ b/pkgs/development/python-modules/zwave-js-server-python/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "zwave-js-server-python";
-  version = "0.65.0";
+  version = "0.67.1";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "zwave-js-server-python";
     tag = version;
-    hash = "sha256-X7QXHxoMryicc/ouImxg2iMtJEnXI7UHxjtbEPAZ4F4=";
+    hash = "sha256-9z0IYeH2Tch2de18UnEwQ+lmVaZwb/3kJmvcl0MWJ60=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.7.4";
+  version = "2025.8.0";
   components = {
     "3_day_blinds" =
       ps: with ps; [
@@ -95,6 +95,7 @@
       ps: with ps; [
         hassil
         home-assistant-intents
+        pyturbojpeg
       ];
     "air_quality" =
       ps: with ps; [
@@ -111,6 +112,9 @@
       ps: with ps; [
         pyairnow
       ];
+    "airos" =
+      ps: with ps; [
+      ]; # missing inputs: airos
     "airq" =
       ps: with ps; [
         aioairq
@@ -543,6 +547,9 @@
     "bang_olufsen" =
       ps: with ps; [
         mozart-api
+      ];
+    "bauknecht" =
+      ps: with ps; [
       ];
     "bayesian" =
       ps: with ps; [
@@ -4144,8 +4151,8 @@
       ];
     "onkyo" =
       ps: with ps; [
-        pyeiscp
-      ];
+        ifaddr
+      ]; # missing inputs: aioonkyo
     "onvif" =
       ps: with ps; [
         ha-ffmpeg
@@ -4156,6 +4163,16 @@
       ps: with ps; [
         open-meteo
       ];
+    "open_router" =
+      ps: with ps; [
+        ha-ffmpeg
+        hassil
+        home-assistant-intents
+        mutagen
+        openai
+        pymicro-vad
+        pyspeex-noise
+      ]; # missing inputs: python-open-router
     "openai_conversation" =
       ps: with ps; [
         ha-ffmpeg
@@ -6268,6 +6285,9 @@
     "uptime" =
       ps: with ps; [
       ];
+    "uptime_kuma" =
+      ps: with ps; [
+      ]; # missing inputs: pythonkuma
     "uptimerobot" =
       ps: with ps; [
         pyuptimerobot
@@ -6401,6 +6421,9 @@
       ps: with ps; [
         pyvolumio
       ];
+    "volvo" =
+      ps: with ps; [
+      ]; # missing inputs: volvocarsapi
     "volvooncall" =
       ps: with ps; [
         volvooncall
@@ -6749,6 +6772,9 @@
     "zamg" =
       ps: with ps; [
         zamg
+      ];
+    "zbox_hub" =
+      ps: with ps; [
       ];
     "zengge" =
       ps: with ps; [
@@ -7402,7 +7428,6 @@
     "ondilo_ico"
     "onedrive"
     "onewire"
-    "onkyo"
     "onvif"
     "open_meteo"
     "openai_conversation"

--- a/pkgs/servers/home-assistant/custom-components/home_connect_alt/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/home_connect_alt/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "ekutner";
   domain = "home_connect_alt";
-  version = "1.2.1";
+  version = "1.3.0-b1";
 
   src = fetchFromGitHub {
     owner = "ekutner";
     repo = "home-connect-hass";
     tag = version;
-    hash = "sha256-v/C4KV/WddaXQIO709nHP4DJM/K3J3WQSrJnVaXQDSY=";
+    hash = "sha256-jWrVHwMdzjG0gHWl1NS6WAzdmlmS20BUmh6HzplsGgw=";
   };
 
   dependencies = [ home-connect-async ];

--- a/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
@@ -9,13 +9,13 @@
 buildHomeAssistantComponent rec {
   owner = "SukramJ";
   domain = "homematicip_local";
-  version = "1.84.1";
+  version = "1.85.1b2";
 
   src = fetchFromGitHub {
     owner = "SukramJ";
     repo = "custom_homematic";
     tag = version;
-    hash = "sha256-iR+y2hY8wF4flMWsh52gcupZbnaAlbwibHx1sY5JmmM=";
+    hash = "sha256-6dZKr65uGW67pExyhIYDu+3U7QmCVU9CaeUcBl2XPm4=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/custom-components/localtuya/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/localtuya/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "xZetsubou";
   domain = "localtuya";
-  version = "2025.6.0";
+  version = "2025.7.0";
 
   src = fetchFromGitHub {
     owner = "xZetsubou";
     repo = "hass-localtuya";
     rev = version;
-    hash = "sha256-P5qUvlpKwcbIERzDyImc79Gzmr1IHweH8SLM6QFhb5I=";
+    hash = "sha256-H1/7bAjxjpw4mlzcPh0gztxw6XcSG98VPD9wE9RNrAM=";
   };
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/custom-components/midea_ac_lan/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea_ac_lan/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "wuwentao";
   domain = "midea_ac_lan";
-  version = "0.6.8";
+  version = "0.6.9";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     tag = "v${version}";
-    hash = "sha256-y78Leb+XxEpijP7XbmjDGSD2RArfxlSgdtXkeYggxto=";
+    hash = "sha256-pPPJFs4earRbh6ovR57k9xgZtrYN0L26eupOoFuBVz8=";
   };
 
   dependencies = [ midea-local ];

--- a/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "pymitsubishi";
   domain = "mitsubishi";
-  version = "0.1.4";
+  version = "0.1.8";
 
   src = fetchFromGitHub {
     owner = "pymitsubishi";
     repo = "homeassistant-mitsubishi";
     tag = "v${version}";
-    hash = "sha256-cJBhIck33gyFTITQKlLZSdKDA3VXeVJFGcQoD49BgWQ=";
+    hash = "sha256-qxYdE70APMO+ydv+lQzJY3gRYr/y5p0zJSgPt/k1cys=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
@@ -13,13 +13,13 @@
 buildHomeAssistantComponent rec {
   owner = "amitfin";
   domain = "oref_alert";
-  version = "3.1.3";
+  version = "3.2.1";
 
   src = fetchFromGitHub {
     owner = "amitfin";
     repo = "oref_alert";
     tag = "v${version}";
-    hash = "sha256-Mr9zNq5KMuzwRAGoxi0P7ruYpKHoxy/DQWWjCisn7tA=";
+    hash = "sha256-DnxHF24YQOQoeAHNzWFd0omEStaJBeuy8Jpsqp2VkGY=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/solax_modbus/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/solax_modbus/package.nix
@@ -8,20 +8,14 @@
 buildHomeAssistantComponent rec {
   owner = "wills106";
   domain = "solax_modbus";
-  version = "2025.06.1";
+  version = "2025.07.8b1";
 
   src = fetchFromGitHub {
     owner = "wills106";
     repo = "homeassistant-solax-modbus";
     tag = version;
-    hash = "sha256-aKbd/eNzROHF4evFS4sH8+dJwj5f3xZsF4qjTzHIu9g=";
+    hash = "sha256-6/fMAOSfdj5jTTJa8ySygeipS+5P0ZCURhmkSv/e0Sk=";
   };
-
-  postPatch = ''
-    substituteInPlace custom_components/solax_modbus/payload.py --replace-fail \
-      'from pymodbus.utilities import (' \
-      'from pymodbus.pdu.pdu import ('
-  '';
 
   dependencies = [ pymodbus ];
 

--- a/pkgs/servers/home-assistant/custom-components/tuya_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/tuya_local/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "make-all";
   domain = "tuya_local";
-  version = "2025.6.0";
+  version = "2025.7.1";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "tuya-local";
     tag = version;
-    hash = "sha256-2Fvb2WcFNGSFxYHoxxL89DcbcIFa+OFyGodoop0KauA=";
+    hash = "sha256-RIvtz6f3Jj4INvL0JdL+EsFUoLoG9vQNn5iPq2nF26I=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/volvo_cars/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/volvo_cars/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "thomasddn";
   domain = "volvo_cars";
-  version = "1.5.6";
+  version = "1.5.7";
 
   src = fetchFromGitHub {
     owner = "thomasddn";
     repo = "ha-volvo-cars";
     tag = "v${version}";
-    hash = "sha256-2eTUIbwAadJsOp1ETDY6+cEPVMOzhj1otEyzobysqaY=";
+    hash = "sha256-2wRqEa7jVumbRNCGrFa0gYEzgGwUrMnW2A8JhPTTMCc=";
   };
 
   meta = {

--- a/pkgs/servers/home-assistant/custom-components/yoto_ha/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/yoto_ha/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "cdnninja";
   domain = "yoto";
-  version = "1.24.4";
+  version = "1.24.5";
 
   src = fetchFromGitHub {
     owner = "cdnninja";
     repo = "yoto_ha";
     tag = "v${version}";
-    hash = "sha256-iiS5bns7la17Wf/mRkraE9xL9i+OzI4ru4BaHiLtA6U=";
+    hash = "sha256-z9BrZAjjtt9EC84CzDe3AzmJHQtCBLgEoWrCJpOPBK0=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/card-mod/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/card-mod/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "lovelace-card-mod";
-  version = "3.5.0";
+  version = "3.4.5";
 
   src = fetchFromGitHub {
     owner = "thomasloven";
     repo = "lovelace-card-mod";
     rev = "v${version}";
-    hash = "sha256-MjeLbo1r/PMbzDfZurZYm1fHUukHfzOx6njRgEB8rWk=";
+    hash = "sha256-yd07C3/tpnoclrztWBAVwU6Ic2a4hY45xcjmgSp/uZA=";
   };
 
-  npmDepsHash = "sha256-JJexFmVbDHi2JCiCpcDupzVf0xfwy+vqWILq/dLVcBo=";
+  npmDepsHash = "sha256-IjN0sBWa6y/j0x5XRvDU0F6kA9RTfKFlVsnqwBkgx2Q=";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/clock-weather-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/clock-weather-card/package.nix
@@ -9,18 +9,18 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "clock-weather-card";
-  version = "2.8.12";
+  version = "2.9.0";
 
   src = fetchFromGitHub {
     owner = "pkissling";
     repo = "clock-weather-card";
     tag = "v${version}";
-    hash = "sha256-zggZEfbLLEUzt3ax6ag1IUbCQzjFCN6TWoMWD64mBEg=";
+    hash = "sha256-cLqHVBjsSq3t7ft9Ap6kjNSgM87+ftqlF5ZfcJKAAzQ=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = src + "/yarn.lock";
-    hash = "sha256-KSuhHH06wkO9IdgoIu3cahOMmfzrjqoXqfER2N/J93A=";
+    hash = "sha256-zaKrvsT1Lgcyk4a9vO97j9yHkaD+5zbnsM5+GHxb4uk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/custom-sidebar/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/custom-sidebar/package.nix
@@ -8,19 +8,19 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "custom-sidebar";
-  version = "10.3.0";
+  version = "10.5.1";
 
   src = fetchFromGitHub {
     owner = "elchininet";
     repo = "custom-sidebar";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Uono4z8jd+OwxNnBl4Ge9g3YbLAprNrmFJPh7rKsvSM=";
+    hash = "sha256-sDVilhMIMkehKXPz7p2DH6NGn43h0WHpYABUpL3ylrE=";
   };
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-ZWh2R6wr7FH2RfoFAE81Kl+wHnUeNjUbFG3KIk8ZN3g=";
+    hash = "sha256-4928fyjVZ6C4Fyt2+c+cWSOeyCrix2xrhufNrxGZSAU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/universal-remote-card/dont-call-git.patch
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/universal-remote-card/dont-call-git.patch
@@ -1,8 +1,8 @@
-diff --git a/webpack.config.js b/webpack.config.js
-index 469ffe1..3233c4b 100644
---- a/webpack.config.js
-+++ b/webpack.config.js
-@@ -1,11 +1,7 @@
+diff --git a/rspack.config.js b/rspack.config.js
+index 30b7568..dc10273 100644
+--- a/rspack.config.js
++++ b/rspack.config.js
+@@ -2,11 +2,7 @@
  const path = require('path');
  const { execSync } = require('child_process');
  

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/universal-remote-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/universal-remote-card/package.nix
@@ -6,18 +6,18 @@
 
 buildNpmPackage rec {
   pname = "universal-remote-card";
-  version = "4.6.1";
+  version = "4.6.5";
 
   src = fetchFromGitHub {
     owner = "Nerwyn";
     repo = "android-tv-card";
     rev = version;
-    hash = "sha256-cJu07eIluZFZfIq+3D0xlQs2L3NmSKf3EBSA/S2jx7Y=";
+    hash = "sha256-ciIWo2m4Cvktzqz6fPLdvBEfGoxH98L/AtzWsrIJmgg=";
   };
 
   patches = [ ./dont-call-git.patch ];
 
-  npmDepsHash = "sha256-eldbaWZq/TV7V3wPOmgZrYNQsNP1Dgt6vqEc0hiqy+c=";
+  npmDepsHash = "sha256-NHt0CB8DCcMMaNvH4eERcSxMar2Uhc3BoUqy1KnqYqQ=";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -97,7 +97,7 @@ let
         };
       });
 
-      av = super.av.overridePythonAttrs (rec {
+      av = super.av.overridePythonAttrs rec {
         version = "13.1.0";
         src = fetchFromGitHub {
           owner = "PyAV-Org";
@@ -105,16 +105,14 @@ let
           tag = "v${version}";
           hash = "sha256-x2a9SC4uRplC6p0cD7fZcepFpRidbr6JJEEOaGSWl60=";
         };
-      });
+      };
 
-      brother = super.brother.overridePythonAttrs (rec {
-        version = "4.3.1";
-        src = fetchFromGitHub {
-          owner = "bieniu";
-          repo = "brother";
-          tag = version;
-          hash = "sha256-fWa5FNBGV8tnJ3CozMicXLGsDvnTjNzU8PdV266MeeQ=";
-        };
+      imageio = super.imageio.overridePythonAttrs (oldAttrs: {
+        disabledTests = oldAttrs.disabledTests or [ ] ++ [
+          # broken by pyav pin
+          "test_keyframe_intervals"
+          "test_lagging_video_stream"
+        ];
       });
 
       google-genai = super.google-genai.overridePythonAttrs (old: rec {
@@ -247,44 +245,6 @@ let
         };
       });
 
-      pyoctoprintapi = super.pyoctoprintapi.overridePythonAttrs (oldAttrs: rec {
-        version = "0.1.12";
-        src = fetchFromGitHub {
-          owner = "rfleming71";
-          repo = "pyoctoprintapi";
-          rev = "refs/tags/v${version}";
-          hash = "sha256-Jf/zYnBHVl3TYxFy9Chy6qNH/eCroZkmUOEWfd62RIo=";
-        };
-      });
-
-      # snmp component does not support pysnmp 7.0+
-      pysnmp = super.pysnmp.overridePythonAttrs (oldAttrs: rec {
-        version = "6.2.6";
-        src = fetchFromGitHub {
-          owner = "lextudio";
-          repo = "pysnmp";
-          tag = "v${version}";
-          hash = "sha256-+FfXvsfn8XzliaGUKZlzqbozoo6vDxUkgC87JOoVasY=";
-        };
-      });
-
-      pysnmpcrypto = super.pysnmpcrypto.overridePythonAttrs (oldAttrs: rec {
-        version = "0.0.4";
-        src = fetchFromGitHub {
-          owner = "lextudio";
-          repo = "pysnmpcrypto";
-          tag = "v${version}";
-          hash = "sha256-f0w4Nucpe+5VE6nhlnePRH95AnGitXeT3BZb3dhBOTk=";
-        };
-        build-system = with self; [ setuptools ];
-        postPatch = ''
-          # ValueError: invalid literal for int() with base 10: 'post0' in File "<string>", line 104, in <listcomp>
-          substituteInPlace setup.py --replace \
-            "observed_version = [int(x) for x in setuptools.__version__.split('.')]" \
-            "observed_version = [36, 2, 0]"
-        '';
-      });
-
       pysnooz = super.pysnooz.overridePythonAttrs (oldAttrs: rec {
         version = "0.8.6";
         src = fetchFromGitHub {
@@ -293,6 +253,8 @@ let
           rev = "refs/tags/v${version}";
           hash = "sha256-hJwIObiuFEAVhgZXYB9VCeAlewBBnk0oMkP83MUCpyU=";
         };
+        patches = [ ];
+        doCheck = false;
       });
 
       pytradfri = super.pytradfri.overridePythonAttrs (oldAttrs: rec {
@@ -305,6 +267,16 @@ let
         };
         patches = [ ];
         doCheck = false;
+      });
+
+      python-telegram-bot = super.python-telegram-bot.overridePythonAttrs (oldAttrs: rec {
+        version = "21.5";
+
+        src = fetchFromGitHub {
+          inherit (oldAttrs.src) owner repo;
+          tag = version;
+          hash = "sha256-i1YEcN615xeI4HcygXV9kzuXpT2yDSnlNU6bZqu1dPM=";
+        };
       });
 
       # Pinned due to API changes ~1.0
@@ -358,7 +330,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.7.4";
+  hassVersion = "2025.8.0";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -379,13 +351,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-2seMh1trP3PYnuQmWadTAiAPaI+v45+uzn9xkgUuGNE=";
+    hash = "sha256-o8NZ06GorRmICeu8GQzomkCuE2aALnodT5UuiJ4EOEc=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-KwiwgQ8gAMlHLzpuYYdcLXabVrukhnfFlaODyFpuF88=";
+    hash = "sha256-U06ttXEWe46h8O2wurYyaCN78EdSCvOs10VbnyOQdsM=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20250702.3";
+  version = "20250806.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-Uj7auy5emdP8l9vUxLbAL28UNoAi1OQ/8qIhmJMmA8Q=";
+    hash = "sha256-krx62/hxF9MAFOQygZGAgcwbTuYKXTPcRpfmrHfKzEQ=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/intents.nix
+++ b/pkgs/servers/home-assistant/intents.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-intents";
-  version = "2025.6.23";
+  version = "2025.7.30";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     repo = "intents-package";
     rev = "refs/tags/${version}";
     fetchSubmodules = true;
-    hash = "sha256-0xFa4Xz2zjN5EQVd9XafkUvroAH4AIiF/9bqFAZcJ9U=";
+    hash = "sha256-eXEZNeEWeTFFwnMuDS9HqTGmqQ23NN5WTiklhcoOWbg=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.263";
+  version = "0.13.269";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     rev = "refs/tags/${version}";
-    hash = "sha256-JqWe/tNYnNkFNx3D6E3X2TMyNwmfgoK2fkejX3f9NL8=";
+    hash = "sha256-5GKUfFxAs3plr5C9F6BQ5J+DU8J77lgyAQrj6xmuSHo=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.7.4";
+  version = "2025.8.0";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-boOhdro11wbLHWVuJHHSuov8qxSiOCuaS8yfJgIRyJk=";
+    hash = "sha256-YPWAeAqR6s2jMdN85S+7PZdr6epuCqPfzr7DdmpqsiE=";
   };
 
   build-system = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16272,6 +16272,8 @@ self: super: with self; {
 
   sentence-splitter = callPackage ../development/python-modules/sentence-splitter { };
 
+  sentence-stream = callPackage ../development/python-modules/sentence-stream { };
+
   sentence-transformers = callPackage ../development/python-modules/sentence-transformers { };
 
   sentencepiece = callPackage ../development/python-modules/sentencepiece {


### PR DESCRIPTION
WIP

Missing `home-assistant-intents==2025.07.30`, which breaks a home-assistant test, which tries to install it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
