### PR TITLE
nixos: XDG Base Directory Specification environment variables 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -30,6 +30,8 @@
 
 - [dms-greeter](https://danklinux.com), a modern display manager greeter for DankMaterialShell that works with greetd and supports multiple Wayland compositors. Available as [services.displayManager.dms-greeter](#opt-services.displayManager.dms-greeter.enable).
 
+- Management of `$XDG_*_HOME` environment variables from [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/). Available as [xdg.directories](#opt-xdg.directories.enable).
+
 - [dsearch](https://github.com/AvengeMedia/danksearch), a fast filesystem search service with fuzzy matching. Available as [programs.dsearch](#opt-programs.dsearch.enable).
 
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).
@@ -84,6 +86,11 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 - Support for `reiserfs` in nixpkgs has been removed, following the removal in Linux 6.13.
 
 - support for `ecryptfs` in nixpkgs has been removed.
+
+- Setting the newly added `xdg.directories.enable` to `true` (it is `false` by default) will cause `$XDG_CACHE_HOME`, `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, and `$XDG_STATE_HOME` environment variables to be set to the values that should be used as a fallback if the variables are not set, as per [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/).
+  Theoretically, this should have no effect on compliant applications, but some applications only comply when they see those variables set, and otherwise just spam into the `$HOME` directory.
+  This is wrong, but, hopefully, those applications at least know to *not* ignore their old files/directories in `$HOME` if those already exist.
+  Otherwise, some breakage is going to happen.
 
 - The `networking.wireless` module has been security hardened: the `wpa_supplicant` daemon now runs under an unprivileged user with restricted access to the system.
 

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -24,6 +24,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- Management of `$XDG_*_HOME` environment variables from [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/). Available as [xdg.directories](#opt-xdg.directories.enable).
+
 - [Portmaster](https://safing.io/portmaster/), a privacy-focused application
   firewall, is available through
   [services.portmaster](#opt-services.portmaster.enable).
@@ -109,6 +111,11 @@
 - `services.pid-fan-controller` no longer provides deep configuration rewriting and adheres now fully to RFC42.
 
 - The `extraArgs` and `check` arguments to `nixos/lib/eval-config.nix` (and therefore to `lib.nixosSystem`) have been removed after being deprecated with a warning since 2021. Passing them is now an evaluation error. Instead of `extraArgs`, set `config._module.args`; instead of `check = false`, set `config._module.check = false`. The `extraArgs` attribute on the resulting configuration has been removed as well.
+
+- Setting the newly added `xdg.directories.enable` to `true` (it is `false` by default) will cause `$XDG_CACHE_HOME`, `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, and `$XDG_STATE_HOME` environment variables to be set to the values that should be used as a fallback if the variables are not set, as per [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/).
+  Theoretically, this should have no effect on compliant applications, but some applications only comply when they see those variables set, and otherwise just spam into the `$HOME` directory.
+  This is wrong, but, hopefully, those applications at least know to *not* ignore their old files/directories in `$HOME` if those already exist.
+  Otherwise, some breakage is going to happen.
 
 - Rustical migrates from `settings.http.host` and `settings.http.port` to `settings.http.bind` to support UNIX domain sockets as well as TCP sockets in one setting.
 

--- a/nixos/modules/config/xdg/directories.nix
+++ b/nixos/modules/config/xdg/directories.nix
@@ -1,0 +1,48 @@
+{ config, lib, ... }:
+{
+  meta = {
+    maintainers = [ lib.maintainers.sandarukasa ] ++ lib.teams.freedesktop.members;
+  };
+
+  options = {
+    xdg.directories =
+      let
+        mkXdgHome =
+          name: default:
+          lib.mkOption {
+            type = lib.types.str;
+            default = "$HOME/${default}/";
+            description = "Value of `$XDG_${name}_HOME` environment variable";
+          };
+      in
+      {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to define environment variables for some directories from
+            [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/).
+            Namely:
+            - `$XDG_CACHE_HOME`
+            - `$XDG_CONFIG_HOME`
+            - `$XDG_DATA_HOME`
+            - `$XDG_STATE_HOME`
+          '';
+        };
+        cache-home = mkXdgHome "CACHE" ".cache";
+        config-home = mkXdgHome "CONFIG" ".config";
+        data-home = mkXdgHome "DATA" ".local/share";
+        state-home = mkXdgHome "STATE" ".local/state";
+      };
+  };
+
+  config = lib.mkIf config.xdg.directories.enable {
+    environment.sessionVariables = {
+      XDG_CACHE_HOME = lib.mkDefault config.xdg.directories.cache-home;
+      XDG_CONFIG_HOME = lib.mkDefault config.xdg.directories.config-home;
+      XDG_DATA_HOME = lib.mkDefault config.xdg.directories.data-home;
+      XDG_STATE_HOME = lib.mkDefault config.xdg.directories.state-home;
+    };
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -39,6 +39,7 @@
   ./config/users-groups.nix
   ./config/vte.nix
   ./config/xdg/autostart.nix
+  ./config/xdg/directories.nix
   ./config/xdg/icons.nix
   ./config/xdg/menus.nix
   ./config/xdg/mime.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -40,6 +40,7 @@
   ./config/users-groups.nix
   ./config/vte.nix
   ./config/xdg/autostart.nix
+  ./config/xdg/directories.nix
   ./config/xdg/icons.nix
   ./config/xdg/menus.nix
   ./config/xdg/mime.nix


### PR DESCRIPTION
Issue: #224525.

The spec: https://specifications.freedesktop.org/basedir-spec/latest/

This PR introduces an `xdg.directories.enable` option, which automatically sets up the following environment variables:
- `$XDG_CACHE_HOME`
- `$XDG_CONFIG_HOME`
- `$XDG_DATA_HOME`
- `$XDG_STATE_HOME`

Their default values are taken from the spec, but can be overridden using `config.xdg.directories.cache-home` & so on.

`xdg.directories.enable` is `false` by default, preserving the old behavior. We can discuss changing the default to `true` on newer NixOS `stateVersion`s in a separate PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
