### PR TITLE
stdenv: Move all stdenv lookups out of mkDerivation

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -173,6 +173,79 @@ let
     "allowedRequisites"
   ];
 
+  inherit (stdenv)
+    hostPlatform
+    buildPlatform
+    targetPlatform
+    extraNativeBuildInputs
+    extraBuildInputs
+    extraSandboxProfile
+    __extraImpureHostDeps
+    ;
+
+  stdenvHasCC = stdenv.hasCC;
+  stdenvShell = stdenv.shell;
+
+  buildPlatformSystem = buildPlatform.system;
+  buildIsDarwin = buildPlatform.isDarwin;
+
+  inherit (hostPlatform)
+    isLinux
+    isDarwin
+    isWindows
+    isOpenBSD
+    isStatic
+    isMusl
+    ;
+
+  # Target is not included by default because most programs don't care.
+  # Including it then would cause needless mass rebuilds.
+  #
+  # TODO(@Ericson2314): Make [ "build" "host" ] always the default / resolve #87909
+  useDefaultConfigurePlatforms = hostPlatform != buildPlatform || config.configurePlatformsByDefault;
+  defaultConfigurePlatforms = optionals useDefaultConfigurePlatforms [
+    "build"
+    "host"
+  ];
+  buildPlatformConfigureFlag = "--build=${buildPlatform.config}";
+  hostPlatformConfigureFlag = "--host=${hostPlatform.config}";
+  targetPlatformConfigureFlag = "--target=${targetPlatform.config}";
+  defaultConfigurePlatformsFlags = optionals useDefaultConfigurePlatforms [
+    buildPlatformConfigureFlag
+    hostPlatformConfigureFlag
+  ];
+
+  # TODO(@Ericson2314): Make always true and remove / resolve #178468
+  defaultStrictDeps = if config.strictDepsByDefault then true else hostPlatform != buildPlatform;
+
+  canExecuteHostOnBuild = buildPlatform.canExecute hostPlatform;
+  defaultHardeningFlags =
+    (if stdenvHasCC then stdenv.cc else { }).defaultHardeningFlags or
+    # fallback safe-ish set of flags
+    (
+      if isOpenBSD && isStatic then
+        knownHardeningFlags # Need pie, in fact
+      else
+        remove "pie" knownHardeningFlags
+    );
+  stdenvHostSuffix = optionalString (hostPlatform != buildPlatform) "-${hostPlatform.config}";
+  stdenvStaticMarker = optionalString isStatic "-static";
+  userHook = config.stdenv.userHook or null;
+
+  requiredSystemFeaturesShouldBeSet =
+    buildPlatform ? gcc.arch
+    && !(
+      buildPlatform.isAarch64
+      && (
+        # `aarch64-darwin` sets `{gcc.arch = "armv8.3-a+crypto+sha2+...";}`
+        buildPlatform.isDarwin
+        ||
+          # `aarch64-linux` has `{ gcc.arch = "armv8-a"; }` set by default
+          buildPlatform.gcc.arch == "armv8-a"
+      )
+    );
+  gccArchFeature = [ "gccarch-${buildPlatform.gcc.arch}" ];
+
   # Turn a derivation into its outPath without a string context attached.
   # See the comment at the usage site.
   unsafeDerivationToUntrackedOutpath =
@@ -257,16 +330,7 @@ let
 
       # Configure Phase
       configureFlags ? [ ],
-      # Target is not included by default because most programs don't care.
-      # Including it then would cause needless mass rebuilds.
-      #
-      # TODO(@Ericson2314): Make [ "build" "host" ] always the default / resolve #87909
-      configurePlatforms ?
-        optionals (stdenv.hostPlatform != stdenv.buildPlatform || config.configurePlatformsByDefault)
-          [
-            "build"
-            "host"
-          ],
+      configurePlatforms ? defaultConfigurePlatforms,
 
       # TODO(@Ericson2314): Make unconditional / resolve #33599
       # Check phase
@@ -277,8 +341,7 @@ let
       doInstallCheck ? config.doCheckByDefault or false,
 
       # TODO(@Ericson2314): Make always true and remove / resolve #178468
