### PR TITLE
cursor-cli: init at 0-unstable-2025-08-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1581,6 +1581,12 @@
     githubId = 587021;
     name = "André V L Matos";
   };
+  andrewbastin = {
+    email = "andrewbastin.k@gmail.com";
+    github = "AndrewBastin";
+    githubId = 9131943;
+    name = "Andrew Bastin";
+  };
   andrewchambers = {
     email = "ac@acha.ninja";
     github = "andrewchambers";

--- a/pkgs/by-name/cu/cursor-cli/package.nix
+++ b/pkgs/by-name/cu/cursor-cli/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  autoPatchelfHook,
+}:
+
+let
+  inherit (stdenv) hostPlatform;
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://downloads.cursor.com/lab/2025.08.22-82fb571/linux/x64/agent-cli-package.tar.gz";
+      hash = "sha256-jfjYWM9Vuq9sYZcnqiap3TKuVWHHKt/aF7XaVilJjsE=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://downloads.cursor.com/lab/2025.08.22-82fb571/linux/arm64/agent-cli-package.tar.gz";
+      hash = "sha256-uMK5jO77TQntsrR450WWBj9q5VBowNUhO6UkZ/z1ys4=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://downloads.cursor.com/lab/2025.08.22-82fb571/darwin/x64/agent-cli-package.tar.gz";
+      hash = "sha256-gFM+igXGdLLJXVHAou6pRTIVqsg6iPagaghBAzRcPXw=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://downloads.cursor.com/lab/2025.08.22-82fb571/darwin/arm64/agent-cli-package.tar.gz";
+      hash = "sha256-XN2QaFt/lbVHfFfdZaznRvUlMWIHq7nUbe3uptrGjN0=";
+    };
+  };
+in
+stdenv.mkDerivation {
+  pname = "cursor-cli";
+  version = "0-unstable-2025-08-22";
+
+  src = sources.${hostPlatform.system};
+
+  nativeBuildInputs = lib.optionals hostPlatform.isLinux [
+    autoPatchelfHook
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/cursor-agent
+    cp -r * $out/share/cursor-agent/
+    ln -s $out/share/cursor-agent/cursor-agent $out/bin/cursor-agent
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit sources;
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Cursor CLI";
+    homepage = "https://cursor.com/cli";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      sudosubin
+      andrewbastin
+    ];
+    platforms = builtins.attrNames sources;
+    mainProgram = "cursor-agent";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/cu/cursor-cli/update.sh
+++ b/pkgs/by-name/cu/cursor-cli/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl coreutils common-updater-scripts
+set -eu -o pipefail
+
+release=$(curl -s https://cursor.com/install | grep -oP "lab/\K[^/]+")
+
+# Check if release matches the pattern YYYY.MM.DD-{commithash}
+if [[ "$release" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[a-f0-9]+$ ]]; then
+  timestamp=$(echo "$release" | cut -d"-" -f1 | tr "." "-")
+  latestVersion="0-unstable-$timestamp"
+else
+  latestVersion="$release"
+fi
+
+currentVersion=$(nix eval --raw -f . cursor-cli.version)
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+  echo "package is up-to-date"
+  exit 0
+fi
+
+declare -A platforms=( [x86_64-linux]="linux/x64" [aarch64-linux]="linux/arm64" [x86_64-darwin]="darwin/x64" [aarch64-darwin]="darwin/arm64" )
+
+for platform in "${!platforms[@]}"; do
+  url="https://downloads.cursor.com/lab/$release/${platforms[$platform]}/agent-cli-package.tar.gz"
+  source=$(nix-prefetch-url "$url" --name "cursor-cli-$latestVersion")
+  hash=$(nix-hash --to-sri --type sha256 "$source")
+  update-source-version cursor-cli "$latestVersion" "$hash" "$url" --system="$platform" --source-key="sources.$platform" --ignore-same-version
+done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [`cursor-cli`](https://cursor.com/cli), which is currently beta stage.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
