### PR TITLE
flightgear: use forked openscenegraph

### DIFF
--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitLab,
   wrapQtAppsHook,
+  callPackage,
   libglut,
   freealut,
   libGLU,
@@ -10,7 +11,6 @@
   libICE,
   libjpeg,
   openal,
-  openscenegraph,
   plib,
   libSM,
   libunwind,
@@ -55,6 +55,7 @@ let
       cp ${src}/* -a "$out/share/FlightGear/"
     '';
   };
+  openscenegraph = callPackage ./openscenegraph-flightgear.nix { };
 in
 stdenv.mkDerivation rec {
   pname = "flightgear";
@@ -90,7 +91,7 @@ stdenv.mkDerivation rec {
     libXi
     libXmu
     libXt
-    simgear
+    (simgear.override { openscenegraph = openscenegraph; })
     zlib
     boost
     libpng
@@ -104,9 +105,7 @@ stdenv.mkDerivation rec {
     curl
   ];
 
-  qtWrapperArgs = [
-    "--set FG_ROOT ${data}/share/FlightGear"
-  ];
+  qtWrapperArgs = [ "--set FG_ROOT ${data}/share/FlightGear" ];
 
   meta = with lib; {
     description = "Flight simulator";

--- a/pkgs/games/flightgear/openscenegraph-flightgear.nix
+++ b/pkgs/games/flightgear/openscenegraph-flightgear.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  pkg-config,
+  cmake,
+  doxygen,
+  fetchpatch,
+  fetchurl,
+  glib,
+  libxml2,
+  pcre,
+  zlib,
+  libjpeg,
+  giflib,
+  libtiff,
+  libpng,
+  curl,
+  freetype,
+  boost,
+  libGLU,
+  libGL,
+  libX11,
+  libXinerama,
+  libXrandr,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openscenegraph";
+  version = "2024-build";
+
+  src = fetchFromGitLab {
+    owner = "flightgear";
+    repo = "openscenegraph";
+    # release/2024-build as of 2025-08-08
+    rev = "a4ea8ec535cc969e31e2026b13be147dcb978689";
+    sha256 = "sha256-wnxm4G40j2e6Paqx0vfAR4s4L7esfCHcgxUJWNxk1SM=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    doxygen
+  ];
+
+  buildInputs =
+    lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      libX11
+      libXinerama
+      libXrandr
+      libGLU
+      libGL
+    ]
+    ++ [
+      glib
+      libxml2
+      pcre
+      zlib
+      libjpeg
+      giflib
+      libtiff
+      libpng
+      curl
+      freetype
+      boost
+    ];
+
+  patches = [
+    (fetchpatch {
+      name = "opencascade-api-patch";
+      url = "https://github.com/openscenegraph/OpenSceneGraph/commit/bc2daf9b3239c42d7e51ecd7947d31a92a7dc82b.patch";
+      hash = "sha256-VR8YKOV/YihB5eEGZOGaIfJNrig1EPS/PJmpKsK284c=";
+    })
+    # Fix compiling with libtiff when libtiff is compiled using CMake
+    (fetchurl {
+      url = "https://github.com/openscenegraph/OpenSceneGraph/commit/9da8d428f6666427c167b951b03edd21708e1f43.patch";
+      hash = "sha256-YGG/DIHU1f6StbeerZoZrNDm348wYB3ydmVIIGTM7fU=";
+    })
+  ];
+
+  cmakeFlags = [ "-DBUILD_OSG_APPLICATIONS=OFF" ];
+
+  meta = with lib; {
+    description = "3D graphics toolkit";
+    homepage = "http://www.openscenegraph.org/";
+    maintainers = with maintainers; [
+      aanderse
+      raskin
+    ];
+    platforms = with platforms; linux ++ darwin;
+    license = "OpenSceneGraph Public License - free LGPL-based license";
+  };
+}


### PR DESCRIPTION
As discussed on https://gitlab.com/flightgear/flightgear/-/issues/3106 , version 2024.1.1 of flightgear should be compiled against a version of openscenegraph that was forked from the main project, and is hosted in the same gitlab namespace.

This fork includes several fixes such as
https://gitlab.com/flightgear/openscenegraph/-/commit/724ff2ef687d84b266402724239f61a392d36f4c .

This change probably needs to be backported to nixos 25.05, but I have no idea what the process for that looks like.

cc maintainers @7c6f434c (raskin) and @aanderse 

I suppose now simgear is orphaned, let me know if I should
1. leave it as is (inline openscenegraph into flightgear, but use an override for simgear)
2. or create a new package called openscenegraph-flightgear, and reference it in both simgear and flightgear
3. or inline both openscenegraph and simgear into the flightgear derivation, and remove package simgear.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
