### PR TITLE
git: packaging cleanup

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -96,8 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
   separateDebugInfo = true;
   __structuredAttrs = true;
 
-  hardeningDisable = [ "format" ];
-
   enableParallelBuilding = true;
   enableParallelInstalling = true;
 

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -103,7 +103,6 @@ stdenv.mkDerivation (finalAttrs: {
     ./docbook2texi.patch
     ./git-sh-i18n.patch
     ./git-send-email-honor-PATH.patch
-    ./installCheck-path.patch
   ]
   ++ lib.optionals withSsh [
     ./ssh-path.patch
@@ -474,9 +473,6 @@ stdenv.mkDerivation (finalAttrs: {
     disable_test t1301-shared-repo
     # /build/git-2.44.0/contrib/completion/git-completion.bash: line 452: compgen: command not found
     disable_test t9902-completion
-
-    # Our patched gettext never fallbacks
-    disable_test t0201-gettext-fallbacks
   ''
   + lib.optionalString (!sendEmailSupport) ''
     # Disable sendmail tests

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -100,11 +100,19 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelInstalling = true;
 
   patches = [
+    # This patch does two things: (1) use the right name for `docbook2texi',
+    # and (2) make sure `gitman.info' isn't produced since it's broken
+    # (duplicate node names).
     ./docbook2texi.patch
+    # Fix references to gettext.sh at runtime: hard-code it to
+    # ${pkgs.gettext}/bin/gettext.sh instead of assuming gettext.sh is in $PATH
     ./git-sh-i18n.patch
+    # Do not search for sendmail in /usr, only in $PATH
     ./git-send-email-honor-PATH.patch
   ]
   ++ lib.optionals withSsh [
+    # Hard-code the ssh executable to ${pkgs.openssh}/bin/ssh instead of
+    # searching in $PATH
     ./ssh-path.patch
   ];
 


### PR DESCRIPTION
Shave some yaks in the git package. Mostly removes outdated workarounds and adds some comments.

- **git: re-enable "format" hardening**
- **git: re-enable a test and remove unneded patch**
- **git: add comments for patches**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
