### PR TITLE
mesen: don't use absolute path for Exec in generated .desktop files

### DIFF
--- a/pkgs/by-name/me/mesen/desktop-make-non-absolute-exec.patch
+++ b/pkgs/by-name/me/mesen/desktop-make-non-absolute-exec.patch
@@ -1,0 +1,13 @@
+diff --git a/UI/Config/FileAssociationHelper.cs b/UI/Config/FileAssociationHelper.cs
+index bcd40ce..4965c7a 100644
+--- a/UI/Config/FileAssociationHelper.cs
++++ b/UI/Config/FileAssociationHelper.cs
+@@ -152,7 +152,7 @@ namespace Mesen.Config
+ 				"Comment=Emulator" + Environment.NewLine +
+ 				"Keywords=game;emulator;emu" + Environment.NewLine +
+ 				"Categories=GNOME;GTK;Game;Emulator;" + Environment.NewLine +
+-				"Exec=" + mainModule.FileName + " %f" + Environment.NewLine +
++				"Exec=" + "Mesen" + " %f" + Environment.NewLine +
+ 				"NoDisplay=false" + Environment.NewLine +
+ 				"StartupNotify=true" + Environment.NewLine +
+ 				"Icon=MesenIcon" + Environment.NewLine;

--- a/pkgs/by-name/me/mesen/package.nix
+++ b/pkgs/by-name/me/mesen/package.nix
@@ -26,6 +26,8 @@ buildDotnetModule rec {
     ./dont-use-nightly-avalonia.patch
     # upstream has a weird library loading mechanism, which we override with a more sane alternative
     ./dont-zip-libraries.patch
+    # without this the generated .desktop file uses an absolute (and incorrect) path for the binary
+    ./desktop-make-non-absolute-exec.patch
   ];
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/431957

There are two generated `.desktop` files that are now generated differently:
`~/Desktop/mesen.desktop` (the file created with the setup wizard)
`~/.local/share/applications/mesen.desktop` (the file that is modified if you change the file associations toggles in the preferences) (this file is used by app launchers / menus)

Unfortunately, these files don't get regenerated after this PR, so you have to edit/delete them manually...

(Ideally I'd patch every runtime filegen related thing out of the app and do it during build time, but that's much more complicated)
 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