-      strictDeps ?
-        if config.strictDepsByDefault then true else stdenv.hostPlatform != stdenv.buildPlatform,
+      strictDeps ? defaultStrictDeps,
 
       enableParallelBuilding ? config.enableParallelBuildingByDefault,
 
@@ -319,12 +382,12 @@ let
     let
       # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when
       # no package has `doCheck = true`.
-      doCheck' = doCheck && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-      doInstallCheck' = doInstallCheck && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+      doCheck' = doCheck && canExecuteHostOnBuild;
+      doInstallCheck' = doInstallCheck && canExecuteHostOnBuild;
 
       separateDebugInfo' =
         let
-          actualValue = separateDebugInfo && stdenv.hostPlatform.isLinux;
+          actualValue = separateDebugInfo && isLinux;
           conflictingOption =
             attrs ? "disallowedReferences"
             || attrs ? "disallowedRequisites"
@@ -350,7 +413,7 @@ let
           ++ depsTargetTarget
           ++ depsTargetTargetPropagated
         ) == 0;
-      dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenv.hasCC;
+      dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenvHasCC;
 
       concretizeFlagImplications =
         flag: impliesFlags: list:
@@ -364,15 +427,6 @@ let
           (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
         ]
       );
-      defaultHardeningFlags =
-        (if stdenv.hasCC then stdenv.cc else { }).defaultHardeningFlags or
-        # fallback safe-ish set of flags
-        (
-          if with stdenv.hostPlatform; isOpenBSD && isStatic then
-            knownHardeningFlags # Need pie, in fact
-          else
-            remove "pie" knownHardeningFlags
-        );
       enabledHardeningOptions =
         if builtins.elem "all" hardeningDisable' then
           [ ]
@@ -419,7 +473,7 @@ let
         nativeBuildInputs' =
           nativeBuildInputs
           ++ optional separateDebugInfo' ../../build-support/setup-hooks/separate-debug-info.sh
-          ++ optional stdenv.hostPlatform.isWindows ../../build-support/setup-hooks/win-dll-link.sh
+          ++ optional isWindows ../../build-support/setup-hooks/win-dll-link.sh
           ++ optionals doCheck nativeCheckInputs
           ++ optionals doInstallCheck nativeInstallCheckInputs;
 
@@ -484,16 +538,14 @@ let
                 # suffix. But we have some weird ones with run-time deps that are
                 # just used for their side-affects. Those might as well since the
                 # hash can't be the same. See #32986.
-                hostSuffix = optionalString (
-                  stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix
-                ) "-${stdenv.hostPlatform.config}";
+                hostSuffix = optionalString (!dontAddHostSuffix) stdenvHostSuffix;
 
                 # Disambiguate statically built packages. This was originally
                 # introduce as a means to prevent nix-env to get confused between
                 # nix and nixStatic. This should be also achieved by moving the
                 # hostSuffix before the version, so we could contemplate removing
                 # it again.
-                staticMarker = optionalString stdenv.hostPlatform.isStatic "-static";
+                staticMarker = stdenvStaticMarker;
               in
               lib.strings.sanitizeDerivationName (
                 if attrs ? name then
@@ -506,7 +558,7 @@ let
                   "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
               );
 
