### PR TITLE
catppuccin-sddm: 1.1.0 -> 1.1.2

### DIFF
--- a/pkgs/by-name/ca/catppuccin-sddm/package.nix
+++ b/pkgs/by-name/ca/catppuccin-sddm/package.nix
@@ -2,34 +2,45 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  bash,
   just,
+  catppuccin-whiskers,
   kdePackages,
   flavor ? "mocha",
+  accent ? "mauve",
   font ? "Noto Sans",
   fontSize ? "9",
   background ? null,
   loginBackground ? false,
+  userIcon ? false,
+  clockEnabled ? true,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "catppuccin-sddm";
-  version = "1.1.0";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "catppuccin";
     repo = "sddm";
-    rev = "v${version}";
-    hash = "sha256-mDOiIGcpIvl4d3Dtsb2AX/1OggFEJ+hAjCd2LH7lqv0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7S0DKyb+4lP+5HCPAJRw/KDls2ZO9kksdlwYSz2uQC8=";
   };
 
   dontWrapQtApps = true;
 
   nativeBuildInputs = [
     just
+    catppuccin-whiskers
   ];
 
   propagatedBuildInputs = [
     kdePackages.qtsvg
   ];
+
+  postPatch = ''
+    substituteInPlace justfile \
+      --replace-fail '#!/usr/bin/env bash' '#!${lib.getExe bash}'
+  '';
 
   buildPhase = ''
     runHook preBuild
@@ -43,9 +54,9 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
 
     mkdir -p "$out/share/sddm/themes/"
-    cp -r dist/catppuccin-${flavor} "$out/share/sddm/themes/catppuccin-${flavor}"
+    cp -r themes/catppuccin-${flavor}-${accent} "$out/share/sddm/themes/catppuccin-${flavor}-${accent}"
 
-    configFile=$out/share/sddm/themes/catppuccin-${flavor}/theme.conf
+    configFile=$out/share/sddm/themes/catppuccin-${flavor}-${accent}/theme.conf
 
     substituteInPlace $configFile \
       --replace-fail 'Font="Noto Sans"' 'Font="${font}"' \
@@ -62,6 +73,16 @@ stdenvNoCC.mkDerivation rec {
         --replace-fail 'LoginBackground="false"' 'LoginBackground="true"'
     ''}
 
+    ${lib.optionalString userIcon ''
+      substituteInPlace $configFile \
+        --replace-fail 'UserIcon="false"' 'UserIcon="true"'
+    ''}
+
+    ${lib.optionalString (!clockEnabled) ''
+      substituteInPlace $configFile \
+        --replace-fail 'ClockEnabled="true"' 'ClockEnabled="false"'
+    ''}
+
     runHook postInstall
   '';
 
@@ -74,6 +95,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Soothing pastel theme for SDDM";
     homepage = "https://github.com/catppuccin/sddm";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gipphe ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/catppuccin/sddm/releases/tag/v1.1.2
Diff: https://github.com/catppuccin/sddm/compare/v1.1.0...v1.1.2

Adds support for `catppuccin-whiskers`-backed accent colors.

Also adds support for enabling and disabling user icon and clock in the theme.

I am replacing ElysaSrc as the maintainer of this package as they have deleted their GitHub account. I am unsure exactly how the procedure for losing maintainer status is applied when we cannot add them as a reviewer, as prescribed in [the maintainers README](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#how-to-lose-maintainer-status). Removal of their maintainer status is handled in https://github.com/NixOS/nixpkgs/pull/439016, which currently blocks this PR.

Depends on https://github.com/NixOS/nixpkgs/pull/439016

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
