### PR TITLE
github-linguist: fix gem extension build warnings

### DIFF
--- a/pkgs/by-name/gi/github-linguist/package.nix
+++ b/pkgs/by-name/gi/github-linguist/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   buildRubyGem,
   bundlerEnv,
-  ruby,
+  ruby_3_4,
 }:
 
 let
@@ -21,12 +21,20 @@ let
     gemfile = "${src}/Gemfile";
     lockfile = ./Gemfile.lock;
     gemset = ./gemset.nix;
+    inherit ruby;
   };
+
+  ruby = ruby_3_4;
 
 in
 buildRubyGem rec {
   name = "${gemName}-${version}";
-  inherit gemName version src;
+  inherit
+    gemName
+    version
+    src
+    ruby
+    ;
 
   doInstallCheck = true;
   dontBuild = false;


### PR DESCRIPTION
Let `github-linguist` use Ruby 3.4, in order to fix #425375.

See also #416427 and #400243.

No breaking changes. `version` and `Gemfile.lock` & `gemset.nix` will be preserved.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
