### PR TITLE
linkchecker: 10.2.1 -> 10.6.0

### DIFF
--- a/pkgs/by-name/li/linkchecker/package.nix
+++ b/pkgs/by-name/li/linkchecker/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "linkchecker";
-  version = "10.2.1";
+  version = "10.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "linkchecker";
     repo = "linkchecker";
     tag = "v${version}";
-    hash = "sha256-z7Qp74cai8GfsxB4n9dSCWQepp0/4PimFiRJQBaVSoo=";
+    hash = "sha256-CzDShtqcGO2TP5qNVf2zkI3Yyh80I+pSVIFzmi3AaGQ=";
   };
 
   nativeBuildInputs = [ gettext ];
@@ -44,11 +44,6 @@ python3.pkgs.buildPythonApplication rec {
     "test_internet" # uses network, fails on Darwin (not sure why it doesn't fail on linux)
     "test_markdown" # uses sys.version_info for conditional testing
     "test_itms_services" # uses sys.version_info for conditional testing
-  ];
-
-  disabledTestPaths = [
-    "tests/checker/telnetserver.py"
-    "tests/checker/test_telnet.py"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/by-name/li/linkchecker/package.nix
+++ b/pkgs/by-name/li/linkchecker/package.nix
@@ -1,11 +1,12 @@
 {
+  python3Packages,
   lib,
   fetchFromGitHub,
-  python3,
   gettext,
+  pdfSupport ? true,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "linkchecker";
   version = "10.6.0";
   pyproject = true;
@@ -19,31 +20,36 @@ python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [ gettext ];
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     hatchling
     hatch-vcs
     polib # translations
   ];
 
-  dependencies = with python3.pkgs; [
-    argcomplete
-    beautifulsoup4
-    dnspython
-    requests
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      argcomplete
+      beautifulsoup4
+      dnspython
+      requests
+    ]
+    ++ lib.optional pdfSupport pdfminer-six;
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pyopenssl
     parameterized
     pytestCheckHook
+    pyftpdlib
   ];
 
+  # Needed for tests to be able to create a ~/.local/share/linkchecker/plugins directory
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
   disabledTests = [
-    "TestLoginUrl"
     "test_timeit2" # flakey, and depends sleep being precise to the milisecond
-    "test_internet" # uses network, fails on Darwin (not sure why it doesn't fail on linux)
-    "test_markdown" # uses sys.version_info for conditional testing
-    "test_itms_services" # uses sys.version_info for conditional testing
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Update linkchecker to 10.6.0 to fix build issues, cleanup, add PDF reading support. Tested on x86_64-linux and works correctly.

Supersedes #289833

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
