### PR TITLE
flytectl: init at 0.9.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16082,6 +16082,12 @@
       { fingerprint = "838A FE0D 55DC 074E 360F  943A 84B6 9CE6 F3F6 B767"; }
     ];
   };
+  mcuste = {
+    email = "github@muratcanuste.com";
+    github = "mcuste";
+    githubId = 10829864;
+    name = "Murat Can Üste";
+  };
   mcwitt = {
     email = "mcwitt@gmail.com";
     github = "mcwitt";

--- a/pkgs/by-name/fl/flytectl/package.nix
+++ b/pkgs/by-name/fl/flytectl/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+  testers,
+  flytectl,
+}:
+buildGoModule (finalAttrs: {
+  pname = "flytectl";
+  version = "0.9.8";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "flyteorg";
+    repo = "flyte";
+    tag = "flytectl/v${finalAttrs.version}";
+    hash = "sha256-p6fU+BLvhwK+4zDNBy4jwtvIll+s4jXmpYIF1mfeoB4=";
+  };
+
+  vendorHash = "sha256-h4L8BFzRiph4SBffVRH9TU5j7k+CZGshOV160mENAL0=";
+
+  sourceRoot = "${finalAttrs.src.name}/flytectl";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/flyteorg/flyte/flytestdlib/version.Version=v${finalAttrs.version}"
+    "-X github.com/flyteorg/flyte/flytestdlib/version.Build=${finalAttrs.src.tag}"
+    "-X github.com/flyteorg/flyte/flytestdlib/version.BuildTime=1970-01-01"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # Tests require network and file system access
+  doCheck = false;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd flytectl \
+      --bash <($out/bin/flytectl completion bash) \
+      --fish <($out/bin/flytectl completion fish) \
+      --zsh <($out/bin/flytectl completion zsh)
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "flytectl version";
+    version = "v${finalAttrs.src.version}";
+  };
+
+  meta = {
+    description = "Command-line interface for Flyte, a cloud-native workflow orchestration platform";
+    downloadPage = "https://github.com/flyteorg/flyte";
+    homepage = "https://flyte.org/";
+    changelog = "https://github.com/flyteorg/flyte/releases/tag/flytectl%2Fv${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.mcuste ];
+    mainProgram = "flytectl";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
This PR adds configuration for [flytectl](https://github.com/flyteorg/flyte) tool which is a command line interface for Flyte Workflows.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
