### PR TITLE
nixos/audit: fix journald test

### DIFF
--- a/nixos/modules/security/auditd.nix
+++ b/nixos/modules/security/auditd.nix
@@ -202,10 +202,8 @@ in
       }
     ];
 
-    # Starting auditd should also enable loading the audit rules..
+    # Starting the userspace daemon should also enable audit in the kernel
     security.audit.enable = lib.mkDefault true;
-
-    environment.systemPackages = [ pkgs.audit ];
 
     # setting this to anything other than /etc/audit/plugins.d will break, so we pin it here
     security.auditd.settings.plugin_dir = "/etc/audit/plugins.d";

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -12,16 +12,10 @@
   nodes.auditd = {
     security.auditd.enable = true;
     security.audit.enable = true;
-    environment.systemPackages = [ pkgs.audit ];
-    boot.kernel.sysctl."kernel.printk_ratelimit" = 0;
-    boot.kernelParams = [ "audit_backlog_limit=8192" ];
   };
   nodes.journaldAudit = {
     services.journald.audit = true;
     security.audit.enable = true;
-    environment.systemPackages = [ pkgs.audit ];
-    boot.kernel.sysctl."kernel.printk_ratelimit" = 0;
-    boot.kernelParams = [ "audit_backlog_limit=8192" ];
   };
   nodes.containerCheck = {
     containers.c1 = {
@@ -56,11 +50,6 @@
       journaldAudit.succeed("journalctl _TRANSPORT=audit --grep 'unit=systemd-journald'")
       # logs should NOT end up in audit log
       journaldAudit.fail("grep 'unit=systemd-journald' /var/log/audit/audit.log")
-      # FIXME: If systemd fixes #15324 this test will start failing.
-      # You can fix this text by removing the below line.
-      # logs ideally should NOT end up in kmesg, but they do due to
-      # https://github.com/systemd/systemd/issues/15324
-      journaldAudit.succeed("journalctl _TRANSPORT=kernel --grep 'unit=systemd-journald'")
 
 
     with subtest("container systemd-journald-audit not running"):


### PR DESCRIPTION
Follow-up on https://github.com/NixOS/nixpkgs/pull/429553

Fixes `nixosTests.systemd-journal` which is currently broken on master.

Makes the audit module responsible for setting up the audit subsystem of the kernel. The auditd module is now only responsible for setting up the daemon.

Enable the audit subsystem early via kernelParams.

Increase the default audit backlog limit so that it works out of the box for a normal system.

Remove a superfluous and pointless test case.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
