### PR TITLE
pypy: make CFFI builds find libsqlite3

### DIFF
--- a/pkgs/by-name/fb/fbpanel/package.nix
+++ b/pkgs/by-name/fb/fbpanel/package.nix
@@ -49,8 +49,10 @@ stdenv.mkDerivation {
   '';
 
   makeFlags = [ "V=1" ];
-  NIX_CFLAGS_COMPILE = [
+
+  env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-error"
+    "-Wno-error=incompatible-pointer-types" # not implied by -Wno-error
     "-I${gdk-pixbuf-xlib.dev}/include/gdk-pixbuf-2.0"
   ];
 

--- a/pkgs/development/interpreters/python/pypy/sqlite_paths.patch
+++ b/pkgs/development/interpreters/python/pypy/sqlite_paths.patch
@@ -1,7 +1,35 @@
-diff -ur a/lib_pypy/_sqlite3_build.py b/lib_pypy/_sqlite3_build.py
---- a/lib_pypy/_sqlite3_build.py	2021-04-12 01:11:48.000000000 -0400
-+++ b/lib_pypy/_sqlite3_build.py	2021-07-14 18:08:33.000000000 -0400
-@@ -301,6 +301,8 @@
+diff --git a/lib_pypy/_sqlite3_build.py b/lib_pypy/_sqlite3_build.py
+index 2a4e573..92ab786 100644
+--- a/lib_pypy/_sqlite3_build.py
++++ b/lib_pypy/_sqlite3_build.py
+@@ -352,7 +352,7 @@ def _has_load_extension():
+     typedef ... sqlite3;
+     int sqlite3_enable_load_extension(sqlite3 *db, int onoff);
+     """)
+-    libname = 'sqlite3'
++    libname = '@libsqlite@'
+     if sys.platform == 'win32':
+         import os
+         _libname = os.path.join(os.path.dirname(sys.executable), libname)
+@@ -369,7 +369,7 @@ def _has_backup():
+     typedef ... sqlite3_backup;
+     sqlite3_backup* sqlite3_backup_init(sqlite3 *, const char* , sqlite3 *, const char*);
+     """)
+-    libname = 'sqlite3'
++    libname = '@libsqlite@'
+     if sys.platform == 'win32':
+         import os
+         _libname = os.path.join(os.path.dirname(sys.executable), libname)
+@@ -383,7 +383,7 @@ def _get_version():
+     unverified_ffi.cdef("""
+     int sqlite3_libversion_number(void);
+     """)
+-    libname = 'sqlite3'
++    libname = '@libsqlite@'
+     if sys.platform == 'win32':
+         import os
+         _libname = os.path.join(os.path.dirname(sys.executable), libname)
+@@ -554,6 +554,8 @@ if sys.platform.startswith('freebsd'):
  else:
      extra_args = dict(
          libraries=libraries,

--- a/pkgs/development/interpreters/python/pypy/sqlite_paths_2_7.patch
+++ b/pkgs/development/interpreters/python/pypy/sqlite_paths_2_7.patch
@@ -1,0 +1,22 @@
+diff --git a/lib_pypy/_sqlite3_build.py b/lib_pypy/_sqlite3_build.py
+index fb03aee..b3b5f39 100644
+--- a/lib_pypy/_sqlite3_build.py
++++ b/lib_pypy/_sqlite3_build.py
+@@ -234,7 +234,7 @@ def _has_load_extension():
+     typedef ... sqlite3;
+     int sqlite3_enable_load_extension(sqlite3 *db, int onoff);
+     """)
+-    libname = 'sqlite3'
++    libname = '@libsqlite@'
+     if sys.platform == 'win32':
+         import os
+         _libname = os.path.join(os.path.dirname(sys.executable), libname)
+@@ -257,6 +257,8 @@ if sys.platform.startswith('freebsd'):
+ else:
+     extra_args = dict(
+         libraries=libraries,
++        include_dirs=['@dev@/include'],
++        library_dirs=['@out@/lib']
+     )
+ 
+ _ffi.set_source("_sqlite3_cffi", "#include <sqlite3.h>", **extra_args)

--- a/pkgs/development/python-modules/pyflakes/default.nix
+++ b/pkgs/development/python-modules/pyflakes/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
   disabledTests = lib.optionals isPyPy [
     # https://github.com/PyCQA/pyflakes/issues/779
     "test_eofSyntaxError"
+    "test_misencodedFileUTF16"
     "test_misencodedFileUTF8"
     "test_multilineSyntaxError"
   ];


### PR DESCRIPTION
This fixes the PyPy build, which has been [broken since June 2025](https://hydra.nixos.org/build/300429922). The issue was tracked down in #419942:
Basically, SQLite stopped setting `SONAME` for `libsqlite3.so` since their switch to `autosetup` (in v3.50).
This breaks `ctypes.util.find_library()` for CPython 2.7 (and PyPy 2.7) only.
However, both PyPy 2.7 and PyPy 3.x are built using PyPy 2.7, and since this is a build-time issue, it also affects PyPy 3.

This is one approach to fix this. Others would include:
- back-porting the fix from Python3 to `pypy27_prebuilt` and `pypy27`, similar to what is done for CPython 2 (https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/interpreters/python/cpython/2.7/find_library-gcc10.patch),
- ~abandoning PyPy 2.7 fully and buildling PyPy 3.X using CPython 2.7 (but this [apparently can take 2-3 times longer](https://doc.pypy.org/en/latest/build.html))~ (not an option as CPython 2.7 is unsupported, insecure, and due for removal in Nixpkgs soon), or
- setting the `SONAME` again for `libsqlite3`, using `--soname=legacy` configure flag for SQLite (as suggested in #419942).
We could also disable the `sqlite3` module, but that seems like the worst idea.

I noticed that there are also some other patches to the CPython 2.7 standard library which should probably also be applied to PyPy 2.7 (since PyPy's standard library is mostly copied verbatim from CPython). In the end, it boils down to whether PyPy 2.7 should be supported
1. not at all (building PyPy 3.x using CPython);
2. well enough to just build PyPy 3; or
3. fully (in which case there are a number of patches that should probably be applied);

I have tested this locally using a follow-up to #430846, which uses the (now working) PyPy 3.11 in the `icestorm` package.

Resolves #419942.

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
