### PR TITLE
cups-brother-dcpt720dw: init at 3.5.0-1

### DIFF
--- a/pkgs/by-name/cu/cups-brother-dcpt720dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-dcpt720dw/package.nix
@@ -1,0 +1,125 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  perl,
+  ghostscript,
+  coreutils,
+  gnugrep,
+  which,
+  file,
+  gnused,
+  dpkg,
+  makeWrapper,
+  libredirect,
+  debugLvl ? "0",
+}:
+
+let
+  printerName = "DCP-T720DW";
+  model = "dcpt720dw";
+  version = "3.5.0-1";
+  debHash = "sha256-ToUFGnHxd6rnLdfhdDGzhvsgFJukEAVzlm79hmkSV3E=";
+in
+# Based on cups-brother-dcpt725dw package
+stdenv.mkDerivation {
+  pname = "cups-brother-${model}";
+  inherit version;
+  src = fetchurl {
+    # The URL used by the official linux-brprinter-installer. Switched from
+    # https://download.brother.com/welcome/dlf<fileno> used by other
+    # nix packages, avoiding the need for hard-coding the `fileno` identifier.
+    url = "https://download.brother.com/pub/com/linux/linux/packages/${model}pdrv-${version}.i386.deb";
+    hash = debHash;
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+  buildInputs = [ perl ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    mkdir -p $out
+    dpkg-deb -x $src $out
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    LPDDIR=$out/opt/brother/Printers/${model}/lpd
+    WRAPPER=$out/opt/brother/Printers/${model}/cupswrapper/brother_lpdwrapper_${model}
+
+    ln -s $LPDDIR/${stdenv.hostPlatform.linuxArch}/* $LPDDIR/
+
+    substituteInPlace $WRAPPER \
+      --replace-fail "PRINTER =~" "PRINTER = \"${model}\"; #" \
+      --replace-fail "basedir =~" "basedir = \"$out/opt/brother/Printers/${model}/\"; #" \
+      --replace-fail "lpdconf = " "lpdconf = \$lpddir.'/'.\$LPDCONFIGEXE.\$PRINTER; #" \
+      --replace-fail "\$DEBUG=0;" "\$DEBUG=${debugLvl};"
+
+    substituteInPlace $LPDDIR/filter_${model} \
+      --replace-fail "BR_PRT_PATH =~" "BR_PRT_PATH = \"$out/opt/brother/Printers/${model}/\"; #" \
+      --replace-fail "PRINTER =~" "PRINTER = \"${model}\"; #"
+
+    wrapProgram $WRAPPER \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+        ]
+      }
+
+    wrapProgram $LPDDIR/filter_${model} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          ghostscript
+          gnugrep
+          gnused
+          which
+          file
+        ]
+      }
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/br${model}filter
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $LPDDIR/brprintconf_${model}
+
+    wrapProgram $LPDDIR/brprintconf_${model} \
+      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    wrapProgram $LPDDIR/br${model}filter \
+      --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --set NIX_REDIRECTS /opt=$out/opt
+
+    mkdir -p "$out/lib/cups/filter" "$out/share/cups/model"
+
+    ln -s $out/opt/brother/Printers/${model}/cupswrapper/brother_lpdwrapper_${model} \
+      $out/lib/cups/filter/brother_lpdwrapper_${model}
+
+    ln -s "$out/opt/brother/Printers/${model}/cupswrapper/brother_${model}_printer_en.ppd" \
+      "$out/share/cups/model/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Brother ${printerName} printer driver";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ jmendyk ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=pl&lang=pl&prod=${model}_all&os=128&flang=English";
+    homepage = "http://www.brother.com/";
+  };
+}


### PR DESCRIPTION
This PR adds a driver to cups for the Brother DCP-T720DW printer, based on @u2x1's package for DCP-T725DW.

The only significant change is the use of a different path at `https://download.brother.com`, which doesn't require prior knowledge of the (sequential?) file id, instead being solely dependent on the model name. If multiple printers beyond these two would have identical configuration in future, extracting the shared logic could be considered.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
