### PR TITLE
scikit-build-core: Add setup hook to handle cmake flags

### DIFF
--- a/pkgs/development/python-modules/fenics-basix/default.nix
+++ b/pkgs/development/python-modules/fenics-basix/default.nix
@@ -52,10 +52,12 @@ buildPythonPackage rec {
     lapack
   ];
 
-  # Prefer finding BLAS and LAPACK via pkg-config.
-  # Avoid using the Accelerate.framework from the Darwin SDK.
-  # Also, avoid mistaking BLAS for LAPACK.
-  env.CMAKE_ARGS = lib.cmakeBool "BLA_PREFER_PKGCONFIG" true;
+  cmakeFlags = [
+    # Prefer finding BLAS and LAPACK via pkg-config.
+    # Avoid using the Accelerate.framework from the Darwin SDK.
+    # Also, avoid mistaking BLAS for LAPACK.
+    (lib.cmakeBool "BLA_PREFER_PKGCONFIG" true)
+  ];
 
   pythonImportsCheck = [
     "basix"

--- a/pkgs/development/python-modules/islpy/default.nix
+++ b/pkgs/development/python-modules/islpy/default.nix
@@ -47,12 +47,12 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  pypaBuildFlags = [
-    "--config-setting=cmake.define.USE_SHIPPED_ISL=OFF"
-    "--config-setting=cmake.define.USE_SHIPPED_IMATH=OFF"
-    "--config-setting=cmake.define.USE_BARVINOK=OFF"
-    "--config-setting=cmake.define.ISL_INC_DIRS:LIST='${lib.getDev isl}/include'"
-    "--config-setting=cmake.define.ISL_LIB_DIRS:LIST='${lib.getLib isl}/lib'"
+  cmakeFlags = [
+    "-DUSE_SHIPPED_ISL=OFF"
+    "-DUSE_SHIPPED_IMATH=OFF"
+    "-DUSE_BARVINOK=OFF"
+    "-DISL_INC_DIRS:LIST='${lib.getDev isl}/include'"
+    "-DISL_LIB_DIRS:LIST='${lib.getLib isl}/lib'"
   ];
 
   # Force resolving the package from $out to make generated ext files usable by tests

--- a/pkgs/development/python-modules/lightgbm/default.nix
+++ b/pkgs/development/python-modules/lightgbm/default.nix
@@ -87,9 +87,10 @@ buildPythonPackage rec {
     scipy
   ];
 
-  pypaBuildFlags =
-    lib.optionals gpuSupport [ "--config-setting=cmake.define.USE_GPU=ON" ]
-    ++ lib.optionals cudaSupport [ "--config-setting=cmake.define.USE_CUDA=ON" ];
+  cmakeFlags = [
+    (lib.cmakeBool "USE_GPU" gpuSupport)
+    (lib.cmakeBool "USE_CUDA" cudaSupport)
+  ];
 
   optional-dependencies = {
     arrow = [

--- a/pkgs/development/python-modules/llama-cpp-python/default.nix
+++ b/pkgs/development/python-modules/llama-cpp-python/default.nix
@@ -52,7 +52,7 @@ buildPythonPackage rec {
   # src = /home/gaetan/llama-cpp-python;
 
   dontUseCmakeConfigure = true;
-  SKBUILD_CMAKE_ARGS = lib.strings.concatStringsSep ";" (
+  cmakeFlags = [
     # Set GGML_NATIVE=off. Otherwise, cmake attempts to build with
     # -march=native* which is either a no-op (if cc-wrapper is able to ignore
     # it), or an attempt to build a non-reproducible binary.
@@ -61,16 +61,14 @@ buildPythonPackage rec {
     # -mcpu, breaking linux build as follows:
     #
     # cc1: error: unknown value ‘native+nodotprod+noi8mm+nosve’ for ‘-mcpu’
-    [
-      "-DGGML_NATIVE=off"
-      "-DGGML_BUILD_NUMBER=1"
-    ]
-    ++ lib.optionals cudaSupport [
-      "-DGGML_CUDA=on"
-      "-DCUDAToolkit_ROOT=${lib.getDev cudaPackages.cuda_nvcc}"
-      "-DCMAKE_CUDA_COMPILER=${lib.getExe cudaPackages.cuda_nvcc}"
-    ]
-  );
+    "-DGGML_NATIVE=off"
+    "-DGGML_BUILD_NUMBER=1"
+  ]
+  ++ lib.optionals cudaSupport [
+    "-DGGML_CUDA=on"
+    "-DCUDAToolkit_ROOT=${lib.getDev cudaPackages.cuda_nvcc}"
+    "-DCMAKE_CUDA_COMPILER=${lib.getExe cudaPackages.cuda_nvcc}"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/python-modules/pillow-jpls/default.nix
+++ b/pkgs/development/python-modules/pillow-jpls/default.nix
@@ -65,9 +65,8 @@ buildPythonPackage rec {
     pyproject-metadata
   ];
 
-  pypaBuildFlags = [
-    "-C"
-    "cmake.args=--preset=sysdeps"
+  cmakeFlags = [
+    "--preset=sysdeps"
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/scikit-build-core/append-cmakeFlags.sh
+++ b/pkgs/development/python-modules/scikit-build-core/append-cmakeFlags.sh
@@ -1,0 +1,18 @@
+scikitBuildFlagsHook() {
+  OLD_IFS="$IFS"
+  IFS=';'
+
+  local args=()
+  if [[ -n "$SKBUILD_CMAKE_ARGS" ]]; then
+    read -ra existing_args <<< "$SKBUILD_CMAKE_ARGS"
+    args+=("${existing_args[@]}")
+  fi
+  args+=($cmakeFlags)
+  args+=("${cmakeFlagsArray[@]}")
+  export SKBUILD_CMAKE_ARGS="${args[*]}"
+
+  IFS="$OLD_IFS"
+  unset OLD_IFS
+}
+
+preConfigureHooks+=(scikitBuildFlagsHook)

--- a/pkgs/development/python-modules/scikit-build-core/default.nix
+++ b/pkgs/development/python-modules/scikit-build-core/default.nix
@@ -75,6 +75,9 @@ buildPythonPackage rec {
 
   # cmake is only used for tests
   dontUseCmakeConfigure = true;
+  setupHooks = [
+    ./append-cmakeFlags.sh
+  ];
 
   disabledTestMarks = [
     "isolated"

--- a/pkgs/development/python-modules/soxr/default.nix
+++ b/pkgs/development/python-modules/soxr/default.nix
@@ -46,8 +46,8 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  pypaBuildFlags = [
-    "--config-setting=cmake.define.USE_SYSTEM_LIBSOXR=ON"
+  cmakeFlags = [
+    (lib.cmakeBool "USE_SYSTEM_LIBSOXR" true)
   ];
 
   build-system = [

--- a/pkgs/development/python-modules/units-llnl/default.nix
+++ b/pkgs/development/python-modules/units-llnl/default.nix
@@ -36,14 +36,9 @@ buildPythonPackage {
     ninja
   ];
   dontUseCmakeConfigure = true;
-  env = {
-    SKBUILD_CMAKE_ARGS = lib.strings.concatStringsSep ";" (
-      cmakeFlags
-      ++ [
-        (lib.cmakeBool "UNITS_BUILD_PYTHON_LIBRARY" true)
-      ]
-    );
-  };
+  cmakeFlags = cmakeFlags ++ [
+    (lib.cmakeBool "UNITS_BUILD_PYTHON_LIBRARY" true)
+  ];
 
   # Also upstream turns off testing for the python build so it seems, see:
   # https://github.com/LLNL/units/blob/v0.13.1/pyproject.toml#L65-L66 However


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
