### PR TITLE
tsduck: 3.40-4165 -> 3.41-4299

### DIFF
--- a/pkgs/by-name/ts/tsduck/package.nix
+++ b/pkgs/by-name/ts/tsduck/package.nix
@@ -67,13 +67,15 @@ stdenv.mkDerivation (finalAttrs: {
     "NOVATEK=1"
     "SYSPREFIX=/"
     "SYSROOT=${placeholder "out"}"
+    "RIST_DONE=1"
+    "SRT_DONE=1"
   ];
 
   # remove tests which break the sandbox
   patches = [ ./tests.patch ];
   checkTarget = "test";
   doCheck = true;
-  doInstallCheck = true;
+  doInstallCheck = false;
 
   installTargets = [
     "install-tools"

--- a/pkgs/by-name/ts/tsduck/package.nix
+++ b/pkgs/by-name/ts/tsduck/package.nix
@@ -18,6 +18,8 @@
   librist,
   openssl,
   srt,
+  editline,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,12 +45,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     curl
+    editline
     glibcLocales
     jdk
     libedit
     librist
     openssl
     srt
+    zlib
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/ts/tsduck/package.nix
+++ b/pkgs/by-name/ts/tsduck/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tsduck";
-  version = "3.40-4165";
+  version = "3.41-4299";
 
   src = fetchFromGitHub {
     owner = "tsduck";
     repo = "tsduck";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-bFnsGoElXeStIX5KwonJuF0x7DDzhzq+3oygkUOmZE0=";
+    sha256 = "sha256-nBPYKzb6GeBC7tTZgHLp1nAQM9SKpGhU/nHUJqT5TrY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ts/tsduck/package.nix
+++ b/pkgs/by-name/ts/tsduck/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [ ./tests.patch ];
   checkTarget = "test";
   doCheck = true;
-  doInstallCheck = false;
+  doInstallCheck = true;
 
   installTargets = [
     "install-tools"


### PR DESCRIPTION
- Updated to latest tsduck version
- Added support for editline and zlib
- Added environment vars SRT_DONE=1 and RIST_DONE=1 so that scripts/make-config.sh will assume SRT/RIST support.  It checks paths for the .h files, but those paths are different on nix.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
