### PR TITLE
komari-agent: init at 1.0.32

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16814,6 +16814,11 @@
     github = "mlvzk";
     githubId = 44906333;
   };
+  mlyxshi = {
+    name = "mlyxshi";
+    github = "mlyxshi";
+    githubId = 16594754;
+  };
   mmahut = {
     email = "marek.mahut@gmail.com";
     github = "mmahut";

--- a/pkgs/by-name/ko/komari-agent/package.nix
+++ b/pkgs/by-name/ko/komari-agent/package.nix
@@ -1,0 +1,37 @@
+{
+  lib, 
+  buildGoModule, 
+  fetchFromGitHub 
+}:
+
+buildGoModule rec {
+  pname = "komari-agent";
+  version = "1.0.32";
+
+  src = fetchFromGitHub {
+    owner = "komari-monitor";
+    repo = "komari-agent";
+    rev = version;
+    hash = "sha256-Zh1YYDMZXw2KILhMemGWO/BcOxNaeJ1gCoDCkRQ/kAw=";
+  };
+
+  vendorHash = "sha256-Wt2A3rGnY8vpdbWRz9tWBz+PcVxATCjjCwm/YXQz1RY=";
+
+  ldflags = [ 
+    "-s" 
+    "-w" 
+    "-X github.com/komari-monitor/komari-agent/update.CurrentVersion=${version}" 
+  ];
+
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/komari-monitor/komari-agent";
+    description = "A lightweight server probe for simple, efficient monitoring";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      mlyxshi
+    ];
+    mainProgram = "komari-agent";
+  };
+}


### PR DESCRIPTION
This PR packages [komari-agent](https://github.com/komari-monitor/komari-agent) at 1.0.32 and adds myself as a maintainer for it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
