### PR TITLE
linux: allow extraMakeFlags to have arguments with spaces

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -201,11 +201,9 @@ let
         kernelBaseConfig =
           if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig;
 
-        makeFlags =
-          lib.optionals (
-            stdenv.hostPlatform.linux-kernel ? makeFlags
-          ) stdenv.hostPlatform.linux-kernel.makeFlags
-          ++ extraMakeFlags;
+        makeFlags = lib.optionals (
+          stdenv.hostPlatform.linux-kernel ? makeFlags
+        ) stdenv.hostPlatform.linux-kernel.makeFlags;
 
         postPatch = kernel.postPatch + ''
           # Patch kconfig to print "###" after every question so that
@@ -216,6 +214,8 @@ let
         preUnpack = kernel.preUnpack or "";
 
         inherit (kernel) src patches;
+
+        preConfigure = lib.concatStringsSep "\n" (map (flag: "makeFlagsArray+=(${flag})") extraMakeFlags);
 
         buildPhase = ''
           export buildRoot="''${buildRoot:-build}"

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -290,8 +290,12 @@ lib.makeOverridable (
           unset src
         '';
 
+        preConfigure = lib.concatStringsSep "\n" (map (flag: "makeFlagsArray+=(${flag})") extraMakeFlags);
+
         configurePhase = ''
           runHook preConfigure
+
+          # makeFlagsArray+=($extraMakeFlags)
 
           mkdir build
           export buildRoot="$(pwd)/build"
@@ -321,6 +325,8 @@ lib.makeOverridable (
           cd $buildRoot
         '';
 
+        preBuild = lib.concatStringsSep "\n" (map (flag: "buildFlagsArray+=(${flag})") extraMakeFlags);
+
         buildFlags = [
           "KBUILD_BUILD_VERSION=1-NixOS"
           kernelConf.target
@@ -330,8 +336,7 @@ lib.makeOverridable (
         ++ optionals buildDTBs [
           "dtbs"
           "DTC_FLAGS=-@"
-        ]
-        ++ extraMakeFlags;
+        ];
 
         installFlags = [
           "INSTALL_PATH=$(out)"
@@ -543,8 +548,7 @@ lib.makeOverridable (
       # https://github.com/NixOS/nixpkgs/issues/321667
       "LD=${stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ld"
     ]
-    ++ (stdenv.hostPlatform.linux-kernel.makeFlags or [ ])
-    ++ extraMakeFlags;
+    ++ (stdenv.hostPlatform.linux-kernel.makeFlags or [ ]);
   in
 
   stdenv.mkDerivation (


### PR DESCRIPTION
This modifies the processing of `extraMakeFlags` to allow using spaces.  For instance, you can now do:
```nix
pkgs.linux_6_16.override {
  extraMakeFlags = [
    "KCFLAGS=\"-march=znver3 -mtune=znver3\""
    "KCPPFLAGS=\"-march=znver3 -mtune=znver3\""
  ];
}
```

I'm not totally sure, but it may be possible this could break existing configurations if they rely on the flags not handling spaces.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
