### PR TITLE
gnubik: init at 2.4.3

### DIFF
--- a/pkgs/by-name/gn/gnubik/package.nix
+++ b/pkgs/by-name/gn/gnubik/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  guile_2_0,
+  gettext,
+  gtk2-x11,
+  libGL,
+  libGLU,
+  gtk2,
+  gnome2,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gnubik";
+  version = "2.4.3";
+
+  src = fetchurl {
+    url = "https://ftp.gnu.org/gnu/gnubik/gnubik-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Kz7Tb7W6nuyA/Yb5Tqu+hmUG9P4ZSKnXSA8iXIlIju4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    guile_2_0
+    gettext
+    gtk2-x11
+  ];
+
+  buildInputs = [
+    libGL
+    libGLU
+    guile_2_0
+    gtk2
+    gnome2.gtkglext
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "3D Rubik's cube game";
+    longDescription = ''
+      The Gnubik program is an interactive, graphical, single player
+      puzzle. Yes, this is another implementation of the classic game
+      like that invented by Erno Rubik. You have to manipulate the
+      cube using the mouse. When each face shows only one colour, the
+      game is solved.
+
+      Gnubik is written in C and Guile. The latter allows you to
+      extend the program using the Scheme language — a simple
+      programming tool which even novice computer users can use. For
+      example, you can use Scheme to write your own automated solving
+      routines or to create patterns.
+    '';
+    homepage = "https://www.gnu.org/software/gnubik";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "gnubik";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
