### PR TITLE
python3Packages.temporalio: 1.12.0 → 1.15.0

### DIFF
--- a/pkgs/development/python-modules/nexusrpc/default.nix
+++ b/pkgs/development/python-modules/nexusrpc/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  nix-update-script,
+  pythonOlder,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "nexus-rpc";
+  version = "1.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "nexus-rpc";
+    repo = "sdk-python";
+    rev = "refs/tags/${version}";
+    hash = "sha256-CZOCNgYvlQCc/Ws2cEuryyVELS/FiNgLTYHwHp70yhM=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "nexusrpc"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Nexus Python SDK";
+    homepage = "https://temporal.io/";
+    changelog = "https://github.com/nexus-rpc/sdk-python/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jpds
+    ];
+  };
+}

--- a/pkgs/development/python-modules/temporalio/default.nix
+++ b/pkgs/development/python-modules/temporalio/default.nix
@@ -5,9 +5,10 @@
   cargo,
   fetchFromGitHub,
   maturin,
+  nexusrpc,
   pythonOlder,
   poetry-core,
-  protobuf,
+  protobuf5,
   python-dateutil,
   rustc,
   rustPlatform,
@@ -19,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "temporalio";
-  version = "1.12.0";
+  version = "1.15.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -28,7 +29,7 @@ buildPythonPackage rec {
     owner = "temporalio";
     repo = "sdk-python";
     rev = "refs/tags/${version}";
-    hash = "sha256-u74zbzYNVxMi0sdiPlBoEU+wAa24JmMksz7hGvraDeM=";
+    hash = "sha256-NY7+ryldTV60K1Ky9Q1iNEmXqXlZgSMEE4f6PGeZ5BE=";
     fetchSubmodules = true;
   };
 
@@ -39,7 +40,7 @@ buildPythonPackage rec {
       src
       cargoRoot
       ;
-    hash = "sha256-OIapL1+g6gIgyVzdB68PuK2K2RIr01DSm/UbCdt9kNY=";
+    hash = "sha256-Z0LxIGY7af1tcRTcMe4FDCH1zxzX1J9AJuZfZUMAAUI=";
   };
 
   cargoRoot = "temporalio/bridge";
@@ -54,7 +55,8 @@ buildPythonPackage rec {
   '';
 
   dependencies = [
-    protobuf
+    nexusrpc
+    protobuf5
     types-protobuf
     typing-extensions
   ]

--- a/pkgs/development/python-modules/temporalio/default.nix
+++ b/pkgs/development/python-modules/temporalio/default.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   maturin,
   nexusrpc,
+  nix-update-script,
   pythonOlder,
   poetry-core,
   protobuf5,
@@ -77,6 +78,8 @@ buildPythonPackage rec {
     "temporalio.client"
     "temporalio.worker"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Temporal Python SDK";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10329,6 +10329,8 @@ self: super: with self; {
 
   nexusformat = callPackage ../development/python-modules/nexusformat { };
 
+  nexusrpc = callPackage ../development/python-modules/nexusrpc { };
+
   nfcpy = callPackage ../development/python-modules/nfcpy { };
 
   nftables = callPackage ../os-specific/linux/nftables/python.nix { inherit (pkgs) nftables; };


### PR DESCRIPTION
* https://github.com/temporalio/sdk-python/releases/tag/1.15.0
* https://github.com/temporalio/sdk-python/releases/tag/1.14.1
* https://github.com/temporalio/sdk-python/releases/tag/1.14.0
* https://github.com/temporalio/sdk-python/releases/tag/1.13.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
