### PR TITLE
catppuccin-qt5ct: 2023-03-21 -> 0-unstable-2025-03-29, add support for qt6ct

### DIFF
--- a/pkgs/by-name/ca/catppuccin-qt5ct/package.nix
+++ b/pkgs/by-name/ca/catppuccin-qt5ct/package.nix
@@ -21,14 +21,14 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Soothing pastel theme for qt5ct";
     homepage = "https://github.com/catppuccin/qt5ct";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       pluiedev
       nullcube
     ];
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ca/catppuccin-qt5ct/package.nix
+++ b/pkgs/by-name/ca/catppuccin-qt5ct/package.nix
@@ -5,24 +5,25 @@
 }:
 stdenvNoCC.mkDerivation {
   pname = "catppuccin-qt5ct";
-  version = "2023-03-21";
+  version = "0-unstable-2025-03-29";
 
   src = fetchFromGitHub {
     owner = "catppuccin";
     repo = "qt5ct";
-    rev = "89ee948e72386b816c7dad72099855fb0d46d41e";
-    hash = "sha256-t/uyK0X7qt6qxrScmkTU2TvcVJH97hSQuF0yyvSO/qQ=";
+    rev = "cb585307edebccf74b8ae8f66ea14f21e6666535";
+    hash = "sha256-wDj6kQ2LQyMuEvTQP6NifYFdsDLT+fMCe3Fxr8S783w=";
   };
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/share/qt5ct
+    mkdir -p $out/share/qt{5,6}ct
     cp -r themes $out/share/qt5ct/colors
+    cp -r themes $out/share/qt6ct/colors
     runHook postInstall
   '';
 
   meta = {
-    description = "Soothing pastel theme for qt5ct";
+    description = "Soothing pastel theme for qt5ct & qt6ct";
     homepage = "https://github.com/catppuccin/qt5ct";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/ca/catppuccin-qt5ct/package.nix
+++ b/pkgs/by-name/ca/catppuccin-qt5ct/package.nix
@@ -25,7 +25,10 @@ stdenvNoCC.mkDerivation {
     description = "Soothing pastel theme for qt5ct";
     homepage = "https://github.com/catppuccin/qt5ct";
     license = licenses.mit;
-    maintainers = with maintainers; [ pluiedev ];
+    maintainers = with maintainers; [
+      pluiedev
+      nullcube
+    ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
Updated catppuccin-qt5ct to the latest commit in the repo, which includes qt6ct support.

Full changelog: 
https://github.com/catppuccin/qt5ct/compare/89ee948e72386b816c7dad72099855fb0d46d41e...cb585307edebccf74b8ae8f66ea14f21e6666535

Removed `with lib;` #371862.

Added myself as a maintainer.

cc: @pluiedev

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
