### PR TITLE
heroic: disable privateTmp

### DIFF
--- a/pkgs/by-name/he/heroic/package.nix
+++ b/pkgs/by-name/he/heroic/package.nix
@@ -5,7 +5,7 @@
   extraLibraries ? pkgs: [ ],
 }:
 
-steam.buildRuntimeEnv {
+(steam.override { privateTmp = false; }).buildRuntimeEnv {
   pname = "heroic";
   inherit (heroic-unwrapped) version meta;
 

--- a/pkgs/by-name/he/heroic/package.nix
+++ b/pkgs/by-name/he/heroic/package.nix
@@ -5,7 +5,7 @@
   extraLibraries ? pkgs: [ ],
 }:
 
-(steam.override { privateTmp = false; }).buildRuntimeEnv {
+steam.buildRuntimeEnv {
   pname = "heroic";
   inherit (heroic-unwrapped) version meta;
 
@@ -19,4 +19,6 @@
     ln -s ${heroic-unwrapped}/share/applications $out/share
     ln -s ${heroic-unwrapped}/share/icons $out/share
   '';
+
+  privateTmp = false;
 }

--- a/pkgs/by-name/st/steam/package.nix
+++ b/pkgs/by-name/st/steam/package.nix
@@ -21,6 +21,7 @@ let
       extraPreBwrapCmds ? "",
       extraBwrapArgs ? [ ],
       extraEnv ? { },
+      privateTmp ? true,
       ...
     }@args:
     buildFHSEnv (
@@ -150,6 +151,7 @@ buildRuntimeEnv {
     extraPreBwrapCmds
     extraBwrapArgs
     extraEnv
+    privateTmp
     ;
 
   runScript = writeShellScript "steam-wrapped" ''
@@ -175,6 +177,7 @@ buildRuntimeEnv {
             extraPreBwrapCmds
             extraBwrapArgs
             extraEnv
+            privateTmp
             ;
 
           runScript = writeShellScript "steam-run" ''


### PR DESCRIPTION
Disable privateTmp in the Steam runtime env wrapper so that Heroic does not run multiple instances.

Credit to @K900 for suggesting `privateTmp`.

Closes #432037

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
