### PR TITLE
cue: run tests correctly

### DIFF
--- a/pkgs/by-name/cu/cue/package.nix
+++ b/pkgs/by-name/cu/cue/package.nix
@@ -38,17 +38,21 @@ buildGoModule (finalAttrs: {
       --zsh <($out/bin/cue completion zsh)
   '';
 
-  passthru = {
-    writeCueValidator = callPackage ./validator.nix { };
-    tests = {
-      test-001-all-good = callPackage ./tests/001-all-good.nix { };
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "cue version";
-        version = "v${finalAttrs.version}";
+  passthru =
+    let
+      cue = finalAttrs.finalPackage;
+    in
+    {
+      writeCueValidator = callPackage ./validator.nix { inherit cue; };
+      tests = {
+        test-001-all-good = callPackage ./tests/001-all-good.nix { inherit cue; };
+        version = testers.testVersion {
+          package = cue;
+          command = "cue version";
+          version = "v${finalAttrs.version}";
+        };
       };
     };
-  };
 
   meta = {
     description = "Data constraint language which aims to simplify tasks involving defining and using data";

--- a/pkgs/by-name/cu/cue/package.nix
+++ b/pkgs/by-name/cu/cue/package.nix
@@ -5,6 +5,7 @@
   stdenv,
   installShellFiles,
   testers,
+  tests,
   callPackage,
 }:
 
@@ -41,10 +42,16 @@ buildGoModule (finalAttrs: {
   passthru =
     let
       cue = finalAttrs.finalPackage;
+      writeCueValidator = callPackage ./validator.nix { inherit cue; };
     in
     {
-      writeCueValidator = callPackage ./validator.nix { inherit cue; };
+      inherit writeCueValidator;
+
       tests = {
+        validation = tests.cue-validation.override {
+          callPackage = (path: attrs: callPackage path (attrs // { inherit writeCueValidator; }));
+        };
+
         test-001-all-good = callPackage ./tests/001-all-good.nix { inherit cue; };
         version = testers.testVersion {
           package = cue;


### PR DESCRIPTION
- **cue.passthru: ensure all attrs use final overriden package**
- **cue: add tests.cue-validation to tests**

See #430141 and #431813 for context.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
