### PR TITLE
ipe: migrate to by-name

### DIFF
--- a/pkgs/by-name/gh/ghostscriptX/package.nix
+++ b/pkgs/by-name/gh/ghostscriptX/package.nix
@@ -1,0 +1,8 @@
+{
+  ghostscript,
+}:
+
+ghostscript.override {
+  cupsSupport = true;
+  x11Support = true;
+}

--- a/pkgs/by-name/gh/ghostscript_headless/package.nix
+++ b/pkgs/by-name/gh/ghostscript_headless/package.nix
@@ -1,0 +1,8 @@
+{
+  ghostscript,
+}:
+
+ghostscript.override {
+  cupsSupport = false;
+  x11Support = false;
+}

--- a/pkgs/by-name/ip/ipe/package.nix
+++ b/pkgs/by-name/ip/ipe/package.nix
@@ -7,53 +7,53 @@
   copyDesktopItems,
   cairo,
   freetype,
-  ghostscript,
+  ghostscriptX,
   gsl,
   libjpeg,
   libpng,
   libspiro,
   lua5,
-  qtbase,
-  qtsvg,
+  qt6Packages,
   texliveSmall,
   qhull,
-  wrapQtAppsHook,
   zlib,
   withTeXLive ? true,
   withQVoronoi ? false,
   buildPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ipe";
   version = "7.2.30";
 
   src = fetchFromGitHub {
     owner = "otfried";
     repo = "ipe";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-bvwEgEP/cinigixJr8e964sm6secSK+7Ul7WFfwM0gE=";
   };
 
   nativeBuildInputs = [
     pkg-config
     copyDesktopItems
-    wrapQtAppsHook
+    qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [
     cairo
     freetype
-    ghostscript
+    ghostscriptX
     gsl
     libjpeg
     libpng
     libspiro
     lua5
+  ]
+  ++ (with qt6Packages; [
     qtbase
     qtsvg
     zlib
-  ]
+  ])
   ++ (lib.optionals withTeXLive [
     texliveSmall
   ])
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = pname;
+      name = "ipe";
       desktopName = "Ipe";
       genericName = "Drawing editor";
       comment = "A drawing editor for creating figures in PDF format";
@@ -100,19 +100,19 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/share/icons/hicolor/128x128/apps
-    ln -s $out/share/ipe/${version}/icons/icon_128x128.png $out/share/icons/hicolor/128x128/apps/ipe.png
+    ln -s $out/share/ipe/${finalAttrs.version}/icons/icon_128x128.png $out/share/icons/hicolor/128x128/apps/ipe.png
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Editor for drawing figures";
     homepage = "http://ipe.otfried.org"; # https not available
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
     longDescription = ''
       Ipe is an extensible drawing editor for creating figures in PDF and Postscript format.
       It supports making small figures for inclusion into LaTeX-documents
       as well as presentations in PDF.
     '';
-    maintainers = with maintainers; [ ttuegel ];
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ ttuegel ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12513,11 +12513,6 @@ with pkgs;
     lua = lua5_1;
   };
 
-  ipe = qt6Packages.callPackage ../applications/graphics/ipe {
-    ghostscript = ghostscriptX;
-    lua5 = lua5_3;
-  };
-
   ir.lv2 = callPackage ../applications/audio/ir.lv2 { };
 
   jabcode = callPackage ../development/libraries/jabcode { };
@@ -15562,16 +15557,6 @@ with pkgs;
   gajim = callPackage ../applications/networking/instant-messengers/gajim {
     inherit (gst_all_1) gstreamer gst-plugins-base gst-libav;
     gst-plugins-good = gst_all_1.gst-plugins-good.override { gtkSupport = true; };
-  };
-
-  ghostscriptX = ghostscript.override {
-    cupsSupport = true;
-    x11Support = true;
-  };
-
-  ghostscript_headless = ghostscript.override {
-    cupsSupport = false;
-    x11Support = false;
   };
 
   gnuk = callPackage ../misc/gnuk {


### PR DESCRIPTION
refactor package definitions and move ghostscript overrides to by-name to improve evaluation overhead

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
