### PR TITLE
python3Packages.pyobjc-framework-Quartz: init at 11.1

### DIFF
--- a/pkgs/development/python-modules/pyobjc-framework-Quartz/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-Quartz/default.nix
@@ -1,0 +1,74 @@
+{
+  buildPythonPackage,
+  darwin,
+  fetchFromGitHub,
+  lib,
+  pyobjc-core,
+  pyobjc-framework-Cocoa,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-framework-Cocoa";
+  version = "11.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ronaldoussoren";
+    repo = "pyobjc";
+    tag = "v${version}";
+    hash = "sha256-2qPGJ/1hXf3k8AqVLr02fVIM9ziVG9NMrm3hN1de1Us=";
+  };
+
+  sourceRoot = "${src.name}/pyobjc-framework-Quartz";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    darwin.libffi
+  ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  # See https://github.com/ronaldoussoren/pyobjc/pull/641. Remove in next version:
+  postPatch = ''
+    substituteInPlace pyobjc_setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion" \
+      --replace-fail "/usr/bin/sw_vers" "sw_vers" \
+      --replace-fail "/usr/bin/xcrun" "xcrun"
+  '';
+
+  dependencies = [
+    pyobjc-core
+    pyobjc-framework-Cocoa
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${darwin.libffi.dev}/include"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [
+    "Quartz"
+    "Quartz.CoreGraphics"
+    "Quartz.CoreVideo"
+    "Quartz.ImageIO"
+    "Quartz.ImageKit"
+    "Quartz.PDFKit"
+    "Quartz.QuartzComposer"
+    "Quartz.QuartzCore"
+    "Quartz.QuartzFilters"
+    "Quartz.QuickLookUI"
+  ];
+
+  meta = {
+    description = ''Wrappers for the "Quartz" related frameworks on macOS'';
+    homepage = "https://github.com/ronaldoussoren/pyobjc";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ toyboot4e ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13418,6 +13418,8 @@ self: super: with self; {
 
   pyobjc-framework-Cocoa = callPackage ../development/python-modules/pyobjc-framework-Cocoa { };
 
+  pyobjc-framework-Quartz = callPackage ../development/python-modules/pyobjc-framework-Quartz { };
+
   pyocd = callPackage ../development/python-modules/pyocd { };
 
   pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };


### PR DESCRIPTION
Add `pyobjc-framework-Quartz` package from [`onaldoussoren/pyobjc`](https://github.com/ronaldoussoren/pyobjc).

> [`pyobjc-core`](https://github.com/NixOS/nixpkgs/blob/d549f98727d70150b04c16df6ab7e1808dab3ce7/pkgs/development/python-modules/pyobjc-core/default.nix#L10) and [`pyobjc-framework-Cocoa`](https://github.com/NixOS/nixpkgs/blob/d549f98727d70150b04c16df6ab7e1808dab3ce7/pkgs/development/python-modules/pyobjc-framework-Cocoa/default.nix#L11) are already in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
