### PR TITLE
stargz-snapshotter: init at 0.17.0

### DIFF
--- a/pkgs/by-name/st/stargz-snapshotter/package.nix
+++ b/pkgs/by-name/st/stargz-snapshotter/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "stargz-snapshotter";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "containerd";
+    repo = "stargz-snapshotter";
+    tag = "v${version}";
+    hash = "sha256-5KxmUKb06ZSrYkfc3CV4XZLtwiznvRBAZ40L15icbYo=";
+  };
+
+  sourceRoot = "${src.name}/cmd";
+
+  vendorHash = "sha256-zcUi9hIwzOuytwgVQRhlJrn8q6rjdzWv4siHxWSIh1o=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/containerd/stargz-snapshotter/version.Version=${version}"
+    "-X github.com/containerd/stargz-snapshotter/version.Revision=${src.rev}"
+  ];
+
+  subPackages = [
+    "containerd-stargz-grpc"
+    "ctr-remote"
+    "stargz-fuse-manager"
+    "stargz-store"
+    "stargz-store/helper"
+  ];
+
+  postInstall = ''
+    mv $out/bin/helper $out/bin/stargz-store-helper
+  '';
+
+  meta = {
+    description = "Fast container image distribution plugin with lazy pulling.";
+    longDescription = ''
+      Stargz Snapshotter is a containerd snapshotter plugin which enables
+      lazy pulling of container images. It allows containers to launch
+      faster because the snapshotter can start containers before completing
+      the image pull.
+    '';
+    homepage = "https://github.com/containerd/stargz-snapshotter";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ malt3 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "containerd-stargz-grpc";
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
