### PR TITLE
[Backport release-25.05] python3Packages.ansible: 11.4.0 -> 11.8.0

### DIFF
--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -112,6 +112,7 @@ buildPythonPackage rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
       HarisDotParis
+      robsliwi
     ];
   };
 }

--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -110,6 +110,8 @@ buildPythonPackage rec {
     description = "Radically simple IT automation";
     homepage = "https://www.ansible.com";
     license = licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with maintainers; [
+      HarisDotParis
+    ];
   };
 }

--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -25,7 +25,7 @@
 
 let
   pname = "ansible";
-  version = "11.5.0";
+  version = "11.7.0";
 in
 buildPythonPackage {
   inherit pname version;
@@ -35,7 +35,7 @@ buildPythonPackage {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-GKP8cxIKSa3pqaZ+uPnU9QCdIQbDT/65ZjrZKLdu1Zs=";
+    hash = "sha256-+d83xx1Af2W8ucXAbJkY4pfZ6nS1za9ZJsTJqp5E218=";
   };
 
   # we make ansible-core depend on ansible, not the other way around,

--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -25,7 +25,7 @@
 
 let
   pname = "ansible";
-  version = "11.4.0";
+  version = "11.5.0";
 in
 buildPythonPackage {
   inherit pname version;
@@ -35,7 +35,7 @@ buildPythonPackage {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-0lp/Jr9YIfgEO8gGAZgi/SgQvWXmtrr7aYu+7a26cr8=";
+    hash = "sha256-GKP8cxIKSa3pqaZ+uPnU9QCdIQbDT/65ZjrZKLdu1Zs=";
   };
 
   # we make ansible-core depend on ansible, not the other way around,

--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -101,6 +101,7 @@ buildPythonPackage {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [
       HarisDotParis
+      robsliwi
     ];
   };
 }

--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -25,7 +25,7 @@
 
 let
   pname = "ansible";
-  version = "11.7.0";
+  version = "11.8.0";
 in
 buildPythonPackage {
   inherit pname version;
@@ -35,7 +35,7 @@ buildPythonPackage {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-+d83xx1Af2W8ucXAbJkY4pfZ6nS1za9ZJsTJqp5E218=";
+    hash = "sha256-KOoDLHfzRLuOpNfTn5pdTpNebItgg2yMiii5z2ya2xo=";
   };
 
   # we make ansible-core depend on ansible, not the other way around,

--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -99,6 +99,8 @@ buildPythonPackage {
     homepage = "https://www.ansible.com";
     changelog = "https://github.com/ansible-community/ansible-build-data/blob/${version}/${lib.versions.major version}/CHANGELOG-v${lib.versions.major version}.rst";
     license = licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with maintainers; [
+      HarisDotParis
+    ];
   };
 }


### PR DESCRIPTION
Manual backport of #404831 #411654 #419999 #419319 #428104 to `release-25.05`.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
    * Even as a non-committer, if you find that it is not acceptable, leave a comment.
