### PR TITLE
nixos/tests/blint: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -273,6 +273,7 @@ in
   bitbox-bridge = runTest ./bitbox-bridge.nix;
   bitcoind = runTest ./bitcoind.nix;
   bittorrent = runTest ./bittorrent.nix;
+  blint = runTest ./blint.nix;
   blockbook-frontend = runTest ./blockbook-frontend.nix;
   blocky = runTest ./blocky.nix;
   bookstack = runTest ./bookstack.nix;

--- a/nixos/tests/blint.nix
+++ b/nixos/tests/blint.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  name = "owasp blint test";
+
+  meta.maintainers = with lib; [
+    maintainers.ethancedwards8
+    teams.ngi
+  ];
+
+  nodes.machine = {
+    environment.systemPackages = with pkgs; [
+      blint
+      jq
+    ];
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+
+      machine.succeed('blint -i ${lib.getExe pkgs.ripgrep} -o /tmp/ripgrep')
+      machine.succeed('jq . /tmp/ripgrep/*.json')
+    '';
+}

--- a/pkgs/by-name/bl/blint/package.nix
+++ b/pkgs/by-name/bl/blint/package.nix
@@ -3,6 +3,7 @@
   python3Packages,
   fetchFromGitHub,
   versionCheckHook,
+  nixosTests,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -56,6 +57,8 @@ python3Packages.buildPythonApplication rec {
   disabledTests = [
     "test_demangle"
   ];
+
+  passthru.tests = { inherit (nixosTests) blint; };
 
   meta = {
     description = "Binary Linter to check the security properties, and capabilities in executables";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
