### PR TITLE
nixos/mautrix-whatsapp: revert setting keys/secrets to "" from `generate`

### DIFF
--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -50,13 +50,6 @@ let
       servers = { };
       secrets = { };
     };
-    # By default, the following keys/secrets are set to `generate`. This would break when the service
-    # is restarted, since the previously generated configuration will be overwritten everytime.
-    # If encryption is enabled, it's recommended to set those keys via `environmentFile`.
-    encryption.pickle_key = "";
-    provisioning.shared_secret = "";
-    public_media.signing_key = "";
-    direct_media.server_key = "";
     logging = {
       min_level = "info";
       writers = lib.singleton {

--- a/nixos/modules/services/matrix/mautrix-whatsapp.nix
+++ b/nixos/modules/services/matrix/mautrix-whatsapp.nix
@@ -267,6 +267,7 @@ in
     maintainers = with lib.maintainers; [
       pentane
       frederictobiasc
+      SchweGELBin
     ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The following commit broke this module for me: 65a1a7985a7024cce00cf77a688a9f08184f92b5 #420722
It replaced the keys/secrets from generate to "".
I don't have any issues leaving those at generate and setting those to an empty string throws an error that the var isn't set.

In my opinion the keys/secrets should be "generate" at default and a user can change them if they want to.
The documentation and example can stay as I only want the default value to be reverted.

> This would break when the service is restarted

The coment above doesn't apply for me either. The module never broke, no matter how many times I restarted the service.

I've tested it on my server and the bridge works again.
I've also added myself as a maintainer.

Have a great day!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
