### PR TITLE
musializer: init at alpha2

### DIFF
--- a/pkgs/by-name/mu/musializer/package.nix
+++ b/pkgs/by-name/mu/musializer/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  libX11,
+  libXcursor,
+  libXrandr,
+  libXinerama,
+  libXi,
+  libGL,
+  ffmpeg,
+  nix-update-script,
+}:
+
+let
+  xorgDeps = [
+    libX11
+    libXcursor
+    libXrandr
+    libXinerama
+    libXi
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "musializer";
+  version = "2";
+
+  src = fetchFromGitHub {
+    owner = "tsoding";
+    repo = "musializer";
+    tag = "alpha${finalAttrs.version}";
+    hash = "sha256-EKmdv1gVrsajyjFnV6hngGnct4NAZ5SwtPHA43VZDlI=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/{plug.c,musializer.c} \
+      --replace-fail './resources' "$out/share"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  buildInputs = xorgDeps;
+
+  propagatedUserEnvPkgs = [ ffmpeg ];
+
+  env.NIX_CFLAGS_COMPILE = "-D_GNU_SOURCE"; # Ensure `ppoll` is available
+
+  configurePhase = ''
+    runHook preConfigure
+
+    $CC --output nob nob.c
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./nob
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 build/musializer -t $out/bin
+    wrapProgram $out/bin/musializer \
+      --suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath (xorgDeps ++ [ libGL ])} \
+      --suffix PATH : ${lib.makeBinPath finalAttrs.propagatedUserEnvPkgs}
+
+    cp --recursive resources $out/share
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Music Visualizer";
+    longDescription = ''
+      The project aims to make a tool for creating beautiful music
+      visualizations and rendering high quality videos of them.
+    '';
+    homepage = "https://github.com/tsoding/musializer";
+    changelog = "https://github.com/tsoding/musializer/blob/${finalAttrs.src.tag}/CHANGELOG.txt";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "musializer";
+    platforms = lib.platforms.all;
+    badPlatforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
