### PR TITLE
uv: 0.8.6 -> 0.8.11

### DIFF
--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.8.7";
+  version = "0.8.11";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-wJGKaPtrBzByTgAfBj9bNum7B3Vvt1F+MENu/TxLDZM=";
+    hash = "sha256-znTLRCCprUg412h75dK2092/9qpOa+HO3Fe2dFqKON4=";
   };
 
-  cargoHash = "sha256-88ORMuCpfvPU5j7FM16lpOJGA0ktGmbaA8dGYAfvsIU=";
+  cargoHash = "sha256-lKYTKa0x9K0Al3InxjmHOhV225Q7xSZuLGw3xSS3S6c=";
 
   buildInputs = [
     rust-jemalloc-sys

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uv";
-  version = "0.8.6";
+  version = "0.8.7";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = finalAttrs.version;
-    hash = "sha256-82KKnz42Nn2Ef8DHBWBMPTrQVsM+klIOV8hqSKnXqEY=";
+    hash = "sha256-wJGKaPtrBzByTgAfBj9bNum7B3Vvt1F+MENu/TxLDZM=";
   };
 
-  cargoHash = "sha256-l2/PMPiSPE6WpXOuU21NsMx0vsz9cuy/QeCiSTkbvVw=";
+  cargoHash = "sha256-88ORMuCpfvPU5j7FM16lpOJGA0ktGmbaA8dGYAfvsIU=";
 
   buildInputs = [
     rust-jemalloc-sys

--- a/pkgs/development/python-modules/uv/default.nix
+++ b/pkgs/development/python-modules/uv/default.nix
@@ -17,11 +17,12 @@ buildPythonPackage {
   build-system = [ hatchling ];
 
   postPatch =
-    # Do not rely on path lookup at runtime to find the uv binary.
-    # Use the propagated binary instead.
+    # Add the path to the uv binary as a fallback after other path search methods have been exhausted
     ''
       substituteInPlace python/uv/_find_uv.py \
-        --replace-fail '"""Return the uv binary path."""' "return '${lib.getExe uv}'"
+        --replace-fail \
+        'sysconfig.get_path("scripts", scheme=_user_scheme()),' \
+        'sysconfig.get_path("scripts", scheme=_user_scheme()), "${builtins.baseNameOf (lib.getExe uv)}",'
     ''
     # Sidestep the maturin build system in favour of reusing the binary already built by nixpkgs,
     # to avoid rebuilding the uv binary for every active python package set.


### PR DESCRIPTION
Changelog: https://github.com/astral-sh/uv/releases/tag/0.8.7
Changelog: https://github.com/astral-sh/uv/releases/tag/0.8.8
Changelog: https://github.com/astral-sh/uv/releases/tag/0.8.9
Changelog: https://github.com/astral-sh/uv/releases/tag/0.8.10
Changelog: https://github.com/astral-sh/uv/releases/tag/0.8.11

uv's Python module now searches for the binary in more multiple places.
Should the user have installed a separate version of the binary, then the Python module
can consider those first, then fallback to nixpkgs' uv.

In case reviewers find the changes to the Python module to be wrong / breaking / useless etc., we can just remove the second commit 😄 

`$ nom-build -A uv -A python3Packages.uv -A python3Packages.uv-build` succeeded for `aarch64-darwin` on master for all commits

CC @GaetanLepage 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
