### PR TITLE
kanidm: use `finalAttrs` everywhere, nixos/tests/kanidm: restore eval when calling `nixosTests.kanidm` directly

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -772,18 +772,8 @@ in
   k3s = handleTest ./k3s { };
   kafka = handleTest ./kafka { };
   kanboard = runTest ./web-apps/kanboard.nix;
-  kanidm =
-    kanidmVersion:
-    runTest {
-      imports = [ ./kanidm.nix ];
-      _module.args = { inherit kanidmVersion; };
-    };
-  kanidm-provisioning =
-    kanidmVersion:
-    runTest {
-      imports = [ ./kanidm-provisioning.nix ];
-      _module.args = { inherit kanidmVersion; };
-    };
+  kanidm = runTest ./kanidm.nix;
+  kanidm-provisioning = runTest ./kanidm-provisioning.nix;
   karma = runTest ./karma.nix;
   kavita = runTest ./kavita.nix;
   kbd-setfont-decompress = runTest ./kbd-setfont-decompress.nix;

--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -1,4 +1,4 @@
-{ kanidmVersion, pkgs, ... }:
+{ kanidmPackage, pkgs, ... }:
 let
   certs = import ./common/acme/server/snakeoil-certs.nix;
   serverDomain = certs.domain;
@@ -13,12 +13,12 @@ let
   provisionAdminPassword = "very-strong-password-for-admin";
   provisionIdmAdminPassword = "very-strong-password-for-idm-admin";
   provisionIdmAdminPassword2 = "very-strong-alternative-password-for-idm-admin";
-
-  kanidmPackage = pkgs."kanidmWithSecretProvisioning_${kanidmVersion}";
 in
 {
-  name = "kanidm-provisioning";
+  name = "kanidm-provisioning-${kanidmPackage.version}";
   meta.maintainers = with pkgs.lib.maintainers; [ oddlama ];
+
+  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidmWithSecretProvisioning;
 
   nodes.provision =
     { pkgs, lib, ... }:

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -1,4 +1,4 @@
-{ kanidmVersion, pkgs, ... }:
+{ kanidmPackage, pkgs, ... }:
 let
   certs = import ./common/acme/server/snakeoil-certs.nix;
   serverDomain = certs.domain;
@@ -13,15 +13,15 @@ let
     cp ${certs."${serverDomain}".cert} $out/snakeoil.crt
     cp ${certs."${serverDomain}".key} $out/snakeoil.key
   '';
-
-  kanidmPackage = pkgs."kanidm_${kanidmVersion}";
 in
 {
-  name = "kanidm";
+  name = "kanidm-${kanidmPackage.version}";
   meta.maintainers = with pkgs.lib.maintainers; [
     Flakebi
     oddlama
   ];
+
+  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidm;
 
   nodes.server =
     { pkgs, ... }:

--- a/pkgs/by-name/ka/kanidm/generic.nix
+++ b/pkgs/by-name/ka/kanidm/generic.nix
@@ -133,8 +133,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     tests = {
-      kanidm = nixosTests.kanidm (versionUnderscored finalAttrs);
-      kanidm-provisioning = nixosTests.kanidm-provisioning (versionUnderscored finalAttrs);
+      kanidm = nixosTests.kanidm.extend {
+        modules = [ { _module.args.kanidmPackage = finalAttrs.finalPackage; } ];
+      };
+      kanidm-provisioning = nixosTests.kanidm-provisioning.extend {
+        modules = [ { _module.args.kanidmPackage = finalAttrs.finalPackage.withSecretProvisioning; } ];
+      };
     };
 
     updateScript = lib.optionals (!enableSecretProvisioning) (nix-update-script {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10128,23 +10128,20 @@ with pkgs;
 
   jetty = jetty_12;
 
-  kanidm_1_5 = callPackage ../by-name/ka/kanidm/1_5.nix { kanidm = kanidm_1_5; };
-  kanidm_1_6 = callPackage ../by-name/ka/kanidm/1_6.nix { kanidm = kanidm_1_6; };
-  kanidm_1_7 = callPackage ../by-name/ka/kanidm/1_7.nix { kanidm = kanidm_1_7; };
-
-  kanidmWithSecretProvisioning = kanidmWithSecretProvisioning_1_6;
-
-  kanidmWithSecretProvisioning_1_5 = callPackage ../by-name/ka/kanidm/1_5.nix {
-    enableSecretProvisioning = true;
+  kanidm_1_5 = callPackage ../by-name/ka/kanidm/1_5.nix {
+    kanidmWithSecretProvisioning = kanidmWithSecretProvisioning_1_5;
+  };
+  kanidm_1_6 = callPackage ../by-name/ka/kanidm/1_6.nix {
+    kanidmWithSecretProvisioning = kanidmWithSecretProvisioning_1_6;
+  };
+  kanidm_1_7 = callPackage ../by-name/ka/kanidm/1_7.nix {
+    kanidmWithSecretProvisioning = kanidmWithSecretProvisioning_1_7;
   };
 
-  kanidmWithSecretProvisioning_1_6 = callPackage ../by-name/ka/kanidm/1_6.nix {
-    enableSecretProvisioning = true;
-  };
-
-  kanidmWithSecretProvisioning_1_7 = callPackage ../by-name/ka/kanidm/1_7.nix {
-    enableSecretProvisioning = true;
-  };
+  kanidmWithSecretProvisioning = kanidm.override { enableSecretProvisioning = true; };
+  kanidmWithSecretProvisioning_1_5 = kanidm_1_5.override { enableSecretProvisioning = true; };
+  kanidmWithSecretProvisioning_1_6 = kanidm_1_6.override { enableSecretProvisioning = true; };
+  kanidmWithSecretProvisioning_1_7 = kanidm_1_7.override { enableSecretProvisioning = true; };
 
   knot-resolver = callPackage ../servers/dns/knot-resolver {
     systemd = systemdMinimal; # in closure already anyway


### PR DESCRIPTION
This makes the resulting derivation when using `overrideAttrs` more accurate and also fixes a discrepancy in `kanidmWithSecretProvisioning`.

One would expect this change to be a no-op, but it isn't. Not because there is some unwanted change, but rather because unlike `kanidm_1_x.withSecretProvisioning`, `kanidmWithSecretProvisioning_1_x` used `kanidm` as a basis when it should have used `kanidm_1_x`.

~~~
# before
nix-repl> kanidmWithSecretProvisioning_1_5.patches
[
  ./pkgs/by-name/ka/kanidm/provision-patches/1_6/oauth2-basic-secret-modify.patch
  ./pkgs/by-name/ka/kanidm/provision-patches/1_6/recover-account.patch
]

# after
nix-repl> kanidmWithSecretProvisioning_1_5.patches
[
  ./pkgs/by-name/ka/kanidm/provision-patches/1_5/oauth2-basic-secret-modify.patch
  ./pkgs/by-name/ka/kanidm/provision-patches/1_5/recover-account.patch
]
~~~

The change itself is written in a way that minimizes formatting changes enforced by `nixfmt`. For example, it would have been nice to access `finalAttrs.version` in `versionUnderscored` without having to make it a function, but that would have required to move the `let in` into `finalAttrs: {`, causing the entire attrset to reformat. Similarly, offloading this into `passthru` would have caused other bits to reformat because of the variable name length differences.

The other commit is essentially the patch I suggested in <https://github.com/NixOS/nixpkgs/pull/430205#discussion_r2258485958>.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test