### PR TITLE
python313Packages.logutils: disable redis tests for all platforms

### DIFF
--- a/pkgs/development/python-modules/logutils/default.nix
+++ b/pkgs/development/python-modules/logutils/default.nix
@@ -42,14 +42,17 @@ buildPythonPackage rec {
     "test_hashandlers"
   ];
 
-  disabledTestPaths =
-    lib.optionals (stdenv.hostPlatform.isDarwin) [
-      # Exception: unable to connect to Redis server
-      "tests/test_redis.py"
-    ]
-    ++ lib.optionals (pythonAtLeast "3.13") [
-      "tests/test_dictconfig.py"
-    ];
+  disabledTestPaths = [
+    # Disable redis tests on all systems for now
+    "tests/test_redis.py"
+  ]
+  # lib.optionals (stdenv.hostPlatform.isDarwin) [
+  #   # Exception: unable to connect to Redis server
+  #   "tests/test_redis.py"
+  # ]
+  ++ lib.optionals (pythonAtLeast "3.13") [
+    "tests/test_dictconfig.py"
+  ];
 
   pythonImportsCheck = [ "logutils" ];
 


### PR DESCRIPTION
https://hydra.nixos.org/build/303423290

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
