### PR TITLE
mate.mate-panel: 1.28.4 -> 1.28.5

### DIFF
--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -1,9 +1,12 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoconf-archive,
+  autoreconfHook,
   pkg-config,
   gettext,
+  gtk-doc,
   itstool,
   glib,
   gtk-layer-shell,
@@ -14,32 +17,42 @@
   libxml2,
   dconf,
   dconf-editor,
+  mate-common,
   mate-desktop,
   mate-menus,
   hicolor-icon-theme,
   wayland,
   gobject-introspection,
   wrapGAppsHook3,
+  yelp-tools,
   marco,
-  mateUpdateScript,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation rec {
   pname = "mate-panel";
-  version = "1.28.4";
+  version = "1.28.5";
 
-  src = fetchurl {
-    url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-AvCesDFMKsGXtvCJlQpXHNujm/0D1sOguP13JSqWiHQ=";
+  src = fetchFromGitHub {
+    owner = "mate-desktop";
+    repo = "mate-panel";
+    tag = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-P1zrOH1xTbKXIoP13azAFDv2Q05dubR1AfmuLbgh250=";
   };
 
   nativeBuildInputs = [
+    autoconf-archive
+    autoreconfHook
     gobject-introspection
     gettext
+    gtk-doc
     itstool
     libxml2 # xmllint
+    mate-common # mate-common.m4 macros
     pkg-config
     wrapGAppsHook3
+    yelp-tools
   ];
 
   buildInputs = [
@@ -81,7 +94,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.updateScript = mateUpdateScript { inherit pname; };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+    odd-unstable = true;
+  };
 
   meta = with lib; {
     description = "MATE panel";


### PR DESCRIPTION
https://github.com/mate-desktop/mate-panel/compare/v1.28.4...v1.28.5

Upstream is (still) experiencing problems releasing tarballs, so switch to fetchFromGitHub for now.




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

