### PR TITLE
python313Packages.smpclient: 4.5.0 -> 5.0.0

### DIFF
--- a/pkgs/development/python-modules/smpclient/default.nix
+++ b/pkgs/development/python-modules/smpclient/default.nix
@@ -1,31 +1,35 @@
 {
   lib,
-  buildPythonPackage,
-  fetchFromGitHub,
-  poetry-core,
   async-timeout,
   bleak,
+  buildPythonPackage,
+  fetchFromGitHub,
   intelhex,
+  poetry-core,
+  poetry-dynamic-versioning,
   pyserial,
-  smp,
   pytest-asyncio,
   pytestCheckHook,
+  smp,
 }:
 
 buildPythonPackage rec {
   pname = "smpclient";
-  version = "4.5.0";
+  version = "5.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "intercreate";
     repo = "smpclient";
     tag = version;
-    hash = "sha256-Z0glcCy3JsL45iT8Q82Vtxozi3hv6xaRJvJ3BkHX4PQ=";
+    hash = "sha256-NQRVEvi/B+KdhPIzw8pm22uXpYPkoaatkCNFnEcibzo=";
   };
+
+  pythonRelaxDeps = [ "smp" ];
 
   build-system = [
     poetry-core
+    poetry-dynamic-versioning
   ];
 
   dependencies = [
@@ -41,13 +45,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonRelaxDeps = [
-    "smp"
-  ];
-
-  pythonImportsCheck = [
-    "smpclient"
-  ];
+  pythonImportsCheck = [ "smpclient" ];
 
   meta = {
     description = "Simple Management Protocol (SMP) Client for remotely managing MCU firmware";


### PR DESCRIPTION
Changelog: https://github.com/intercreate/smpclient/releases/tag/5.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