-            builder = attrs.realBuilder or stdenv.shell;
+            builder = attrs.realBuilder or stdenvShell;
             args =
               attrs.args or [
                 "-e"
@@ -521,9 +573,9 @@ let
             # indeed more finely than Nix knows or cares about. The `system`
             # attribute of `buildPlatform` matches Nix's degree of specificity.
             # exactly.
-            inherit (stdenv.buildPlatform) system;
+            system = buildPlatformSystem;
 
-            userHook = config.stdenv.userHook or null;
+            inherit userHook;
             __ignoreNulls = true;
             inherit __structuredAttrs strictDeps;
 
@@ -544,9 +596,14 @@ let
             # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
             configureFlags =
               configureFlags
-              ++ optional (elem "build" configurePlatforms) "--build=${stdenv.buildPlatform.config}"
-              ++ optional (elem "host" configurePlatforms) "--host=${stdenv.hostPlatform.config}"
-              ++ optional (elem "target" configurePlatforms) "--target=${stdenv.targetPlatform.config}";
+              ++ (
+                if configurePlatforms == defaultConfigurePlatforms then
+                  defaultConfigurePlatformsFlags
+                else
+                  optional (elem "build" configurePlatforms) buildPlatformConfigureFlag
+                  ++ optional (elem "host" configurePlatforms) hostPlatformConfigureFlag
+                  ++ optional (elem "target" configurePlatforms) targetPlatformConfigureFlag
+              );
 
             inherit patches;
 
@@ -568,7 +625,7 @@ let
               attrs.enableParallelInstalling or true;
 
             ${
-              if (hardeningDisable != [ ] || hardeningEnable != [ ] || stdenv.hostPlatform.isMusl) then
+              if (hardeningDisable != [ ] || hardeningEnable != [ ] || isMusl) then
                 "NIX_HARDENING_ENABLE"
               else
                 null
@@ -578,35 +635,16 @@ let
             # TODO: remove platform condition
             # Enabling this check could be a breaking change as it requires to edit nix.conf
             # NixOS module already sets gccarch, unsure of nix installers and other distributions
-            ${
-              if
-                stdenv.buildPlatform ? gcc.arch
-                && !(
-                  stdenv.buildPlatform.isAarch64
-                  && (
-                    # `aarch64-darwin` sets `{gcc.arch = "armv8.3-a+crypto+sha2+...";}`
-                    stdenv.buildPlatform.isDarwin
-                    ||
-                      # `aarch64-linux` has `{ gcc.arch = "armv8-a"; }` set by default
-                      stdenv.buildPlatform.gcc.arch == "armv8-a"
-                  )
-                )
-              then
-                "requiredSystemFeatures"
-              else
-                null
-            } =
-              attrs.requiredSystemFeatures or [ ] ++ [
-                "gccarch-${stdenv.buildPlatform.gcc.arch}"
-              ];
+            ${if requiredSystemFeaturesShouldBeSet then "requiredSystemFeatures" else null} =
+              attrs.requiredSystemFeatures or [ ] ++ gccArchFeature;
           }
-          // optionalAttrs (stdenv.buildPlatform.isDarwin) (
+          // optionalAttrs buildIsDarwin (
             let
               allDependencies = concatLists (concatLists dependencies);
               allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
 
               computedSandboxProfile = concatMap (input: input.__propagatedSandboxProfile or [ ]) (
-                stdenv.extraNativeBuildInputs ++ stdenv.extraBuildInputs ++ allDependencies
+                extraNativeBuildInputs ++ extraBuildInputs ++ allDependencies
               );
 
               computedPropagatedSandboxProfile = concatMap (
@@ -615,7 +653,7 @@ let
 
               computedImpureHostDeps = unique (
                 concatMap (input: input.__propagatedImpureHostDeps or [ ]) (
-                  stdenv.extraNativeBuildInputs ++ stdenv.extraBuildInputs ++ allDependencies
+                  extraNativeBuildInputs ++ extraBuildInputs ++ allDependencies
                 )
               );
 
@@ -629,7 +667,7 @@ let
               __sandboxProfile =
                 let
                   profiles = [
-                    stdenv.extraSandboxProfile
+                    extraSandboxProfile
                   ]
                   ++ computedSandboxProfile
                   ++ computedPropagatedSandboxProfile
@@ -648,7 +686,7 @@ let
                 ++ computedPropagatedImpureHostDeps
                 ++ __propagatedImpureHostDeps
                 ++ __impureHostDeps
-                ++ stdenv.__extraImpureHostDeps
+                ++ __extraImpureHostDeps
                 ++ [
                   "/dev/zero"
                   "/dev/random"
@@ -833,7 +871,7 @@ let
             _derivation_original_builder = derivationArg.builder;
             _derivation_original_args = derivationArg.args;
 
-            builder = stdenv.shell;
+            builder = stdenvShell;
             # The builtin `declare -p` dumps all bash and environment variables,
             # which is where all build input references end up (e.g. $PATH for
             # binaries). By writing this to $out, Nix can find and register


### PR DESCRIPTION
All lookups and expressions that don't depend on derivation attrs are moved to the outer let block. Saves over 10% lookups for eval on x86_64-linux, along with 53MiB memory (over 1%).
For some reason lists concats go 14% up, but defaultConfigurePlatformsFlags optimisation removes ~7% of them.

Overall time is down ~3%.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
