### PR TITLE
openwebrx: migrate to by-name

### DIFF
--- a/pkgs/by-name/op/openwebrx/package.nix
+++ b/pkgs/by-name/op/openwebrx/package.nix
@@ -1,19 +1,15 @@
 {
   stdenv,
   lib,
-  buildPythonPackage,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
   pkg-config,
   cmake,
-  setuptools,
   libsamplerate,
   fftwFloat,
   rtl-sdr,
   soapysdr-with-plugins,
   csdr,
-  pycsdr,
-  pydigiham,
   direwolf,
   sox,
   wsjtx,
@@ -22,16 +18,16 @@
 
 let
 
-  js8py = buildPythonPackage rec {
+  js8py = python3Packages.buildPythonPackage rec {
     pname = "js8py";
     version = "0.1.1";
     format = "setuptools";
 
     src = fetchFromGitHub {
       owner = "jketterl";
-      repo = pname;
-      rev = version;
-      sha256 = "1j80zclg1cl5clqd00qqa16prz7cyc32bvxqz2mh540cirygq24w";
+      repo = "js8py";
+      tag = version;
+      hash = "sha256-nAj8fI4MkAKr+LjvJQbz7Px8TVAYA9AwZYWy8Cj7AMk=";
     };
 
     pythonImportsCheck = [
@@ -39,11 +35,11 @@ let
       "test"
     ];
 
-    meta = with lib; {
+    meta = {
       homepage = "https://github.com/jketterl/js8py";
       description = "Library to decode the output of the js8 binary of JS8Call";
-      license = licenses.gpl3Only;
-      teams = [ teams.c3d2 ];
+      license = lib.licenses.gpl3Only;
+      teams = with lib.teams; [ c3d2 ];
     };
   };
 
@@ -53,9 +49,9 @@ let
 
     src = fetchFromGitHub {
       owner = "jketterl";
-      repo = pname;
-      rev = version;
-      sha256 = "sha256-1H0TJ8QN3b6Lof5TWvyokhCeN+dN7ITwzRvEo2X8OWc=";
+      repo = "owrx_connector";
+      tag = version;
+      hash = "sha256-1H0TJ8QN3b6Lof5TWvyokhCeN+dN7ITwzRvEo2X8OWc=";
     };
 
     nativeBuildInputs = [
@@ -71,41 +67,45 @@ let
       soapysdr-with-plugins
     ];
 
-    meta = with lib; {
+    meta = {
       homepage = "https://github.com/jketterl/owrx_connector";
       description = "Set of connectors that are used by OpenWebRX to interface with SDR hardware";
-      license = licenses.gpl3Only;
-      platforms = platforms.unix;
-      teams = [ teams.c3d2 ];
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.unix;
+      teams = with lib.teams; [ c3d2 ];
     };
   };
 
 in
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "openwebrx";
   version = "1.2.2";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "jketterl";
-    repo = pname;
-    rev = version;
+    repo = "openwebrx";
+    tag = version;
     hash = "sha256-i3Znp5Sxs/KtJazHh2v9/2P+3cEocWB5wIpF7E4pK9s=";
   };
 
-  propagatedBuildInputs = [
-    setuptools
-    csdr
-    pycsdr
-    pydigiham
-    js8py
-    soapysdr-with-plugins
-    owrx_connector
-    direwolf
-    sox
-    wsjtx
-    codecserver
-  ];
+  dependencies =
+    with python3Packages;
+    [
+      setuptools
+      csdr
+      pycsdr
+      pydigiham
+    ]
+    ++ [
+      js8py
+      soapysdr-with-plugins
+      owrx_connector
+      direwolf
+      sox
+      wsjtx
+      codecserver
+    ];
 
   pythonImportsCheck = [
     "csdr"
@@ -117,11 +117,11 @@ buildPythonApplication rec {
     inherit js8py owrx_connector;
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/jketterl/openwebrx";
     description = "Simple DSP library and command-line tool for Software Defined Radio";
     mainProgram = "openwebrx";
-    license = licenses.gpl3Only;
-    teams = [ teams.c3d2 ];
+    license = lib.licenses.gpl3Only;
+    teams = with lib.teams; [ c3d2 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9015,16 +9015,6 @@ with pkgs;
     openssl_3_5
     ;
 
-  openwebrx = callPackage ../applications/radio/openwebrx {
-    inherit (python3Packages)
-      buildPythonPackage
-      buildPythonApplication
-      setuptools
-      pycsdr
-      pydigiham
-      ;
-  };
-
   pcre = callPackage ../development/libraries/pcre { };
   # pcre32 seems unused
   pcre-cpp = res.pcre.override { variant = "cpp"; };


### PR DESCRIPTION
openwebrx: refactor package definitions
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
