### PR TITLE
jol: init at 0.17

### DIFF
--- a/pkgs/by-name/jo/jol/package.nix
+++ b/pkgs/by-name/jo/jol/package.nix
@@ -1,0 +1,62 @@
+{
+  maven,
+  lib,
+  fetchFromGitHub,
+  jre_minimal,
+  makeWrapper,
+  nix-update-script,
+}:
+maven.buildMavenPackage rec {
+  pname = "jol";
+  version = "0.17";
+
+  src = fetchFromGitHub {
+    owner = "OpenJDK";
+    repo = "jol";
+    tag = version;
+    hash = "sha256-ZJFuY2QYB8eUS3y3VRMGGwklCS93HHVkNe/dhyIx0SY=";
+  };
+
+  mvnHash = "sha256-yQfiHlAZZgINGAYVlK5JflWX3d8Axtv1Ke89S7x86G4=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace jol-cli/src/main/java/org/openjdk/jol/Main.java \
+      --replace-fail 'Usage: jol-cli.jar' 'Usage: jol-cli'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 jol-cli/target/jol-cli.jar $out/share/jol-cli/jol-cli.jar
+    makeWrapper ${lib.getExe' jre_minimal "java"} $out/bin/jol-cli \
+      --add-flags "-jar $out/share/jol-cli/jol-cli.jar"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Java Object Layout (JOL)";
+    longDescription = ''
+      JOL (Java Object Layout) is the tiny toolbox to analyze object layout in JVMs.
+      These tools are using Unsafe, JVMTI, and Serviceability Agent (SA) heavily to decode the actual object layout, footprint, and references.
+      This makes JOL much more accurate than other tools relying on heap dumps, specification assumptions, etc.
+    '';
+    homepage = "https://openjdk.org/projects/code-tools/jol/";
+    changelog = "https://github.com/openjdk/jol/releases/tag/${version}";
+    license = lib.licenses.gpl2ClasspathPlus;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+    mainProgram = "jol-cli";
+    maintainers = with lib.maintainers; [
+      debling
+      progrm_jarvis
+    ];
+    inherit (jre_minimal.meta) platforms;
+  };
+}


### PR DESCRIPTION
Added JOL (Java Object Layout utility) built from sources with its CLI exposed as `mainProgram`.

This is based on #430726 but builds the app from sources.

Closes #430724

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
