### PR TITLE
spirv-llvm-translator: update all versions, support LLVM 20 and 21

### DIFF
--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -49,9 +49,9 @@ let
       hash = "sha256-30i73tGl+1KlP92XA0uxdMTydd9EtaQ4SZ0W1kdm1fQ=";
     };
     "15" = rec {
-      version = "15.0.13";
+      version = "15.0.15";
       rev = "v${version}";
-      hash = "sha256-RnGbBHUUGjIBcakQJO4nAm3/oIrQ8nkx+BC8Evw6Jmc=";
+      hash = "sha256-kFVDS+qwoG1AXrZ8LytoiLVbZkTGR9sO+Wrq3VGgWNQ=";
     };
     "14" = {
       version = "14.0.11+unstable-2025-01-28";

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -44,9 +44,9 @@ let
       hash = "sha256-ETpTQYMMApECDfuRY87HrO/PUxZ13x9dBRJ3ychslUI=";
     };
     "16" = rec {
-      version = "16.0.11";
+      version = "16.0.15";
       rev = "v${version}";
-      hash = "sha256-PI4cT/PGqpaF5SysOTrEE4D+OcIUsIOMzww4CRPtwBQ=";
+      hash = "sha256-30i73tGl+1KlP92XA0uxdMTydd9EtaQ4SZ0W1kdm1fQ=";
     };
     "15" = rec {
       version = "15.0.13";

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -34,9 +34,9 @@ let
       hash = "sha256-VgA47AGMnOKYNeW95nxJZzmKnYK8D/9okgssPnPqXXI=";
     };
     "18" = rec {
-      version = "18.1.11";
+      version = "18.1.15";
       rev = "v${version}";
-      hash = "sha256-VoALyFqShKL3bpeoOIdKoseNfDWiRE+j0ppHapXOmEU=";
+      hash = "sha256-rt3RTZut41uDEh0YmpOzH3sOezeEVWtAIGMKCHLSJBw=";
     };
     "17" = rec {
       version = "17.0.11";

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -39,9 +39,9 @@ let
       hash = "sha256-rt3RTZut41uDEh0YmpOzH3sOezeEVWtAIGMKCHLSJBw=";
     };
     "17" = rec {
-      version = "17.0.11";
+      version = "17.0.15";
       rev = "v${version}";
-      hash = "sha256-Ba4GZS7Rc93Fphj2xaBZ3AqwXvxB9UU0gzPNoDEoaQM=";
+      hash = "sha256-ETpTQYMMApECDfuRY87HrO/PUxZ13x9dBRJ3ychslUI=";
     };
     "16" = rec {
       version = "16.0.11";

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -29,9 +29,9 @@ let
       hash = "sha256-GdlC/Vl61nTNdua2s+CW2YOvkSKK6MNOvBc/393iths=";
     };
     "19" = rec {
-      version = "19.1.6";
+      version = "19.1.10";
       rev = "v${version}";
-      hash = "sha256-mUvDF5y+cBnqUaHjyiiE8cJGH5MfQMqGFy6bYv9vCVY=";
+      hash = "sha256-VgA47AGMnOKYNeW95nxJZzmKnYK8D/9okgssPnPqXXI=";
     };
     "18" = rec {
       version = "18.1.11";

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -53,10 +53,10 @@ let
       rev = "v${version}";
       hash = "sha256-kFVDS+qwoG1AXrZ8LytoiLVbZkTGR9sO+Wrq3VGgWNQ=";
     };
-    "14" = {
-      version = "14.0.11+unstable-2025-01-28";
-      rev = "9df26b6af308cb834a4013deb8094f386f29accd";
-      hash = "sha256-8VRQwXFbLcYgHtWKs73yuTsy2kkCgYgPqD+W/GPy1BM=";
+    "14" = rec {
+      version = "14.0.14";
+      rev = "v${version}";
+      hash = "sha256-PW+5w93omLYPZXjRtU4BNY2ztZ86pcjgUQZkrktMq+4=";
     };
   };
 

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -23,6 +23,11 @@ let
       rev = "v${version}";
       hash = "sha256-kk8BbPl/UBW1gaO/cuOQ9OsiNTEk0TkvRDLKUAh6exk=";
     };
+    "20" = rec {
+      version = "20.1.5";
+      rev = "v${version}";
+      hash = "sha256-GdlC/Vl61nTNdua2s+CW2YOvkSKK6MNOvBc/393iths=";
+    };
     "19" = rec {
       version = "19.1.6";
       rev = "v${version}";

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -18,6 +18,11 @@ let
 
   # ROCm, if actively updated will always be at the latest version
   versions = {
+    "21" = rec {
+      version = "21.1.0";
+      rev = "v${version}";
+      hash = "sha256-kk8BbPl/UBW1gaO/cuOQ9OsiNTEk0TkvRDLKUAh6exk=";
+    };
     "19" = rec {
       version = "19.1.6";
       rev = "v${version}";

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -102,7 +102,9 @@ stdenv.mkDerivation {
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
     "-DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${spirv-headers.src}"
   ]
-  ++ lib.optional (llvmMajor == "19") "-DBASE_LLVM_VERSION=${lib.versions.majorMinor llvm.version}.0";
+  ++ lib.optional (
+    lib.toInt llvmMajor >= 19
+  ) "-DBASE_LLVM_VERSION=${lib.versions.majorMinor llvm.version}.0";
 
   # FIXME: CMake tries to run "/llvm-lit" which of course doesn't exist
   doCheck = false;

--- a/pkgs/by-name/sp/spirv-llvm-translator/package.nix
+++ b/pkgs/by-name/sp/spirv-llvm-translator/package.nix
@@ -133,5 +133,13 @@ stdenv.mkDerivation {
     license = licenses.ncsa;
     platforms = platforms.unix;
     maintainers = with maintainers; [ gloaming ];
+
+    # For the LLVM 21 build some commits to spirv-headers
+    # are required that didn't make it into the final release of 1.4.321
+    # For example: 9e3836d Add SPV_INTEL_function_variants
+    # Once spirv-headers are released again and updated on nixpkgs,
+    # this will switch over to the nixpkgs version and should no
+    # longer be broken.
+    broken = llvmMajor == "21" && lib.versionOlder spirv-headers.version "1.4.322";
   };
 }


### PR DESCRIPTION
Builds with LLVM 14-20 pass, 21 is currently building.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
