### PR TITLE
fetchtorrent: use free torrent file for tests

### DIFF
--- a/pkgs/build-support/fetchtorrent/tests.nix
+++ b/pkgs/build-support/fetchtorrent/tests.nix
@@ -1,50 +1,57 @@
-{ testers, fetchtorrent, ... }:
+{
+  lib,
+  testers,
+  fetchtorrent,
+  ...
+}:
 
 let
-  wired-cd.meta.license = [
-    # track 1, 4 and 11
-    {
-      spdxID = "CC NC-SAMPLING+ 1.0 Deed";
-      fullName = "NonCommercial Sampling Plus 1.0 Generic";
-      url = "https://creativecommons.org/licenses/nc-sampling+/1.0/";
-      free = false; # for noncommercial purposes only
-    }
-    # the rest
-    {
-      spdxID = "CC SAMPLING+ 1.0 Deed";
-      fullName = "Sampling Plus 1.0 Generic";
-      url = "https://creativecommons.org/licenses/sampling+/1.0/";
-      free = true; # no use in advertisement
-    }
-  ];
+  sintel.meta = {
+    description = "An open source short film to show off open source technologies.";
+    longDescription = ''
+      An independently produced short film, initiated by the Blender Foundation
+      as a means to further improve andvalidate the free/open source 3D
+      creation suite Blender.
+    '';
+    license = lib.licenses.cc-by-30;
+    homepage = "https://durian.blender.org/";
+  };
+
+  # Via https://webtorrent.io/free-torrents
+  httpUrl = "https://webtorrent.io/torrents/sintel.torrent";
+  magnetUrl = "magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent";
+
+  # All routes to download the torrent should produce the same output and
+  # therefore have the same FOD hash.
+  hash = "sha256-EzbmBiTEWOlFUNaV5R4eDeD9EBbp6d93rfby88ACg0s=";
 in
 
 {
   http-link = testers.invalidateFetcherByDrvHash fetchtorrent {
-    url = "https://webtorrent.io/torrents/wired-cd.torrent";
-    hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
+    inherit hash;
+    url = httpUrl;
     backend = "transmission";
-    inherit (wired-cd) meta;
+    inherit (sintel) meta;
   };
   magnet-link = testers.invalidateFetcherByDrvHash fetchtorrent {
-    url = "magnet:?xt=urn:btih:a88fda5954e89178c372716a6a78b8180ed4dad3&dn=The+WIRED+CD+-+Rip.+Sample.+Mash.+Share&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fwired-cd.torrent";
-    hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
+    inherit hash;
+    url = magnetUrl;
     backend = "transmission";
-    inherit (wired-cd) meta;
+    inherit (sintel) meta;
   };
   http-link-rqbit = testers.invalidateFetcherByDrvHash fetchtorrent {
-    url = "https://webtorrent.io/torrents/wired-cd.torrent";
-    hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
+    inherit hash;
+    url = httpUrl;
     backend = "rqbit";
-    meta = wired-cd.meta // {
+    meta = sintel.meta // {
       broken = true;
     };
   };
   magnet-link-rqbit = testers.invalidateFetcherByDrvHash fetchtorrent {
-    url = "magnet:?xt=urn:btih:a88fda5954e89178c372716a6a78b8180ed4dad3&dn=The+WIRED+CD+-+Rip.+Sample.+Mash.+Share&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fwired-cd.torrent";
-    hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
+    inherit hash;
+    url = magnetUrl;
     backend = "rqbit";
-    meta = wired-cd.meta // {
+    meta = sintel.meta // {
       broken = true;
     };
   };

--- a/pkgs/build-support/fetchtorrent/tests.nix
+++ b/pkgs/build-support/fetchtorrent/tests.nix
@@ -36,12 +36,16 @@ in
     url = "https://webtorrent.io/torrents/wired-cd.torrent";
     hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
     backend = "rqbit";
-    inherit (wired-cd) meta;
+    meta = wired-cd.meta // {
+      broken = true;
+    };
   };
   magnet-link-rqbit = testers.invalidateFetcherByDrvHash fetchtorrent {
     url = "magnet:?xt=urn:btih:a88fda5954e89178c372716a6a78b8180ed4dad3&dn=The+WIRED+CD+-+Rip.+Sample.+Mash.+Share&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fwired-cd.torrent";
     hash = "sha256-OCsC22WuanqoN6lPv5wDT5ZxPcEHDpZ1EgXGvz1SDYo=";
     backend = "rqbit";
-    inherit (wired-cd) meta;
+    meta = wired-cd.meta // {
+      broken = true;
+    };
   };
 }


### PR DESCRIPTION
The fetchtorrent tests have been broken for a while, per #432001.  This wasn't picked up promptly because, I suspect, the tests tried to download a non-free torrent, so would be silently skipped by most automated CI tools.

This replaces the non-free [Wired CD](https://creativecommons.org/extras/wired/) previously used in the tests with the free [Sintel](https://durian.blender.org/) short film.  It also marks the failing tests as such.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
