### PR TITLE
nixos/matrix-conduit: add secretFile option

### DIFF
--- a/nixos/modules/services/matrix/conduit.nix
+++ b/nixos/modules/services/matrix/conduit.nix
@@ -11,7 +11,10 @@ let
   configFile = format.generate "conduit.toml" cfg.settings;
 in
 {
-  meta.maintainers = with lib.maintainers; [ pstn ];
+  meta.maintainers = with lib.maintainers; [
+    pstn
+    SchweGELBin
+  ];
   options.services.matrix-conduit = {
     enable = lib.mkEnableOption "matrix-conduit";
 

--- a/nixos/modules/services/matrix/conduit.nix
+++ b/nixos/modules/services/matrix/conduit.nix
@@ -26,6 +26,22 @@ in
 
     package = lib.mkPackageOption pkgs "matrix-conduit" { };
 
+    secretFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/matrix-conduit.env";
+      description = ''
+        Path to file containing sensitive environment variables.
+        Some variables that can be considered secrets are:
+
+        - CONDUIT_JWT_SECRET:
+          The secret used in the JWT to enable JWT login without it a 400 error will be returned
+
+        - CONDUIT_TURN_SECRET:
+          The TURN secret
+      '';
+    };
+
     settings = lib.mkOption {
       type = lib.types.submodule {
         freeformType = format.type;
@@ -112,6 +128,7 @@ in
         <https://docs.conduit.rs/configuration.html>
         for details on supported values.
         Note that database_path can not be edited because the service's reliance on systemd StateDir.
+        For secrets use secretFile option instead.
       '';
     };
   };
@@ -158,6 +175,9 @@ in
         Restart = "on-failure";
         RestartSec = 10;
         UMask = "077";
+      }
+      // lib.optionalAttrs (cfg.secretFile != null) {
+        EnvironmentFile = cfg.secretFile;
       };
       unitConfig = {
         StartLimitBurst = 5;

--- a/nixos/modules/services/matrix/conduit.nix
+++ b/nixos/modules/services/matrix/conduit.nix
@@ -34,11 +34,11 @@ in
       default = null;
       example = "/run/secrets/matrix-conduit.env";
       description = ''
-        Path to file containing sensitive environment variables.
+        Path to a file containing sensitive environment as described in {manpage}`systemd.exec(5).
         Some variables that can be considered secrets are:
 
         - CONDUIT_JWT_SECRET:
-          The secret used in the JWT to enable JWT login without it a 400 error will be returned
+          The secret used to enable JWT login. Without it a 400 error will be returned.
 
         - CONDUIT_TURN_SECRET:
           The TURN secret
@@ -131,7 +131,7 @@ in
         <https://docs.conduit.rs/configuration.html>
         for details on supported values.
         Note that database_path can not be edited because the service's reliance on systemd StateDir.
-        For secrets use secretFile option instead.
+        For secrets use the `secretFile` option instead.
       '';
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Conduit doesn't support setting secret files in their settings, but they allow setting environment variables.
To not save the secrets like the turn secret in plain text, I've added a secretFile option, where you can pass a path to the secret file containing all the necessary environment variables.

I've also added myself as a maintainer.
I'm using it in my server and didn't experience any problems.

Have a great day!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
