### PR TITLE
e2fsprogs: move scripts to separate output

### DIFF
--- a/pkgs/by-name/e2/e2fsprogs/package.nix
+++ b/pkgs/by-name/e2/e2fsprogs/package.nix
@@ -13,11 +13,15 @@
   e2fsprogs,
   runCommand,
   libarchive,
+  bash,
+  bashNonInteractive,
 }:
 
 stdenv.mkDerivation rec {
   pname = "e2fsprogs";
   version = "1.47.3";
+
+  __structuredAttrs = true;
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/people/tytso/e2fsprogs/v${version}/e2fsprogs-${version}.tar.xz";
@@ -31,8 +35,11 @@ stdenv.mkDerivation rec {
     "out"
     "man"
     "info"
+    "scripts"
   ]
   ++ lib.optionals withFuse [ "fuse2fs" ];
+
+  strictDeps = true;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [
@@ -43,6 +50,7 @@ stdenv.mkDerivation rec {
     libuuid
     gettext
     libarchive
+    bash
   ]
   ++ lib.optionals withFuse [ fuse3 ];
 
@@ -75,6 +83,11 @@ stdenv.mkDerivation rec {
     if [ -f $out/lib/${pname}/e2scrub_all_cron ]; then
       mv $out/lib/${pname}/e2scrub_all_cron $bin/bin/
     fi
+
+    moveToOutput bin/mk_cmds "$scripts"
+    moveToOutput bin/compile_et "$scripts"
+    moveToOutput sbin/e2scrub "$scripts"
+    moveToOutput sbin/e2scrub_all "$scripts"
   ''
   + lib.optionalString withFuse ''
     mkdir -p $fuse2fs/bin
@@ -82,6 +95,17 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  outputChecks = {
+    bin.disallowedRequisites = [
+      bash
+      bashNonInteractive
+    ];
+    out.disallowedRequisites = [
+      bash
+      bashNonInteractive
+    ];
+  };
 
   passthru.tests = {
     simple-filesystem = runCommand "e2fsprogs-create-fs" { } ''


### PR DESCRIPTION
This enables us to use the bin and out output without pulling in bash.

- Enable structuredAttrs
- Enable strictDeps
- Add bash to disallowedRequisites

Part of https://github.com/NixOS/nixpkgs/issues/428908

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
