### PR TITLE
osqp: 0.6.3 -> 1.0.0 & clean, qdldl: init at 0.1.8, casadi: 3.7.0 -> 3.7.1

### DIFF
--- a/pkgs/by-name/ca/casadi/package.nix
+++ b/pkgs/by-name/ca/casadi/package.nix
@@ -38,24 +38,37 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "casadi";
-  version = "3.7.0";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "casadi";
     repo = "casadi";
-    rev = finalAttrs.version;
-    hash = "sha256-WumXAWO65XnNQqHMqAwfj2Y+KGOVTWx95qIuyE1M9us=";
+    tag = finalAttrs.version;
+    hash = "sha256-554ZN+GfkGHN0cthsb/fPWdo+U2IqLz4q+x60SxRAfk=";
   };
 
   patches = [
-    (fetchpatch {
-      name = "fix-FindMUMPS.cmake.patch";
-      url = "https://github.com/casadi/casadi/pull/3899/commits/274f4b23f73e60c5302bec0479fe1e92682b63d2.patch";
-      hash = "sha256-3GWEWlN8dKLD6htpnOQLChldcT3hE09JWLeuCfAhY+4=";
-    })
     # update include file path and link with clangAPINotes
     # https://github.com/casadi/casadi/issues/3969
     ./clang-19.diff
+
+    # Add missing include
+    # ref. https://github.com/casadi/casadi/pull/4192
+    (fetchpatch {
+      url = "https://github.com/casadi/casadi/pull/4192/commits/fc1a83e8db37f328657eabff41f00a9a34d3cc74.patch";
+      hash = "sha256-9GXOtYa/BFq5vp6tE8HxO8xW3ep3my6TPD3FvkDhUUA=";
+    })
+
+    # Fix build with osqp v1
+    # ref. https://github.com/casadi/casadi/pull/4105
+    (fetchpatch {
+      url = "https://github.com/casadi/casadi/pull/4105/commits/cca4eb5d423c9d034f0666f71338063d3f8c9c43.patch";
+      hash = "sha256-pDI9x4yzPj+rjtzZpFKwfSsyE52Jt20izfqo5blkUOA=";
+    })
+    (fetchpatch {
+      url = "https://github.com/casadi/casadi/pull/4105/commits/6035a95e48088928134c3827ab90a2a3a82b1389.patch";
+      hash = "sha256-1nOcCLXVwFBRH/abAhTly28+1oNjDumJCjT0NyRAgz0=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/by-name/os/osqp/package.nix
+++ b/pkgs/by-name/os/osqp/package.nix
@@ -5,25 +5,24 @@
   cmake,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "osqp";
   version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "oxfordcontrol";
     repo = "osqp";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-BOAytzJzHcggncQzeDrXwJOq8B3doWERJ6CKIVg1yJY=";
-    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake ];
 
-  meta = with lib; {
+  meta = {
     description = "Quadratic programming solver using operator splitting";
     homepage = "https://osqp.org";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ taktoa ];
-    platforms = platforms.all;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ taktoa ];
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/os/osqp/package.nix
+++ b/pkgs/by-name/os/osqp/package.nix
@@ -7,23 +7,15 @@
 
 stdenv.mkDerivation rec {
   pname = "osqp";
-  version = "0.6.3";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "oxfordcontrol";
     repo = "osqp";
     tag = "v${version}";
-    hash = "sha256-enkK5EFyAeLaUnHNYS3oq43HsHY5IuSLgsYP0k/GW8c=";
+    hash = "sha256-BOAytzJzHcggncQzeDrXwJOq8B3doWERJ6CKIVg1yJY=";
     fetchSubmodules = true;
   };
-
-  # ref https://github.com/osqp/osqp/pull/481
-  # but this patch does not apply directly on v0.6.3
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace-fail \
-      "$<INSTALL_PREFIX>/\''${CMAKE_INSTALL_INCLUDEDIR}" \
-      "\''${CMAKE_INSTALL_FULL_INCLUDEDIR}"
-  '';
 
   nativeBuildInputs = [ cmake ];
 

--- a/pkgs/by-name/os/osqp/package.nix
+++ b/pkgs/by-name/os/osqp/package.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ qdldl ];
+  cmakeFlags = [ (lib.cmakeFeature "OSQP_VERSION" finalAttrs.version) ];
 
   meta = {
     description = "Quadratic programming solver using operator splitting";

--- a/pkgs/by-name/os/osqp/package.nix
+++ b/pkgs/by-name/os/osqp/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  qdldl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -16,7 +17,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-BOAytzJzHcggncQzeDrXwJOq8B3doWERJ6CKIVg1yJY=";
   };
 
+  postPatch = ''
+    substituteInPlace algebra/_common/lin_sys/qdldl/qdldl.cmake --replace-fail \
+      "GIT_REPOSITORY https://github.com/osqp/qdldl.git" \
+      "URL ${qdldl.src}"
+  '';
+
   nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ qdldl ];
 
   meta = {
     description = "Quadratic programming solver using operator splitting";

--- a/pkgs/by-name/qd/qdldl/package.nix
+++ b/pkgs/by-name/qd/qdldl/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qdldl";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "osqp";
+    repo = "qdldl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qCeOs4UjZLuqlbiLgp6BMxvw4niduCPDOOqFt05zi2E=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    description = "Free LDL factorisation routine";
+    homepage = "https://github.com/osqp/qdldl";
+    changelog = "https://github.com/osqp/qdldl/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+    mainProgram = "qdldl";
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})


### PR DESCRIPTION
This use `qdldl.src` in osqp `FetchContent` for now.
Attempts to improve that upstream were [tried](https://github.com/osqp/osqp/pull/567), but are not ready yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
