### PR TITLE
ninja: remove impure dependency on /bin/sh

### DIFF
--- a/pkgs/by-name/ni/ninja/0001-spawn-sh-instead-of-bin-sh.patch
+++ b/pkgs/by-name/ni/ninja/0001-spawn-sh-instead-of-bin-sh.patch
@@ -1,0 +1,27 @@
+From cf438f7a3ab2e70b06ec12653d1111e35084733f Mon Sep 17 00:00:00 2001
+From: Max <max@privatevoid.net>
+Date: Fri, 8 Aug 2025 18:20:48 +0200
+Subject: [PATCH] spawn sh instead of /bin/sh
+
+---
+ src/subprocess-posix.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/subprocess-posix.cc b/src/subprocess-posix.cc
+index 0e62b3b..c1c31aa 100644
+--- a/src/subprocess-posix.cc
++++ b/src/subprocess-posix.cc
+@@ -129,8 +129,8 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
+   if (err != 0)
+     Fatal("posix_spawnattr_setflags: %s", strerror(err));
+ 
+-  const char* spawned_args[] = { "/bin/sh", "-c", command.c_str(), NULL };
+-  err = posix_spawn(&pid_, "/bin/sh", &action, &attr,
++  const char* spawned_args[] = { "sh", "-c", command.c_str(), NULL };
++  err = posix_spawnp(&pid_, "sh", &action, &attr,
+         const_cast<char**>(spawned_args), environ);
+   if (err != 0)
+     Fatal("posix_spawn: %s", strerror(err));
+-- 
+2.50.1
+

--- a/pkgs/by-name/ni/ninja/package.nix
+++ b/pkgs/by-name/ni/ninja/package.nix
@@ -52,8 +52,11 @@ stdenv.mkDerivation (finalAttrs: {
     libxslt.bin
   ];
 
+  patches = [
+    ./0001-spawn-sh-instead-of-bin-sh.patch
+  ]
   # TODO: remove together with ninja 1.11
-  patches = lib.optionals (lib.versionOlder finalAttrs.version "1.12") [
+  ++ lib.optionals (lib.versionOlder finalAttrs.version "1.12") [
     (fetchpatch {
       name = "ninja1.11-python3.13-compat.patch";
       url = "https://github.com/ninja-build/ninja/commit/9cf13cd1ecb7ae649394f4133d121a01e191560b.patch";


### PR DESCRIPTION
Instead, `sh` is now looked up on `PATH`. Same idea as #120501

I've built `systemdMinimal`, which uses ninja, on this branch to test it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
