### PR TITLE
{scotch, mumps}: fix musl and static, remove perl by default

### DIFF
--- a/pkgs/by-name/mu/mumps/package.nix
+++ b/pkgs/by-name/mu/mumps/package.nix
@@ -17,9 +17,12 @@
   withParmetis ? false, # default to false due to unfree license
   withPtScotch ? mpiSupport,
 }:
+
+assert mpiSupport -> !stdenv.hostPlatform.isMusl;
 assert withParmetis -> mpiSupport;
 assert withPtScotch -> mpiSupport;
 let
+  scotch' = scotch.override { inherit withPtScotch; };
   profile = if mpiSupport then "debian.PAR" else "debian.SEQ";
   LMETIS = toString ([ "-lmetis" ] ++ lib.optional withParmetis "-lparmetis");
   LSCOTCH = toString (
@@ -78,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
       "LIBEXT_SHARED=.dylib"
     ]
     ++ [
-      "ISCOTCH=-I${lib.getDev scotch}/include"
+      "ISCOTCH=-I${lib.getDev scotch'}/include"
       "LMETIS=${LMETIS}"
       "LSCOTCH=${LSCOTCH}"
       "ORDERINGSF=${ORDERINGSF}"
@@ -115,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
       blas
       lapack
       metis
-      scotch
+      scotch'
     ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/sc/scotch/musl.patch
+++ b/pkgs/by-name/sc/scotch/musl.patch
@@ -1,0 +1,32 @@
+diff --git a/src/libscotch/common.h b/src/libscotch/common.h
+index 5694da3..d94a76f 100644
+--- a/src/libscotch/common.h
++++ b/src/libscotch/common.h
+@@ -80,6 +80,11 @@
+ #endif /* COMMON_TIMING_OLD */
+ #endif /* COMMON_OS_MACOS */
+ 
++#ifdef COMMON_PTHREAD_AFFINITY_LINUX
++#define _GNU_SOURCE
++#include <sched.h>
++#endif /* COMMON_PTHREAD_AFFINITY_LINUX */
++
+ #ifdef COMMON_OS_WINDOWS
+ #include            <io.h>                        /* For _pipe ()              */
+ #include            <fcntl.h>                     /* Fow Windows _pipe () call */
+diff --git a/src/libscotch/common_thread.c b/src/libscotch/common_thread.c
+index 1134a2c..53ad285 100644
+--- a/src/libscotch/common_thread.c
++++ b/src/libscotch/common_thread.c
+@@ -51,11 +51,6 @@
+ 
+ #define SCOTCH_COMMON_THREAD
+ 
+-#ifdef COMMON_PTHREAD_AFFINITY_LINUX
+-#define _GNU_SOURCE
+-#include <sched.h>
+-#endif /* COMMON_PTHREAD_AFFINITY_LINUX */
+-
+ #include "module.h"
+ #include "common.h"
+ #include "common_thread.h"

--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -10,6 +10,7 @@
   stdenv,
   zlib,
   xz,
+  withPtScotch ? !stdenv.hostPlatform.isMusl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,27 +25,38 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-AtpaBxgV9EamkAlvH9psp+K0o923EhSu6LQA89qyG3w=";
   };
 
+  patches = [
+    ./musl.patch
+  ];
+
   outputs = [
     "bin"
     "dev"
     "out"
   ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "BUILD_PTSCOTCH" withPtScotch)
+  ];
 
   nativeBuildInputs = [
     cmake
     gfortran
+    bison
+    flex
+  ]
+  ++ lib.optionals withPtScotch [
+    mpi
   ];
 
   buildInputs = [
-    bison
     bzip2
-    mpi
-    flex
     xz
     zlib
   ];
+
+  strictDeps = true;
 
   meta = {
     description = "Graph and mesh/hypergraph partitioning, graph clustering, and sparse matrix ordering";


### PR DESCRIPTION
- fixed `scotch` on static (was building shared libs unconditionally)
- fixed `scotch` on musl by disabling PtScotch
  - (required an extra patch to fix the includes of `sched.h`)
  - PtScotch is broken, because `mpi` is broken on musl
- fixed `mumps` on musl (`scotch` is no longer broken)
- propagate `withPtScotch` override parameter to `scotch`

Happy side effect: If scotch is built without `PtScotch`, it does not indirectly depend on perl at runtime. This means maths-intensive things such as freecad are one step closer to run on a perlless system.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
