### PR TITLE
ed-odyssey-materials-helper: remove sentry

### DIFF
--- a/pkgs/by-name/ed/ed-odyssey-materials-helper/package.nix
+++ b/pkgs/by-name/ed/ed-odyssey-materials-helper/package.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation rec {
     # so this removes 1) the popup about it when you first start the program, 2) the option in the settings
     # and makes the program always know that it is set up
     ./remove-urlscheme-settings.patch
+
+    # Upstream requested that sentry is only to be used with official builds, remove it so it doesn't complain about the lack of DSN
+    ./remove-sentry.patch
   ];
   postPatch = ''
     # oslib doesn't seem to do releases and hasn't had a change since 2021, so always use commit d6ee6549bb
@@ -70,11 +73,6 @@ stdenv.mkDerivation rec {
   ];
 
   gradleBuildTask = "application:jpackage";
-
-  env = {
-    # The source no longer contains this, so this has been extracted from the binary releases
-    SENTRY_DSN = "https://1aacf97280717f749dfc93a1713f9551@o4507814449774592.ingest.de.sentry.io/4507814504759376";
-  };
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ed/ed-odyssey-materials-helper/remove-sentry.patch
+++ b/pkgs/by-name/ed/ed-odyssey-materials-helper/remove-sentry.patch
@@ -1,0 +1,53 @@
+diff --git a/application/src/main/java/nl/jixxed/eliteodysseymaterials/Main.java b/application/src/main/java/nl/jixxed/eliteodysseymaterials/Main.java
+index 04b101f0..2e589e12 100644
+--- a/application/src/main/java/nl/jixxed/eliteodysseymaterials/Main.java
++++ b/application/src/main/java/nl/jixxed/eliteodysseymaterials/Main.java
+@@ -51,48 +51,6 @@ public class Main {
+                 System.exit(0);
+             }
+             log.info("launching app with java version: " + getVersion());
+-            if (System.getProperty("sentry.dsn") == null || System.getProperty("sentry.dsn").isBlank() || System.getProperty("sentry.dsn").equals("null")) {
+-                log.error("Sentry DSN is not set. Please set the DSN.");
+-            }
+-            Sentry.init(options -> {
+-
+-                final String buildVersion = getBuildVersion();
+-                options.setDsn(System.getProperty("sentry.dsn"));
+-                options.setEnvironment(getEnvironment(buildVersion));
+-                options.setRelease("edomh-app@" + buildVersion);
+-                options.setEnabled(!buildVersion.equals("dev"));
+-                options.setBeforeSend((event, hint) -> {
+-                    if (!VersionService.isLatestVersion()) {
+-                        return null;  // Returning null prevents the event from being sent to Sentry
+-                    }
+-                    if (Duration.between(lastSentTime, Instant.now()).getSeconds() < 30) {
+-                        return null;  // Throttle if less than 30 seconds have passed
+-                    }
+-                    lastSentTime = Instant.now();
+-                    String supportFile = "";
+-                    try {
+-                        supportFile = SupportService.createSupportPackage();
+-                    } catch (Exception e) {
+-                        log.error("Failed to create support package", e);
+-                    }
+-                    if (!supportFile.isBlank()) {
+-                        Attachment attachment = new Attachment(supportFile);
+-                        hint.addAttachment(attachment);
+-                    }
+-                    OperatingSystem os = new OperatingSystem();
+-                    os.setName(System.getProperty("os.name"));
+-                    os.setVersion(System.getProperty("os.version"));
+-                    os.setBuild(System.getProperty("os.arch"));
+-                    event.getContexts().setOperatingSystem(os);
+-                    if (APPLICATION_STATE.getFileheader() != null) {
+-                        event.setTag("game.version", APPLICATION_STATE.getFileheader().getGameversion());
+-                        event.setTag("game.build", APPLICATION_STATE.getFileheader().getBuild());
+-                        event.setTag("game.language", APPLICATION_STATE.getFileheader().getLanguage());
+-                        event.setTag("game.odyssey", String.valueOf(APPLICATION_STATE.getFileheader().getOdyssey()));
+-                    }
+-                    return event;
+-                });
+-            });
+             FXApplication.launchFx(args);
+         }
+     }


### PR DESCRIPTION
## Things done
This removes sentry as requested by upstream in https://github.com/jixxed/ed-odyssey-materials-helper/issues/692#issuecomment-3162069733

That comment also requests that this package is marked/renamed as an unofficial distribution of the program, but I don't think it is necessary, as the only patches here do not change the main function of the program, and anyone geting software from nixpkgs knowns that it is maintained by nixpkgs maintainers.

I'll mark this as a draft for now to allow @jixxed to respond.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
