### PR TITLE
huenicorn: init at 1.0.11

### DIFF
--- a/pkgs/by-name/hu/huenicorn/package.nix
+++ b/pkgs/by-name/hu/huenicorn/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  opencv,
+  curl,
+  mbedtls,
+  glm,
+  nlohmann_json,
+  crow,
+  glib,
+  pipewire,
+  libsysprof-capture,
+  pcre2,
+  util-linux,
+  libselinux,
+  libsepol,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "huenicorn";
+  version = "1.0.11";
+
+  src = fetchFromGitLab {
+    owner = "openjowelsofts";
+    repo = "huenicorn";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OoAc1TtJT9BzoPHzTEtDEsLcaSS/nIf5WJDz7BA+d0k=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.com/openjowelsofts/huenicorn/-/commit/5d5a8c72dfb3e2986aac685acade30f8367e2a0f.patch";
+      sha256 = "sha256-IPKHLh5F5A5nAYzA2ZsnF9OELsBSfeIM/UxcOcs+kME=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    opencv
+    curl
+    mbedtls
+    glm
+    nlohmann_json
+    crow
+    glib
+    pipewire
+
+    # builds without these, but cmake complains
+    libsysprof-capture
+    pcre2
+    util-linux
+    libselinux
+    libsepol
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D huenicorn --target-directory=$out/bin
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Linux Ambilight driver for Philips Hue™ devices";
+    homepage = "https://gitlab.com/openjowelsofts/huenicorn";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ XBagon ];
+    mainProgram = "huenicorn";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
