### PR TITLE
python313Packages.time-machine: 2.16.0 -> 2.17.0

### DIFF
--- a/pkgs/development/python-modules/time-machine/default.nix
+++ b/pkgs/development/python-modules/time-machine/default.nix
@@ -2,36 +2,34 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
-  pythonOlder,
-  setuptools,
-  python-dateutil,
   pytestCheckHook,
+  python-dateutil,
+  setuptools,
+  tokenize-rt,
 }:
 
 buildPythonPackage rec {
   pname = "time-machine";
-  version = "2.16.0";
+  version = "2.17.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "adamchainz";
     repo = "time-machine";
     tag = version;
-    hash = "sha256-xNoLtgON1dfKAgK0XhSMLHLsUr/nST3lepy15YWDEcE=";
+    hash = "sha256-5W5uObx+ZZf2mYPE1aLSM1sedeYZcrk5LgujFxilaDw=";
   };
 
   build-system = [ setuptools ];
 
-  dependencies = [
-    python-dateutil
+  dependencies = [ python-dateutil ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    tokenize-rt
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTests = lib.optionals (pythonAtLeast "3.9") [
+  disabledTests = [
     # https://github.com/adamchainz/time-machine/issues/405
     "test_destination_string_naive"
     # Assertion Errors related to Africa/Addis_Ababa
@@ -46,7 +44,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Travel through time in your tests";
     homepage = "https://github.com/adamchainz/time-machine";
-    changelog = "https://github.com/adamchainz/time-machine/blob/${src.rev}/CHANGELOG.rst";
+    changelog = "https://github.com/adamchainz/time-machine/blob/${src.tag}/CHANGELOG.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
Diff: https://github.com/adamchainz/time-machine/compare/refs/tags/2.16.0...refs/tags/2.17.0

Changelog: https://github.com/adamchainz/time-machine/blob/refs/tags/2.17.0/CHANGELOG.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
