### PR TITLE
munbyn-itpp941-cups: init

### DIFF
--- a/pkgs/by-name/mu/munbyn-itpp941-cups/package.nix
+++ b/pkgs/by-name/mu/munbyn-itpp941-cups/package.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+  autoPatchelfHook,
+  cups,
+}:
+
+stdenv.mkDerivation {
+  pname = "munbyn-itpp941-cups";
+  # This was the first file packaged for NixOS, I'm not sure what the actual driver version is.
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://filedn.com/lN6To1twXYMYeSDMQm2JQWV/ITPP941/01-Driver/Munbyn_Driver_Ubuntu_Install.run";
+    hash = "sha256-qibdUgT0VOWnW7bMSriI89hrRYigjL+jTgr+2vp/6j0=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [ cups ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    tail +9 $src > src.tar.gz
+    tar zxf src.tar.gz
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/cups/filter/Munbyn/Filter
+    cp -rf Munbyn_Driver_Ubuntu/Munbyn/Filter/rastertolabel $out/lib/cups/filter/Munbyn/Filter
+
+    mkdir -p $out/share/cups/model
+    cp Munbyn_Driver_Ubuntu/Munbyn/PPDs/Munbyn_Label_Printer.ppd $out/share/cups/model
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "CUPS Linux drivers for MUNBYN ITPP941 Label Printer (203 DPI version)";
+    downloadPage = "https://munbyn.com/products/thermal-shipping-label-printer";
+    homepage = "https://munbyn.com/products/thermal-shipping-label-printer";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ChocolateLoverRaj ];
+    license = licenses.unfree;
+  };
+}


### PR DESCRIPTION
I contacted Munbyn to ask:
- Driver license
- Driver version
- Driver source code if possible
They said no to everything because they abandoned their Linux driver. But it still works so it's useful.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
