### PR TITLE
llama-swap: init at 156, nixos/llama-swap: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20394,6 +20394,12 @@
     name = "Kevin Mullins";
     keys = [ { fingerprint = "2CD2 B030 BD22 32EF DF5A  008A 3618 20A4 5DB4 1E9A"; } ];
   };
+  podium868909 = {
+    email = "89096245@proton.me";
+    github = "podium868909";
+    githubId = 150333826;
+    name = "podium868909";
+  };
   podocarp = {
     email = "xdjiaxd@gmail.com";
     github = "podocarp";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -50,6 +50,8 @@
 
 - [go-httpbin](https://github.com/mccutchen/go-httpbin), a reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib. Available as [services.go-httpbin](#opt-services.go-httpbin.enable).
 
+- [llama-swap](https://github.com/mostlygeek/llama-swap), a light weight transparent proxy server that provides automatic model swapping to llama.cpp's server (or any server with an OpenAI compatible endpoint). Available as [](#opt-services.llama-swap.enable).
+
 - [tuwunel](https://matrix-construct.github.io/tuwunel/), a federated chat server implementing the Matrix protocol, forked from Conduwuit. Available as [services.matrix-tuwunel](#opt-services.matrix-tuwunel.enable).
 
 - [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1213,6 +1213,7 @@
   ./services/networking/libreswan.nix
   ./services/networking/livekit-ingress.nix
   ./services/networking/livekit.nix
+  ./services/networking/llama-swap.nix
   ./services/networking/lldpd.nix
   ./services/networking/logmein-hamachi.nix
   ./services/networking/lokinet.nix

--- a/nixos/modules/services/networking/llama-swap.nix
+++ b/nixos/modules/services/networking/llama-swap.nix
@@ -1,0 +1,124 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.llama-swap;
+  settingsFormat = pkgs.formats.yaml { };
+  configFile = settingsFormat.generate "config.yaml" cfg.settings;
+in
+{
+  options.services.llama-swap = {
+    enable = lib.mkEnableOption "enable the llama-swap service";
+
+    package = lib.mkPackageOption pkgs "llama-swap" { };
+
+    port = lib.mkOption {
+      default = 8080;
+      example = 11343;
+      type = lib.types.port;
+      description = ''
+        Port that llama-swap listens on.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to open the firewall for llama-swap.
+        This adds {option}`port` to [](#opt-networking.firewall.allowedTCPPorts).
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = settingsFormat.type; };
+      description = ''
+        llama-swap configuration. Refer to the [llama-swap example configuration](https://github.com/mostlygeek/llama-swap/blob/main/config.example.yaml)
+        for details on supported values.
+      '';
+      example = lib.literalExpression ''
+        let
+          llama-cpp = pkgs.llama-cpp.override { rocmSupport = true; };
+          llama-server = lib.getExe' llama-cpp "llama-server";
+        in
+        {
+          healthCheckTimeout = 60;
+          models = {
+            "some-model" = {
+              cmd = "$\{llama-server\} --port ''\${PORT} -m /var/lib/llama-cpp/models/some-model.gguf -ngl 0 --no-webui";
+              aliases = [
+                "the-best"
+              ];
+            };
+            "other-model" = {
+              proxy = "http://127.0.0.1:5555";
+              cmd = "$\{llama-server\} --port 5555 -m /var/lib/llama-cpp/models/other-model.gguf -ngl 0 -c 4096 -np 4 --no-webui";
+              concurrencyLimit = 4;
+            };
+          };
+        };
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    systemd.services.llama-swap = {
+      description = "Model swapping for LLaMA C++ Server (or any local OpenAPI compatible server)";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "exec";
+        ExecStart = "${lib.getExe cfg.package} --listen :${toString cfg.port} --config ${configFile}";
+        Restart = "on-failure";
+        RestartSec = 3;
+
+        # for GPU acceleration
+        PrivateDevices = false;
+
+        # hardening
+        DynamicUser = true;
+        CapabilityBoundingSet = "";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        NoNewPrivileges = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        RemoveIPC = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+        SystemCallErrorNumber = "EPERM";
+        ProtectProc = "invisible";
+        ProtectHostname = true;
+        ProcSubset = "pid";
+      };
+    };
+    networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.port ]; };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    jk
+    podium868909
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -846,6 +846,7 @@ in
   litellm = runTest ./litellm.nix;
   litestream = runTest ./litestream.nix;
   lk-jwt-service = runTest ./matrix/lk-jwt-service.nix;
+  llama-swap = runTest ./web-servers/llama-swap.nix;
   lldap = runTest ./lldap.nix;
   localsend = runTest ./localsend.nix;
   locate = runTest ./locate.nix;

--- a/nixos/tests/web-servers/llama-swap.nix
+++ b/nixos/tests/web-servers/llama-swap.nix
@@ -1,0 +1,258 @@
+{ pkgs, lib, ... }:
+
+let
+  wrapSrc = attrs: pkgs.runCommand "${attrs.pname}-${attrs.version}" attrs "ln -s $src $out";
+
+  smollm2-135m = wrapSrc rec {
+    pname = "smollm2-135m";
+    version = "9e6855bc4be717fca1ef21360a1db4b29d5c559a";
+    src = pkgs.fetchurl {
+      url = "https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/${version}/SmolLM2-135M-Instruct-Q4_K_M.gguf";
+      hash = "sha256-7V+jDEh7KC7BVsKQYvEiLlwgh1qUSsmCidvSQulH90c=";
+    };
+
+    meta.license = with lib.licenses; [
+      asl20 # actual license of the model
+      unfree # to force an opt-in - do not remove
+    ];
+  };
+
+  # grab allowUnfreePredicate if it exists or default deny
+  allowUnfreePredicate =
+    if builtins.hasAttr "allowUnfreePredicate" pkgs.config then
+      pkgs.config.allowUnfreePredicate
+    else
+      (_: false);
+
+  # check if we can use smollm2-135m taking either globally allowUnfree or
+  # explicit allow with predicate
+  useSmollm2-135m = pkgs.config.allowUnfree || allowUnfreePredicate smollm2-135m;
+in
+{
+  name = "llama-swap";
+  meta.maintainers = with lib.maintainers; [
+    jk
+    podium868909
+  ];
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        # running models can be memory intensive but
+        # default `virtualisation.memorySize` is fine
+
+        services.llama-swap = {
+          enable = true;
+          settings =
+            # config for basic tests
+            if !useSmollm2-135m then
+              { }
+            # config for extended tests using SmolLM2
+            else
+              let
+                llama-cpp = pkgs.llama-cpp;
+                llama-server = lib.getExe' llama-cpp "llama-server";
+              in
+              {
+                hooks.on_startup.preload = [
+                  "smollm2"
+                ];
+                # temperature and top-k important for SmolLM2 performance/accuracy
+                models = {
+                  "smollm2" = {
+                    ttl = 10;
+                    cmd = "${llama-server} --port \${PORT} -m ${smollm2-135m} --no-webui --temp 0.2 --top-k 9";
+                  };
+                  "smollm2-group-1" = {
+                    cmd = "${llama-server} --port \${PORT} -m ${smollm2-135m} --no-webui --temp 0.2 --top-k 9 -c 1024";
+                  };
+                  "smollm2-group-2" = {
+                    proxy = "http://127.0.0.1:5802";
+                    cmd = "${llama-server} --port 5802 -m ${smollm2-135m} --no-webui --temp 0.2 --top-k 9 -c 1024";
+                  };
+                };
+                groups = {
+                  "standalone" = {
+                    swap = true;
+                    exclusive = true;
+                    members = [
+                      "smollm2"
+                    ];
+                  };
+                  "group" = {
+                    swap = false;
+                    exclusive = true;
+                    members = [
+                      "smollm2-group-1"
+                      "smollm2-group-2"
+                    ];
+                  };
+                };
+              };
+        };
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      # core tests
+      import json
+
+      def get_json(route):
+        args = [
+          '-v',
+          '-s',
+          '--fail',
+          '-H "Content-Type: application/json"'
+        ]
+        return json.loads(machine.succeed("curl {args} http://localhost:8080{route}".format(args=" ".join(args), route=route)))
+
+      def post_json(route, data):
+        args = [
+          '-v',
+          '-s',
+          '--fail',
+          '-H "Content-Type: application/json"',
+          '-H "Authorization: Bearer no-key"',
+          "-d '{d}'".format(d=json.dumps(data))
+        ]
+        return json.loads(machine.succeed('curl {args} http://localhost:8080{route}'.format(args=" ".join(args), route=route)))
+
+      machine.wait_for_unit('llama-swap')
+      machine.wait_for_open_port(8080)
+
+      with subtest('check is serving ui'):
+        machine.succeed('curl --fail http:/localhost:8080/ui/')
+
+      with subtest('check is healthy'):
+        machine.wait_until_succeeds('curl --silent --fail http://localhost:8080/health | grep "OK"')
+
+    ''
+    + lib.optionalString useSmollm2-135m ''
+      # extended tests using SmolLM2
+      with subtest('check `/running` for preloaded smollm2'):
+        machine.wait_until_succeeds('curl --silent --fail http://localhost:8080/running | grep "smollm2"')
+        running_response = get_json('/running')
+        assert len(running_response['running']) == 1
+        running_model = running_response['running'][0]
+        assert running_model['model'] == 'smollm2'
+        assert running_model['state'] == 'ready'
+
+      with subtest('runs smollm2'):
+        response = None
+        with subtest('send request to smollm2'):
+          data = {
+            'model': 'smollm2',
+            'messages': [
+              {
+                'role': 'user',
+                'content': 'Say hello'
+              }
+            ]
+          }
+          response = post_json('/v1/chat/completions', data)
+
+        with subtest('response is from smollm2'):
+          assert response['model'] == 'smollm2'
+
+        with subtest('response contains at least one item in "choices"'):
+          assert len(response['choices']) >= 1
+
+        assistant_choices = None
+        with subtest('response contains at least one "assistant" message'):
+          assistant_choices = [c for c in response['choices'] if c['message']['role'] == 'assistant']
+          assert len(assistant_choices) >= 1
+
+        with subtest('first message (lowercase) starts with "hello"'):
+          assert assistant_choices[0]['message']['content'].lower()[:5] == 'hello'
+
+        with subtest('check `/running` for just smollm2'):
+          running_response = get_json('/running')
+          assert len(running_response['running']) == 1
+          running_model = running_response['running'][0]
+          assert running_model['model'] == 'smollm2'
+          assert running_model['state'] == 'ready'
+
+      with subtest('check `/running` for smollm2 to timeout'):
+        machine.succeed('curl --silent --fail http://localhost:8080/running | grep "smollm2"')
+        machine.wait_until_succeeds('curl --silent --fail http://localhost:8080/running | grep -v "smollm2"', timeout=11)
+        running_response = get_json('/running')
+        assert len(running_response['running']) == 0
+
+      with subtest('runs smollm2-group-1 and smollm2-group-2'):
+        response_1 = None
+        with subtest('send request to smollm2-group-1'):
+          data = {
+            'model': 'smollm2-group-1',
+            'messages': [
+              {
+                'role': 'user',
+                'content': 'Say hello'
+              }
+            ]
+          }
+          response_1 = post_json('/v1/chat/completions', data)
+
+        with subtest('response 1 is from smollm2-group-1'):
+          assert response_1['model'] == 'smollm2-group-1'
+
+        with subtest('response 1 contains at least one item in "choices"'):
+          assert len(response['choices']) >= 1
+
+        assistant_choices_1 = None
+        with subtest('response 1 contains at least one "assistant" message'):
+          assistant_choices_1 = [c for c in response_1['choices'] if c['message']['role'] == 'assistant']
+          assert len(assistant_choices_1) >= 1
+
+        with subtest('first message (lowercase) in response 1 starts with "hello"'):
+          assert assistant_choices_1[0]['message']['content'].lower()[:5] == 'hello'
+
+        with subtest('check `/running` for just smollm2-group-1'):
+          running_response = get_json('/running')
+          assert len(running_response['running']) == 1
+          running_model = running_response['running'][0]
+          assert running_model['model'] == 'smollm2-group-1'
+          assert running_model['state'] == 'ready'
+
+        response_2 = None
+        with subtest('send request to smollm2-group-2'):
+          data = {
+            'model': 'smollm2-group-2',
+            'messages': [
+              {
+                'role': 'user',
+                'content': 'Say hello'
+              }
+            ]
+          }
+          response_2 = post_json('/v1/chat/completions', data)
+
+        with subtest('response 2 is from smollm2-group-2'):
+          assert response_2['model'] == 'smollm2-group-2'
+
+        with subtest('response 2 contains at least one item in "choices"'):
+          assert len(response['choices']) >= 1
+
+        assistant_choices_2 = None
+        with subtest('response 2 contains at least one "assistant" message'):
+          assistant_choices_2 = [c for c in response_2['choices'] if c['message']['role'] == 'assistant']
+          assert len(assistant_choices_2) >= 1
+
+        with subtest('first message (lowercase) in response 1 starts with "hello"'):
+          assert assistant_choices_2[0]['message']['content'].lower()[:5] == 'hello'
+
+        with subtest('check `/running` for both smollm2-group-1 and smollm2-group-2'):
+          running_response = get_json('/running')['running']
+          assert len(running_response) == 2
+          assert len([
+            rm for rm in running_response
+            if rm['state'] == 'ready' and rm['model'] == 'smollm2-group-1'
+          ]) == 1
+          assert len([
+            rm for rm in running_response
+            if rm['state'] == 'ready' and rm['model'] == 'smollm2-group-2'
+          ]) == 1
+    '';
+}

--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -7,6 +7,8 @@
   versionCheckHook,
 
   callPackage,
+
+  nixosTests,
 }:
 
 let
@@ -86,6 +88,8 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
   versionCheckProgramArg = "-version";
+
+  passthru.tests.nixos = nixosTests.llama-swap;
 
   meta = {
     homepage = "https://github.com/mostlygeek/llama-swap";

--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  stdenv,
+
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+
+  callPackage,
+}:
+
+let
+  canExecute = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+in
+buildGoModule (finalAttrs: {
+  pname = "llama-swap";
+  version = "156";
+
+  src = fetchFromGitHub {
+    owner = "mostlygeek";
+    repo = "llama-swap";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-z0262afVjsdGe6WPoWO1wbccLO538fXBuxOOqLnJHRU=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      # '0000-00-00T00:00:00Z'
+      date -u -d "@$(git log -1 --pretty=%ct)" "+'%Y-%m-%dT%H:%M:%SZ'" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  vendorHash = "sha256-5mmciFAGe8ZEIQvXejhYN+ocJL3wOVwevIieDuokhGU=";
+
+  passthru.ui = callPackage ./ui.nix { llama-swap = finalAttrs.finalPackage; };
+  passthru.npmDepsHash = "sha256-Sbvz3oudMVf+PxOJ6s7LsDaxFwvftNc8ZW5KPpbI/cA=";
+
+  nativeBuildInputs = [
+    versionCheckHook
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  preBuild = ''
+    # ldflags based on metadata from git and source
+    ldflags+=" -X main.commit=$(cat COMMIT)"
+    ldflags+=" -X main.date=$(cat SOURCE_DATE_EPOCH)"
+
+    # copy for go:embed in proxy/ui_embed.go
+    cp -r ${finalAttrs.passthru.ui}/ui_dist proxy/
+  '';
+
+  excludedPackages = [
+    # regression testing tool
+    "misc/process-cmd-test"
+    # benchmark/regression testing tool
+    "misc/benchmark-chatcompletion"
+  ]
+  ++ lib.optionals (!canExecute) [
+    # some tests expect to execute `simple-something`; if it can't be executed
+    # it's unneeded
+    "misc/simple-responder"
+  ];
+
+  # some tests expect to execute `simple-something` and proxy/helpers_test.go
+  # checks the file exists
+  doCheck = canExecute;
+  preCheck = ''
+    mkdir build
+    ln -s "$GOPATH/bin/simple-responder" "./build/simple-responder_''${GOOS}_''${GOARCH}"
+  '';
+  postCheck = ''
+    rm "$GOPATH/bin/simple-responder"
+  '';
+
+  preInstall = ''
+    install -Dm444 -t "$out/share/llama-swap" config.example.yaml
+  '';
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "-version";
+
+  meta = {
+    homepage = "https://github.com/mostlygeek/llama-swap";
+    changelog = "https://github.com/mostlygeek/llama-swap/releases/tag/${finalAttrs.src.tag}";
+    description = "Model swapping for llama.cpp (or any local OpenAPI compatible server)";
+    longDescription = ''
+      llama-swap is a light weight, transparent proxy server that provides
+      automatic model swapping to llama.cpp's server.
+
+      When a request is made to an OpenAI compatible endpoint, llama-swap will
+      extract the `model` value and load the appropriate server configuration to
+      serve it. If the wrong upstream server is running, it will be replaced
+      with the correct one. This is where the "swap" part comes in. The upstream
+      server is automatically swapped to the correct one to serve the request.
+
+      In the most basic configuration llama-swap handles one model at a time.
+      For more advanced use cases, the `groups` feature allows multiple models
+      to be loaded at the same time. You have complete control over how your
+      system resources are used.
+    '';
+    license = lib.licenses.mit;
+    mainProgram = "llama-swap";
+    maintainers = with lib.maintainers; [
+      jk
+      podium868909
+    ];
+  };
+})

--- a/pkgs/by-name/ll/llama-swap/ui.nix
+++ b/pkgs/by-name/ll/llama-swap/ui.nix
@@ -1,0 +1,26 @@
+{
+  llama-swap,
+
+  buildNpmPackage,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "${llama-swap.pname}-ui";
+  inherit (llama-swap) version src npmDepsHash;
+
+  postPatch = ''
+    substituteInPlace vite.config.ts \
+      --replace-fail "../proxy/ui_dist" "${placeholder "out"}/ui_dist"
+  '';
+
+  sourceRoot = "${finalAttrs.src.name}/ui";
+
+  # bundled "ui_dist" doesn't need node_modules
+  postInstall = ''
+    rm -rf $out/lib
+  '';
+
+  meta = (builtins.removeAttrs llama-swap.meta [ "mainProgram" ]) // {
+    description = "${llama-swap.meta.description} - UI";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Packages llama-swap for nixpkgs

UI also working
<img width="800" height="800" alt="image" src="https://github.com/user-attachments/assets/1e74b200-234d-435c-a4dc-9401472535b7" />

Adopted module from @podium868909 , tweaked docs a bit, and added hardening copied from llama-cpp
Added module test with opt-in SmolLM2 model usage with model switching.

Either set 

or you can test with this file:

```nix
{
  lib ? (import ./. { }).lib,
  pkgs ? import ./. {
    config.allowUnfreePredicate =
      pkg:
      builtins.elem (lib.getName pkg) [
        "smollm2-135m" # try commenting this out
      ];
  },
}:
pkgs.nixosTests.llama-swap
```

`nix-build ./thefileyoumade.nix` in the copy of `nixpkgs` with this change.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
