### PR TITLE
pythonPackages.pytest-ansible: 25.5.0 -> 25.6.3, pythonPackages.pytest-plus: init at 0.8.1

### DIFF
--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -8,6 +8,9 @@
   fetchFromGitHub,
   packaging,
   pytest,
+  pytest-plus,
+  pytest-sugar,
+  pytest-xdist,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -16,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-ansible";
-  version = "25.5.0";
+  version = "25.6.3";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -25,7 +28,7 @@ buildPythonPackage rec {
     owner = "ansible";
     repo = "pytest-ansible";
     tag = "v${version}";
-    hash = "sha256-k6JFaB5VbUCwknN8SkNotdPRvSvW1tFmTx5p3hGfesg=";
+    hash = "sha256-NOvVzZCqbPbzbDgrs94qgS82c+8U+ysyH/LdQRsawt4=";
   };
 
   postPatch = ''
@@ -44,6 +47,9 @@ buildPythonPackage rec {
     ansible-core
     ansible-compat
     packaging
+    pytest-plus
+    pytest-sugar
+    pytest-xdist
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
@@ -55,6 +61,8 @@ buildPythonPackage rec {
   enabledTestPaths = [ "tests/" ];
 
   disabledTests = [
+    # pytest unrecognized arguments in test_pool.py
+    "test_ansible_test"
     # Host unreachable in the inventory
     "test_become"
     # [Errno -3] Temporary failure in name resolution

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -97,6 +97,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/jlaska/pytest-ansible";
     changelog = "https://github.com/ansible-community/pytest-ansible/releases/tag/${src.tag}";
     license = licenses.mit;
-    maintainers = with maintainers; [ tjni ];
+    maintainers = with maintainers; [
+      tjni
+      robsliwi
+    ];
   };
 }

--- a/pkgs/development/python-modules/pytest-plus/default.nix
+++ b/pkgs/development/python-modules/pytest-plus/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-plus";
+  version = "0.8.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "pytest-dev";
+    repo = "pytest-plus";
+    tag = "v${version}";
+    hash = "sha256-XlEtekOASIjZretTbQAf0eyQN6qZ9c6zI1ESss/hxfI=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  enabledTestPaths = [ "test/" ];
+
+  pythonImportsCheck = [ "pytest_plus" ];
+
+  meta = with lib; {
+    description = "pytest-plus adds new features to pytest";
+    homepage = "https://github.com/pytest-dev/pytest-plus";
+    changelog = "https://github.com/pytest-dev/pytest-plus/releases/tag/${src.tag}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ robsliwi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14299,6 +14299,8 @@ self: super: with self; {
 
   pytest-plt = callPackage ../development/python-modules/pytest-plt { };
 
+  pytest-plus = callPackage ../development/python-modules/pytest-plus { };
+
   pytest-pook = callPackage ../development/python-modules/pytest-pook { };
 
   pytest-postgresql = callPackage ../development/python-modules/pytest-postgresql { };


### PR DESCRIPTION
Release notes for `pytest-ansible`: https://github.com/ansible/pytest-ansible/releases/tag/v25.6.3
Release notes for `pytest-plus`: https://github.com/pytest-dev/pytest-plus/releases/tag/v0.8.1

This change reduces build failures for newer `ansible-core` versions as seen in https://github.com/NixOS/nixpkgs/pull/428656
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
