### PR TITLE
tilinggallery: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ti/tilinggallery/package.nix
+++ b/pkgs/by-name/ti/tilinggallery/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  fontconfig,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tiling-gallery";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "roothch";
+    repo = "TilingGallery";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-k6AHNvizXitrdY/K13B/eVBCvdmfVou7Zv3tslHA4T8=";
+  };
+
+  cargoHash = "sha256-xr+gVDaxGtu7U/HaJoFXzNztvp+LNYAGuMqKA9QyXHg=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ fontconfig ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI tool for generating aperiodic tilings";
+    longDescription = ''
+      Tiling Gallery is a Rust-based CLI tool for generating SVG
+      images of two types of aperiodic tilings:
+
+      - Penrose tiling using the De Bruijn pentagrid method Pinwheel
+
+      - tiling with recursive triangle subdivision
+
+      This project is ideal for generating mathematical and artistic
+      patterns based on non-periodic tilings.
+    '';
+    homepage = "https://github.com/roothch/TilingGallery";
+    changelog = "https://github.com/roothch/TilingGallery/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "tiling-gallery";
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
