### PR TITLE
handheld-daemon: remove appsforartists as maintainer

### DIFF
--- a/pkgs/by-name/ha/handheld-daemon/package.nix
+++ b/pkgs/by-name/ha/handheld-daemon/package.nix
@@ -100,7 +100,6 @@ python3Packages.buildPythonApplication rec {
     changelog = "https://github.com/hhd-dev/hhd/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      appsforartists
       toast
     ];
     mainProgram = "hhd";


### PR DESCRIPTION
I'm no longer using NixOS.