### PR TITLE
precice: 3.1.2 -> 3.2.0-unstable-05-23

### DIFF
--- a/pkgs/by-name/pr/precice/package.nix
+++ b/pkgs/by-name/pr/precice/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   boost,
   eigen,
@@ -15,22 +14,14 @@
 
 stdenv.mkDerivation rec {
   pname = "precice";
-  version = "3.1.2";
+  version = "3.2.0-unstable-2025-05-23";
 
   src = fetchFromGitHub {
     owner = "precice";
     repo = "precice";
-    rev = "v${version}";
-    hash = "sha256-KpmcQj8cv5V5OXCMhe2KLTsqUzKWtTeQyP+zg+Y+yd0=";
+    rev = "6ee3e347843d4d3c416a32917f6505d35b822445";
+    hash = "sha256-BxNAbpeLqJPzQ9dvvgC9jJQQFBdVMunSqIekz7SIHv4=";
   };
-
-  patches = lib.optionals (!lib.versionOlder "3.1.2" version) [
-    (fetchpatch {
-      name = "boost-187-fixes.patch";
-      url = "https://github.com/precice/precice/commit/23788e9eeac49a2069e129a0cb1ac846e8cbeb9f.patch";
-      hash = "sha256-Z8qOGOkXoCui8Wy0H/OeE+NaTDvyRuPm2A+VJKtjH4s=";
-    })
-  ];
 
   cmakeFlags = [
     (lib.cmakeBool "PRECICE_PETScMapping" false)

--- a/pkgs/by-name/pr/precice/package.nix
+++ b/pkgs/by-name/pr/precice/package.nix
@@ -7,7 +7,7 @@
   eigen,
   libxml2,
   mpi,
-  python3,
+  python3Packages,
   petsc,
   pkg-config,
 }:
@@ -26,15 +26,11 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     (lib.cmakeBool "PRECICE_PETScMapping" false)
     (lib.cmakeBool "BUILD_SHARED_LIBS" true)
-    (lib.cmakeFeature "PYTHON_LIBRARIES" python3.libPrefix)
-    (lib.cmakeFeature "PYTHON_INCLUDE_DIR" "${python3}/include/${python3.libPrefix}")
   ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    python3
-    python3.pkgs.numpy
   ];
 
   buildInputs = [
@@ -43,6 +39,8 @@ stdenv.mkDerivation rec {
     libxml2
     mpi
     petsc
+    python3Packages.python
+    python3Packages.numpy
   ];
 
   meta = {

--- a/pkgs/development/python-modules/pyprecice/default.nix
+++ b/pkgs/development/python-modules/pyprecice/default.nix
@@ -17,20 +17,19 @@
 
 buildPythonPackage rec {
   pname = "pyprecice";
-  version = "3.1.2";
+  version = "3.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "precice";
     repo = "python-bindings";
     tag = "v${version}";
-    hash = "sha256-/atuMJVgvY4kgvrB+LuQZmJuSK4O8TJdguC7NCiRS2Y=";
+    hash = "sha256-8AM2wbPX54UaMO4MzLOV0TljLTAPOqR9gUbtT2McNjs=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=61,<72" "setuptools" \
-      --replace-fail "numpy<2" "numpy"
+      --replace-fail "setuptools>=61,<72" "setuptools"
   '';
 
   build-system = [
@@ -38,10 +37,6 @@ buildPythonPackage rec {
     pip
     pkgconfig
     setuptools
-  ];
-
-  pythonRelaxDeps = [
-    "numpy"
   ];
 
   dependencies = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13563,7 +13563,11 @@ self: super: with self; {
 
   pyppmd = callPackage ../development/python-modules/pyppmd { };
 
-  pyprecice = callPackage ../development/python-modules/pyprecice { };
+  pyprecice = callPackage ../development/python-modules/pyprecice {
+    precice = pkgs.precice.override {
+      python3Packages = self;
+    };
+  };
 
   pypresence = callPackage ../development/python-modules/pypresence { };
 


### PR DESCRIPTION
1. Fix build failure with libxml2
2. use python3Packages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
