### PR TITLE
cemu-ti: platform changes

### DIFF
--- a/pkgs/applications/science/math/cemu-ti/default.nix
+++ b/pkgs/applications/science/math/cemu-ti/default.nix
@@ -47,6 +47,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ];
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin || (stdenv.system == "x86_64-linux");
   };
 })

--- a/pkgs/applications/science/math/cemu-ti/default.nix
+++ b/pkgs/applications/science/math/cemu-ti/default.nix
@@ -46,11 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://ce-programming.github.io/CEmu";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ];
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-linux"
-    ];
+    platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin || (stdenv.system == "x86_64-linux");
   };
 })


### PR DESCRIPTION
In #356874, I marked `x86_64-linux` as broken at the maintainer's request, and left out `aarch64-darwin` as a supported platform because `cemu-ti` didn't build. Now, it builds on `x86_64-darwin` and `aarch64-darwin` (#429216). Additionally, the issue with `x86_64-linux` has been magically resolved (#354358). Therefore, there is no reason to exclude `aarch64-darwin`, as well as mark any supported platform as broken.

Resolves #429216 and #357141.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
